### PR TITLE
Canonical Public API v1 base URL, nginx 301 redirects, optional config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ AviationWX provides a free public API for developers to integrate aviation weath
 
 - **Documentation:** [api.aviationwx.org](https://api.aviationwx.org)
 - **OpenAPI Spec:** [api.aviationwx.org/openapi.json](https://api.aviationwx.org/openapi.json)
+- **Canonical base URL (v1):** `https://api.aviationwx.org/v1` -- use this for all Public API v1 requests against the public AviationWX service. Older `/api/v1/` paths on other AviationWX hostnames redirect here (HTTP 301). Self-hosted: set `config.public_api.canonical_base_url` in `airports.json` so docs and examples match your origin.
 
 ### Quick Start
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ AviationWX provides a free public API for developers to integrate aviation weath
 
 - **Documentation:** [api.aviationwx.org](https://api.aviationwx.org)
 - **OpenAPI Spec:** [api.aviationwx.org/openapi.json](https://api.aviationwx.org/openapi.json)
-- **Canonical base URL (v1):** `https://api.aviationwx.org/v1` -- use this for all Public API v1 requests against the public AviationWX service. Older `/api/v1/` paths on other AviationWX hostnames redirect here (HTTP 301). Self-hosted: set `config.public_api.canonical_base_url` in `airports.json` so docs and examples match your origin.
+- **Canonical base URL (v1):** `https://api.aviationwx.org/v1` -- default for Public API v1 against the public service. Legacy `/api/v1/` paths on AviationWX hostnames redirect here (HTTP 301). Self-hosted: set `config.public_api.canonical_base_url` in `airports.json` when your origin differs.
 
 ### Quick Start
 

--- a/api/docs/index.php
+++ b/api/docs/index.php
@@ -453,9 +453,9 @@ $attribution = getPublicApiAttributionText();
         ?>
         <div class="canonical-base" role="region" aria-label="Canonical API base URL">
             <h3>Canonical base URL (v1)</h3>
-            <p>Use this HTTPS origin and <code>/v1</code> prefix for all Public API v1 requests against AviationWX production:</p>
+            <p>Use this HTTP(S) origin and <code>/v1</code> prefix for all Public API v1 requests for this deployment (when unset, the default matches the public AviationWX service; <code>http://</code> is for local development only):</p>
             <p class="canonical-url"><code><?= htmlspecialchars($canonicalV1, ENT_QUOTES, 'UTF-8') ?></code></p>
-            <p class="canonical-note">Example: <code><?= htmlspecialchars($canonicalV1, ENT_QUOTES, 'UTF-8') ?>/airports/kspb/weather</code>. Older <code>/api/v1/</code> URLs on other <code>aviationwx.org</code> hostnames redirect here (HTTP 301). Self-hosted: set <code>config.public_api.canonical_base_url</code> in <code>airports.json</code> so this page matches your deployment.</p>
+            <p class="canonical-note">Example: <code><?= htmlspecialchars($canonicalV1, ENT_QUOTES, 'UTF-8') ?>/airports/kspb/weather</code>. Legacy <code>/api/v1/</code> entry points on <code>aviationwx.org</code>, <code>*.aviationwx.org</code>, <code>embed.aviationwx.org</code>, and <code>api.aviationwx.org</code> redirect here (HTTP 301). Self-hosted: set <code>config.public_api.canonical_base_url</code> in <code>airports.json</code> so this page matches your public origin.</p>
         </div>
         
         <div class="quick-start">

--- a/api/docs/index.php
+++ b/api/docs/index.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * Public API Documentation Page
- * 
- * Serves as the landing page for api.aviationwx.org
- * Displays comprehensive API documentation in a styled HTML format.
+ *
+ * Landing page for api.aviationwx.org. Shows the canonical Public API v1 base URL
+ * (see getCanonicalPublicApiV1BaseUrl()) for third-party integrations.
  */
 
 require_once __DIR__ . '/../../lib/public-api/config.php';
@@ -190,6 +190,31 @@ $attribution = getPublicApiAttributionText();
         .quick-start h3 {
             margin-top: 0;
             color: var(--accent-green);
+        }
+        
+        .canonical-base {
+            background: var(--bg-secondary);
+            border: 1px solid var(--accent-blue);
+            border-radius: 8px;
+            padding: 1.25rem 1.5rem;
+            margin: 1.5rem 0;
+        }
+        
+        .canonical-base h3 {
+            margin-top: 0;
+            color: var(--accent-blue);
+            font-size: 1.1rem;
+        }
+        
+        .canonical-base .canonical-url code {
+            font-size: 1rem;
+            word-break: break-all;
+        }
+        
+        .canonical-base .canonical-note {
+            margin-bottom: 0;
+            font-size: 0.9rem;
+            color: var(--text-muted);
         }
         
         code {
@@ -422,6 +447,16 @@ $attribution = getPublicApiAttributionText();
             <p>The public API is not currently enabled. Please check back later.</p>
         </div>
         <?php else: ?>
+        
+        <?php
+        $canonicalV1 = getCanonicalPublicApiV1BaseUrl();
+        ?>
+        <div class="canonical-base" role="region" aria-label="Canonical API base URL">
+            <h3>Canonical base URL (v1)</h3>
+            <p>Use this HTTPS origin and <code>/v1</code> prefix for all Public API v1 requests against AviationWX production:</p>
+            <p class="canonical-url"><code><?= htmlspecialchars($canonicalV1, ENT_QUOTES, 'UTF-8') ?></code></p>
+            <p class="canonical-note">Example: <code><?= htmlspecialchars($canonicalV1, ENT_QUOTES, 'UTF-8') ?>/airports/kspb/weather</code>. Older <code>/api/v1/</code> URLs on other <code>aviationwx.org</code> hostnames redirect here (HTTP 301). Self-hosted: set <code>config.public_api.canonical_base_url</code> in <code>airports.json</code> so this page matches your deployment.</p>
+        </div>
         
         <div class="quick-start">
             <h3>🚀 Quick Start</h3>

--- a/api/docs/index.php
+++ b/api/docs/index.php
@@ -2,8 +2,7 @@
 /**
  * Public API Documentation Page
  *
- * Landing page for api.aviationwx.org. Shows the canonical Public API v1 base URL
- * (see getCanonicalPublicApiV1BaseUrl()) for third-party integrations.
+ * Landing page for api.aviationwx.org. When the Public API is enabled, displays `getCanonicalPublicApiV1BaseUrl()`.
  */
 
 require_once __DIR__ . '/../../lib/public-api/config.php';
@@ -453,9 +452,9 @@ $attribution = getPublicApiAttributionText();
         ?>
         <div class="canonical-base" role="region" aria-label="Canonical API base URL">
             <h3>Canonical base URL (v1)</h3>
-            <p>Use this HTTP(S) origin and <code>/v1</code> prefix for all Public API v1 requests for this deployment (when unset, the default matches the public AviationWX service; <code>http://</code> is for local development only):</p>
+            <p>Use this HTTP(S) base URL and <code>/v1</code> prefix for Public API v1 requests to this deployment.</p>
             <p class="canonical-url"><code><?= htmlspecialchars($canonicalV1, ENT_QUOTES, 'UTF-8') ?></code></p>
-            <p class="canonical-note">Example: <code><?= htmlspecialchars($canonicalV1, ENT_QUOTES, 'UTF-8') ?>/airports/kspb/weather</code>. Legacy <code>/api/v1/</code> entry points on <code>aviationwx.org</code>, <code>*.aviationwx.org</code>, <code>embed.aviationwx.org</code>, and <code>api.aviationwx.org</code> redirect here (HTTP 301). Self-hosted: set <code>config.public_api.canonical_base_url</code> in <code>airports.json</code> so this page matches your public origin.</p>
+            <p class="canonical-note">Example: <code><?= htmlspecialchars($canonicalV1, ENT_QUOTES, 'UTF-8') ?>/airports/kspb/weather</code>. Legacy <code>/api/v1/</code> paths on <code>aviationwx.org</code>, <code>*.aviationwx.org</code>, <code>embed.aviationwx.org</code>, or <code>api.aviationwx.org</code> redirect here (HTTP 301). Override with <code>config.public_api.canonical_base_url</code> in <code>airports.json</code> when your public origin differs.</p>
         </div>
         
         <div class="quick-start">

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "AviationWX.org Public API",
-    "description": "Real-time aviation weather data, webcam images, and airport information. Free access with rate limiting. Partner API keys available for higher limits.\n\nCanonical base URL (AviationWX production): https://api.aviationwx.org/v1 -- use this host and /v1 path prefix for all v1 requests against that deployment. Legacy /api/v1/ URLs on aviationwx.org, *.aviationwx.org, embed.aviationwx.org, or api.aviationwx.org redirect to the matching path under this base (HTTP 301). Self-hosted instances: set config.public_api.canonical_base_url and use the API docs served by your deployment for your effective base.",
+    "description": "Real-time aviation weather data, webcam images, and airport information. Free access with rate limiting. Partner API keys available for higher limits.\n\nPublic deployment server URL: https://api.aviationwx.org/v1. Paths in this spec are relative to that base. Legacy /api/v1/ URLs on aviationwx.org, *.aviationwx.org, embed.aviationwx.org, and api.aviationwx.org receive HTTP 301 to this host. Optional config.public_api.canonical_base_url overrides the documented base for self-hosted installs.",
     "version": "1.0.0",
     "contact": {
       "name": "AviationWX.org",

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "AviationWX.org Public API",
-    "description": "Real-time aviation weather data, webcam images, and airport information. Free access with rate limiting. Partner API keys available for higher limits.",
+    "description": "Real-time aviation weather data, webcam images, and airport information. Free access with rate limiting. Partner API keys available for higher limits.\n\nCanonical base URL (AviationWX production): https://api.aviationwx.org/v1 -- use this host and /v1 path prefix for all v1 requests against that deployment. Legacy /api/v1/ URLs on aviationwx.org, *.aviationwx.org, embed.aviationwx.org, or api.aviationwx.org redirect to the matching path under this base (HTTP 301). Self-hosted instances: set config.public_api.canonical_base_url and use the API docs served by your deployment for your effective base.",
     "version": "1.0.0",
     "contact": {
       "name": "AviationWX.org",

--- a/api/v1/router.php
+++ b/api/v1/router.php
@@ -1,12 +1,11 @@
 <?php
 /**
  * Public API v1 Router
- * 
- * Routes incoming requests to the appropriate endpoint handler.
- * This is the main entry point for all /v1/* requests.
- * 
- * Routing is handled by parsing the request path and dispatching
- * to the appropriate endpoint file.
+ *
+ * Entry point for versioned Public API requests. Integrators should use the base URL from
+ * `getCanonicalPublicApiV1BaseUrl()` (AviationWX production by default; override via `config.public_api.canonical_base_url` for OSS/self-hosted).
+ *
+ * Routing parses the request path (after stripping `/api/v1` or `/v1`) and dispatches to endpoint handlers.
  */
 
 // Start output buffering to catch any stray output
@@ -31,6 +30,13 @@ if (empty($path)) {
 
 // Process through middleware (checks API enabled, auth, rate limits)
 $context = processPublicApiRequest();
+
+// Deployment version JSON: not a REST route; shared middleware/rate limits apply (same as other /v1 calls).
+if ($path === '/version.php') {
+    ob_clean();
+    require_once __DIR__ . '/version.php';
+    exit;
+}
 
 // Route the request
 try {

--- a/api/v1/router.php
+++ b/api/v1/router.php
@@ -2,10 +2,8 @@
 /**
  * Public API v1 Router
  *
- * Entry point for versioned Public API requests. Integrators should use the base URL from
- * `getCanonicalPublicApiV1BaseUrl()` (AviationWX production by default; override via `config.public_api.canonical_base_url` for OSS/self-hosted).
- *
- * Routing parses the request path (after stripping `/api/v1` or `/v1`) and dispatches to endpoint handlers.
+ * Dispatches requests after path normalization (strip `/api/v1` or `/v1`). Client-facing base URL:
+ * `getCanonicalPublicApiV1BaseUrl()` (optional `config.public_api.canonical_base_url` in `airports.json`).
  */
 
 // Start output buffering to catch any stray output
@@ -31,7 +29,7 @@ if (empty($path)) {
 // Process through middleware (checks API enabled, auth, rate limits)
 $context = processPublicApiRequest();
 
-// Deployment version JSON: not a REST route; shared middleware/rate limits apply (same as other /v1 calls).
+// /version.php: deployment metadata JSON; uses the same middleware and rate limits as other v1 routes.
 if ($path === '/version.php') {
     ob_clean();
     require_once __DIR__ . '/version.php';

--- a/config/airports.json.example
+++ b/config/airports.json.example
@@ -89,7 +89,7 @@
     },
     "public_api": {
       "enabled": false,
-      "_comment_canonical_base_url": "Optional. Public API v1 base URL for docs (no trailing slash). Omit to use the AviationWX production default (https://api.aviationwx.org/v1). Set for self-hosted forks.",
+      "_comment_canonical_base_url": "Optional. Public API v1 base URL for docs (no trailing slash). Default: https://api.aviationwx.org/v1. Set when the deployment public origin differs.",
       "version": "1",
       "rate_limits": {
         "anonymous": {

--- a/config/airports.json.example
+++ b/config/airports.json.example
@@ -89,6 +89,7 @@
     },
     "public_api": {
       "enabled": false,
+      "_comment_canonical_base_url": "Optional. Public API v1 base URL for docs (no trailing slash). Omit to use the AviationWX production default (https://api.aviationwx.org/v1). Set for self-hosted forks.",
       "version": "1",
       "rate_limits": {
         "anonymous": {

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -79,6 +79,11 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Legacy /api/v1 on API host -> canonical https://api.aviationwx.org/v1/
+    location ~ ^/api/v1/(.*)$ {
+        return 301 https://api.aviationwx.org/v1/$1$is_args$args;
+    }
+
     # OpenAPI Specification
     location = /openapi.json {
         # Handle CORS preflight requests (allowlist *.aviationwx.org)
@@ -164,6 +169,11 @@ server {
     # Logging
     access_log /dev/stdout json_access;
     error_log /dev/stderr warn;
+
+    # Public API v1: canonical URL is https://api.aviationwx.org/v1/ (301 from legacy /api/v1 paths)
+    location ~ ^/api/v1/(.*)$ {
+        return 301 https://api.aviationwx.org/v1/$1$is_args$args;
+    }
 
     # Proxy to PHP application
     location / {
@@ -295,15 +305,9 @@ server {
         proxy_read_timeout 60s;
     }
     
-    # Public API v1 endpoints - route to router.php
-    location /api/v1/ {
-        rewrite ^/api/v1/(.*)$ /api/v1/router.php break;
-        proxy_pass http://localhost:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Original-URI $request_uri;
+    # Public API v1: canonical URL is https://api.aviationwx.org/v1/ (do not proxy legacy paths here)
+    location ~ ^/api/v1/(.*)$ {
+        return 301 https://api.aviationwx.org/v1/$1$is_args$args;
     }
     
     # Map Tiles Proxy - aggressive caching to reduce OpenWeatherMap API usage

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -80,7 +80,8 @@ server {
     }
 
     # Public API v1: HTTP 301 from legacy /api/v1 paths to https://api.aviationwx.org/v1/...
-    # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... . Self-hosted: replace this host in the vhost (nginx does not read airports.json).
+    # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... .
+    # Redirect host matches DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL; CD may inject from deployment airports.json. Nginx does not read JSON at request time.
     location = /api/v1 {
         return 301 https://api.aviationwx.org/v1$is_args$args;
     }
@@ -178,7 +179,8 @@ server {
     error_log /dev/stderr warn;
 
     # Public API v1: HTTP 301 from legacy /api/v1 paths to https://api.aviationwx.org/v1/...
-    # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... . Self-hosted: replace this host in the vhost (nginx does not read airports.json).
+    # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... .
+    # Redirect host matches DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL; CD may inject from deployment airports.json. Nginx does not read JSON at request time.
     location = /api/v1 {
         return 301 https://api.aviationwx.org/v1$is_args$args;
     }
@@ -320,7 +322,8 @@ server {
     }
     
     # Public API v1: HTTP 301 from legacy /api/v1 paths to https://api.aviationwx.org/v1/...
-    # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... . Self-hosted: replace this host in the vhost (nginx does not read airports.json).
+    # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... .
+    # Redirect host matches DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL; CD may inject from deployment airports.json. Nginx does not read JSON at request time.
     location = /api/v1 {
         return 301 https://api.aviationwx.org/v1$is_args$args;
     }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -79,9 +79,8 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Legacy /api/v1 on API host -> canonical https://api.aviationwx.org/v1/...
-    # Target host/path must match DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL in lib/public-api/config.php
-    # (nginx cannot read airports.json; self-hosted stacks customize this file or vhost).
+    # Public API v1: HTTP 301 from legacy /api/v1 paths to https://api.aviationwx.org/v1/...
+    # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... . Self-hosted: replace this host in the vhost (nginx does not read airports.json).
     location = /api/v1 {
         return 301 https://api.aviationwx.org/v1$is_args$args;
     }
@@ -178,7 +177,8 @@ server {
     access_log /dev/stdout json_access;
     error_log /dev/stderr warn;
 
-    # Public API v1: 301 legacy /api/v1 to canonical host (see api.aviationwx.org server block for notes)
+    # Public API v1: HTTP 301 from legacy /api/v1 paths to https://api.aviationwx.org/v1/...
+    # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... . Self-hosted: replace this host in the vhost (nginx does not read airports.json).
     location = /api/v1 {
         return 301 https://api.aviationwx.org/v1$is_args$args;
     }
@@ -319,7 +319,8 @@ server {
         proxy_read_timeout 60s;
     }
     
-    # Public API v1: 301 legacy /api/v1 to canonical host (see api.aviationwx.org server block for notes)
+    # Public API v1: HTTP 301 from legacy /api/v1 paths to https://api.aviationwx.org/v1/...
+    # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... . Self-hosted: replace this host in the vhost (nginx does not read airports.json).
     location = /api/v1 {
         return 301 https://api.aviationwx.org/v1$is_args$args;
     }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -79,7 +79,12 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Legacy /api/v1 on API host -> canonical https://api.aviationwx.org/v1/
+    # Legacy /api/v1 on API host -> canonical https://api.aviationwx.org/v1/...
+    # Target host/path must match DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL in lib/public-api/config.php
+    # (nginx cannot read airports.json; self-hosted stacks customize this file or vhost).
+    location = /api/v1 {
+        return 301 https://api.aviationwx.org/v1$is_args$args;
+    }
     location ~ ^/api/v1/(.*)$ {
         return 301 https://api.aviationwx.org/v1/$1$is_args$args;
     }
@@ -170,7 +175,10 @@ server {
     access_log /dev/stdout json_access;
     error_log /dev/stderr warn;
 
-    # Public API v1: canonical URL is https://api.aviationwx.org/v1/ (301 from legacy /api/v1 paths)
+    # Public API v1: 301 legacy /api/v1 to canonical host (see api.aviationwx.org server block for notes)
+    location = /api/v1 {
+        return 301 https://api.aviationwx.org/v1$is_args$args;
+    }
     location ~ ^/api/v1/(.*)$ {
         return 301 https://api.aviationwx.org/v1/$1$is_args$args;
     }
@@ -305,7 +313,10 @@ server {
         proxy_read_timeout 60s;
     }
     
-    # Public API v1: canonical URL is https://api.aviationwx.org/v1/ (do not proxy legacy paths here)
+    # Public API v1: 301 legacy /api/v1 to canonical host (see api.aviationwx.org server block for notes)
+    location = /api/v1 {
+        return 301 https://api.aviationwx.org/v1$is_args$args;
+    }
     location ~ ^/api/v1/(.*)$ {
         return 301 https://api.aviationwx.org/v1/$1$is_args$args;
     }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -85,6 +85,9 @@ server {
     location = /api/v1 {
         return 301 https://api.aviationwx.org/v1$is_args$args;
     }
+    location = /api/v1/ {
+        return 301 https://api.aviationwx.org/v1$is_args$args;
+    }
     location ~ ^/api/v1/(.*)$ {
         return 301 https://api.aviationwx.org/v1/$1$is_args$args;
     }
@@ -177,6 +180,9 @@ server {
 
     # Public API v1: 301 legacy /api/v1 to canonical host (see api.aviationwx.org server block for notes)
     location = /api/v1 {
+        return 301 https://api.aviationwx.org/v1$is_args$args;
+    }
+    location = /api/v1/ {
         return 301 https://api.aviationwx.org/v1$is_args$args;
     }
     location ~ ^/api/v1/(.*)$ {
@@ -315,6 +321,9 @@ server {
     
     # Public API v1: 301 legacy /api/v1 to canonical host (see api.aviationwx.org server block for notes)
     location = /api/v1 {
+        return 301 https://api.aviationwx.org/v1$is_args$args;
+    }
+    location = /api/v1/ {
         return 301 https://api.aviationwx.org/v1$is_args$args;
     }
     location ~ ^/api/v1/(.*)$ {

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,7 +12,7 @@ This document describes the **Internal API** endpoints used by the AviationWX.or
 > Visit **[api.aviationwx.org](https://api.aviationwx.org)** for documentation.
 >
 > **Canonical Public API base URL (AviationWX production):** `https://api.aviationwx.org/v1`  
-> Requests to `/api/v1/...` on `aviationwx.org`, `*.aviationwx.org`, or `embed.aviationwx.org` receive **HTTP 301** to the matching path under that canonical base. Integrations should call `https://api.aviationwx.org/v1/...` directly. Self-hosted deployments may set `config.public_api.canonical_base_url` so documentation reflects their public API origin.
+> Requests to `/api/v1/...` on `aviationwx.org`, `*.aviationwx.org`, `embed.aviationwx.org`, or `api.aviationwx.org` (mistaken legacy path on the API host) receive **HTTP 301** to the matching path under that canonical base. Integrations should call `https://api.aviationwx.org/v1/...` directly. Self-hosted deployments may set `config.public_api.canonical_base_url` so documentation reflects their public API origin.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,6 +10,9 @@ This document describes the **Internal API** endpoints used by the AviationWX.or
 > - Support for API keys with higher rate limits
 >
 > Visit **[api.aviationwx.org](https://api.aviationwx.org)** for documentation.
+>
+> **Canonical Public API base URL (AviationWX production):** `https://api.aviationwx.org/v1`  
+> Requests to `/api/v1/...` on `aviationwx.org`, `*.aviationwx.org`, or `embed.aviationwx.org` receive **HTTP 301** to the matching path under that canonical base. Integrations should call `https://api.aviationwx.org/v1/...` directly. Self-hosted deployments may set `config.public_api.canonical_base_url` so documentation reflects their public API origin.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -11,8 +11,8 @@ This document describes the **Internal API** endpoints used by the AviationWX.or
 >
 > Visit **[api.aviationwx.org](https://api.aviationwx.org)** for documentation.
 >
-> **Canonical Public API base URL (AviationWX production):** `https://api.aviationwx.org/v1`  
-> Requests to `/api/v1/...` on `aviationwx.org`, `*.aviationwx.org`, `embed.aviationwx.org`, or `api.aviationwx.org` (mistaken legacy path on the API host) receive **HTTP 301** to the matching path under that canonical base. Integrations should call `https://api.aviationwx.org/v1/...` directly. Self-hosted deployments may set `config.public_api.canonical_base_url` so documentation reflects their public API origin.
+> **Canonical Public API base URL (public deployment):** `https://api.aviationwx.org/v1`  
+> Requests to `/api/v1/...` on `aviationwx.org`, `*.aviationwx.org`, `embed.aviationwx.org`, or `api.aviationwx.org` receive **HTTP 301** to the matching path under that base. Integrations should call `https://api.aviationwx.org/v1/...` directly. Self-hosted deployments may set `config.public_api.canonical_base_url` so documentation matches their public origin.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1532,6 +1532,8 @@ When `config.public_api.enabled` is true, the Public API and weather history fea
 |--------|---------|-------------|
 | `canonical_base_url` | `https://api.aviationwx.org/v1` | Optional. Absolute `http://` or `https://` base URL for Public API v1 with no trailing slash. Used by `getCanonicalPublicApiV1BaseUrl()` and the API docs page. Omit to use this default. Set when your deployment’s public API origin differs (self-hosted). |
 
+**Nginx:** Legacy `/api/v1/` redirects must target the same host and path prefix as this value. The committed `docker/nginx.conf` uses the public default; production CD may render or push the vhost from deployment `airports.json` so nginx stays aligned with PHP (nginx does not read JSON at request time).
+
 ### Rate limits
 
 Anonymous and partner tiers use `config.public_api.rate_limits` with `requests_per_minute`, `requests_per_hour`, and `requests_per_day` per tier. **Numeric defaults are not listed here** so documentation does not drift from code.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1526,6 +1526,12 @@ php -r "require 'lib/config.php'; \$c = loadConfig(); var_dump(isset(\$c['config
 
 When `config.public_api.enabled` is true, the Public API and weather history features are available. Wind rose data uses a configurable rolling window.
 
+### Canonical base URL (optional)
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `canonical_base_url` | (see code) | HTTPS (or `http://` for local dev) base URL for Public API v1 without a trailing slash, used by the API docs page and integrator-facing helpers (`getCanonicalPublicApiV1BaseUrl()`). Omit to use the AviationWX production default. Set this on self-hosted or fork deployments so documentation matches your public origin. |
+
 ### Rate limits
 
 Anonymous and partner tiers use `config.public_api.rate_limits` with `requests_per_minute`, `requests_per_hour`, and `requests_per_day` per tier. **Numeric defaults are not listed here** so documentation does not drift from code.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1530,7 +1530,7 @@ When `config.public_api.enabled` is true, the Public API and weather history fea
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `canonical_base_url` | (see code) | HTTPS (or `http://` for local dev) base URL for Public API v1 without a trailing slash, used by the API docs page and integrator-facing helpers (`getCanonicalPublicApiV1BaseUrl()`). Omit to use the AviationWX production default. Set this on self-hosted or fork deployments so documentation matches your public origin. |
+| `canonical_base_url` | `https://api.aviationwx.org/v1` | Optional. Absolute `http://` or `https://` base URL for Public API v1 with no trailing slash. Used by `getCanonicalPublicApiV1BaseUrl()` and the API docs page. Omit to use this default. Set when your deployment’s public API origin differs (self-hosted). |
 
 ### Rate limits
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -382,6 +382,8 @@ curl https://aviationwx.org/health.php
 curl https://aviationwx.org/diagnostics.php
 ```
 
+**Public API v1 (nginx):** Committed `docker/nginx.conf` defines HTTP 301 redirects from legacy `/api/v1/` paths to the canonical API host. Production should keep redirect targets aligned with `config.public_api.canonical_base_url` when set; deployment may generate or install nginx configuration from deployment `airports.json` (nginx does not read JSON at request time).
+
 ### 5. Scheduler Daemon (Automatic)
 
 **The scheduler daemon is automatically started on container boot** - no host-side setup required!

--- a/lib/config.php
+++ b/lib/config.php
@@ -1562,7 +1562,7 @@ function validateCropMargins(mixed $margins, string $context): array {
  * - bulk_max_airports
  * - weather_history settings
  * - partner_keys
- * - canonical_base_url (optional override for docs and integrator copy)
+ * - canonical_base_url (optional override for docs and integrator copy; explicit null is invalid)
  * 
  * @param mixed $publicApi The public_api config value to validate
  * @return array Array of error messages (empty if valid)
@@ -1633,7 +1633,8 @@ function validatePublicApiConfig(mixed $publicApi): array {
     }
     
     // canonical_base_url: optional absolute URL for Public API v1 base (docs, OSS forks)
-    if (isset($publicApi['canonical_base_url'])) {
+    // Use array_key_exists so explicit JSON null is rejected (isset() would skip validation)
+    if (array_key_exists('canonical_base_url', $publicApi)) {
         if (!is_string($publicApi['canonical_base_url'])) {
             $errors[] = "config.public_api.canonical_base_url must be a string";
         } else {

--- a/lib/config.php
+++ b/lib/config.php
@@ -1562,6 +1562,7 @@ function validateCropMargins(mixed $margins, string $context): array {
  * - bulk_max_airports
  * - weather_history settings
  * - partner_keys
+ * - canonical_base_url (optional override for docs and integrator copy)
  * 
  * @param mixed $publicApi The public_api config value to validate
  * @return array Array of error messages (empty if valid)
@@ -1628,6 +1629,20 @@ function validatePublicApiConfig(mixed $publicApi): array {
     if (isset($publicApi['attribution_text'])) {
         if (!is_string($publicApi['attribution_text'])) {
             $errors[] = "config.public_api.attribution_text must be a string";
+        }
+    }
+    
+    // canonical_base_url: optional absolute URL for Public API v1 base (docs, OSS forks)
+    if (isset($publicApi['canonical_base_url'])) {
+        if (!is_string($publicApi['canonical_base_url'])) {
+            $errors[] = "config.public_api.canonical_base_url must be a string";
+        } else {
+            $trimmed = trim($publicApi['canonical_base_url']);
+            if ($trimmed === '') {
+                $errors[] = "config.public_api.canonical_base_url must be a non-empty string when set";
+            } elseif (!preg_match('#^https?://#i', $trimmed)) {
+                $errors[] = "config.public_api.canonical_base_url must start with http:// or https://";
+            }
         }
     }
     

--- a/lib/config.php
+++ b/lib/config.php
@@ -1562,7 +1562,7 @@ function validateCropMargins(mixed $margins, string $context): array {
  * - bulk_max_airports
  * - weather_history settings
  * - partner_keys
- * - canonical_base_url (optional override for docs and integrator copy; explicit null is invalid)
+ * - canonical_base_url (optional; must be string if key present)
  * 
  * @param mixed $publicApi The public_api config value to validate
  * @return array Array of error messages (empty if valid)
@@ -1632,8 +1632,7 @@ function validatePublicApiConfig(mixed $publicApi): array {
         }
     }
     
-    // canonical_base_url: optional absolute URL for Public API v1 base (docs, OSS forks)
-    // Use array_key_exists so explicit JSON null is rejected (isset() would skip validation)
+    // canonical_base_url: optional absolute URL; array_key_exists rejects explicit null
     if (array_key_exists('canonical_base_url', $publicApi)) {
         if (!is_string($publicApi['canonical_base_url'])) {
             $errors[] = "config.public_api.canonical_base_url must be a string";

--- a/lib/public-api/config.php
+++ b/lib/public-api/config.php
@@ -10,6 +10,11 @@
 require_once __DIR__ . '/../config.php';
 
 /**
+ * Default Public API v1 base URL for AviationWX production when `config.public_api.canonical_base_url` is omitted (no trailing slash).
+ */
+const DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL = 'https://api.aviationwx.org/v1';
+
+/**
  * Check if the public API is enabled
  * 
  * @return bool True if public_api.enabled is true in config
@@ -41,6 +46,35 @@ function getPublicApiVersion(): string
 {
     $config = getPublicApiConfig();
     return $config['version'] ?? '1';
+}
+
+/**
+ * Canonical HTTPS base URL for Public API v1 documentation and integrator-facing links (no trailing slash).
+ *
+ * Self-hosted and fork deployments may set `config.public_api.canonical_base_url` in `airports.json` so the API
+ * docs page and related copy match their public origin. When omitted, returns DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL
+ * (AviationWX production).
+ *
+ * On AviationWX production, nginx issues HTTP 301 from legacy `/api/v1/` paths on `aviationwx.org`,
+ * `*.aviationwx.org`, and `embed.aviationwx.org` to the matching path under the production base. Local development
+ * typically hits PHP directly (e.g. Docker nginx to `/api/v1/`); see project docs.
+ *
+ * @return string Base URL for v1 paths, e.g. `https://api.aviationwx.org/v1` or a self-hosted equivalent
+ */
+function getCanonicalPublicApiV1BaseUrl(): string
+{
+    $config = getPublicApiConfig();
+    if ($config !== null && array_key_exists('canonical_base_url', $config)) {
+        $raw = $config['canonical_base_url'];
+        if (is_string($raw)) {
+            $url = rtrim(trim($raw), '/');
+            if ($url !== '') {
+                return $url;
+            }
+        }
+    }
+
+    return DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL;
 }
 
 /**

--- a/lib/public-api/config.php
+++ b/lib/public-api/config.php
@@ -49,15 +49,16 @@ function getPublicApiVersion(): string
 }
 
 /**
- * Canonical HTTPS base URL for Public API v1 documentation and integrator-facing links (no trailing slash).
+ * Canonical HTTP(S) base URL for Public API v1 documentation and integrator-facing links (no trailing slash).
  *
  * Self-hosted and fork deployments may set `config.public_api.canonical_base_url` in `airports.json` so the API
- * docs page and related copy match their public origin. When omitted, returns DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL
- * (AviationWX production).
+ * docs page and related copy match their public origin. Values must use an absolute URL with `http://` or `https://`
+ * (validation in `validatePublicApiConfig()`). When omitted, returns DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL
+ * (HTTPS, AviationWX production).
  *
  * On AviationWX production, nginx issues HTTP 301 from legacy `/api/v1/` paths on `aviationwx.org`,
- * `*.aviationwx.org`, and `embed.aviationwx.org` to the matching path under the production base. Local development
- * typically hits PHP directly (e.g. Docker nginx to `/api/v1/`); see project docs.
+ * `*.aviationwx.org`, `embed.aviationwx.org`, and `api.aviationwx.org` to the matching path under the production base.
+ * Local development typically hits PHP directly (e.g. Docker nginx to `/api/v1/`); see project docs.
  *
  * @return string Base URL for v1 paths, e.g. `https://api.aviationwx.org/v1` or a self-hosted equivalent
  */

--- a/lib/public-api/config.php
+++ b/lib/public-api/config.php
@@ -54,9 +54,10 @@ function getPublicApiVersion(): string
  * Optional `config.public_api.canonical_base_url` in `airports.json` overrides the default. Values must be absolute
  * `http://` or `https://` URLs; validation is in `validatePublicApiConfig()`. Otherwise returns DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL.
  *
- * Production nginx returns HTTP 301 for legacy `/api/v1/` paths on `aviationwx.org`, `*.aviationwx.org`,
- * `embed.aviationwx.org`, and `api.aviationwx.org` to `https://api.aviationwx.org/v1/...`.
- * Local development serves `/api/v1/` and `/v1/` via Docker; see `docs/LOCAL_SETUP.md`.
+ * Production serves HTTP 301 for legacy `/api/v1/` paths on `aviationwx.org`, `*.aviationwx.org`,
+ * `embed.aviationwx.org`, and `api.aviationwx.org` toward the canonical API host (`https://api.aviationwx.org/v1/...` by default).
+ * The running vhost should stay aligned with `canonical_base_url` when set. Deployment may generate or install nginx
+ * configuration from the same `airports.json` as the application. Committed `docker/nginx.conf` is the local Docker default; see `docs/LOCAL_SETUP.md`.
  *
  * @return string Base URL for appending v1 paths (e.g. `/airports/...`)
  */

--- a/lib/public-api/config.php
+++ b/lib/public-api/config.php
@@ -10,7 +10,7 @@
 require_once __DIR__ . '/../config.php';
 
 /**
- * Default Public API v1 base URL for AviationWX production when `config.public_api.canonical_base_url` is omitted (no trailing slash).
+ * Default Public API v1 base URL when `config.public_api.canonical_base_url` is absent or unused (HTTPS, no trailing slash).
  */
 const DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL = 'https://api.aviationwx.org/v1';
 
@@ -49,18 +49,16 @@ function getPublicApiVersion(): string
 }
 
 /**
- * Canonical HTTP(S) base URL for Public API v1 documentation and integrator-facing links (no trailing slash).
+ * Public API v1 base URL for documentation and integrator-facing links (no trailing slash).
  *
- * Self-hosted and fork deployments may set `config.public_api.canonical_base_url` in `airports.json` so the API
- * docs page and related copy match their public origin. Values must use an absolute URL with `http://` or `https://`
- * (validation in `validatePublicApiConfig()`). When omitted, returns DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL
- * (HTTPS, AviationWX production).
+ * Optional `config.public_api.canonical_base_url` in `airports.json` overrides the default. Values must be absolute
+ * `http://` or `https://` URLs; validation is in `validatePublicApiConfig()`. Otherwise returns DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL.
  *
- * On AviationWX production, nginx issues HTTP 301 from legacy `/api/v1/` paths on `aviationwx.org`,
- * `*.aviationwx.org`, `embed.aviationwx.org`, and `api.aviationwx.org` to the matching path under the production base.
- * Local development typically hits PHP directly (e.g. Docker nginx to `/api/v1/`); see project docs.
+ * Production nginx returns HTTP 301 for legacy `/api/v1/` paths on `aviationwx.org`, `*.aviationwx.org`,
+ * `embed.aviationwx.org`, and `api.aviationwx.org` to `https://api.aviationwx.org/v1/...`.
+ * Local development serves `/api/v1/` and `/v1/` via Docker; see `docs/LOCAL_SETUP.md`.
  *
- * @return string Base URL for v1 paths, e.g. `https://api.aviationwx.org/v1` or a self-hosted equivalent
+ * @return string Base URL for appending v1 paths (e.g. `/airports/...`)
  */
 function getCanonicalPublicApiV1BaseUrl(): string
 {

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -4680,6 +4680,47 @@ class ConfigValidationTest extends TestCase
         $this->assertTrue($result['valid'], 'Valid wind_rose_period_label should pass: ' . implode(', ', $result['errors']));
     }
 
+    /**
+     * Test public_api.canonical_base_url validation - Valid HTTPS URL
+     */
+    public function testPublicApiCanonicalBaseUrl_Valid()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => 'https://api.example.com/v1',
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], 'Valid canonical_base_url should pass: ' . implode(', ', $result['errors']));
+    }
+
+    /**
+     * Test public_api.canonical_base_url validation - Invalid (not a URL prefix)
+     */
+    public function testPublicApiCanonicalBaseUrl_InvalidScheme()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => 'ftp://example.com/v1',
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid'], 'ftp canonical_base_url should be invalid');
+        $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
+    }
+
+    /**
+     * Test public_api.canonical_base_url validation - Invalid (empty when set)
+     */
+    public function testPublicApiCanonicalBaseUrl_InvalidEmpty()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => '   ',
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid'], 'Whitespace-only canonical_base_url should be invalid');
+        $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
+    }
+
     // =========================================================================
     // Existing Config Fields - Ensure Still Validated
     // =========================================================================

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -4721,6 +4721,20 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
     }
 
+    /**
+     * Test public_api.canonical_base_url validation - explicit null must fail (not silently ignored)
+     */
+    public function testPublicApiCanonicalBaseUrl_InvalidNull()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => null,
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid'], 'Null canonical_base_url should be invalid');
+        $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
+    }
+
     // =========================================================================
     // Existing Config Fields - Ensure Still Validated
     // =========================================================================

--- a/tests/Unit/PublicApiConfigTest.php
+++ b/tests/Unit/PublicApiConfigTest.php
@@ -434,5 +434,58 @@ class PublicApiConfigTest extends TestCase
 
         $this->assertSame('last 3 hours', $label);
     }
+
+    /**
+     * Default canonical base matches AviationWX production when config omits canonical_base_url
+     */
+    public function testGetCanonicalPublicApiV1BaseUrl_Default(): void
+    {
+        $this->createTestConfig([
+            'config' => [
+                'public_api' => [
+                    'enabled' => true,
+                ],
+            ],
+            'airports' => [],
+        ]);
+
+        $this->assertSame(DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL, getCanonicalPublicApiV1BaseUrl());
+    }
+
+    /**
+     * canonical_base_url in config overrides the default (OSS / self-hosted)
+     */
+    public function testGetCanonicalPublicApiV1BaseUrl_ConfigOverride(): void
+    {
+        $this->createTestConfig([
+            'config' => [
+                'public_api' => [
+                    'enabled' => true,
+                    'canonical_base_url' => 'https://weather.example.com/v1',
+                ],
+            ],
+            'airports' => [],
+        ]);
+
+        $this->assertSame('https://weather.example.com/v1', getCanonicalPublicApiV1BaseUrl());
+    }
+
+    /**
+     * Trailing slashes on canonical_base_url are normalized away
+     */
+    public function testGetCanonicalPublicApiV1BaseUrl_TrimsTrailingSlash(): void
+    {
+        $this->createTestConfig([
+            'config' => [
+                'public_api' => [
+                    'enabled' => true,
+                    'canonical_base_url' => 'https://weather.example.com/v1///',
+                ],
+            ],
+            'airports' => [],
+        ]);
+
+        $this->assertSame('https://weather.example.com/v1', getCanonicalPublicApiV1BaseUrl());
+    }
 }
 


### PR DESCRIPTION
## Summary

This change makes `https://api.aviationwx.org/v1` the single documented Public API v1 entry for AviationWX production. Legacy `/api/v1/` URLs on `aviationwx.org`, `*.aviationwx.org`, `embed.aviationwx.org`, and mistaken paths on `api.aviationwx.org` receive HTTP 301 to the matching path under that base.

## Implementation

- **nginx (`docker/nginx.conf`):** Return 301 from `^/api/v1/(.*)$` to `https://api.aviationwx.org/v1/$1` (preserve query string) on the relevant server blocks; remove prior proxy of legacy paths to the PHP router where replaced.
- **PHP:** `getCanonicalPublicApiV1BaseUrl()` in `lib/public-api/config.php` with default constant `DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL`; optional `config.public_api.canonical_base_url` in `airports.json` for self-hosted forks, validated in `validatePublicApiConfig()`.
- **Router (`api/v1/router.php`):** Serve `/version.php` after middleware; file docblock updated.
- **Docs:** README, `docs/API.md`, `docs/CONFIGURATION.md`, `api/docs/index.php` (canonical callout), `api/docs/openapi.json` (plain-text description, no markdown bold). `config/airports.json.example` includes a comment for the new key.

## Tests

- `PublicApiConfigTest`: default vs override vs trailing-slash normalization.
- `ConfigValidationTest`: `canonical_base_url` valid URL, invalid scheme, empty/whitespace.

## Deployment notes

- Deploy **PHP and nginx config together**; reload nginx so 301 rules apply.
- Production does not require setting `canonical_base_url` unless an explicit override is desired.

## Checklist

- [x] `make test-ci` passes locally.