### PR TITLE
Potential fix for code scanning alert no. 10: Bad HTML filtering regexp

### DIFF
--- a/tests/Browser/tests/aviationwx.spec.js
+++ b/tests/Browser/tests/aviationwx.spec.js
@@ -691,7 +691,8 @@ test.describe('Aviation Weather Dashboard', () => {
     
     // Verify each script tag is properly closed
     // Extract all script tags and verify they have closing tags
-    const scriptTagRegex = /<script[^>]*>(.*?)<\/script>/gis;
+    // Enhanced regex to match script tags with attributes and tolerant closing
+    const scriptTagRegex = /<script\b[^>]*>(.*?)<\/script\b[^>]*>/gis;
     const matches = [];
     let match;
     while ((match = scriptTagRegex.exec(html)) !== null) {
@@ -707,7 +708,7 @@ test.describe('Aviation Weather Dashboard', () => {
     // Additional check: verify no script tag content contains unclosed HTML
     matches.forEach((scriptTag, index) => {
       // Extract content between <script> and </script>
-      const contentMatch = scriptTag.match(/<script[^>]*>(.*?)<\/script>/is);
+      const contentMatch = scriptTag.match(/<script\b[^>]*>(.*?)<\/script\b[^>]*>/is);
       if (contentMatch && contentMatch[1]) {
         const content = contentMatch[1];
         // Check for HTML tags that aren't in strings/template literals


### PR DESCRIPTION
Potential fix for [https://github.com/alexwitherspoon/aviationwx/security/code-scanning/10](https://github.com/alexwitherspoon/aviationwx/security/code-scanning/10)

The right way to fix the problem is to update the regular expression so it accepts all valid closing script tags that browsers accept, including those with spaces, attributes, or irregular casing. In this test context, the script tag regex should:
- Match both uppercase and lowercase `script` tags.
- Match `</script>` as well as `</script >`, `</SCRIPT >`, `</script foo="bar">`, and variants.
- Not assume only one possible closing tag form.
- Remain readable and robust.

To do this, update the regex in lines 694 and 710:
- For closing script tags: change `</script>` to `</script\b[^>]*>`, accepting optional whitespace/attributes after the tag name until the next `>`.
- Update the opening tag similarly, although this is less risky.
- Ensure the regex is case-insensitive (`i` flag), and spans multiple lines (`s` flag).
You only need to update the regex in two places: defining `scriptTagRegex` (line 694) and the inline match (line 710).

No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
