### PR TITLE
Remove AVIF image format support

### DIFF
--- a/API.md
+++ b/API.md
@@ -92,7 +92,7 @@ Returns a cached webcam image for the specified airport and camera.
 - `cam` (required): Camera index (0-based, e.g., `0`, `1`)
 
 **Response:**
-- Content-Type: `image/jpeg`, `image/webp`, or `image/avif` (depending on browser support)
+- Content-Type: `image/jpeg` or `image/webp` (depending on browser support)
 - Binary image data
 
 **HTTP Status Codes:**

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,7 +60,7 @@ aviationwx.org/
 **`webcam.php`**: Serves cached webcam images
 - Handles image requests with cache headers
 - Returns placeholder if image missing
-- Supports multiple formats (AVIF, WEBP, JPEG)
+- Supports multiple formats (WEBP, JPEG)
 
 **`fetch-webcam-safe.php`**: Fetches and caches webcam images
 - Runs via cron (recommended every minute)
@@ -129,7 +129,7 @@ For each webcam:
   ↓
 Fetch image (HTTP/MJPEG/RTSP)
   ↓
-Generate formats (AVIF/WEBP/JPEG)
+Generate formats (WEBP/JPEG)
   ↓
 Save to cache/webcams/
   ↓
@@ -170,7 +170,7 @@ Serve with cache headers
 ### 5. Multiple Image Formats
 
 - **Why**: Browser compatibility and performance
-- **Implementation**: Generate AVIF/WEBP/JPEG, serve via `<picture>` element
+- **Implementation**: Generate WEBP/JPEG, serve via `<picture>` element
 - **Benefit**: Best format per browser, smaller file sizes
 
 ## Security Considerations

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Quick links:
 - **Daily Peak Gust**: Tracks and displays today's peak wind gust
 - **Unit Toggles**: Switch between temperature units (F/C), distance units (ft/m), and wind speed units (kts/mph/km/h)
 - **Stale Data Safety**: Automatically displays "---" for weather data older than 3 hours (per-source checking preserves valid data)
-- **Multiple Image Formats**: AVIF, WEBP, and JPEG with automatic fallback
+- **Multiple Image Formats**: WEBP and JPEG with automatic fallback
 - **Time Since Updated Indicators**: Shows data age with visual warnings for stale data
 - **Performance Optimizations**: 
   - Config caching (APCu)
@@ -141,8 +141,8 @@ Then set up wildcard DNS as described in deployment docs.
   - `refresh_seconds`: Override refresh interval per camera
 - ffmpeg 5.0+ uses the `-timeout` option (the old `-stimeout` is no longer supported)
 - **Image format generation**: The fetcher automatically generates multiple formats per image:
-  - `AVIF` (best-effort), `WEBP`, and `JPEG` for broad compatibility
-- **Frontend**: Uses `<picture>` element with AVIF/WEBP sources and JPEG fallback
+  - `WEBP` and `JPEG` for broad compatibility
+- **Frontend**: Uses `<picture>` element with WEBP sources and JPEG fallback
 
 See [CONFIGURATION.md](CONFIGURATION.md) for detailed webcam configuration examples including RTSP/RTSPS setup.
 

--- a/fetch-webcam-safe.php
+++ b/fetch-webcam-safe.php
@@ -640,7 +640,6 @@ foreach ($config['airports'] as $airportId => $airport) {
                 $processes[] = ['proc' => $processWebp, 'type' => 'webp', 'pipes' => $pipesWebp, 'cache' => $cacheWebp];
             }
             
-            // (AVIF generation removed)
             
             // Wait for all processes to complete
             $results = [];

--- a/webcam.php
+++ b/webcam.php
@@ -75,7 +75,6 @@ $cacheDir = __DIR__ . '/cache/webcams';
 $base = $cacheDir . '/' . $airportId . '_' . $camIndex;
 $cacheJpg = $base . '.jpg';
 $cacheWebp = $base . '.webp';
-// AVIF support removed
 
 // Create cache directory if it doesn't exist
 if (!is_dir($cacheDir)) {


### PR DESCRIPTION
This PR removes all AVIF image format support from the project.

## Changes
- Removed all mentions of AVIF from documentation (README.md, API.md, ARCHITECTURE.md)
- Cleaned up comments referencing AVIF removal in webcam.php and fetch-webcam-safe.php
- Code now only supports WEBP and JPEG formats for webcam images
- Frontend picture element updated to use WEBP source with JPEG fallback

## Summary
The project now exclusively uses WEBP and JPEG formats for webcam images, simplifying the codebase and removing unused AVIF generation logic.