### PR TITLE
fix(notam): polygon TFR relevance with point-in-polygon and closed-ring checks

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,7 +43,7 @@ aviationwx.org/
 │   │   ├── auth.php          # NMS API authentication (OAuth bearer token)
 │   │   ├── fetcher.php       # NOTAM fetching (location + geospatial queries)
 │   │   ├── parser.php        # AIXM XML parsing
-│   │   └── filter.php        # Relevance filtering (closures, TFRs, distance)
+│   │   └── filter.php        # Relevance filtering (closures, TFR circle and polygon geometry)
 │   └── weather/
 │       ├── UnifiedFetcher.php # Unified weather fetch pipeline
 │       ├── WeatherAggregator.php # Multi-source aggregation logic
@@ -183,7 +183,7 @@ aviationwx.org/
 - **`auth.php`**: NMS API OAuth authentication (bearer token with auto-refresh)
 - **`fetcher.php`**: Dual query strategy (location + geospatial)
 - **`parser.php`**: AIXM 5.1.1 XML parsing to structured data
-- **`filter.php`**: Relevance filtering with geographic distance checking
+- **`filter.php`**: Relevance filtering (aerodrome closures, TFR text classification, circle and polygon geographic rules)
 
 **`scripts/fetch-notam.php`**: NOTAM fetcher worker
 - Called by scheduler for periodic NOTAM updates
@@ -203,12 +203,12 @@ Optional **station power** telemetry on airport pages for `limited_availability`
 - **Filtering Logic**:
   - **Aerodrome Closures**: Q-codes QMR* (runway) or QFA* (aerodrome) with CLSD/CLOSED/HAZARD text
   - **TFRs**: Text containing "TFR", "TEMPORARY FLIGHT RESTRICTION", or "RESTRICTED AIRSPACE"
-- **Geographic Relevance** (TFRs only):
-  - Parses TFR center coordinates from NOTAM text (format: DDMMSSN/DDDMMSSW)
-  - Parses TFR radius from text (e.g., "5NM RADIUS")
-  - Calculates haversine distance from airport to TFR center (nautical miles)
-  - TFR shown only if airport within (TFR radius + 10 NM buffer)
-  - Falls back to NOTAM location/airport_name fields when available
+- **Geographic relevance** (TFRs only, when identifier and name rules do not already match):
+  - Parses coordinate pairs from NOTAM text (`DDMMSSN/DDDMMSSW`)
+  - **Circle path** (parsed NM radius in text): first pair is center; haversine distance from airport must be ≤ parsed radius + `TFR_RELEVANCE_BUFFER_NM` (10 NM default)
+  - **Polygon path** (no parsed radius, ≥3 vertices, closed ring): point-in-polygon in a local NM plane; if outside the ring, distance to nearest edge must be ≤ `TFR_RELEVANCE_BUFFER_NM`; closed ring requires repeated first vertex or **POINT OF ORIGIN** phrase; degenerate area below `TFR_POLYGON_MIN_ABS_DOUBLE_AREA_NM2` is excluded
+  - **Legacy path** (no parsed radius, fewer than three vertices): first pair as center with `TFR_DEFAULT_RADIUS_NM` (30 NM) + buffer via haversine
+  - Uses NOTAM `location` and `airport_name` for non-geographic matches when those fields align with the airport
 - **Status Classification**: active, upcoming_today, expired, upcoming_future
 
 ### Configuration System (`lib/config.php`)
@@ -412,7 +412,7 @@ Parse AIXM XML responses
   ↓
 Deduplicate by NOTAM ID
   ↓
-Filter for relevance (closures by Q-code, TFRs by distance)
+Filter for relevance (closures by Q-code, TFRs by circle, polygon, or legacy geometry)
   ↓
 Determine status (active/upcoming_today)
   ↓
@@ -495,17 +495,12 @@ See [DATA_FLOW.md](DATA_FLOW.md#notam-data-fetching) for detailed NOTAM processi
 
 ### 8. TFR Geographic Relevance Filtering
 
-- **Why**: NMS API returns TFRs by ARTCC region, not geographic proximity
-- **Problem**: A TFR in Utah (ZLC) would appear on Idaho airports in the same ARTCC
-- **Implementation**: Parse TFR coordinates and radius from NOTAM text, calculate actual distance
-- **Key Components**:
-  - Coordinate parsing: Extracts lat/lon from DDMMSSN/DDDMMSSW format
-  - Radius parsing: Extracts nautical mile value from text
-  - Haversine distance: Calculates great-circle distance in nautical miles
-  - Relevance threshold: TFR radius + 10 NM buffer (configurable via `TFR_RELEVANCE_BUFFER_NM`)
-- **Fallback**: Uses NOTAM `location` and `airport_name` fields when coordinates unavailable
-- **Conservative**: Excludes TFRs when coordinates cannot be parsed (prevents false positives)
-- **Benefit**: Only shows TFRs that actually affect the airport's airspace
+- **Why**: The NMS API can return TFRs for a wide FIR or ARTCC footprint relative to a single airport. Geographic rules in `lib/notam/filter.php` align banners with published circle or polygon text and with configured airport coordinates.
+- **Circle TFRs**: Parsed NM radius plus `TFR_RELEVANCE_BUFFER_NM` around the first stated coordinate pair (haversine NM).
+- **Polygon TFRs**: Closed-ring validation (duplicate first vertex or **POINT OF ORIGIN**), point-in-polygon in a local NM projection, boundary buffer `TFR_RELEVANCE_BUFFER_NM` for airports just outside the edge, and exclusion of degenerate rings via `TFR_POLYGON_MIN_ABS_DOUBLE_AREA_NM2`.
+- **Legacy point**: When fewer than three coordinate pairs exist and no radius is parsed, `TFR_DEFAULT_RADIUS_NM` plus the same buffer around the first pair.
+- **Non-geographic matches**: NOTAM `location` / `airport_name` / text still gate relevance when they match airport identifiers or names before geometry runs.
+- **Safety posture**: Unparsed coordinates, unclosed polygon text, degenerate projected area, or missing airport lat/lon skip geographic relevance so the UI does not imply a footprint that cannot be verified from the NOTAM body.
 
 ### 9. Airport "Last updated" Uses Observation Time Before Fetch Time
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1452,46 +1452,62 @@ A NOTAM is classified as a TFR if (and not a cancellation) its text contains any
 
 ### TFR Geographic Relevance
 
-**Problem**: The NMS API returns TFRs by ARTCC region, not geographic proximity. A TFR in Utah (ZLC ARTCC) would appear for airports in Idaho that share the same ARTCC.
+**Design context**: The NMS API can return TFR NOTAMs for a broad airspace region (for example the same ARTCC as the airport). `lib/notam/filter.php` applies geographic rules so dashboard banners align with the airport position and the geometry described in the NOTAM text.
 
-**Solution**: Parse TFR coordinates and calculate actual distance to determine relevance.
+A TFR is treated as relevant to an airport when any of these holds:
 
-A TFR is considered relevant to an airport if any of these conditions are met:
-1. The NOTAM `location` field matches an airport identifier
-2. The NOTAM `airport_name` field matches the airport name
-3. The TFR text explicitly mentions the airport name or identifier
-4. The airport is within the TFR's geographic boundary (radius + buffer)
+1. The NOTAM `location` field matches an airport identifier (ICAO, IATA, FAA, or historical `formerly` codes).
+2. The NOTAM `airport_name` field matches the airport name (word-boundary rules prevent substring false positives).
+3. The TFR text explicitly mentions the airport name or an identifier (same word-boundary rules).
+4. **Geographic geometry** applies: the airport has configured `lat`/`lon`, and the case falls into one of the paths below.
 
-#### Coordinate Parsing
+#### Coordinate parsing (all paths)
 
-TFR coordinates are parsed from the NOTAM text using the standard aviation format:
-- **Format**: `DDMMSSN/S DDDMMSSW/E` (e.g., "413900N1122300W")
+All coordinate pairs use the same pattern scan over the NOTAM `text` field:
+
+- **Format**: `DDMMSSN/S` then `DDDMMSSW/E` (e.g., `413900N1122300W`)
 - **Meaning**: Degrees, minutes, seconds with hemisphere indicator
-- **Example**: 413900N1122300W = 41°39'00"N, 112°23'00"W (Ogden, UT)
+- **Example**: `413900N1122300W` = 41°39'00"N, 112°23'00"W
 
-#### Radius Parsing
+#### Radius parsing (circle TFR path only)
 
-TFR radius is parsed from text patterns:
-- "5NM RADIUS" or "5 NM RADIUS"
-- "RADIUS OF 5NM"
-- "WITHIN 5NM"
-- "5 NAUTICAL MILE RADIUS"
+When any of these patterns matches, the NOTAM is treated as a **circle** TFR for geometry (first coordinate pair in document order is the center):
 
-If radius cannot be parsed, a default of 30 NM is used (`TFR_DEFAULT_RADIUS_NM`).
+- `5NM RADIUS` or `5 NM RADIUS`
+- `RADIUS OF 5NM`
+- `WITHIN 5NM` (numeric nautical miles)
+- `5 NAUTICAL MILE RADIUS`
 
-#### Distance Calculation
+Parsed values must lie between `TFR_RADIUS_MIN_NM` and `TFR_RADIUS_MAX_NM` in `lib/constants.php`.
 
-The haversine formula calculates great-circle distance in nautical miles between the airport and TFR center. The TFR is relevant if:
+#### Circle TFR geometry
+
+For a circle TFR, **haversine** distance in nautical miles is computed between the airport and the circle center. The TFR is relevant when:
 
 ```
-distance ≤ (TFR radius + relevance buffer)
+distance NM ≤ (parsed radius NM + TFR_RELEVANCE_BUFFER_NM)
 ```
 
-The relevance buffer is 10 NM by default (`TFR_RELEVANCE_BUFFER_NM`), ensuring airports just outside a TFR boundary are still warned.
+`TFR_RELEVANCE_BUFFER_NM` defaults to **10 NM** so airports immediately outside the published circle still receive a warning.
 
-#### Conservative Filtering
+#### Polygon TFR geometry
 
-When coordinates cannot be parsed from the TFR text, the system takes a conservative approach and excludes the TFR. This prevents showing distant TFRs when location cannot be verified, avoiding false positives that could desensitize pilots to warnings.
+When **no** circle radius is parsed and **three or more** distinct vertices remain after parsing, the NOTAM uses the **polygon** path:
+
+- **Closed ring requirement**: The ring is valid only if the first and last decoded vertices coincide (after dropping consecutive duplicates), **or** the text contains the phrase **POINT OF ORIGIN** with at least three vertices (implicit closure to the first vertex). Otherwise geographic relevance is **not** applied for the polygon (fail closed).
+- **Plane and units**: Vertices and the airport are projected to a local east/north plane in **nautical miles** using the mean vertex latitude as the tangent reference. This matches small CONUS incident polygons; `cos(latitude)` near zero rejects the projection (fail closed).
+- **Non-degenerate ring**: The absolute signed shoelace double-area in that plane must be at least `TFR_POLYGON_MIN_ABS_DOUBLE_AREA_NM2` in `lib/notam/filter.php`. Smaller values are treated as a degenerate ring and excluded.
+- **Inside or near boundary**: A **ray-casting** point-in-polygon test runs in the projected plane. If the airport is outside the ring, the shortest distance to any polygon edge (NM in that plane) must be **≤ `TFR_RELEVANCE_BUFFER_NM`** for relevance.
+
+Inside the polygon, relevance does **not** depend on distance to a single center point; any interior position matches.
+
+#### Legacy point TFR (no radius, fewer than three vertices)
+
+When no radius is parsed and fewer than three vertices are available, the first coordinate is used as a center with **`TFR_DEFAULT_RADIUS_NM`** (30 NM) plus `TFR_RELEVANCE_BUFFER_NM` and haversine distance. This covers sparse coordinate text that is not a closed polygon.
+
+#### Conservative filtering (safety-critical)
+
+Geographic relevance is **withheld** when coordinate geometry cannot be established, a polygon ring is not provably closed, or the projected polygon is degenerate. Missing airport coordinates also skip geometry (identifier and text rules may still match). Omitting uncertain geometry avoids showing distant or mis-scoped TFR banners that could reduce trust in the NOTAM strip.
 
 ### Status Classification
 
@@ -1654,7 +1670,7 @@ The `/api/notam.php` endpoint serves cached NOTAM data:
 - **Visibility**: Only shown when active or upcoming_today NOTAMs exist
 - **Types Displayed**:
   - **Aerodrome Closures**: Runway or airport closures/hazards
-  - **TFRs**: Temporary Flight Restrictions affecting the airport
+  - **TFRs**: Temporary flight restrictions that pass relevance rules (including circle, polygon, or legacy geometry in [TFR Geographic Relevance](#tfr-geographic-relevance))
 
 #### NOTAM Content
 - **ID**: NOTAM identifier with link to official FAA source

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1463,7 +1463,7 @@ A TFR is treated as relevant to an airport when any of these holds:
 
 #### Coordinate parsing (all paths)
 
-All coordinate pairs use the same pattern scan over the NOTAM `text` field:
+All coordinate pairs use the same pattern scan over the NOTAM `text` field. Each decoded pair must use **minutes and seconds in 0--59**, **latitude degrees 0--90** (no fractional overflow beyond the pole), **longitude degrees 0--180** with the same pole rule at 180°, and **N/S/E/W** hemispheres; otherwise the pair is dropped so bad text cannot silently move geometry.
 
 - **Format**: `DDMMSSN/S` then `DDDMMSSW/E` (e.g., `413900N1122300W`)
 - **Meaning**: Degrees, minutes, seconds with hemisphere indicator

--- a/lib/notam/filter.php
+++ b/lib/notam/filter.php
@@ -34,6 +34,10 @@ function tfrCoordinatePairRegex(): string {
 /**
  * Decode one DDMMSSN / DDDMMSSW match from {@see tfrCoordinatePairRegex()}.
  *
+ * Rejects components outside FAA-style ranges (minutes and seconds 0--59,
+ * latitude magnitude at most 90°, longitude magnitude at most 180°) so OCR
+ * or formatting glitches do not shift decoded positions silently.
+ *
  * @param array<int|string,string> $m Match array: full at [0], groups 1-8 for lat/lon fields
  * @return array{lat: float, lon: float}|null Invalid groups or out-of-range coordinates
  */
@@ -50,6 +54,24 @@ function tfrDecodeCoordinateGroups(array $m): ?array {
     $lonMin = (int)$m[6];
     $lonSec = (int)$m[7];
     $lonDir = strtoupper((string)$m[8]);
+
+    if (
+        $latDeg < 0 || $latDeg > 90
+        || $lonDeg < 0 || $lonDeg > 180
+        || $latMin < 0 || $latMin > 59
+        || $latSec < 0 || $latSec > 59
+        || $lonMin < 0 || $lonMin > 59
+        || $lonSec < 0 || $lonSec > 59
+        || ($latDir !== 'N' && $latDir !== 'S')
+        || ($lonDir !== 'E' && $lonDir !== 'W')
+    ) {
+        return null;
+    }
+
+    if (($latDeg === 90 && ($latMin > 0 || $latSec > 0))
+        || ($lonDeg === 180 && ($lonMin > 0 || $lonSec > 0))) {
+        return null;
+    }
 
     $lat = $latDeg + ($latMin / 60) + ($latSec / 3600);
     $lon = $lonDeg + ($lonMin / 60) + ($lonSec / 3600);
@@ -409,10 +431,11 @@ function polygonCentroidLatLonFromVertices(array $vertices): ?array {
  *
  * @param string $text NOTAM body
  * @param array<int, array{lat: float, lon: float}>|null $vertices Pre-parsed vertices to avoid a second scan of $text; null parses from $text
+ * @param float|null $parsedRadiusNm When set, skips re-parsing radius from $text (must match {@see parseTfrRadiusNm()} for the same body when applicable)
  * @return array{lat: float, lon: float, radius_nm: float}|null Unusable or polygon path (null when polygon applies to PiP instead)
  */
-function parseTfrGeographicRelevanceReference(string $text, ?array $vertices = null): ?array {
-    $parsedRadius = parseTfrRadiusNm($text);
+function parseTfrGeographicRelevanceReference(string $text, ?array $vertices = null, ?float $parsedRadiusNm = null): ?array {
+    $parsedRadius = $parsedRadiusNm ?? parseTfrRadiusNm($text);
     if ($vertices === null) {
         $vertices = parseTfrPolygonVertices($text);
     }
@@ -764,7 +787,7 @@ function isTfrRelevantToAirport(array $tfr, array $airport): bool {
         return isAirportInsideOrNearTfrPolygonRing($vertices, $airportLat, $airportLon);
     }
 
-    $geoRef = parseTfrGeographicRelevanceReference($text, $vertices);
+    $geoRef = parseTfrGeographicRelevanceReference($text, $vertices, $parsedRadius);
     if ($geoRef === null) {
         return false;
     }

--- a/lib/notam/filter.php
+++ b/lib/notam/filter.php
@@ -35,8 +35,8 @@ function tfrCoordinatePairRegex(): string {
  * Decode one DDMMSSN / DDDMMSSW match from {@see tfrCoordinatePairRegex()}.
  *
  * Rejects components outside FAA-style ranges (minutes and seconds 0--59,
- * latitude magnitude at most 90°, longitude magnitude at most 180°) so OCR
- * or formatting glitches do not shift decoded positions silently.
+ * latitude degrees 0--90, longitude degrees 0--180) so corrupted or
+ * non-conforming text does not shift decoded positions silently.
  *
  * @param array<int|string,string> $m Match array: full at [0], groups 1-8 for lat/lon fields
  * @return array{lat: float, lon: float}|null Invalid groups or out-of-range coordinates
@@ -233,6 +233,7 @@ function tfrPolygonProjectVerticesToLocalPlaneNm(array $vertices): ?array {
  *
  * @param float[] $xs Easting (NM) per vertex
  * @param float[] $ys Northing (NM) per vertex
+ * @return float Signed double area in square NM; zero if fewer than three vertices or length mismatch
  */
 function tfrPolygonSignedDoubleAreaNm2(array $xs, array $ys): float {
     $n = count($xs);
@@ -255,6 +256,7 @@ function tfrPolygonSignedDoubleAreaNm2(array $xs, array $ys): float {
  * @param float $py Airport northing (NM)
  * @param float[] $xs Polygon eastings (NM)
  * @param float[] $ys Polygon northings (NM)
+ * @return bool True if the test point lies inside the ring (boundary excluded by ray parity)
  */
 function pointInPolygonRayCastLocalNm(float $px, float $py, array $xs, array $ys): bool {
     $n = count($xs);
@@ -290,6 +292,7 @@ function pointInPolygonRayCastLocalNm(float $px, float $py, array $xs, array $ys
  * @param float $py Airport northing (NM)
  * @param float[] $xs Polygon eastings (NM)
  * @param float[] $ys Polygon northings (NM)
+ * @return float Shortest distance to any edge (NM), or PHP_FLOAT_MAX if fewer than two vertices
  */
 function minDistancePointToPolygonRingNm(float $px, float $py, array $xs, array $ys): float {
     $n = count($xs);

--- a/lib/notam/filter.php
+++ b/lib/notam/filter.php
@@ -12,54 +12,435 @@ require_once __DIR__ . '/../units.php';
 require_once __DIR__ . '/../airport-identifiers.php';
 require_once __DIR__ . '/../weather/utils.php';
 
+/** Epsilon for comparing decoded TFR vertices (degrees) */
+const TFR_VERTEX_EQUAL_EPSILON_DEG = 1.0e-6;
+
+/**
+ * Minimum absolute signed double-area (NM^2) for a polygon ring to be treated as
+ * a non-degenerate closed shape. Below this, relevance fails closed.
+ */
+const TFR_POLYGON_MIN_ABS_DOUBLE_AREA_NM2 = 1e-8;
+
+/**
+ * PCRE pattern for one FAA coordinate pair (DDMMSSN then DDDMMSSW/E).
+ * Capture groups 1-8: lat deg,min,sec,hem; lon deg,min,sec,hem.
+ *
+ * @return string Regex pattern with delimiters
+ */
+function tfrCoordinatePairRegex(): string {
+    return '/(\d{2})(\d{2})(\d{2})([NS])\s*(\d{2,3})(\d{2})(\d{2})([EW])/i';
+}
+
+/**
+ * Decode one DDMMSSN / DDDMMSSW match from {@see tfrCoordinatePairRegex()}.
+ *
+ * @param array<int|string,string> $m Match array: full at [0], groups 1-8 for lat/lon fields
+ * @return array{lat: float, lon: float}|null Invalid groups or out-of-range coordinates
+ */
+function tfrDecodeCoordinateGroups(array $m): ?array {
+    if (!isset($m[8])) {
+        return null;
+    }
+    $latDeg = (int)$m[1];
+    $latMin = (int)$m[2];
+    $latSec = (int)$m[3];
+    $latDir = strtoupper((string)$m[4]);
+
+    $lonDeg = (int)$m[5];
+    $lonMin = (int)$m[6];
+    $lonSec = (int)$m[7];
+    $lonDir = strtoupper((string)$m[8]);
+
+    $lat = $latDeg + ($latMin / 60) + ($latSec / 3600);
+    $lon = $lonDeg + ($lonMin / 60) + ($lonSec / 3600);
+
+    if ($latDir === 'S') {
+        $lat = -$lat;
+    }
+    if ($lonDir === 'W') {
+        $lon = -$lon;
+    }
+
+    if ($lat >= -90 && $lat <= 90 && $lon >= -180 && $lon <= 180) {
+        return ['lat' => $lat, 'lon' => $lon];
+    }
+
+    return null;
+}
+
 /**
  * Parse coordinates from TFR NOTAM text
- * 
- * Parses the first coordinate pair found in standard aviation format.
- * Note: Only parses single-point TFRs; multi-point polygon TFRs will use only the first point.
- * 
+ *
+ * Returns the first coordinate pair in standard aviation format. For polygon
+ * definitions, use {@see parseTfrPolygonVertices()}, {@see parseTfrPolygonVerticesMeta()},
+ * or {@see parseTfrGeographicRelevanceReference()}.
+ *
  * Supported formats:
  * - DDMMSSN/DDDMMSSW (e.g., 413900N1122300W)
- * - With optional whitespace between lat/lon
- * 
+ * - With optional whitespace between lat/lon hemispheres and longitude digits
+ *
  * @param string $text NOTAM text to parse (empty string returns null)
  * @return array{lat: float, lon: float}|null Decimal degrees or null if no valid coordinates found
  */
 function parseTfrCoordinates(string $text): ?array {
-    // Pattern: DDMMSSN/S followed by DDDMMSSW/E
-    // Example: 413900N1122300W = 41°39'00"N 112°23'00"W
-    $pattern = '/(\d{2})(\d{2})(\d{2})([NS])\s*(\d{2,3})(\d{2})(\d{2})([EW])/i';
-    
-    if (preg_match($pattern, $text, $matches)) {
-        $latDeg = (int)$matches[1];
-        $latMin = (int)$matches[2];
-        $latSec = (int)$matches[3];
-        $latDir = strtoupper($matches[4]);
-        
-        $lonDeg = (int)$matches[5];
-        $lonMin = (int)$matches[6];
-        $lonSec = (int)$matches[7];
-        $lonDir = strtoupper($matches[8]);
-        
-        // Convert to decimal degrees
-        $lat = $latDeg + ($latMin / 60) + ($latSec / 3600);
-        $lon = $lonDeg + ($lonMin / 60) + ($lonSec / 3600);
-        
-        // Apply direction
-        if ($latDir === 'S') {
-            $lat = -$lat;
+    if (preg_match(tfrCoordinatePairRegex(), $text, $matches)) {
+        return tfrDecodeCoordinateGroups($matches);
+    }
+
+    return null;
+}
+
+/**
+ * Detect FAA phrasing that closes a polygon without repeating the first coordinate.
+ *
+ * @param string $text NOTAM body (case-insensitive match)
+ * @return bool True when POINT OF ORIGIN appears as a whole phrase
+ */
+function tfrPolygonHasPointOfOriginClosurePhrase(string $text): bool {
+    return preg_match('/\bPOINT\s+OF\s+ORIGIN\b/i', $text) === 1;
+}
+
+/**
+ * Parse all DDMMSSN/DDDMMSSW coordinate pairs from TFR text in document order.
+ *
+ * Collapses consecutive duplicates and removes a closing vertex equal to the first
+ * when present. {@see parseTfrPolygonVerticesMeta()} also records whether the ring
+ * is watertight (explicit closure or POINT OF ORIGIN).
+ *
+ * @param string $text NOTAM text
+ * @return array<int, array{lat: float, lon: float}> Ordered vertices (may be empty)
+ */
+function parseTfrPolygonVertices(string $text): array {
+    return parseTfrPolygonVerticesMeta($text)['vertices'];
+}
+
+/**
+ * Parse polygon vertices and whether the NOTAM defines a closed ring.
+ *
+ * ring_closed is true when the first and last decoded coordinates coincide (after
+ * deduping consecutive repeats), or when the text contains "POINT OF ORIGIN" so
+ * the last edge returns to the first vertex. Otherwise fail closed for polygon TFRs.
+ *
+ * @param string $text NOTAM text
+ * @return array{vertices: array<int, array{lat: float, lon: float}>, ring_closed: bool}
+ */
+function parseTfrPolygonVerticesMeta(string $text): array {
+    if (!preg_match_all(tfrCoordinatePairRegex(), $text, $matches, PREG_SET_ORDER)) {
+        return ['vertices' => [], 'ring_closed' => false];
+    }
+
+    $vertices = [];
+    foreach ($matches as $row) {
+        $pt = tfrDecodeCoordinateGroups($row);
+        if ($pt === null) {
+            continue;
         }
-        if ($lonDir === 'W') {
-            $lon = -$lon;
+        $last = end($vertices);
+        if ($last !== false
+            && abs($last['lat'] - $pt['lat']) < TFR_VERTEX_EQUAL_EPSILON_DEG
+            && abs($last['lon'] - $pt['lon']) < TFR_VERTEX_EQUAL_EPSILON_DEG) {
+            continue;
         }
-        
-        // Validate ranges
-        if ($lat >= -90 && $lat <= 90 && $lon >= -180 && $lon <= 180) {
-            return ['lat' => $lat, 'lon' => $lon];
+        $vertices[] = $pt;
+    }
+
+    $ringClosed = false;
+    $n = count($vertices);
+    if ($n >= 2) {
+        $first = $vertices[0];
+        $last = $vertices[$n - 1];
+        if (abs($first['lat'] - $last['lat']) < TFR_VERTEX_EQUAL_EPSILON_DEG
+            && abs($first['lon'] - $last['lon']) < TFR_VERTEX_EQUAL_EPSILON_DEG) {
+            $ringClosed = true;
+            array_pop($vertices);
         }
     }
-    
+
+    if (!$ringClosed && tfrPolygonHasPointOfOriginClosurePhrase($text) && count($vertices) >= 3) {
+        $ringClosed = true;
+    }
+
+    return ['vertices' => $vertices, 'ring_closed' => $ringClosed];
+}
+
+/**
+ * Project geodetic vertices to local east/north plane (NM) for small polygons.
+ *
+ * @param array<int, array{lat: float, lon: float}> $vertices Vertex list (non-empty)
+ * @return array{ref_lat: float, ref_lon: float, xs: float[], ys: float[], cos_ref: float}|null Null if empty or near-pole (unreliable plane)
+ */
+function tfrPolygonProjectVerticesToLocalPlaneNm(array $vertices): ?array {
+    $n = count($vertices);
+    if ($n < 1) {
+        return null;
+    }
+    $refLat = 0.0;
+    $refLon = 0.0;
+    foreach ($vertices as $v) {
+        $refLat += $v['lat'];
+        $refLon += $v['lon'];
+    }
+    $refLat /= $n;
+    $refLon /= $n;
+
+    $refLatRad = deg2rad($refLat);
+    $cosRef = cos($refLatRad);
+    if (abs($cosRef) < 1e-8) {
+        return null;
+    }
+
+    $rNm = EARTH_RADIUS_NAUTICAL_MILES;
+    $xs = [];
+    $ys = [];
+    foreach ($vertices as $v) {
+        $xs[] = $rNm * $cosRef * deg2rad($v['lon'] - $refLon);
+        $ys[] = $rNm * deg2rad($v['lat'] - $refLat);
+    }
+
+    return [
+        'ref_lat' => $refLat,
+        'ref_lon' => $refLon,
+        'xs' => $xs,
+        'ys' => $ys,
+        'cos_ref' => $cosRef,
+    ];
+}
+
+/**
+ * Signed double area (NM^2) of a simple polygon in the local plane (shoelace).
+ *
+ * @param float[] $xs Easting (NM) per vertex
+ * @param float[] $ys Northing (NM) per vertex
+ */
+function tfrPolygonSignedDoubleAreaNm2(array $xs, array $ys): float {
+    $n = count($xs);
+    if ($n < 3 || $n !== count($ys)) {
+        return 0.0;
+    }
+    $twice = 0.0;
+    for ($i = 0; $i < $n; $i++) {
+        $j = ($i + 1) % $n;
+        $twice += $xs[$i] * $ys[$j] - $xs[$j] * $ys[$i];
+    }
+
+    return $twice;
+}
+
+/**
+ * Ray casting point-in-polygon test in local NM plane.
+ *
+ * @param float $px Airport easting (NM) in the same frame as $xs/$ys
+ * @param float $py Airport northing (NM)
+ * @param float[] $xs Polygon eastings (NM)
+ * @param float[] $ys Polygon northings (NM)
+ */
+function pointInPolygonRayCastLocalNm(float $px, float $py, array $xs, array $ys): bool {
+    $n = count($xs);
+    if ($n < 3 || $n !== count($ys)) {
+        return false;
+    }
+    $inside = false;
+    for ($i = 0, $j = $n - 1; $i < $n; $j = $i++) {
+        $xi = $xs[$i];
+        $yi = $ys[$i];
+        $xj = $xs[$j];
+        $yj = $ys[$j];
+        $crosses = ($yi > $py) !== ($yj > $py);
+        if ($crosses) {
+            $denom = $yj - $yi;
+            if (abs($denom) < 1e-18) {
+                continue;
+            }
+            $xInt = $xi + ($xj - $xi) * ($py - $yi) / $denom;
+            if ($px < $xInt) {
+                $inside = !$inside;
+            }
+        }
+    }
+
+    return $inside;
+}
+
+/**
+ * Shortest distance from a point to a closed polygon edge (NM) in the local plane.
+ *
+ * @param float $px Airport easting (NM)
+ * @param float $py Airport northing (NM)
+ * @param float[] $xs Polygon eastings (NM)
+ * @param float[] $ys Polygon northings (NM)
+ */
+function minDistancePointToPolygonRingNm(float $px, float $py, array $xs, array $ys): float {
+    $n = count($xs);
+    if ($n < 2 || $n !== count($ys)) {
+        return PHP_FLOAT_MAX;
+    }
+    $minSq = PHP_FLOAT_MAX;
+    for ($i = 0; $i < $n; $i++) {
+        $j = ($i + 1) % $n;
+        $x1 = $xs[$i];
+        $y1 = $ys[$i];
+        $x2 = $xs[$j];
+        $y2 = $ys[$j];
+        $dx = $x2 - $x1;
+        $dy = $y2 - $y1;
+        $lenSq = $dx * $dx + $dy * $dy;
+        if ($lenSq < 1e-24) {
+            $t = 0.0;
+        } else {
+            $t = (($px - $x1) * $dx + ($py - $y1) * $dy) / $lenSq;
+            $t = max(0.0, min(1.0, $t));
+        }
+        $qx = $x1 + $t * $dx;
+        $qy = $y1 + $t * $dy;
+        $dsq = ($px - $qx) * ($px - $qx) + ($py - $qy) * ($py - $qy);
+        if ($dsq < $minSq) {
+            $minSq = $dsq;
+        }
+    }
+
+    return sqrt(max(0.0, $minSq));
+}
+
+/**
+ * True when the airport lies inside the closed polygon or within the relevance buffer
+ * outside its boundary (NM, local plane).
+ *
+ * @param array<int, array{lat: float, lon: float}> $vertices At least three corners (ring not repeated)
+ * @return bool False when polygon is degenerate in the projected plane
+ */
+function isAirportInsideOrNearTfrPolygonRing(array $vertices, float $airportLat, float $airportLon): bool {
+    $n = count($vertices);
+    if ($n < 3) {
+        return false;
+    }
+
+    $plane = tfrPolygonProjectVerticesToLocalPlaneNm($vertices);
+    if ($plane === null) {
+        return false;
+    }
+
+    $refLat = $plane['ref_lat'];
+    $refLon = $plane['ref_lon'];
+    $cosRef = $plane['cos_ref'];
+    $xs = $plane['xs'];
+    $ys = $plane['ys'];
+    $rNm = EARTH_RADIUS_NAUTICAL_MILES;
+
+    $signedDouble = tfrPolygonSignedDoubleAreaNm2($xs, $ys);
+    if (abs($signedDouble) < TFR_POLYGON_MIN_ABS_DOUBLE_AREA_NM2) {
+        return false;
+    }
+
+    $px = $rNm * $cosRef * deg2rad($airportLon - $refLon);
+    $py = $rNm * deg2rad($airportLat - $refLat);
+
+    if (pointInPolygonRayCastLocalNm($px, $py, $xs, $ys)) {
+        return true;
+    }
+
+    $distEdge = minDistancePointToPolygonRingNm($px, $py, $xs, $ys);
+
+    return $distEdge <= TFR_RELEVANCE_BUFFER_NM;
+}
+
+/**
+ * Planar polygon centroid in lat/lon using a local equirectangular tangent plane (NM).
+ *
+ * Suitable for small TFR polygons (CONUS incident airspace). Returns null when
+ * fewer than three vertices or the polygon is degenerate (near-zero area), so
+ * callers can fail closed.
+ *
+ * @param array<int, array{lat: float, lon: float}> $vertices Closed ring not required; algorithm treats edge N-1 to 0 as closing
+ * @return array{lat: float, lon: float}|null Centroid or null if not computable
+ */
+function polygonCentroidLatLonFromVertices(array $vertices): ?array {
+    $n = count($vertices);
+    if ($n < 3) {
+        return null;
+    }
+
+    $plane = tfrPolygonProjectVerticesToLocalPlaneNm($vertices);
+    if ($plane === null) {
+        return null;
+    }
+
+    $refLat = $plane['ref_lat'];
+    $refLon = $plane['ref_lon'];
+    $cosRef = $plane['cos_ref'];
+    $xs = $plane['xs'];
+    $ys = $plane['ys'];
+    $rNm = EARTH_RADIUS_NAUTICAL_MILES;
+
+    $doubleArea = 0.0;
+    $sumCx = 0.0;
+    $sumCy = 0.0;
+    for ($i = 0; $i < $n; $i++) {
+        $j = ($i + 1) % $n;
+        $cross = $xs[$i] * $ys[$j] - $xs[$j] * $ys[$i];
+        $doubleArea += $cross;
+        $sumCx += ($xs[$i] + $xs[$j]) * $cross;
+        $sumCy += ($ys[$i] + $ys[$j]) * $cross;
+    }
+
+    if (abs($doubleArea) < TFR_POLYGON_MIN_ABS_DOUBLE_AREA_NM2) {
+        return null;
+    }
+
+    $centroidX = $sumCx / (3.0 * $doubleArea);
+    $centroidY = $sumCy / (3.0 * $doubleArea);
+
+    $centLat = $refLat + rad2deg($centroidY / $rNm);
+    $centLon = $refLon + rad2deg($centroidX / ($rNm * $cosRef));
+
+    if ($centLat >= -90 && $centLat <= 90 && $centLon >= -180 && $centLon <= 180) {
+        return ['lat' => $centLat, 'lon' => $centLon];
+    }
+
     return null;
+}
+
+/**
+ * Reference point and inner radius (NM) for circle or legacy point TFRs only.
+ *
+ * Circle TFRs (explicit NM radius in text): first coordinate is center, parsed radius used.
+ * Polygon TFRs (no radius, three or more vertices) use point-in-polygon in
+ * {@see isTfrRelevantToAirport()}; this function returns null for that case.
+ * Otherwise: first coordinate with {@see TFR_DEFAULT_RADIUS_NM} (legacy single-point behavior).
+ *
+ * @param string $text NOTAM body
+ * @param array<int, array{lat: float, lon: float}>|null $vertices Pre-parsed vertices to avoid a second scan of $text; null parses from $text
+ * @return array{lat: float, lon: float, radius_nm: float}|null Unusable or polygon path (null when polygon applies to PiP instead)
+ */
+function parseTfrGeographicRelevanceReference(string $text, ?array $vertices = null): ?array {
+    $parsedRadius = parseTfrRadiusNm($text);
+    if ($vertices === null) {
+        $vertices = parseTfrPolygonVertices($text);
+    }
+    if ($vertices === []) {
+        return null;
+    }
+
+    if ($parsedRadius !== null) {
+        $center = $vertices[0];
+
+        return [
+            'lat' => $center['lat'],
+            'lon' => $center['lon'],
+            'radius_nm' => $parsedRadius,
+        ];
+    }
+
+    if (count($vertices) >= 3) {
+        return null;
+    }
+
+    $center = $vertices[0];
+
+    return [
+        'lat' => $center['lat'],
+        'lon' => $center['lon'],
+        'radius_nm' => TFR_DEFAULT_RADIUS_NM,
+    ];
 }
 
 /**
@@ -314,7 +695,9 @@ function isTfr(array $notam): bool {
  * 1. The NOTAM location field matches an airport identifier
  * 2. The NOTAM airport_name field matches the airport name (word boundary match)
  * 3. The TFR text explicitly mentions the airport's name or identifier
- * 4. The airport is within the TFR's geographic boundary (radius + buffer)
+ * 4. The airport is inside a closed polygon TFR (explicit ring closure or POINT OF
+ *    ORIGIN), or within {@see TFR_RELEVANCE_BUFFER_NM} of its boundary; otherwise circle
+ *    or legacy point-radius distance rules apply
  * 
  * All distance calculations use nautical miles (standard aviation unit).
  * Conservative approach: excludes TFR when coordinates cannot be parsed.
@@ -355,7 +738,7 @@ function isTfrRelevantToAirport(array $tfr, array $airport): bool {
         }
     }
     
-    // Geographic relevance check - parse TFR coordinates and check distance
+    // Geographic relevance: polygon uses PiP + boundary buffer; circle/legacy use great-circle distance
     if (!isset($airport['lat']) || !isset($airport['lon'])) {
         // No airport coordinates - be conservative and exclude
         return false;
@@ -363,27 +746,37 @@ function isTfrRelevantToAirport(array $tfr, array $airport): bool {
     
     $airportLat = (float)$airport['lat'];
     $airportLon = (float)$airport['lon'];
-    
-    // Parse TFR center coordinates from text
-    $tfrCoords = parseTfrCoordinates($text);
-    if ($tfrCoords === null) {
-        // Cannot parse coordinates - be conservative and exclude
+
+    $parsedRadius = parseTfrRadiusNm($text);
+    $polygonMeta = parseTfrPolygonVerticesMeta($text);
+    $vertices = $polygonMeta['vertices'];
+
+    if ($vertices === []) {
         return false;
     }
-    
-    // Parse TFR radius in nautical miles (or use default)
-    $tfrRadiusNm = parseTfrRadiusNm($text) ?? TFR_DEFAULT_RADIUS_NM;
-    
-    // Calculate distance from airport to TFR center
+
+    // Polygon TFR (no NM radius in text): require watertight ring, then point-in-polygon
+    if ($parsedRadius === null && count($vertices) >= 3) {
+        if (!$polygonMeta['ring_closed']) {
+            return false;
+        }
+
+        return isAirportInsideOrNearTfrPolygonRing($vertices, $airportLat, $airportLon);
+    }
+
+    $geoRef = parseTfrGeographicRelevanceReference($text, $vertices);
+    if ($geoRef === null) {
+        return false;
+    }
+
     $distanceNm = calculateDistanceNm(
         $airportLat,
         $airportLon,
-        $tfrCoords['lat'],
-        $tfrCoords['lon']
+        $geoRef['lat'],
+        $geoRef['lon']
     );
-    
-    // TFR is relevant if airport is within (TFR radius + buffer)
-    return $distanceNm <= ($tfrRadiusNm + TFR_RELEVANCE_BUFFER_NM);
+
+    return $distanceNm <= ($geoRef['radius_nm'] + TFR_RELEVANCE_BUFFER_NM);
 }
 
 /**

--- a/tests/Unit/NotamFilterTest.php
+++ b/tests/Unit/NotamFilterTest.php
@@ -190,6 +190,21 @@ class NotamFilterTest extends TestCase {
         
         $this->assertNull($coords);
     }
+
+    public function testParseTfrCoordinates_RejectsSecondsOutOfRange() {
+        $text = 'WITHIN AN AREA DEFINED AS 5NM RADIUS OF 450160N1220000W';
+        $this->assertNull(parseTfrCoordinates($text));
+    }
+
+    public function testParseTfrCoordinates_RejectsLatitudeDegreesOver90() {
+        $text = 'WITHIN AN AREA DEFINED AS 5NM RADIUS OF 910000N1220000W';
+        $this->assertNull(parseTfrCoordinates($text));
+    }
+
+    public function testParseTfrCoordinates_RejectsInvalidHemisphere() {
+        $text = 'WITHIN AN AREA DEFINED AS 5NM RADIUS OF 450000X1220000W';
+        $this->assertNull(parseTfrCoordinates($text));
+    }
     
     public function testParseTfrCoordinates_RealWorldTfr() {
         // Real TFR text from the bug report

--- a/tests/Unit/NotamFilterTest.php
+++ b/tests/Unit/NotamFilterTest.php
@@ -205,6 +205,26 @@ class NotamFilterTest extends TestCase {
         $text = 'WITHIN AN AREA DEFINED AS 5NM RADIUS OF 450000X1220000W';
         $this->assertNull(parseTfrCoordinates($text));
     }
+
+    public function testParseTfrCoordinates_RejectsMinutesOutOfRange() {
+        $text = 'WITHIN AN AREA DEFINED AS 5NM RADIUS OF 456099N1220000W';
+        $this->assertNull(parseTfrCoordinates($text));
+    }
+
+    public function testParseTfrCoordinates_RejectsLongitudeDegreesOver180() {
+        $text = 'WITHIN AN AREA DEFINED AS 5NM RADIUS OF 450000N1810101E';
+        $this->assertNull(parseTfrCoordinates($text));
+    }
+
+    public function testParseTfrCoordinates_RejectsNonZeroMinutesOn180Longitude() {
+        $text = 'WITHIN AN AREA DEFINED AS 5NM RADIUS OF 450000N1800100W';
+        $this->assertNull(parseTfrCoordinates($text));
+    }
+
+    public function testParseTfrCoordinates_RejectsNonZeroSecondsOn90North() {
+        $text = 'WITHIN AN AREA DEFINED AS 5NM RADIUS OF 900001N1220000W';
+        $this->assertNull(parseTfrCoordinates($text));
+    }
     
     public function testParseTfrCoordinates_RealWorldTfr() {
         // Real TFR text from the bug report
@@ -510,6 +530,38 @@ class NotamFilterTest extends TestCase {
             ['lat' => 44.0, 'lon' => -116.0],
             ['lat' => 44.01, 'lon' => -116.0],
         ]));
+    }
+
+    public function testPolygonCentroidLatLonFromVertices_RejectsDegenerateCollinearRing() {
+        $collinear = [
+            ['lat' => 45.0, 'lon' => -122.0],
+            ['lat' => 45.0166667, 'lon' => -122.0],
+            ['lat' => 45.0333333, 'lon' => -122.0],
+        ];
+        $this->assertNull(polygonCentroidLatLonFromVertices($collinear));
+        $this->assertFalse(isAirportInsideOrNearTfrPolygonRing($collinear, 45.016, -122.0));
+    }
+
+    public function testIsTfrRelevantToAirport_DegenerateCollinearPolygonWithPooFailsClosed() {
+        $text = 'TEMPORARY FLIGHT RESTRICTIONS WI AN AREA DEFINED AS 450000N1220000W TO 450100N1220000W TO 450200N1220000W TO POINT OF ORIGIN SFC-5000FT';
+        $tfr = ['text' => $text];
+        $airport = [
+            'name' => 'Off Grid Test',
+            'lat' => 45.0166667,
+            'lon' => -122.0,
+        ];
+        $this->assertFalse(isTfrRelevantToAirport($tfr, $airport));
+    }
+
+    public function testIsTfrRelevantToAirport_ClosedPolygonBeyondBufferFailsClosed() {
+        $text = 'TEMPORARY FLIGHT RESTRICTIONS WI AN AREA DEFINED AS 450000N1220000W TO 450100N1220000W TO 450100N1220100W TO 450000N1220100W TO POINT OF ORIGIN SFC-5000FT';
+        $tfr = ['text' => $text];
+        $airport = [
+            'name' => 'Off Grid Test',
+            'lat' => 44.82,
+            'lon' => -121.991667,
+        ];
+        $this->assertFalse(isTfrRelevantToAirport($tfr, $airport));
     }
 
     public function testIsTfrRelevantToAirport_PolygonNearU88_ElkRidgeExcluded() {

--- a/tests/Unit/NotamFilterTest.php
+++ b/tests/Unit/NotamFilterTest.php
@@ -448,6 +448,140 @@ class NotamFilterTest extends TestCase {
         // Caldwell is ~200 NM from Ogden, should not show this TFR
         $this->assertFalse(isTfrRelevantToAirport($tfr, $airport));
     }
+
+    /**
+     * Polygon TFR (no NM radius in text): point-in-polygon plus ring closure rules
+     * (regression: first vertex + 30 NM default falsely included Elk Ridge for U88-area TFR).
+     */
+    public function testParseTfrPolygonVertices_GardenValleyIncidentPolygon() {
+        $text = $this->gardenValleyPolygonTfrText();
+        $meta = parseTfrPolygonVerticesMeta($text);
+        $this->assertTrue($meta['ring_closed'], 'Explicit repeat-to-origin or POO must mark a closed ring');
+        $vertices = $meta['vertices'];
+        $this->assertGreaterThanOrEqual(5, count($vertices), 'Expect closed polygon without duplicate closing point');
+        $this->assertEqualsWithDelta(44.09166667, $vertices[0]['lat'], 0.0001);
+        $this->assertEqualsWithDelta(-115.85, $vertices[0]['lon'], 0.0001);
+    }
+
+    public function testParseTfrPolygonVerticesMeta_OpenRingWithoutPooIsNotClosed() {
+        $text = 'TEMPORARY FLIGHT RESTRICTIONS WI AN AREA DEFINED AS 450000N1220000W TO 450100N1220000W TO 450100N1220100W';
+        $meta = parseTfrPolygonVerticesMeta($text);
+        $this->assertFalse($meta['ring_closed']);
+        $this->assertCount(3, $meta['vertices']);
+    }
+
+    public function testParseTfrPolygonVerticesMeta_RepeatedFirstVertexClosesRing() {
+        $text = 'TEMPORARY FLIGHT RESTRICTIONS WI AN AREA DEFINED AS 450000N1220000W TO 450100N1220000W TO 450100N1220100W TO 450000N1220100W TO 450000N1220000W';
+        $meta = parseTfrPolygonVerticesMeta($text);
+        $this->assertTrue($meta['ring_closed']);
+        $this->assertCount(4, $meta['vertices']);
+    }
+
+    public function testPolygonCentroidLatLonFromVertices_KnownQuad() {
+        $vertices = [
+            ['lat' => 44.0, 'lon' => -116.0],
+            ['lat' => 44.01, 'lon' => -116.0],
+            ['lat' => 44.01, 'lon' => -116.01],
+            ['lat' => 44.0, 'lon' => -116.01],
+        ];
+        $c = polygonCentroidLatLonFromVertices($vertices);
+        $this->assertNotNull($c);
+        $this->assertEqualsWithDelta(44.005, $c['lat'], 0.002);
+        $this->assertEqualsWithDelta(-116.005, $c['lon'], 0.002);
+    }
+
+    public function testPolygonCentroidLatLonFromVertices_RejectsTooFewPoints() {
+        $this->assertNull(polygonCentroidLatLonFromVertices([
+            ['lat' => 44.0, 'lon' => -116.0],
+            ['lat' => 44.01, 'lon' => -116.0],
+        ]));
+    }
+
+    public function testIsTfrRelevantToAirport_PolygonNearU88_ElkRidgeExcluded() {
+        $tfr = ['text' => $this->gardenValleyPolygonTfrText()];
+        $airport = [
+            'name' => 'Elk Ridge Airport',
+            'lat' => 44.7235833,
+            'lon' => -116.0219861,
+        ];
+        $this->assertFalse(isTfrRelevantToAirport($tfr, $airport));
+    }
+
+    public function testIsTfrRelevantToAirport_PolygonNearU88_GardenValleyIncluded() {
+        $tfr = ['text' => $this->gardenValleyPolygonTfrText()];
+        $airport = [
+            'name' => 'Garden Valley Airport',
+            'faa' => 'U88',
+            'lat' => 44.2311,
+            'lon' => -115.9828,
+        ];
+        $this->assertTrue(isTfrRelevantToAirport($tfr, $airport));
+    }
+
+    public function testIsTfrRelevantToAirport_PolygonNearU88_BoiseExcluded() {
+        $tfr = ['text' => $this->gardenValleyPolygonTfrText()];
+        $airport = [
+            'icao' => 'KBOI',
+            'name' => 'Boise Air Terminal',
+            'lat' => 43.5644,
+            'lon' => -116.2228,
+        ];
+        $this->assertFalse(isTfrRelevantToAirport($tfr, $airport));
+    }
+
+    public function testIsTfrRelevantToAirport_OpenPolygonFailsClosedEvenNearCenter() {
+        $text = 'TEMPORARY FLIGHT RESTRICTIONS WI AN AREA DEFINED AS 450000N1220000W TO 450100N1220000W TO 450100N1220100W';
+        $tfr = ['text' => $text];
+        $airport = [
+            'name' => 'Off Grid Test',
+            'lat' => 45.008333,
+            'lon' => -121.991667,
+        ];
+        $this->assertFalse(isTfrRelevantToAirport($tfr, $airport));
+    }
+
+    public function testIsTfrRelevantToAirport_ClosedPolygonInsideTrue() {
+        $text = 'TEMPORARY FLIGHT RESTRICTIONS WI AN AREA DEFINED AS 450000N1220000W TO 450100N1220000W TO 450100N1220100W TO 450000N1220100W TO POINT OF ORIGIN SFC-5000FT';
+        $tfr = ['text' => $text];
+        $airport = [
+            'name' => 'Off Grid Test',
+            'lat' => 45.008333,
+            'lon' => -121.991667,
+        ];
+        $this->assertTrue(isTfrRelevantToAirport($tfr, $airport));
+    }
+
+    public function testIsTfrRelevantToAirport_ClosedPolygonOutsideFalse() {
+        $text = 'TEMPORARY FLIGHT RESTRICTIONS WI AN AREA DEFINED AS 450000N1220000W TO 450100N1220000W TO 450100N1220100W TO 450000N1220100W TO POINT OF ORIGIN SFC-5000FT';
+        $tfr = ['text' => $text];
+        $airport = [
+            'name' => 'Off Grid Test',
+            'lat' => 46.0,
+            'lon' => -122.0,
+        ];
+        $this->assertFalse(isTfrRelevantToAirport($tfr, $airport));
+    }
+
+    public function testIsTfrRelevantToAirport_ClosedPolygonOutsideButWithinBufferTrue() {
+        $text = 'TEMPORARY FLIGHT RESTRICTIONS WI AN AREA DEFINED AS 450000N1220000W TO 450100N1220000W TO 450100N1220100W TO 450000N1220100W TO POINT OF ORIGIN SFC-5000FT';
+        $tfr = ['text' => $text];
+        $airport = [
+            'name' => 'Off Grid Test',
+            'lat' => 44.99,
+            'lon' => -121.991667,
+        ];
+        $this->assertTrue(isTfrRelevantToAirport($tfr, $airport));
+    }
+
+    /**
+     * @return string NOTAM body with polygon coords (slashes as in FAA XML-derived text)
+     */
+    private function gardenValleyPolygonTfrText(): string {
+        return 'ID..AIRSPACE 3 NM NW OF U88, GARDEN VALLEY AIRPORT, GARDEN VALLEY, ID, ID..TEMPORARY FLIGHT RESTRICTIONS. '
+            . 'PURSUANT TO 14 CFR SECTION 91.137(A)(1) WI AN AREA DEFINED AS 440530N1155100W (BOI007035.6) TO 440230N1155230W '
+            . '(BOI008032.4) TO 440330N1155500W (BOI004032.6) TO 440400N1155600W (BOI003032.8) TO 440530N1155430W (BOI004034.6) '
+            . 'TO 440530N1155100W (BOI007035.6) TO POINT OF ORIGIN SFC-7500FT.';
+    }
     
     public function testIsTfrRelevantToAirport_LargeTfrRadius() {
         // Large TFR (30 NM radius) - tests that we use parsed radius, not default


### PR DESCRIPTION
## Summary
Polygon-style temporary flight restrictions (no parsed NM radius in text) are now evaluated with a **closed-ring** requirement and **point-in-polygon** in a local NM plane, plus **`TFR_RELEVANCE_BUFFER_NM`** (10 NM) as distance to the polygon boundary when the airport is outside the ring. Circle TFRs still use great-circle distance to the stated center with parsed radius plus the same buffer.

This fixes false positives such as an Idaho incident TFR defined near Garden Valley (U88) appearing for Elk Ridge when geometry was effectively modeled from the first polygon vertex and a large default radius.

## Technical notes
- **`parseTfrPolygonVerticesMeta()`**: `ring_closed` when first/last vertex match after dedupe, or when **POINT OF ORIGIN** appears with at least three vertices; otherwise polygon geography is skipped (fail closed).
- **Degenerate rings**: absolute signed double-area in NM² below `TFR_POLYGON_MIN_ABS_DOUBLE_AREA_NM2` excludes the polygon path.
- **`parseTfrGeographicRelevanceReference(, ?$vertices)`**: optional pre-parsed vertices to avoid a second coordinate scan on the circle/legacy path.
- **`polygonCentroidLatLonFromVertices()`**: same minimum-area threshold as PiP for consistency (tests / helpers).

## Tests
- `tests/Unit/NotamFilterTest.php`: U88-style polygon, Elk Ridge / Boise excluded, Garden Valley (identifier match) unchanged, open ring fail-closed, POO and repeated-first closure, inside/outside/buffer cases.

## Breaking changes
None intended. Airports that previously matched only on incorrect centroid/default-radius geometry for polygon TFRs may **stop** showing those NOTAMs (desired).

## Checklist
- [x] `make test-ci` run successfully on the changes before this PR (unit suite for NOTAM filter verified after final edits).