### PR TITLE
Fix station power battery meter styling in night vision mode

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1311,16 +1311,57 @@ body.night-mode .station-power-battery-secondary {
     color: var(--night-text-bright) !important;
 }
 
+/* Night vision: <meter> fill comes from UA optimum/suboptimum bands (WebKit/Mozilla pseudos), not accent-color; override so the bar matches the red theme */
 body.night-mode .station-power-meter {
-    accent-color: var(--night-accent);
+    accent-color: var(--night-text-bright);
 }
 
-body.night-mode .station-power-meter.station-power-meter--low {
-    accent-color: #e53935;
+body.night-mode .station-power-meter::-webkit-meter-inner-element {
+    border: 1px solid var(--night-border-light);
+    border-radius: 999px;
 }
 
-body.night-mode .station-power-meter.station-power-meter--medium {
-    accent-color: #ffca28;
+body.night-mode .station-power-meter::-webkit-meter-bar {
+    background: var(--night-bg-item);
+    border-radius: 999px;
+}
+
+body.night-mode .station-power-meter::-webkit-meter-optimum-value,
+body.night-mode .station-power-meter::-webkit-meter-suboptimum-value,
+body.night-mode .station-power-meter::-webkit-meter-even-less-good-value {
+    background: var(--night-text-bright);
+    border-radius: 999px;
+}
+
+body.night-mode .station-power-meter.station-power-meter--medium::-webkit-meter-optimum-value,
+body.night-mode .station-power-meter.station-power-meter--medium::-webkit-meter-suboptimum-value,
+body.night-mode .station-power-meter.station-power-meter--medium::-webkit-meter-even-less-good-value {
+    background: var(--night-text-primary);
+}
+
+body.night-mode .station-power-meter.station-power-meter--low::-webkit-meter-optimum-value,
+body.night-mode .station-power-meter.station-power-meter--low::-webkit-meter-suboptimum-value,
+body.night-mode .station-power-meter.station-power-meter--low::-webkit-meter-even-less-good-value {
+    background: var(--night-text-muted);
+}
+
+body.night-mode .station-power-meter:-moz-meter-optimum::-moz-meter-bar,
+body.night-mode .station-power-meter:-moz-meter-sub-optimum::-moz-meter-bar,
+body.night-mode .station-power-meter:-moz-meter-sub-sub-optimum::-moz-meter-bar {
+    background: var(--night-text-bright);
+    border-radius: 999px;
+}
+
+body.night-mode .station-power-meter.station-power-meter--medium:-moz-meter-optimum::-moz-meter-bar,
+body.night-mode .station-power-meter.station-power-meter--medium:-moz-meter-sub-optimum::-moz-meter-bar,
+body.night-mode .station-power-meter.station-power-meter--medium:-moz-meter-sub-sub-optimum::-moz-meter-bar {
+    background: var(--night-text-primary);
+}
+
+body.night-mode .station-power-meter.station-power-meter--low:-moz-meter-optimum::-moz-meter-bar,
+body.night-mode .station-power-meter.station-power-meter--low:-moz-meter-sub-optimum::-moz-meter-bar,
+body.night-mode .station-power-meter.station-power-meter--low:-moz-meter-sub-sub-optimum::-moz-meter-bar {
+    background: var(--night-text-muted);
 }
 
 body.night-mode #station-power-last-updated {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1314,10 +1314,21 @@ body.night-mode .station-power-battery-secondary {
 /* Night vision: <meter> fill comes from UA optimum/suboptimum bands (WebKit/Mozilla pseudos), not accent-color; override so the bar matches the red theme */
 body.night-mode .station-power-meter {
     accent-color: var(--night-text-bright);
+    background-color: var(--night-bg-item);
+    border: 1px solid var(--night-border-light);
+    border-radius: 999px;
+}
+
+body.night-mode .station-power-meter.station-power-meter--medium {
+    accent-color: var(--night-text-primary);
+}
+
+body.night-mode .station-power-meter.station-power-meter--low {
+    accent-color: var(--night-text-muted);
 }
 
 body.night-mode .station-power-meter::-webkit-meter-inner-element {
-    border: 1px solid var(--night-border-light);
+    border: none;
     border-radius: 999px;
 }
 


### PR DESCRIPTION
Night vision mode showed the battery state-of-charge `<meter>` with the browser default green/yellow/red fill because WebKit/Blink and Gecko paint from optimum/suboptimum pseudo-elements, not only `accent-color`.

This change overrides those pseudos (and sets `accent-color`) under `body.night-mode` so the bar uses the same red palette as the rest of the night theme, with muted variants for medium/low SOC classes.

<img width="966" height="324" alt="image" src="https://github.com/user-attachments/assets/9b562bf0-e374-4386-8f48-8d0bad7dbc02" />


Validation: `make test-ci` passed.