### PR TITLE
fix(weather): Tempest ST device fallback when federated station obs are empty or sensor-less

### DIFF
--- a/.github/instructions/weather.instructions.md
+++ b/.github/instructions/weather.instructions.md
@@ -2,31 +2,33 @@
 applyTo: "lib/weather/**/*.php,api/weather.php"
 ---
 
-# Weather Subsystem – Safety-Critical
+# Weather Subsystem -- Safety-Critical
 
 ## Data Flow
 
 1. `api/weather.php` → `fetchWeatherUnified()` in `lib/weather/UnifiedFetcher.php`
 2. Parallel fetch via `curl_multi` → adapters in `lib/weather/adapter/` parse to `WeatherSnapshot`
-3. `WeatherAggregator` selects freshest valid data per field
-4. Staleness check: null fields exceeding `MAX_STALE_HOURS`
-5. Cache and serve
+3. **Tempest only:** After each successful HTTP response for `observations/station`, `tempestApplyDeviceFallbackIfNeeded()` may call `GET /stations/{station_id}` and `GET /observations/device/{first_ST}` when federated `obs` is empty, then parse device `obs_st` rows into the same internal shape as station data (`lib/weather/adapter/tempest-v1.php`). Do not log API tokens.
+4. `WeatherAggregator` selects freshest valid data per field
+5. Staleness check: null fields exceeding `MAX_STALE_HOURS`
+6. Cache and serve
 
 ## Adapter Pattern
 
 - Each source has an adapter: `tempest-v1.php`, `metar-v1.php`, `ambient-v1.php`, etc.
 - Use `WeatherReading` factory methods: `WeatherReading::celsius()`, `::knots()`, `::inHg()`, `::feet()`
-- Never hardcode conversion factors – use `lib/units.php`
+- Never hardcode conversion factors; use `lib/units.php`
 - Wind direction: internal values use **true north**; conversion in `lib/heading-conversion.php`. Display: use `wind_direction_magnetic`; fail closed (`---`) when missing.
 
 ## Staleness
 
-- After `MAX_STALE_HOURS` (3 hours), null out fields – never serve stale data to pilots
+- After `MAX_STALE_HOURS` (3 hours), null out fields; never serve stale data to pilots
 - METAR has separate threshold: `WEATHER_STALENESS_WARNING_HOURS_METAR`
 - Use `nullStaleFieldsBySource()` for consistency
 
 ## Testing
 
-- Mocks in `lib/test-mocks.php` and `tests/mock-weather-responses.php`
-- `phpunit.xml` sets `APP_ENV=testing`; adapters receive mock responses
-- Add tests for new adapters and aggregation logic
+- Mocks in `lib/test-mocks.php` and `tests/mock-weather-responses.php`. For `swd.weatherflow.com`, mocks are **URL-specific**: `/observations/device/` uses `getMockTempestDeviceObsStResponse()`, `/rest/stations/` uses `getMockTempestStationsMetadataResponse()`, and the default station observation URL uses `getMockTempestResponse()`.
+- `phpunit.xml` sets `APP_ENV=testing`; adapters receive mock responses via `getMockHttpResponse()` before real curl.
+- **Tempest regression suite:** `tests/Unit/TempestAdapterTest.php` (behavior-driven cases for federated vs `obs_st`, ST extraction, fallback, URL builders, malformed `obs[0]` rejection). Extend this file when changing Tempest parsing or fallback order.
+- Add tests for new adapters and aggregation logic beyond Tempest as needed.

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -335,8 +335,7 @@ lib/
     parser.php           # Weather data parsing
     calculator.php        # Weather calculations (density altitude, etc.)
     adapter/
-      tempest-v1.php     # Tempest API adapter v1
-      tempest-v2.php     # Tempest API adapter v2
+      tempest-v1.php     # Tempest API adapter (federated station + ST device fallback, obs_st mapping)
       ambient-v1.php     # Ambient Weather API adapter
       weatherlink-v1.php # WeatherLink API adapter
       metar-v1.php       # METAR adapter
@@ -622,18 +621,9 @@ lib/constants/
 Use adapter pattern for each API provider with versioning:
 
 ```php
-// lib/weather/adapter/tempest-v1.php
-class TempestApiV1 {
-    public function fetchWeather(string $stationId, string $apiKey): ?array {
-        // Tempest API v1 implementation
-    }
-}
-
-// lib/weather/adapter/tempest-v2.php
-class TempestApiV2 {
-    public function fetchWeather(string $stationId, string $apiKey): ?array {
-        // Tempest API v2 implementation
-    }
+// lib/weather/adapter/tempest-v1.php -- TempestAdapter + parseTempestResponse(); device fallback when station obs empty
+class TempestAdapter {
+    public static function buildUrl(array $config): ?string { /* ... */ }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ See the [Deployment Guide](docs/DEPLOYMENT.md) for:
 ## Weather Sources
 
 AviationWX supports multiple weather data sources. See the [Configuration Guide](docs/CONFIGURATION.md) for complete setup instructions and examples for:
-- Tempest Weather
+- Tempest Weather (including automatic device fallback when federated station `obs` is empty; see [DATA_FLOW.md](docs/DATA_FLOW.md#tempest-weatherflow-api))
 - Ambient Weather
 - Davis WeatherLink
 - PWSWeather.com (via AerisWeather API)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,7 +118,7 @@ aviationwx.org/
 1. Request validation (airport ID, rate limiting)
 2. Cache check (fresh/stale/expired)
 3. Build source list (primary + backup + METAR)
-4. Fetch all sources in parallel via `curl_multi`
+4. Fetch all sources in parallel via `curl_multi` (Tempest may perform up to two **sequential** follow-up HTTP calls per airport source when federated station `obs` is empty: `GET /stations/{id}` then `GET /observations/device/{st_id}`; see [DATA_FLOW.md](DATA_FLOW.md#tempest-weatherflow-api))
 5. Parse responses into `WeatherSnapshot` objects
 6. Aggregate using `WeatherAggregator` with freshness-based selection:
    - Wind fields must come from single source (complete group)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -494,6 +494,8 @@ All weather sources are configured in a unified `weather_sources` array. Sources
 ]
 ```
 
+**Fetch behavior (safety-critical):** The worker always requests the **federated station** observation URL first. If WeatherFlow returns HTTP success but **no usable `obs` row**, or **`obs[0]` exists but has no sensor measurements** (e.g. only a timestamp), the same fetch cycle **automatically** calls the **stations metadata** endpoint, resolves the first **`ST`** (Tempest sensor) `device_id`, and requests **`/observations/device/{device_id}`**. Parsing then maps WeatherFlow's **`obs_st`** numeric layout into the same internal fields as a normal station response. You still configure only `station_id` and `api_key`; no extra fields are required for standard hub-plus-one-Tempest installs. Stations with multiple `ST` devices use the **first `ST` entry** in the API device list (documented for deterministic behavior).
+
 ### Ambient Weather
 
 ```json

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -64,15 +64,25 @@ All weather sources are configured in a unified `weather_sources` array. Each so
 ### Primary Weather Sources
 
 #### Tempest WeatherFlow API
-- **Endpoint**: `https://swd.weatherflow.com/swd/rest/observations/station/{station_id}?token={api_key}`
-- **Data Provided**:
+- **Primary endpoint (federated station snapshot)**: `https://swd.weatherflow.com/swd/rest/observations/station/{station_id}?token={api_key}`
+  - WeatherFlow builds this from devices on the station; it can be empty while a physical sensor still has data (federation gap).
+- **Automatic device fallback** (when the primary response does not parse, or parses to a timestamp-only / sensor-empty federated row with no temperature, humidity, pressure, dew point, wind, or non-zero precip):
+  1. `GET https://swd.weatherflow.com/swd/rest/stations/{station_id}?token={api_key}` -- response lists devices (typically hub `HB` plus one Tempest unit `ST`).
+  2. The integration selects the **first device with `device_type` `ST`** (the Tempest unit that publishes `obs_st` rows).
+  3. `GET https://swd.weatherflow.com/swd/rest/observations/device/{device_id}?token={api_key}` -- latest observation uses the **`obs_st` numeric row layout** from WeatherFlow's API docs.
+  4. The adapter maps that row into the same internal shape as federated `obs[0]`, then applies the same unit conversions. **Dew point** is not present on raw `obs_st` rows; it may be derived later from temperature and humidity when both exist (same as any missing dew point path).
+  5. **Pressure**: device index 6 is station pressure in mb and is run through the same mb → inHg path as federated `sea_level_pressure`; when only the device path is used, treat displayed pressure as sensor-reported pressure, not a guaranteed sea-level reduction.
+  6. **Logging**: when the device path is used, an internal structured log records `airport_id`, `station_id`, and `device_id` (no secrets).
+  7. **Device body guard**: if `/observations/device` returns HTTP success but parses to another sensor-less row, the integration keeps the original station response (no success log, same as a failed follow-up).
+- **Malformed guard**: if `obs[0]` is a JSON list (numeric array) instead of a federated object, parsing returns null so numeric indices are never mis-read as field names.
+- **Data Provided** (after successful parse, federated or device fallback):
   - Temperature (Celsius)
   - Humidity (%)
   - Pressure (mb, converted to inHg)
   - Wind speed (m/s, converted to knots)
   - Wind direction (degrees)
   - Gust speed (m/s, converted to knots)
-  - Dewpoint (Celsius)
+  - Dewpoint (Celsius) when present on federated obs; otherwise may be computed from T/RH downstream
   - Precipitation accumulation (mm, converted to inches)
   - Observation timestamp (Unix seconds)
 - **Unit Conversions** (see [Server-Side Conversions](#server-side-conversions-api-adapters) for formulas):

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -145,6 +145,7 @@ vendor/bin/phpunit --testsuite Unit
 - Weather calculations
 - Data parsing and formatting
 - Utility functions
+- **Tempest / WeatherFlow:** `tests/Unit/TempestAdapterTest.php` locks in federated parsing, **`obs_st` device row normalization**, ST device discovery from `/stations` JSON, device fallback when federated `obs` is empty, URL builders, and rejection of malformed `obs[0]` list payloads (safety). Related error-path coverage: `tests/Unit/ErrorHandlingTest.php` (Tempest malformed `obs`). Mock routing for `swd.weatherflow.com` is **path-specific** in `lib/test-mocks.php` (station vs `/rest/stations/` vs `/observations/device/`).
 
 ### Integration Tests (`tests/Integration/`)
 

--- a/guides/09-weather-station-configuration.md
+++ b/guides/09-weather-station-configuration.md
@@ -255,6 +255,10 @@ Tempest is our **recommended default** for new community installs.
 }
 ```
 
+### How AviationWX reads Tempest data
+
+The integration always calls WeatherFlow's **federated station** observation endpoint first (the same URL pattern documented above). If that response is HTTP success but has **no observation row**, or a row with **no real sensor values** (for example only a timestamp while federation is stuck), AviationWX **automatically** loads station metadata, picks the first **Tempest sensor (`ST`)** device, and reads **`/observations/device/{id}`** so pilots still see current conditions when the sensor is online. You do **not** need a separate device ID in config for a normal hub + one Tempest setup. Details: [DATA_FLOW.md](../docs/DATA_FLOW.md#tempest-weatherflow-api) and [CONFIGURATION.md](../docs/CONFIGURATION.md#tempest-weather).
+
 ### API Documentation
 
 - [WeatherFlow Tempest API](https://weatherflow.github.io/Tempest/api/)

--- a/guides/12-submit-an-airport-to-aviationwx.md
+++ b/guides/12-submit-an-airport-to-aviationwx.md
@@ -75,6 +75,7 @@ Please send:
 How to find/create these:
 - Tempest's API uses a URL pattern like: `.../observations/station/[your_station_id]?token=[your_access_token]` (so we need both the station ID and token).  
 - Tempest also supports creating a personal access token in the Tempest settings ("Data Authorizations").
+- AviationWX may also call WeatherFlow's **`/stations/{id}`** and **`/observations/device/{id}`** automatically when the federated station observation is empty but hardware is still reporting; you still only send **station ID + token** (no device ID required for typical installs). See [DATA_FLOW.md](../docs/DATA_FLOW.md#tempest-weatherflow-api).
 
 References (if you want the official docs):
 ```text

--- a/lib/test-mocks.php
+++ b/lib/test-mocks.php
@@ -1,32 +1,32 @@
 <?php
 /**
  * Test Mocking Infrastructure
- * 
- * Provides HTTP request mocking for test environments.
- * Intercepts file_get_contents() and curl_exec() calls to return mock responses
- * instead of making real HTTP requests.
+ *
+ * `getMockHttpResponse($url)` returns fixtures in test mode so adapters skip real HTTP. WeatherFlow URLs are
+ * routed by path (station observation vs `/rest/stations/` vs `/observations/device/`).
  */
 
 require_once __DIR__ . '/config.php';
 
 /**
- * Get mock HTTP response for a given URL
- * 
- * Maps API URLs to appropriate mock responses based on the provider type.
- * Returns null if no mock is available (allows real request to proceed).
- * 
- * @param string $url The URL to get a mock response for
- * @return string|null Mock response string, or null if no mock available
+ * Resolve a canned HTTP body for a URL in test mode, or null so callers may use real HTTP.
+ *
+ * @param string $url Request URL
+ * @return string|null Fixture body, or null when not mocked
  */
 function getMockHttpResponse(string $url): ?string {
     if (!isTestMode()) {
-        return null; // Not in test mode, don't mock
+        return null;
     }
-    
-    // Map URLs to mock responses
+
     if (strpos($url, 'swd.weatherflow.com') !== false) {
-        // Tempest API
         require_once __DIR__ . '/../tests/mock-weather-responses.php';
+        if (strpos($url, '/observations/device/') !== false) {
+            return getMockTempestDeviceObsStResponse();
+        }
+        if (strpos($url, '/rest/stations/') !== false) {
+            return getMockTempestStationsMetadataResponse();
+        }
         return getMockTempestResponse();
     }
     

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -239,6 +239,10 @@ function fetchAllSources(array $sources, string $airportId): array {
         // The aggregator and staleness system will handle missing/old weather data
         if ($httpCode >= 200 && $httpCode < 300) {
             // Success: API returned valid response (even if weather data is null/empty)
+            // Tempest: avoid losing primary data when federation returns empty `obs` but ST still reports (tempest-v1.php).
+            if ($sourceType === 'tempest' && is_string($response)) {
+                $response = tempestApplyDeviceFallbackIfNeeded($response, $sources[$sourceKey], $airportId);
+            }
             $responses[$sourceKey] = $response; // Pass through even if empty - aggregator will handle it
             recordWeatherSuccess($airportId, $sourceType);
             weather_health_track_fetch($airportId, $sourceType, true, $httpCode);

--- a/lib/weather/adapter/tempest-v1.php
+++ b/lib/weather/adapter/tempest-v1.php
@@ -1,12 +1,17 @@
 <?php
 /**
  * Tempest WeatherFlow API Adapter v1
- * 
+ *
  * Handles fetching and parsing weather data from Tempest WeatherFlow API.
+ * Primary data path: federated GET /observations/station/{id}. When that response has no usable `obs`
+ * row, or `obs[0]` parses but has no sensor measurements (timestamp-only skeleton), the unified fetcher
+ * may follow with GET /stations/{id} and GET /observations/device/{st_device_id} for the first device_type ST.
+ *
  * API documentation: https://weatherflow.github.io/Tempest/api/
  */
 
 require_once __DIR__ . '/../../constants.php';
+require_once __DIR__ . '/../../logger.php';
 require_once __DIR__ . '/../../test-mocks.php';
 require_once __DIR__ . '/../data/WeatherReading.php';
 require_once __DIR__ . '/../data/WindGroup.php';
@@ -80,13 +85,41 @@ class TempestAdapter {
     }
     
     /**
-     * Build the API URL for fetching data
+     * Build the federated station observation URL (primary Tempest fetch).
+     *
+     * @param array $config Must include `station_id` and `api_key`
+     * @return string|null URL or null if config incomplete
      */
     public static function buildUrl(array $config): ?string {
         if (!isset($config['api_key']) || !isset($config['station_id'])) {
             return null;
         }
         return "https://swd.weatherflow.com/swd/rest/observations/station/{$config['station_id']}?token={$config['api_key']}";
+    }
+
+    /**
+     * Station metadata URL (lists devices: hub HB + sensor ST).
+     *
+     * @param array $config Tempest source config
+     * @return string|null URL or null if invalid
+     */
+    public static function buildStationsMetadataUrl(array $config): ?string {
+        if (!isset($config['api_key']) || !isset($config['station_id'])) {
+            return null;
+        }
+        return "https://swd.weatherflow.com/swd/rest/stations/{$config['station_id']}?token={$config['api_key']}";
+    }
+
+    /**
+     * Latest device observation URL (raw obs_st layout).
+     *
+     * @param int|string $deviceId WeatherFlow device_id
+     * @param string $apiKey API token
+     * @return string URL
+     */
+    public static function buildDeviceObservationsUrl($deviceId, string $apiKey): string {
+        return 'https://swd.weatherflow.com/swd/rest/observations/device/' . rawurlencode((string) $deviceId)
+            . '?token=' . rawurlencode($apiKey);
     }
     
     /**
@@ -104,7 +137,6 @@ class TempestAdapter {
      * @return WeatherSnapshot|null
      */
     public static function parseToSnapshot(string $response, array $config = []): ?WeatherSnapshot {
-        // Use existing parser
         $parsed = parseTempestResponse($response);
         if ($parsed === null) {
             return WeatherSnapshot::empty(self::SOURCE_TYPE);
@@ -138,18 +170,204 @@ class TempestAdapter {
     }
 }
 
+/**
+ * GET helper for Tempest REST; test mode consults fixtures before curl so CI stays deterministic.
+ *
+ * @param string $url Full request URL
+ * @return string|null Response body or null on failure
+ */
+function tempestHttpGet(string $url): ?string {
+    $mock = getMockHttpResponse($url);
+    if ($mock !== null) {
+        return $mock;
+    }
+    $ch = curl_init($url);
+    if ($ch === false) {
+        return null;
+    }
+    $timeout = defined('CURL_TIMEOUT') ? CURL_TIMEOUT : 30;
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT => $timeout,
+        CURLOPT_CONNECTTIMEOUT => 10,
+        CURLOPT_USERAGENT => 'AviationWX/2.0',
+        CURLOPT_FAILONERROR => false,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_MAXREDIRS => 3,
+        CURLOPT_HTTPHEADER => ['Accept: application/json'],
+    ]);
+    $body = curl_exec($ch);
+    $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($body === false || $code < 200 || $code >= 300) {
+        return null;
+    }
+    return (string) $body;
+}
+
+/**
+ * Map one WeatherFlow `obs_st` numeric row to federated-style keys for a single code path through conversions.
+ * Index 6 is mb on the wire; it is stored in `sea_level_pressure` so the same mb→inHg path runs as for federated obs.
+ *
+ * @param array<int, mixed> $row Observation value array
+ * @return array<string, mixed>|null
+ */
+function tempestObsStRowToStationObservationAssoc(array $row): ?array {
+    if (!isset($row[0]) || !is_numeric($row[0])) {
+        return null;
+    }
+    $assoc = [
+        'timestamp' => (int) $row[0],
+    ];
+    if (isset($row[2]) && is_numeric($row[2])) {
+        $assoc['wind_avg'] = (float) $row[2];
+    }
+    if (isset($row[3]) && is_numeric($row[3])) {
+        $assoc['wind_gust'] = (float) $row[3];
+    }
+    if (isset($row[4]) && is_numeric($row[4])) {
+        $assoc['wind_direction'] = (float) $row[4];
+    }
+    if (isset($row[6]) && is_numeric($row[6])) {
+        $assoc['sea_level_pressure'] = (float) $row[6];
+    }
+    if (isset($row[7]) && is_numeric($row[7])) {
+        $assoc['air_temperature'] = (float) $row[7];
+    }
+    if (isset($row[8]) && is_numeric($row[8])) {
+        $assoc['relative_humidity'] = (float) $row[8];
+    }
+    if (isset($row[18]) && is_numeric($row[18])) {
+        $assoc['precip_accum_local_day_final'] = (float) $row[18];
+    }
+    return $assoc;
+}
+
+/**
+ * Parse /stations/{id} JSON and return the first `device_type` ST device_id (deterministic when several ST exist).
+ *
+ * @param string $json Raw JSON from stations endpoint
+ * @return int|null
+ */
+function tempestExtractStDeviceIdFromStationsJson(string $json): ?int {
+    $data = json_decode($json, true);
+    if (!is_array($data)) {
+        return null;
+    }
+    $stations = $data['stations'] ?? null;
+    if (!is_array($stations) || $stations === []) {
+        return null;
+    }
+    $devices = $stations[0]['devices'] ?? null;
+    if (!is_array($devices)) {
+        return null;
+    }
+    foreach ($devices as $device) {
+        if (!is_array($device)) {
+            continue;
+        }
+        if (($device['device_type'] ?? null) === 'ST' && isset($device['device_id']) && is_numeric($device['device_id'])) {
+            return (int) $device['device_id'];
+        }
+    }
+    return null;
+}
+
+/**
+ * True when parsed output includes at least one sensor field we would show (not timestamp-only skeleton data).
+ * Parser defaults missing precip to 0, so only non-zero precip counts as usable without other fields.
+ *
+ * @param array<string, mixed> $parsed Return value of parseTempestResponse()
+ * @return bool
+ */
+function tempestParsedObservationHasUsableSensorFields(array $parsed): bool {
+    if (($parsed['temperature'] ?? null) !== null) {
+        return true;
+    }
+    if (($parsed['humidity'] ?? null) !== null) {
+        return true;
+    }
+    if (($parsed['pressure'] ?? null) !== null) {
+        return true;
+    }
+    if (($parsed['dewpoint'] ?? null) !== null) {
+        return true;
+    }
+    if (($parsed['wind_speed'] ?? null) !== null
+        || ($parsed['wind_direction'] ?? null) !== null
+        || ($parsed['gust_speed'] ?? null) !== null) {
+        return true;
+    }
+    $precip = $parsed['precip_accum'] ?? null;
+    if ($precip !== null && is_numeric($precip) && (float) $precip !== 0.0) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * When federated data is missing or has no usable sensor fields, follow station metadata to the ST device endpoint.
+ *
+ * @param string $stationObservationBody Body from observations/station
+ * @param array $source weather_sources tempest entry
+ * @param string $airportId Airport id for logs (may be empty for legacy callers)
+ * @return string Body to feed into parseTempestResponse (station or device JSON)
+ */
+function tempestApplyDeviceFallbackIfNeeded(string $stationObservationBody, array $source, string $airportId): string {
+    $parsedStation = parseTempestResponse($stationObservationBody);
+    if ($parsedStation !== null && tempestParsedObservationHasUsableSensorFields($parsedStation)) {
+        return $stationObservationBody;
+    }
+    $stationId = $source['station_id'] ?? null;
+    $apiKey = $source['api_key'] ?? null;
+    if (!is_string($apiKey) || $apiKey === '' || $stationId === null || $stationId === '') {
+        return $stationObservationBody;
+    }
+    $metaUrl = TempestAdapter::buildStationsMetadataUrl($source);
+    if ($metaUrl === null) {
+        return $stationObservationBody;
+    }
+    $stationsBody = tempestHttpGet($metaUrl);
+    if ($stationsBody === null) {
+        return $stationObservationBody;
+    }
+    $deviceId = tempestExtractStDeviceIdFromStationsJson($stationsBody);
+    if ($deviceId === null) {
+        return $stationObservationBody;
+    }
+    $deviceUrl = TempestAdapter::buildDeviceObservationsUrl($deviceId, $apiKey);
+    $deviceBody = tempestHttpGet($deviceUrl);
+    if ($deviceBody === null) {
+        return $stationObservationBody;
+    }
+    $parsedDevice = parseTempestResponse($deviceBody);
+    if ($parsedDevice === null || !tempestParsedObservationHasUsableSensorFields($parsedDevice)) {
+        return $stationObservationBody;
+    }
+    aviationwx_log('info', 'Tempest: using device observations after empty or sensor-less federated station obs', [
+        'airport_id' => $airportId,
+        'station_id' => (string) $stationId,
+        'device_id' => $deviceId,
+    ], 'app', true);
+    return $deviceBody;
+}
+
 // =============================================================================
 // LEGACY FUNCTIONS (kept for backward compatibility during migration)
 // =============================================================================
 
 /**
- * Parse Tempest API response
- * 
- * Parses JSON response from Tempest WeatherFlow API and converts to standard format.
- * Handles unit conversions (m/s to knots, mb to inHg, mm to inches).
- * Observation time is provided as Unix timestamp in seconds.
- * 
- * @param string|null $response JSON response from Tempest API
+ * Parse Tempest API response (federated station or device ObservationSet).
+ *
+ * Accepts:
+ * - Station federated JSON: `obs[0]` is an associative observation object (WeatherFlow station layout).
+ * - Device JSON: top-level `type` === `obs_st` and `obs` is a list of numeric rows; the last row is used
+ *   and mapped into the same associative shape before conversions run.
+ *
+ * Rejects malformed payloads where `obs[0]` is a list (prevents mis-reading numeric arrays as keyed fields).
+ * Handles unit conversions (m/s to knots, mb to inHg, mm to inches). Observation time is Unix seconds.
+ *
+ * @param string|null $response JSON from observations/station, observations/device, or equivalent mock
  * @return array|null Weather data array with standard keys, or null on parse error
  */
 function parseTempestResponse($response): ?array {
@@ -157,14 +375,33 @@ function parseTempestResponse($response): ?array {
         return null;
     }
     $data = json_decode($response, true);
+    if (!is_array($data)) {
+        return null;
+    }
+
+    if (($data['type'] ?? null) === 'obs_st' && isset($data['obs']) && is_array($data['obs']) && $data['obs'] !== []) {
+        $rows = $data['obs'];
+        $last = $rows[count($rows) - 1];
+        if (!is_array($last)) {
+            return null;
+        }
+        $assoc = tempestObsStRowToStationObservationAssoc($last);
+        if ($assoc === null) {
+            return null;
+        }
+        $data = ['obs' => [$assoc]];
+    }
+
     if (!isset($data['obs'][0])) {
         return null;
     }
-    
+
     $obs = $data['obs'][0];
-    
-    // Parse observation time (when the weather was actually measured)
-    // Tempest provides timestamp as Unix timestamp in seconds
+    if (!is_array($obs) || array_is_list($obs)) {
+        return null;
+    }
+
+    // Timestamp is Unix seconds on both federated and device-normalized payloads.
     $obsTime = null;
     if (isset($obs['timestamp']) && is_numeric($obs['timestamp'])) {
         $obsTime = (int)$obs['timestamp'];
@@ -254,7 +491,8 @@ function fetchTempestWeather($source): ?array {
             return null;
         }
     }
-    
+
+    $response = tempestApplyDeviceFallbackIfNeeded((string) $response, $source, '');
     return parseTempestResponse($response);
 }
 

--- a/lib/weather/adapter/tempest-v1.php
+++ b/lib/weather/adapter/tempest-v1.php
@@ -48,6 +48,12 @@ class TempestAdapter {
     
     /** Source type identifier */
     public const SOURCE_TYPE = 'tempest';
+
+    /**
+     * Timeout (seconds) for follow-up `/stations` and `/observations/device` HTTP calls.
+     * Capped below the primary `CURL_TIMEOUT` so fallback cannot stack three full primary waits serially.
+     */
+    public const FALLBACK_HTTP_TIMEOUT_SECONDS = 8;
     
     /**
      * Get fields this adapter can provide
@@ -171,12 +177,13 @@ class TempestAdapter {
 }
 
 /**
- * GET helper for Tempest REST; test mode consults fixtures before curl so CI stays deterministic.
+ * GET helper for Tempest REST; test mode consults fixtures before curl (no network in CI).
  *
  * @param string $url Full request URL
+ * @param int|null $requestTimeoutSeconds CURLOPT_TIMEOUT; null uses CURL_TIMEOUT or 30s default
  * @return string|null Response body or null on failure
  */
-function tempestHttpGet(string $url): ?string {
+function tempestHttpGet(string $url, ?int $requestTimeoutSeconds = null): ?string {
     $mock = getMockHttpResponse($url);
     if ($mock !== null) {
         return $mock;
@@ -185,11 +192,14 @@ function tempestHttpGet(string $url): ?string {
     if ($ch === false) {
         return null;
     }
-    $timeout = defined('CURL_TIMEOUT') ? CURL_TIMEOUT : 30;
+    $timeout = $requestTimeoutSeconds ?? (defined('CURL_TIMEOUT') ? CURL_TIMEOUT : 30);
+    $connectTimeout = $requestTimeoutSeconds !== null
+        ? max(3, min(10, $requestTimeoutSeconds))
+        : 10;
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT => $timeout,
-        CURLOPT_CONNECTTIMEOUT => 10,
+        CURLOPT_CONNECTTIMEOUT => $connectTimeout,
         CURLOPT_USERAGENT => 'AviationWX/2.0',
         CURLOPT_FAILONERROR => false,
         CURLOPT_FOLLOWLOCATION => true,
@@ -327,7 +337,10 @@ function tempestApplyDeviceFallbackIfNeeded(string $stationObservationBody, arra
     if ($metaUrl === null) {
         return $stationObservationBody;
     }
-    $stationsBody = tempestHttpGet($metaUrl);
+    $fallbackTimeout = defined('CURL_TIMEOUT')
+        ? max(5, min(TempestAdapter::FALLBACK_HTTP_TIMEOUT_SECONDS, (int) CURL_TIMEOUT))
+        : TempestAdapter::FALLBACK_HTTP_TIMEOUT_SECONDS;
+    $stationsBody = tempestHttpGet($metaUrl, $fallbackTimeout);
     if ($stationsBody === null) {
         return $stationObservationBody;
     }
@@ -336,7 +349,7 @@ function tempestApplyDeviceFallbackIfNeeded(string $stationObservationBody, arra
         return $stationObservationBody;
     }
     $deviceUrl = TempestAdapter::buildDeviceObservationsUrl($deviceId, $apiKey);
-    $deviceBody = tempestHttpGet($deviceUrl);
+    $deviceBody = tempestHttpGet($deviceUrl, $fallbackTimeout);
     if ($deviceBody === null) {
         return $stationObservationBody;
     }

--- a/lib/weather/adapter/tempest-v1.php
+++ b/lib/weather/adapter/tempest-v1.php
@@ -220,6 +220,31 @@ function tempestHttpGet(string $url, ?int $requestTimeoutSeconds = null): ?strin
 }
 
 /**
+ * Wall-clock deadline for the two-request Tempest device fallback (`/stations` then `/observations/device`).
+ * Caps total wait near `CURL_MULTI_OVERALL_TIMEOUT` so serial follow-ups do not dominate the worker budget.
+ *
+ * @param int $fallbackTimeoutPerRequest Seconds passed to CURLOPT_TIMEOUT for each hop
+ */
+function tempestDeviceFallbackSequenceDeadline(int $fallbackTimeoutPerRequest): float {
+    $pairCeiling = 2 * $fallbackTimeoutPerRequest;
+    if (defined('CURL_MULTI_OVERALL_TIMEOUT')) {
+        $pairCeiling = min($pairCeiling, (int) CURL_MULTI_OVERALL_TIMEOUT);
+    }
+    return microtime(true) + $pairCeiling;
+}
+
+/**
+ * CURLOPT_TIMEOUT for one request within a deadline (null if under 1s remains).
+ */
+function tempestHttpTimeoutWithinDeadline(int $preferredSeconds, float $deadlineSeconds): ?int {
+    $remain = (int) floor($deadlineSeconds - microtime(true));
+    if ($remain < 1) {
+        return null;
+    }
+    return max(1, min($preferredSeconds, $remain));
+}
+
+/**
  * Map one WeatherFlow `obs_st` numeric row to federated-style keys for a single code path through conversions.
  * Index 6 is mb on the wire; it is stored in `sea_level_pressure` so the same mb→inHg path runs as for federated obs.
  *
@@ -344,7 +369,12 @@ function tempestApplyDeviceFallbackIfNeeded(string $stationObservationBody, arra
     $fallbackTimeout = defined('CURL_TIMEOUT')
         ? max(5, min(TempestAdapter::FALLBACK_HTTP_TIMEOUT_SECONDS, (int) CURL_TIMEOUT))
         : TempestAdapter::FALLBACK_HTTP_TIMEOUT_SECONDS;
-    $stationsBody = tempestHttpGet($metaUrl, $fallbackTimeout);
+    $deadline = tempestDeviceFallbackSequenceDeadline($fallbackTimeout);
+    $tStations = tempestHttpTimeoutWithinDeadline($fallbackTimeout, $deadline);
+    if ($tStations === null) {
+        return $stationObservationBody;
+    }
+    $stationsBody = tempestHttpGet($metaUrl, $tStations);
     if ($stationsBody === null) {
         return $stationObservationBody;
     }
@@ -353,7 +383,11 @@ function tempestApplyDeviceFallbackIfNeeded(string $stationObservationBody, arra
         return $stationObservationBody;
     }
     $deviceUrl = TempestAdapter::buildDeviceObservationsUrl($deviceId, $apiKey);
-    $deviceBody = tempestHttpGet($deviceUrl, $fallbackTimeout);
+    $tDevice = tempestHttpTimeoutWithinDeadline($fallbackTimeout, $deadline);
+    if ($tDevice === null) {
+        return $stationObservationBody;
+    }
+    $deviceBody = tempestHttpGet($deviceUrl, $tDevice);
     if ($deviceBody === null) {
         return $stationObservationBody;
     }
@@ -365,7 +399,7 @@ function tempestApplyDeviceFallbackIfNeeded(string $stationObservationBody, arra
         'airport_id' => $airportId,
         'station_id' => (string) $stationId,
         'device_id' => $deviceId,
-    ], 'app', true);
+    ], 'app', false);
     return $deviceBody;
 }
 

--- a/lib/weather/adapter/tempest-v1.php
+++ b/lib/weather/adapter/tempest-v1.php
@@ -100,7 +100,9 @@ class TempestAdapter {
         if (!isset($config['api_key']) || !isset($config['station_id'])) {
             return null;
         }
-        return "https://swd.weatherflow.com/swd/rest/observations/station/{$config['station_id']}?token={$config['api_key']}";
+        $sid = rawurlencode((string) $config['station_id']);
+        $tok = rawurlencode((string) $config['api_key']);
+        return "https://swd.weatherflow.com/swd/rest/observations/station/{$sid}?token={$tok}";
     }
 
     /**
@@ -113,7 +115,9 @@ class TempestAdapter {
         if (!isset($config['api_key']) || !isset($config['station_id'])) {
             return null;
         }
-        return "https://swd.weatherflow.com/swd/rest/stations/{$config['station_id']}?token={$config['api_key']}";
+        $sid = rawurlencode((string) $config['station_id']);
+        $tok = rawurlencode((string) $config['api_key']);
+        return "https://swd.weatherflow.com/swd/rest/stations/{$sid}?token={$tok}";
     }
 
     /**
@@ -357,7 +361,7 @@ function tempestApplyDeviceFallbackIfNeeded(string $stationObservationBody, arra
     if ($parsedDevice === null || !tempestParsedObservationHasUsableSensorFields($parsedDevice)) {
         return $stationObservationBody;
     }
-    aviationwx_log('info', 'Tempest: using device observations after empty or sensor-less federated station obs', [
+    aviationwx_log('debug', 'Tempest: using device observations after empty or sensor-less federated station obs', [
         'airport_id' => $airportId,
         'station_id' => (string) $stationId,
         'device_id' => $deviceId,
@@ -479,11 +483,10 @@ function fetchTempestWeather($source): ?array {
         return null;
     }
     
-    $apiKey = $source['api_key'];
-    $stationId = $source['station_id'];
-    
-    // Fetch current observation
-    $url = "https://swd.weatherflow.com/swd/rest/observations/station/{$stationId}?token={$apiKey}";
+    $url = TempestAdapter::buildUrl($source);
+    if ($url === null) {
+        return null;
+    }
     
     // Check for mock response in test mode
     $mockResponse = getMockHttpResponse($url);

--- a/lib/weather/adapter/tempest-v1.php
+++ b/lib/weather/adapter/tempest-v1.php
@@ -50,8 +50,8 @@ class TempestAdapter {
     public const SOURCE_TYPE = 'tempest';
 
     /**
-     * Timeout (seconds) for follow-up `/stations` and `/observations/device` HTTP calls.
-     * Capped below the primary `CURL_TIMEOUT` so fallback cannot stack three full primary waits serially.
+     * Upper bound (seconds) for follow-up `/stations` and `/observations/device` per-hop CURLOPT_TIMEOUT.
+     * Actual timeout is `min(self, max(1, CURL_TIMEOUT))` so each hop never exceeds the primary fetch budget.
      */
     public const FALLBACK_HTTP_TIMEOUT_SECONDS = 8;
     
@@ -245,6 +245,16 @@ function tempestHttpTimeoutWithinDeadline(int $preferredSeconds, float $deadline
 }
 
 /**
+ * Per-hop CURLOPT_TIMEOUT for Tempest device fallback HTTP (never above primary `CURL_TIMEOUT`).
+ */
+function tempestFallbackPerHopTimeoutSeconds(): int {
+    if (!defined('CURL_TIMEOUT')) {
+        return TempestAdapter::FALLBACK_HTTP_TIMEOUT_SECONDS;
+    }
+    return min(TempestAdapter::FALLBACK_HTTP_TIMEOUT_SECONDS, max(1, (int) CURL_TIMEOUT));
+}
+
+/**
  * Map one WeatherFlow `obs_st` numeric row to federated-style keys for a single code path through conversions.
  * Index 6 is mb on the wire; it is stored in `sea_level_pressure` so the same mb→inHg path runs as for federated obs.
  *
@@ -366,9 +376,7 @@ function tempestApplyDeviceFallbackIfNeeded(string $stationObservationBody, arra
     if ($metaUrl === null) {
         return $stationObservationBody;
     }
-    $fallbackTimeout = defined('CURL_TIMEOUT')
-        ? max(5, min(TempestAdapter::FALLBACK_HTTP_TIMEOUT_SECONDS, (int) CURL_TIMEOUT))
-        : TempestAdapter::FALLBACK_HTTP_TIMEOUT_SECONDS;
+    $fallbackTimeout = tempestFallbackPerHopTimeoutSeconds();
     $deadline = tempestDeviceFallbackSequenceDeadline($fallbackTimeout);
     $tStations = tempestHttpTimeoutWithinDeadline($fallbackTimeout, $deadline);
     if ($tStations === null) {

--- a/tests/Unit/ErrorHandlingTest.php
+++ b/tests/Unit/ErrorHandlingTest.php
@@ -72,6 +72,19 @@ class ErrorHandlingTest extends TestCase
     }
 
     /**
+     * parseTempestResponse: list-shaped obs[0] is invalid federated shape (avoids bogus field reads).
+     */
+    public function testParseTempestResponse_ObsFirstElementNumericList_ReturnsNull()
+    {
+        $response = json_encode([
+            'status' => ['status_code' => 0, 'status_message' => 'OK'],
+            'obs' => [[1, 2, 3, 4]],
+        ]);
+        $result = parseTempestResponse($response);
+        $this->assertNull($result, 'Should return null when obs[0] is a list, not a federated object');
+    }
+
+    /**
      * Test parseTempestResponse with missing required fields (graceful degradation)
      */
     public function testParseTempestResponse_MissingFields()

--- a/tests/Unit/TempestAdapterTest.php
+++ b/tests/Unit/TempestAdapterTest.php
@@ -228,12 +228,13 @@ class TempestAdapterTest extends TestCase
 
     public function test_givenTempestConfig_whenBuildUrls_thenPathsAndEncodingAreCorrect(): void
     {
-        $cfg = ['station_id' => '214348', 'api_key' => 'ab-cd'];
+        $cfg = ['station_id' => '214348', 'api_key' => 'a+b/c'];
         $stationObs = TempestAdapter::buildUrl($cfg);
         $this->assertStringContainsString('/observations/station/214348', $stationObs);
-        $this->assertStringContainsString('token=ab-cd', $stationObs);
+        $this->assertStringContainsString('token=a%2Bb%2Fc', $stationObs);
         $meta = TempestAdapter::buildStationsMetadataUrl($cfg);
         $this->assertStringContainsString('/rest/stations/214348', $meta);
+        $this->assertStringContainsString('token=a%2Bb%2Fc', $meta);
         $dev = TempestAdapter::buildDeviceObservationsUrl(1215470, 'tok/1');
         $this->assertStringContainsString('/observations/device/1215470', $dev);
         $this->assertStringContainsString('token=tok%2F1', $dev);

--- a/tests/Unit/TempestAdapterTest.php
+++ b/tests/Unit/TempestAdapterTest.php
@@ -18,7 +18,7 @@ require_once __DIR__ . '/../mock-weather-responses.php';
 
 class TempestAdapterTest extends TestCase
 {
-    public function test_givenFederatedStationJson_whenParsed_thenFieldsMatchStationContract(): void
+    public function testParseTempestResponse_FederatedMockJson_HasTemperaturePressureDewpoint(): void
     {
         $response = getMockTempestResponse();
         $result = parseTempestResponse($response);
@@ -28,7 +28,7 @@ class TempestAdapterTest extends TestCase
         $this->assertNotNull($result['dewpoint']);
     }
 
-    public function test_givenDeviceObsStJson_whenParsed_thenUsesLastRowAndNullDewpoint(): void
+    public function testParseTempestResponse_DeviceObsStTwoRows_UsesLastRowNullDewpoint(): void
     {
         $early = array_fill(0, 22, 0);
         $early[0] = 100;
@@ -50,7 +50,7 @@ class TempestAdapterTest extends TestCase
         $this->assertNull($result['dewpoint']);
     }
 
-    public function test_givenObsStWithEmptyObs_whenParsed_thenReturnsNull(): void
+    public function testParseTempestResponse_ObsStEmptyObs_ReturnsNull(): void
     {
         $response = json_encode([
             'type' => 'obs_st',
@@ -59,7 +59,7 @@ class TempestAdapterTest extends TestCase
         $this->assertNull(parseTempestResponse($response));
     }
 
-    public function test_givenObsStRowMissingEpoch_whenMappedToAssoc_thenReturnsNull(): void
+    public function testTempestObsStRowToStationObservationAssoc_MissingEpoch_ReturnsNull(): void
     {
         $row = array_fill(0, 22, 0);
         $row[7] = 20.0;
@@ -67,13 +67,13 @@ class TempestAdapterTest extends TestCase
         $this->assertNull(tempestObsStRowToStationObservationAssoc($row));
     }
 
-    public function test_givenStationsMetadataWithHbAndSt_whenExtractSt_thenReturnsStDeviceId(): void
+    public function testTempestExtractStDeviceIdFromStationsJson_HubAndSensor_ReturnsSensorDeviceId(): void
     {
         $json = getMockTempestStationsMetadataResponse();
         $this->assertSame(900002, tempestExtractStDeviceIdFromStationsJson($json));
     }
 
-    public function test_givenStationsMetadataWithTwoStDevices_whenExtractSt_thenReturnsFirstSt(): void
+    public function testTempestExtractStDeviceIdFromStationsJson_TwoSensorDevices_ReturnsFirstSensor(): void
     {
         $json = json_encode([
             'stations' => [[
@@ -86,7 +86,7 @@ class TempestAdapterTest extends TestCase
         $this->assertSame(111, tempestExtractStDeviceIdFromStationsJson($json));
     }
 
-    public function test_givenStationsMetadataWithoutSt_whenExtractSt_thenReturnsNull(): void
+    public function testTempestExtractStDeviceIdFromStationsJson_OnlyHub_ReturnsNull(): void
     {
         $json = json_encode([
             'stations' => [[
@@ -98,12 +98,12 @@ class TempestAdapterTest extends TestCase
         $this->assertNull(tempestExtractStDeviceIdFromStationsJson($json));
     }
 
-    public function test_givenInvalidStationsJson_whenExtractSt_thenReturnsNull(): void
+    public function testTempestExtractStDeviceIdFromStationsJson_InvalidJson_ReturnsNull(): void
     {
         $this->assertNull(tempestExtractStDeviceIdFromStationsJson('not-json'));
     }
 
-    public function test_givenFederatedObsFirstElementIsList_whenParsed_thenReturnsNull(): void
+    public function testParseTempestResponse_FederatedObsListShapedFirstElement_ReturnsNull(): void
     {
         $response = json_encode([
             'status' => ['status_code' => 0],
@@ -112,7 +112,7 @@ class TempestAdapterTest extends TestCase
         $this->assertNull(parseTempestResponse($response));
     }
 
-    public function test_givenEmptyStationObsAndValidSource_whenApplyDeviceFallback_thenReturnsParsableDeviceBody(): void
+    public function testTempestApplyDeviceFallbackIfNeeded_EmptyFederatedObs_ReturnsDeviceObservationPayload(): void
     {
         $station = json_encode([
             'status' => ['status_code' => 0],
@@ -129,7 +129,7 @@ class TempestAdapterTest extends TestCase
         $this->assertEqualsWithDelta(5.6, $parsed['temperature'], 0.0001);
     }
 
-    public function test_givenFederatedSkeletonObsOnlyTimestamp_whenApplyDeviceFallback_thenReturnsParsableDeviceBody(): void
+    public function testTempestApplyDeviceFallbackIfNeeded_TimestampOnlySkeleton_ReturnsDeviceObservationPayload(): void
     {
         $station = json_encode([
             'status' => ['status_code' => 0],
@@ -151,7 +151,7 @@ class TempestAdapterTest extends TestCase
         $this->assertEqualsWithDelta(5.6, $parsed['temperature'], 0.0001);
     }
 
-    public function test_givenParsableStationBody_whenApplyDeviceFallback_thenReturnsOriginalBody(): void
+    public function testTempestApplyDeviceFallbackIfNeeded_UsableFederatedObs_ReturnsOriginalBody(): void
     {
         $station = getMockTempestResponse();
         $source = [
@@ -162,7 +162,7 @@ class TempestAdapterTest extends TestCase
         $this->assertSame($station, tempestApplyDeviceFallbackIfNeeded($station, $source, 'kxxx'));
     }
 
-    public function test_givenEmptyStationObsAndMissingApiKey_whenApplyDeviceFallback_thenReturnsOriginalBody(): void
+    public function testTempestApplyDeviceFallbackIfNeeded_MissingApiKey_ReturnsOriginalBody(): void
     {
         $station = json_encode(['status' => ['status_code' => 0], 'obs' => []], JSON_THROW_ON_ERROR);
         $source = [
@@ -172,7 +172,7 @@ class TempestAdapterTest extends TestCase
         $this->assertSame($station, tempestApplyDeviceFallbackIfNeeded($station, $source, 'kxxx'));
     }
 
-    public function test_givenDeviceObsStBody_whenParseToSnapshot_thenIsValid(): void
+    public function testTempestAdapter_ParseToSnapshot_DeviceObsSt_ReturnsValidSnapshot(): void
     {
         $snap = TempestAdapter::parseToSnapshot(getMockTempestDeviceObsStResponse(), []);
         $this->assertNotNull($snap);
@@ -181,7 +181,7 @@ class TempestAdapterTest extends TestCase
         $this->assertFalse($snap->dewpoint->hasValue());
     }
 
-    public function test_tempestParsedObservationHasUsableSensorFields_trueForWindOrPrecipOrTemp(): void
+    public function testTempestParsedObservationHasUsableSensorFields_WindOrPrecipOrTemp_ReturnsTrue(): void
     {
         $this->assertTrue(tempestParsedObservationHasUsableSensorFields([
             'temperature' => null,
@@ -215,7 +215,7 @@ class TempestAdapterTest extends TestCase
         ]));
     }
 
-    public function test_tempestParsedObservationHasUsableSensorFields_falseWhenOnlyTimestampLikeParsedOutput(): void
+    public function testTempestParsedObservationHasUsableSensorFields_TimestampOnly_ReturnsFalse(): void
     {
         $skeleton = json_encode([
             'status' => ['status_code' => 0],
@@ -226,7 +226,7 @@ class TempestAdapterTest extends TestCase
         $this->assertFalse(tempestParsedObservationHasUsableSensorFields($parsed));
     }
 
-    public function test_givenTempestConfig_whenBuildUrls_thenPathsAndEncodingAreCorrect(): void
+    public function testTempestAdapter_BuildUrlAndStationsUrl_EncodeReservedCharactersInToken(): void
     {
         $cfg = ['station_id' => '214348', 'api_key' => 'a+b/c'];
         $stationObs = TempestAdapter::buildUrl($cfg);
@@ -238,5 +238,24 @@ class TempestAdapterTest extends TestCase
         $dev = TempestAdapter::buildDeviceObservationsUrl(1215470, 'tok/1');
         $this->assertStringContainsString('/observations/device/1215470', $dev);
         $this->assertStringContainsString('token=tok%2F1', $dev);
+    }
+
+    public function testTempestHttpTimeoutWithinDeadline_Expired_ReturnsNull(): void
+    {
+        $this->assertNull(tempestHttpTimeoutWithinDeadline(8, microtime(true) - 1.0));
+    }
+
+    public function testTempestHttpTimeoutWithinDeadline_AmpleTime_ReturnsPreferred(): void
+    {
+        $this->assertSame(8, tempestHttpTimeoutWithinDeadline(8, microtime(true) + 60.0));
+    }
+
+    public function testTempestDeviceFallbackSequenceDeadline_RespectsCurlMultiOverallCap(): void
+    {
+        $this->assertLessThanOrEqual(
+            15.0,
+            tempestDeviceFallbackSequenceDeadline(8) - microtime(true),
+            'deadline span should not exceed CURL_MULTI_OVERALL_TIMEOUT when defined'
+        );
     }
 }

--- a/tests/Unit/TempestAdapterTest.php
+++ b/tests/Unit/TempestAdapterTest.php
@@ -258,4 +258,13 @@ class TempestAdapterTest extends TestCase
             'deadline span should not exceed CURL_MULTI_OVERALL_TIMEOUT when defined'
         );
     }
+
+    public function testTempestFallbackPerHopTimeoutSeconds_LteCurlTimeoutAndFallbackCap(): void
+    {
+        $this->assertTrue(defined('CURL_TIMEOUT'));
+        $t = tempestFallbackPerHopTimeoutSeconds();
+        $this->assertGreaterThanOrEqual(1, $t);
+        $this->assertLessThanOrEqual((int) CURL_TIMEOUT, $t);
+        $this->assertLessThanOrEqual(TempestAdapter::FALLBACK_HTTP_TIMEOUT_SECONDS, $t);
+    }
 }

--- a/tests/Unit/TempestAdapterTest.php
+++ b/tests/Unit/TempestAdapterTest.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Tempest WeatherFlow adapter tests (safety-critical path).
+ *
+ * Covers: federated parsing; `obs_st` normalization (last row wins); first ST from `/stations` JSON;
+ * device fallback when federated `obs` is empty or federated row is timestamp-only; URL builders;
+ * rejection of list-shaped `obs[0]` (avoids mis-reading numeric arrays as keyed fields). Requires APP_ENV=testing
+ * and URL mocks in lib/test-mocks.php.
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/config.php';
+require_once __DIR__ . '/../../lib/weather/adapter/tempest-v1.php';
+require_once __DIR__ . '/../mock-weather-responses.php';
+
+class TempestAdapterTest extends TestCase
+{
+    public function test_givenFederatedStationJson_whenParsed_thenFieldsMatchStationContract(): void
+    {
+        $response = getMockTempestResponse();
+        $result = parseTempestResponse($response);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('temperature', $result);
+        $this->assertArrayHasKey('pressure', $result);
+        $this->assertNotNull($result['dewpoint']);
+    }
+
+    public function test_givenDeviceObsStJson_whenParsed_thenUsesLastRowAndNullDewpoint(): void
+    {
+        $early = array_fill(0, 22, 0);
+        $early[0] = 100;
+        $early[7] = 1.0;
+        $late = array_fill(0, 22, 0);
+        $late[0] = 200;
+        $late[7] = 22.5;
+        $late[8] = 50.0;
+        $response = json_encode([
+            'status' => ['status_code' => 0],
+            'device_id' => 1,
+            'type' => 'obs_st',
+            'obs' => [$early, $late],
+        ], JSON_THROW_ON_ERROR);
+        $result = parseTempestResponse($response);
+        $this->assertIsArray($result);
+        $this->assertEqualsWithDelta(22.5, $result['temperature'], 0.0001);
+        $this->assertSame(200, $result['obs_time']);
+        $this->assertNull($result['dewpoint']);
+    }
+
+    public function test_givenObsStWithEmptyObs_whenParsed_thenReturnsNull(): void
+    {
+        $response = json_encode([
+            'type' => 'obs_st',
+            'obs' => [],
+        ], JSON_THROW_ON_ERROR);
+        $this->assertNull(parseTempestResponse($response));
+    }
+
+    public function test_givenObsStRowMissingEpoch_whenMappedToAssoc_thenReturnsNull(): void
+    {
+        $row = array_fill(0, 22, 0);
+        $row[7] = 20.0;
+        unset($row[0]);
+        $this->assertNull(tempestObsStRowToStationObservationAssoc($row));
+    }
+
+    public function test_givenStationsMetadataWithHbAndSt_whenExtractSt_thenReturnsStDeviceId(): void
+    {
+        $json = getMockTempestStationsMetadataResponse();
+        $this->assertSame(900002, tempestExtractStDeviceIdFromStationsJson($json));
+    }
+
+    public function test_givenStationsMetadataWithTwoStDevices_whenExtractSt_thenReturnsFirstSt(): void
+    {
+        $json = json_encode([
+            'stations' => [[
+                'devices' => [
+                    ['device_id' => 111, 'device_type' => 'ST'],
+                    ['device_id' => 222, 'device_type' => 'ST'],
+                ],
+            ]],
+        ], JSON_THROW_ON_ERROR);
+        $this->assertSame(111, tempestExtractStDeviceIdFromStationsJson($json));
+    }
+
+    public function test_givenStationsMetadataWithoutSt_whenExtractSt_thenReturnsNull(): void
+    {
+        $json = json_encode([
+            'stations' => [[
+                'devices' => [
+                    ['device_id' => 1, 'device_type' => 'HB'],
+                ],
+            ]],
+        ], JSON_THROW_ON_ERROR);
+        $this->assertNull(tempestExtractStDeviceIdFromStationsJson($json));
+    }
+
+    public function test_givenInvalidStationsJson_whenExtractSt_thenReturnsNull(): void
+    {
+        $this->assertNull(tempestExtractStDeviceIdFromStationsJson('not-json'));
+    }
+
+    public function test_givenFederatedObsFirstElementIsList_whenParsed_thenReturnsNull(): void
+    {
+        $response = json_encode([
+            'status' => ['status_code' => 0],
+            'obs' => [[1, 2, 3, 4]],
+        ], JSON_THROW_ON_ERROR);
+        $this->assertNull(parseTempestResponse($response));
+    }
+
+    public function test_givenEmptyStationObsAndValidSource_whenApplyDeviceFallback_thenReturnsParsableDeviceBody(): void
+    {
+        $station = json_encode([
+            'status' => ['status_code' => 0],
+            'obs' => [],
+        ], JSON_THROW_ON_ERROR);
+        $source = [
+            'type' => 'tempest',
+            'station_id' => '12345',
+            'api_key' => 'test-token-for-mock',
+        ];
+        $out = tempestApplyDeviceFallbackIfNeeded($station, $source, 'kxxx');
+        $parsed = parseTempestResponse($out);
+        $this->assertNotNull($parsed);
+        $this->assertEqualsWithDelta(5.6, $parsed['temperature'], 0.0001);
+    }
+
+    public function test_givenFederatedSkeletonObsOnlyTimestamp_whenApplyDeviceFallback_thenReturnsParsableDeviceBody(): void
+    {
+        $station = json_encode([
+            'status' => ['status_code' => 0],
+            'obs' => [[
+                'timestamp' => 1700000000,
+            ]],
+        ], JSON_THROW_ON_ERROR);
+        $parsedSkeleton = parseTempestResponse($station);
+        $this->assertIsArray($parsedSkeleton, 'skeleton row must parse to an array');
+        $this->assertFalse(tempestParsedObservationHasUsableSensorFields($parsedSkeleton));
+        $source = [
+            'type' => 'tempest',
+            'station_id' => '12345',
+            'api_key' => 'test-token-for-mock',
+        ];
+        $out = tempestApplyDeviceFallbackIfNeeded($station, $source, 'kxxx');
+        $parsed = parseTempestResponse($out);
+        $this->assertNotNull($parsed);
+        $this->assertEqualsWithDelta(5.6, $parsed['temperature'], 0.0001);
+    }
+
+    public function test_givenParsableStationBody_whenApplyDeviceFallback_thenReturnsOriginalBody(): void
+    {
+        $station = getMockTempestResponse();
+        $source = [
+            'type' => 'tempest',
+            'station_id' => '12345',
+            'api_key' => 'x',
+        ];
+        $this->assertSame($station, tempestApplyDeviceFallbackIfNeeded($station, $source, 'kxxx'));
+    }
+
+    public function test_givenEmptyStationObsAndMissingApiKey_whenApplyDeviceFallback_thenReturnsOriginalBody(): void
+    {
+        $station = json_encode(['status' => ['status_code' => 0], 'obs' => []], JSON_THROW_ON_ERROR);
+        $source = [
+            'type' => 'tempest',
+            'station_id' => '12345',
+        ];
+        $this->assertSame($station, tempestApplyDeviceFallbackIfNeeded($station, $source, 'kxxx'));
+    }
+
+    public function test_givenDeviceObsStBody_whenParseToSnapshot_thenIsValid(): void
+    {
+        $snap = TempestAdapter::parseToSnapshot(getMockTempestDeviceObsStResponse(), []);
+        $this->assertNotNull($snap);
+        $this->assertTrue($snap->isValid);
+        $this->assertTrue($snap->temperature->hasValue());
+        $this->assertFalse($snap->dewpoint->hasValue());
+    }
+
+    public function test_tempestParsedObservationHasUsableSensorFields_trueForWindOrPrecipOrTemp(): void
+    {
+        $this->assertTrue(tempestParsedObservationHasUsableSensorFields([
+            'temperature' => null,
+            'humidity' => null,
+            'pressure' => null,
+            'dewpoint' => null,
+            'wind_speed' => 5,
+            'wind_direction' => null,
+            'gust_speed' => null,
+            'precip_accum' => 0.0,
+        ]));
+        $this->assertTrue(tempestParsedObservationHasUsableSensorFields([
+            'temperature' => null,
+            'humidity' => null,
+            'pressure' => null,
+            'dewpoint' => null,
+            'wind_speed' => null,
+            'wind_direction' => null,
+            'gust_speed' => null,
+            'precip_accum' => 0.01,
+        ]));
+        $this->assertTrue(tempestParsedObservationHasUsableSensorFields([
+            'temperature' => 1.0,
+            'humidity' => null,
+            'pressure' => null,
+            'dewpoint' => null,
+            'wind_speed' => null,
+            'wind_direction' => null,
+            'gust_speed' => null,
+            'precip_accum' => 0.0,
+        ]));
+    }
+
+    public function test_tempestParsedObservationHasUsableSensorFields_falseWhenOnlyTimestampLikeParsedOutput(): void
+    {
+        $skeleton = json_encode([
+            'status' => ['status_code' => 0],
+            'obs' => [['timestamp' => 1700000000]],
+        ], JSON_THROW_ON_ERROR);
+        $parsed = parseTempestResponse($skeleton);
+        $this->assertIsArray($parsed);
+        $this->assertFalse(tempestParsedObservationHasUsableSensorFields($parsed));
+    }
+
+    public function test_givenTempestConfig_whenBuildUrls_thenPathsAndEncodingAreCorrect(): void
+    {
+        $cfg = ['station_id' => '214348', 'api_key' => 'ab-cd'];
+        $stationObs = TempestAdapter::buildUrl($cfg);
+        $this->assertStringContainsString('/observations/station/214348', $stationObs);
+        $this->assertStringContainsString('token=ab-cd', $stationObs);
+        $meta = TempestAdapter::buildStationsMetadataUrl($cfg);
+        $this->assertStringContainsString('/rest/stations/214348', $meta);
+        $dev = TempestAdapter::buildDeviceObservationsUrl(1215470, 'tok/1');
+        $this->assertStringContainsString('/observations/device/1215470', $dev);
+        $this->assertStringContainsString('token=tok%2F1', $dev);
+    }
+}

--- a/tests/mock-weather-responses.php
+++ b/tests/mock-weather-responses.php
@@ -1,7 +1,9 @@
 <?php
 /**
  * Mock Weather API Responses for Testing
- * This file provides mock responses for weather APIs to avoid requiring real API keys
+ *
+ * Provides deterministic JSON fixtures. For WeatherFlow (`swd.weatherflow.com`), `lib/test-mocks.php`
+ * selects the fixture by URL path: federated station observation, `/rest/stations/`, or `/observations/device/`.
  */
 
 /**
@@ -27,6 +29,56 @@ function getMockTempestResponse() {
             'precip_accum_local_day_final' => 11.94,  // mm (0.47 inches) - consistent with other mocks
             'dew_point' => 4.6  // Celsius
         ]]
+    ]);
+}
+
+/**
+ * Mock GET /swd/rest/stations/{id} (hub + ST) for tests that exercise Tempest device fallback.
+ *
+ * @return string JSON
+ */
+function getMockTempestStationsMetadataResponse(): string {
+    return json_encode([
+        'status' => [
+            'status_code' => 0,
+            'status_message' => 'SUCCESS',
+        ],
+        'stations' => [
+            [
+                'station_id' => 123456,
+                'devices' => [
+                    ['device_id' => 900001, 'device_type' => 'HB', 'serial_number' => 'HB-MOCK'],
+                    ['device_id' => 900002, 'device_type' => 'ST', 'serial_number' => 'ST-MOCK'],
+                ],
+            ],
+        ],
+    ]);
+}
+
+/**
+ * Mock GET /swd/rest/observations/device/{id} (obs_st numeric row) aligned with getMockTempestResponse().
+ *
+ * @return string JSON
+ */
+function getMockTempestDeviceObsStResponse(): string {
+    $t = time();
+    $row = array_fill(0, 22, 0);
+    $row[0] = $t;
+    $row[2] = 2.5;
+    $row[3] = 3.2;
+    $row[4] = 89;
+    $row[6] = 1019.2;
+    $row[7] = 5.6;
+    $row[8] = 93;
+    $row[18] = 11.94;
+    return json_encode([
+        'status' => [
+            'status_code' => 0,
+            'status_message' => 'OK',
+        ],
+        'device_id' => 900002,
+        'type' => 'obs_st',
+        'obs' => [$row],
     ]);
 }
 

--- a/tests/mock-weather-responses.php
+++ b/tests/mock-weather-responses.php
@@ -53,7 +53,7 @@ function getMockTempestStationsMetadataResponse(): string {
                 ],
             ],
         ],
-    ]);
+    ], JSON_THROW_ON_ERROR);
 }
 
 /**
@@ -81,7 +81,7 @@ function getMockTempestDeviceObsStResponse(): string {
         'device_id' => 900002,
         'type' => 'obs_st',
         'obs' => [$row],
-    ]);
+    ], JSON_THROW_ON_ERROR);
 }
 
 /**

--- a/tests/mock-weather-responses.php
+++ b/tests/mock-weather-responses.php
@@ -2,8 +2,9 @@
 /**
  * Mock Weather API Responses for Testing
  *
- * Provides deterministic JSON fixtures. For WeatherFlow (`swd.weatherflow.com`), `lib/test-mocks.php`
- * selects the fixture by URL path: federated station observation, `/rest/stations/`, or `/observations/device/`.
+ * JSON fixtures for tests (many responses use `time()` for observation freshness). For WeatherFlow
+ * (`swd.weatherflow.com`), `lib/test-mocks.php` selects the fixture by URL path: federated station observation,
+ * `/rest/stations/`, or `/observations/device/`.
  */
 
 /**
@@ -61,9 +62,10 @@ function getMockTempestStationsMetadataResponse(): string {
  * @return string JSON
  */
 function getMockTempestDeviceObsStResponse(): string {
-    $t = time();
+    // Fixed epoch so obs_st mock is stable across runs (station mock still uses time() for freshness).
+    $epoch = 1700000000;
     $row = array_fill(0, 22, 0);
-    $row[0] = $t;
+    $row[0] = $epoch;
     $row[2] = 2.5;
     $row[3] = 3.2;
     $row[4] = 89;


### PR DESCRIPTION
## Summary

Tempest integration previously used only WeatherFlow's federated `GET /observations/station/{id}` response. When federation returns HTTP 200 with an empty `obs` array, a timestamp-only `obs[0]`, or otherwise no usable sensor fields, the dashboard could show no Tempest data even though the ST device still had observations.

## What changed

- **After a successful station observation HTTP response**, `UnifiedFetcher` runs `tempestApplyDeviceFallbackIfNeeded()` (`lib/weather/adapter/tempest-v1.php`).
- **Fallback sequence:** `GET /stations/{station_id}` → first `device_type` **ST** → `GET /observations/device/{device_id}`.
- **Parsing:** Device `obs_st` numeric rows are normalized into the same associative shape as federated `obs[0]`, then existing unit conversions apply.
- **Guards:** Reject list-shaped `obs[0]` on federated payloads; require **usable sensor fields** (temp, humidity, pressure, dew point, any wind component, or non-zero precip) on **both** station-parse and device-parse before accepting the device body (avoids false success logs).
- **Logging:** Internal `aviationwx_log` line with `airport_id`, `station_id`, `device_id` only (no tokens).
- **Tests:** `tests/Unit/TempestAdapterTest.php`, `ErrorHandlingTest` addition, path-specific WeatherFlow mocks in `lib/test-mocks.php` and `tests/mock-weather-responses.php`.
- **Docs:** `docs/DATA_FLOW.md`, `docs/CONFIGURATION.md`, `docs/ARCHITECTURE.md`, `docs/TESTING.md`, guides, README, `.github/instructions/weather.instructions.md`, `CODE_STYLE.md`.

## Breaking changes

None. Config shape unchanged (`station_id` + `api_key` only). Worst case up to two extra HTTP requests per Tempest source when federated data is unusable.

## Pressure note

Device `obs_st` index 6 is mapped through the same mb→inHg path as federated `sea_level_pressure`; semantics may differ from true SLP (documented in DATA_FLOW / CONFIGURATION).

## Testing

- `make test-ci` passes locally on this branch.
