### PR TITLE
Add SkyVector and AOPA buttons to airport dashboard

### DIFF
--- a/airport-template.php
+++ b/airport-template.php
@@ -212,8 +212,14 @@
             </div>
 
             <div class="links">
-                <a href="<?= htmlspecialchars($airport['airnav_url']) ?>" target="_blank" rel="noopener" class="btn">
+                <a href="<?= htmlspecialchars($airport['airnav_url']) ?>" target="_blank" rel="noopener" class="btn" style="margin-right: 1rem;">
                     View on AirNav
+                </a>
+                <a href="https://skyvector.com/airport/<?= htmlspecialchars(strtoupper($airport['icao'])) ?>" target="_blank" rel="noopener" class="btn" style="margin-right: 1rem;">
+                    View on SkyVector
+                </a>
+                <a href="https://www.aopa.org/destinations/airports/<?= htmlspecialchars(strtoupper($airport['icao'])) ?>" target="_blank" rel="noopener" class="btn">
+                    View on AOPA
                 </a>
             </div>
         </section>


### PR DESCRIPTION
## Summary
Adds 'View on SkyVector' and 'View on AOPA' buttons next to the existing 'View on AirNav' button on airport dashboard pages.

## Changes
- Added SkyVector button that links directly to airport page on SkyVector (includes NOTAMs)
- Added AOPA button that links to AOPA airport directory page
- Both buttons are styled consistently with the existing AirNav button
- Added proper spacing between all three buttons for better UX
- All buttons open in new tabs with `target="_blank" rel="noopener"`

## URL Formats
- SkyVector: `https://skyvector.com/airport/{ICAO}`
- AOPA: `https://www.aopa.org/destinations/airports/{ICAO}`

## Benefits
- SkyVector provides direct access to airport pages including NOTAMs and charts
- AOPA offers pilot-focused airport information, FBOs, and services
- Better UX than requiring manual entry on external sites
- Consistent styling maintains cohesive user interface
- Quick access to complementary aviation resources alongside AirNav

## Testing
- Verified buttons appear correctly next to AirNav button
- Confirmed URL formats work for airport ICAO codes (e.g., KSPB)
- Tested spacing and styling consistency
- No linting errors