### PR TITLE
Add METAR timestamp to Visibility and Ceiling measurements

### DIFF
--- a/airport-template.php
+++ b/airport-template.php
@@ -796,8 +796,8 @@ function displayWeather(weather) {
         <!-- Visibility & Ceiling -->
         <div class="weather-group">
             <div class="weather-item"><span class="label">Rainfall Today</span><span class="weather-value">${formatRainfall(weather.precip_accum)}</span><span class="weather-unit">${getDistanceUnit() === 'm' ? 'cm' : 'in'}</span></div>
-            <div class="weather-item"><span class="label">Visibility</span><span class="weather-value">${weather.visibility !== null ? weather.visibility.toFixed(1) : '--'}</span><span class="weather-unit">${weather.visibility !== null ? 'SM' : ''}</span></div>
-            <div class="weather-item"><span class="label">Ceiling</span><span class="weather-value">${weather.ceiling !== null ? weather.ceiling : (weather.visibility !== null ? 'Unlimited' : '--')}</span><span class="weather-unit">${weather.ceiling !== null ? 'ft AGL' : ''}</span></div>
+            <div class="weather-item"><span class="label">Visibility</span><span class="weather-value">${weather.visibility !== null ? weather.visibility.toFixed(1) : '--'}</span><span class="weather-unit">${weather.visibility !== null ? 'SM' : ''}</span>${weather.visibility !== null && weather.last_updated_metar ? formatTempTimestamp(weather.last_updated_metar) : ''}</div>
+            <div class="weather-item"><span class="label">Ceiling</span><span class="weather-value">${weather.ceiling !== null ? weather.ceiling : (weather.visibility !== null ? 'Unlimited' : '--')}</span><span class="weather-unit">${weather.ceiling !== null ? 'ft AGL' : ''}</span>${(weather.ceiling !== null || weather.visibility !== null) && weather.last_updated_metar ? formatTempTimestamp(weather.last_updated_metar) : ''}</div>
         </div>
         
         <!-- Pressure & Altitude -->


### PR DESCRIPTION
## Summary
Adds an "at Time" label to Visibility and Ceiling measurements to show when the METAR observation was taken. Since METAR isn't frequently published, this helps users understand the age of the visibility and ceiling data.

## Changes
- Added METAR timestamp display to Visibility and Ceiling measurements
- Shows the observation time when visibility/ceiling data is available
- Uses same visual formatting as unit labels (font-size: 0.9rem, color: #666)
- Reuses existing `formatTempTimestamp` function for consistent formatting

## Implementation Details
- **Visibility**: Shows timestamp when `visibility !== null` and `last_updated_metar` is available
- **Ceiling**: Shows timestamp when either ceiling or visibility data exists and `last_updated_metar` is available
- Formatting matches the existing unit label styling for visual consistency

## Files Changed
- `airport-template.php`: Modified Visibility and Ceiling display to include METAR timestamp when data is available

The timestamp appears as "at h:m:am/pm" (e.g., "at 2:30 PM") in the same style as unit labels, positioned after the unit for both Visibility and Ceiling measurements.