### PR TITLE
tests: cover config.cache_file_max_size_mb via fixture and unit tests

### DIFF
--- a/tests/Fixtures/airports.json.test
+++ b/tests/Fixtures/airports.json.test
@@ -10,6 +10,7 @@
     "stale_failclosed_seconds": 10800,
     "webcam_refresh_default": 60,
     "weather_refresh_default": 60,
+    "cache_file_max_size_mb": 32,
       "webcam_generate_webp": false,
       "webcam_variant_heights": [1080, 720, 360],
     "public_api": {

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -631,9 +631,20 @@ class ConfigTest extends TestCase {
     }
 
     /**
-     * Default webcam cache file cap matches CACHE_FILE_MAX_SIZE when fixture omits config key
+     * Fixture sets config.cache_file_max_size_mb so getCacheFileMaxSizeBytes() reads the configured MiB cap.
      */
-    public function testGetCacheFileMaxSizeBytes_MatchesConstantDefault(): void {
-        $this->assertSame(CACHE_FILE_MAX_SIZE, getCacheFileMaxSizeBytes());
+    public function testGetCacheFileMaxSizeBytes_UsesFixtureCacheFileMaxSizeMb(): void {
+        $this->assertSame(32 * 1024 * 1024, getCacheFileMaxSizeBytes());
+    }
+
+    /**
+     * normalizeCacheFileMaxSizeMb() clamps to 1--100 MiB and treats non-numeric input as 25 MiB.
+     */
+    public function testNormalizeCacheFileMaxSizeMb_ClampsAndDefaults(): void {
+        $this->assertSame(25, normalizeCacheFileMaxSizeMb('not_numeric'));
+        $this->assertSame(1, normalizeCacheFileMaxSizeMb(0));
+        $this->assertSame(100, normalizeCacheFileMaxSizeMb(200));
+        $this->assertSame(32, normalizeCacheFileMaxSizeMb(32));
+        $this->assertSame(1, normalizeCacheFileMaxSizeMb(-5));
     }
 }

--- a/tests/Unit/WebcamFetchTest.php
+++ b/tests/Unit/WebcamFetchTest.php
@@ -90,10 +90,10 @@ class WebcamFetchTest extends TestCase
     {
         // Test that JPEG size validation logic works
         // Minimum: ~1KB (1024 bytes)
-        // Maximum: CACHE_FILE_MAX_SIZE / getCacheFileMaxSizeBytes() default (see constants.php / config.php)
+        // Maximum: effective cap from config (tests/Fixtures/airports.json.test cache_file_max_size_mb)
 
         $minSize = 1024;
-        $maxSize = CACHE_FILE_MAX_SIZE;
+        $maxSize = getCacheFileMaxSizeBytes();
         
         // Too small - should be rejected
         $smallJpeg = "\xFF\xD8" . str_repeat("\x00", 100) . "\xFF\xD9";


### PR DESCRIPTION
## Summary
Exercises `config.cache_file_max_size_mb` in the PHPUnit fixture and asserts resolved byte limits and `normalizeCacheFileMaxSizeMb()`. Updates webcam fetch size test to use `getCacheFileMaxSizeBytes()`.

## Scope
- `tests/Fixtures/airports.json.test`
- `tests/Unit/ConfigTest.php`
- `tests/Unit/WebcamFetchTest.php`

## Merge order
Independent of #68 and #70 (disjoint files). Target branch: `merge-base/cache-max-followups`.