### PR TITLE
Remove AOPA from airport dashboards and public API

### DIFF
--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -851,7 +851,7 @@
               },
               "external_links": {
                 "type": "array",
-                "description": "Resolved external links (AirNav, AOPA, etc.)",
+                "description": "Resolved external links (AirNav, FAA Weather, regional cameras, ForeFlight, etc.)",
                 "items": {
                   "type": "object",
                   "properties": {

--- a/api/v1/airport.php
+++ b/api/v1/airport.php
@@ -174,7 +174,7 @@ function formatAirportDetails(string $airportId, array $airport): array
         $formatted['links'] = [];
     }
 
-    // Resolved external links (same logic as dashboard - AirNav, AOPA, etc.)
+    // Resolved external links (same logic as dashboard - AirNav, FAA Weather, etc.)
     $formatted['external_links'] = buildResolvedExternalLinks($airport);
     
     // Add availability flags
@@ -186,10 +186,14 @@ function formatAirportDetails(string $airportId, array $airport): array
 }
 
 /**
- * Build resolved external link URLs for dashboard parity
- * 
- * Uses config helpers - no I/O. Returns array of {label, url} for display.
- * 
+ * Build resolved external link URLs for dashboard parity.
+ *
+ * Matches the dashboard links section: AirNav, FAA Weather (US or override),
+ * regional weather when applicable, ForeFlight. Per-airport custom links are
+ * returned separately in the v1 airport detail payload under `links`.
+ *
+ * Uses config helpers only (no network I/O).
+ *
  * @param array $airport Airport configuration
  * @return array<array{label: string, url: string}>
  */
@@ -205,14 +209,6 @@ function buildResolvedExternalLinks(array $airport): array
         : ($linkIdentifier ? 'https://www.airnav.com/airport/' . $linkIdentifier : null);
     if ($airnavUrl !== null) {
         $links[] = ['label' => 'AirNav', 'url' => $airnavUrl];
-    }
-
-    // AOPA (US or manual override)
-    $aopaUrl = !empty($airport['aopa_url'])
-        ? $airport['aopa_url']
-        : (($aviationRegion === 'US' && $linkIdentifier) ? 'https://www.aopa.org/destinations/airports/' . $linkIdentifier : null);
-    if ($aopaUrl !== null) {
-        $links[] = ['label' => 'AOPA', 'url' => $aopaUrl];
     }
 
     // FAA Weather (US or manual override)

--- a/config/airports.json.example
+++ b/config/airports.json.example
@@ -427,7 +427,6 @@
       "webcams": [],
       "partners": [],
       "airnav_url": "https://www.airnav.com/airport/CUSTOM",
-      "aopa_url": "https://www.aopa.org/destinations/airports/CUSTOM",
       "faa_weather_url": "https://weathercams.faa.gov/map/-124.0,44.0,-120.0,46.0/airport/CUSTOM/",
       "foreflight_url": "foreflightmobile://maps/search?q=CUSTOM",
       "links": [

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -114,13 +114,12 @@ All configuration lives in a single `airports.json` file with two sections:
 | `links` | `[]` | Custom external links |
 | **Link Overrides** |||
 | `airnav_url` | auto | Override AirNav link |
-| `aopa_url` | auto | Override AOPA link (US airports only by default) |
 | `faa_weather_url` | auto | Override FAA Weather link (US airports only by default) |
 | `regional_weather_url` | — | Override or add regional weather camera link (Canada, Australia, or custom) |
 | `regional_weather_label` | — | Label for regional weather link (e.g., "NAV Canada WxCam") |
 | `foreflight_url` | auto | Override ForeFlight link |
 
-**Regional link behavior:** FAA Weather and AOPA are shown only for US airports. For Canadian airports, "NAV Canada Weather" (plan.navcanada.ca/wxrecall) is shown by default. For Australian airports, "Airservices Weather Cams" is shown. Region is inferred from ICAO first; for airports without ICAO (e.g. 7S5 with FAA LID only), region falls back to FAA LID (US), coordinates (lat/lon), or address (US state / Canadian province abbreviations). Use `regional_weather_url` to override with a specific camera site (e.g., a NAV Canada metcam site with known ID) or to add a regional link for other areas. Use `links` for additional custom links.
+**Regional link behavior:** FAA Weather is shown only for US airports. For Canadian airports, "NAV Canada Weather" (plan.navcanada.ca/wxrecall) is shown by default. For Australian airports, "Airservices Weather Cams" is shown. Region is inferred from ICAO first; for airports without ICAO (e.g. 7S5 with FAA LID only), region falls back to FAA LID (US), coordinates (lat/lon), or address (US state / Canadian province abbreviations). Use `regional_weather_url` to override with a specific camera site (e.g., a NAV Canada metcam site with known ID) or to add a regional link for other areas. Use `links` for additional custom links.
 
 ### Radio frequencies
 
@@ -1322,7 +1321,7 @@ Logos are cached locally for 30 days. Text fallback if logo fails.
 
 ### Custom Links
 
-Appear after standard links (AirNav, AOPA, etc.):
+Appear after standard links (AirNav, FAA Weather, etc.):
 
 ```json
 "links": [

--- a/guides/13-using-the-airport-dashboard.md
+++ b/guides/13-using-the-airport-dashboard.md
@@ -9,7 +9,7 @@ This guide helps you get the most out of an AviationWX airport dashboard. Think 
 
 AviationWX dashboards focus on **essential, at-a-glance information** - the stuff you actually need when checking conditions before a flight. We keep it simple and fast.
 
-For deeper research, every dashboard includes links to trusted external resources like **AirNav**, **AOPA**, and **FAA Weather Cams**. We're not trying to replace these great tools - we're giving you a quick visual check and then connecting you to the experts when you need more.
+For deeper research, every dashboard includes links to trusted external resources like **AirNav** and **FAA Weather Cams** (plus regional camera links where they apply). We're not trying to replace these great tools - we're giving you a quick visual check and then connecting you to the experts when you need more.
 
 > ⚠️ **Important**: AviationWX is a **supplemental** information source. Always obtain official weather briefings and NOTAMs before flight.
 
@@ -364,12 +364,11 @@ Each airport dashboard includes quick links to external resources:
 ```
 +-----------------------------------------------------------------------------+
 |                                                                             |
-|       [ AirNav ]      [ AOPA ]      [ FAA Weather ]      |
-|                                                                             |
-|           |                |                |             |
-|           v                v                v             |
-|      Airport info      Pilot info      FAA weather          |
-|      & frequencies     & planning      & directory     cams (if avail)      |
+|         [ AirNav ]                    [ FAA Weather ]                       |
+|              |                              |                             |
+|              v                              v                             |
+|       Airport info                   FAA weather cams                     |
+|       & frequencies                  (when available)                     |
 |                                                                             |
 +-----------------------------------------------------------------------------+
 ```

--- a/lib/config.php
+++ b/lib/config.php
@@ -4010,9 +4010,6 @@ function validateAirportsJsonStructure(array $config): array {
         if (isset($airport['airnav_url']) && !$validateUrl($airport['airnav_url'])) {
             $errors[] = "Airport '{$airportCode}' has invalid airnav_url: must be a valid URL";
         }
-        if (isset($airport['aopa_url']) && !$validateUrl($airport['aopa_url'])) {
-            $errors[] = "Airport '{$airportCode}' has invalid aopa_url: must be a valid URL";
-        }
         if (isset($airport['faa_weather_url']) && !$validateUrl($airport['faa_weather_url'])) {
             $errors[] = "Airport '{$airportCode}' has invalid faa_weather_url: must be a valid URL";
         }

--- a/lib/seo.php
+++ b/lib/seo.php
@@ -128,8 +128,8 @@ function generateWebSiteSchema() {
  *
  * Creates Schema.org Airport structured data for airport pages.
  * Uses the specific Airport type (better than generic LocalBusiness) with
- * aviation-specific properties like icaoCode, iataCode, and sameAs links
- * to authoritative aviation databases.
+ * aviation-specific properties like icaoCode, iataCode, and a sameAs URL
+ * for the airport on AirNav (primary identifier).
  *
  * PostalAddress is omitted when the configured address is GPS-style text
  * (addressLooksLikeGpsCoordinates); location is expressed with GeoCoordinates only.
@@ -177,14 +177,9 @@ function generateAirportSchema($airport, $airportId) {
         $schema['iataCode'] = $airport['iata'];
     }
     
-    // Build sameAs links to authoritative aviation databases
+    // sameAs: AirNav (works with ICAO, FAA LID, or other primary identifier)
     $sameAs = [];
-    // AirNav works with any identifier (ICAO, FAA LID, etc.)
     $sameAs[] = 'https://www.airnav.com/airport/' . $primaryIdentifier;
-    // AOPA works best with ICAO codes
-    if (!empty($airport['icao'])) {
-        $sameAs[] = 'https://www.aopa.org/destinations/airports/' . $airport['icao'];
-    }
     $schema['sameAs'] = $sameAs;
     
     $addr = isset($airport['address']) ? trim((string) $airport['address']) : '';

--- a/pages/airport.php
+++ b/pages/airport.php
@@ -1877,20 +1877,6 @@ if ($themeCookie === 'dark') {
                 <?php endif; ?>
                 
                 <?php
-                // AOPA link (US-focused; manual override or auto-generated for US airports only)
-                $aopaUrl = null;
-                if (!empty($airport['aopa_url'])) {
-                    $aopaUrl = $airport['aopa_url'];
-                } elseif ($aviationRegion === 'US' && $linkIdentifier !== null) {
-                    $aopaUrl = 'https://www.aopa.org/destinations/airports/' . $linkIdentifier;
-                }
-                if ($aopaUrl !== null): ?>
-                <a href="<?= htmlspecialchars($aopaUrl) ?>" target="_blank" rel="noopener" class="btn" title="View AOPA airport directory page (opens in new tab)">
-                    AOPA
-                </a>
-                <?php endif; ?>
-                
-                <?php
                 // FAA Weather link (US-focused; manual override or auto-generated for US airports only)
                 $faaWeatherUrl = null;
                 if (!empty($airport['faa_weather_url'])) {

--- a/pages/config-generator.php
+++ b/pages/config-generator.php
@@ -708,9 +708,6 @@ function generateConfigSnippet($formData) {
     if (!empty($formData['airnav_url'] ?? '')) {
         $airport['airnav_url'] = trim($formData['airnav_url']);
     }
-    if (!empty($formData['aopa_url'] ?? '')) {
-        $airport['aopa_url'] = trim($formData['aopa_url']);
-    }
     if (!empty($formData['faa_weather_url'] ?? '')) {
         $airport['faa_weather_url'] = trim($formData['faa_weather_url']);
     }
@@ -1594,13 +1591,6 @@ $pageDescription = 'Generate airports.json configuration snippets for adding new
                         <input type="url" id="airnav_url" name="airnav_url"
                                value="<?= htmlspecialchars($_POST['airnav_url'] ?? '') ?>"
                                placeholder="https://www.airnav.com/airport/KSPB">
-                    </div>
-                    
-                    <div class="form-group">
-                        <label for="aopa_url">AOPA URL</label>
-                        <input type="url" id="aopa_url" name="aopa_url"
-                               value="<?= htmlspecialchars($_POST['aopa_url'] ?? '') ?>"
-                               placeholder="https://www.aopa.org/destinations/airports/KSPB">
                     </div>
                     
                     <div class="form-group">

--- a/tests/Integration/ExternalLinksTest.php
+++ b/tests/Integration/ExternalLinksTest.php
@@ -2,7 +2,7 @@
 /**
  * External Links Validation Tests
  * 
- * Tests that external links (AirNav, AOPA, FAA Weather, ForeFlight) are:
+ * Tests that external links (AirNav, FAA Weather, ForeFlight) are:
  * - Generating correct URL formats
  * - Supporting manual overrides
  * - Reachable (returning valid HTTP status codes)
@@ -76,35 +76,6 @@ class ExternalLinksTest extends TestCase
             $this->assertTrue(
                 $result['valid'],
                 "AirNav URL for {$identifier} should be valid: {$result['message']}"
-            );
-        }
-    }
-    
-    /**
-     * Test AOPA URLs are valid and reachable (US airports only, or manual override)
-     */
-    public function testAOPALinks_AreValid()
-    {
-        foreach ($this->testAirports as $airportId => $airport) {
-            $region = getAviationRegionFromAirport($airport);
-            if (empty($airport['aopa_url']) && $region !== 'US') {
-                continue; // AOPA only shown for US airports
-            }
-            if (!empty($airport['aopa_url'])) {
-                $url = $airport['aopa_url'];
-            } else {
-                $linkIdentifier = getBestIdentifierForLinks($airport);
-                if ($linkIdentifier === null) {
-                    $this->markTestIncomplete("No identifier available for AOPA URL: $airportId");
-                    continue;
-                }
-                $url = 'https://www.aopa.org/destinations/airports/' . $linkIdentifier;
-            }
-            $result = $this->validateUrl($url, 'aopa.org');
-            $identifier = $airport['icao'] ?? $airport['iata'] ?? $airport['faa'] ?? $airportId;
-            $this->assertTrue(
-                $result['valid'],
-                "AOPA URL for {$identifier} should be valid: {$result['message']}"
             );
         }
     }
@@ -275,18 +246,6 @@ class ExternalLinksTest extends TestCase
         foreach ($this->testAirports as $airportId => $airport) {
             $linkIdentifier = getBestIdentifierForLinks($airport);
             $region = getAviationRegionFromAirport($airport);
-            
-            // Test AOPA format (US only, or override)
-            if ($linkIdentifier !== null && ($region === 'US' || !empty($airport['aopa_url']))) {
-                $aopaUrl = !empty($airport['aopa_url']) 
-                    ? $airport['aopa_url'] 
-                    : "https://www.aopa.org/destinations/airports/$linkIdentifier";
-                $this->assertMatchesRegularExpression(
-                    '/^https:\/\/www\.aopa\.org\/destinations\/airports\/[A-Z0-9]+$/',
-                    $aopaUrl,
-                    "AOPA URL format should match expected pattern for {$linkIdentifier}"
-                );
-            }
             
             // Test FAA Weather format (US only, or override)
             if ($linkIdentifier !== null && !empty($airport['lat']) && !empty($airport['lon'])

--- a/tests/Integration/HtmlOutputValidationTest.php
+++ b/tests/Integration/HtmlOutputValidationTest.php
@@ -310,7 +310,7 @@ class HtmlOutputValidationTest extends TestCase
         
         // First, check if any custom links are rendered in the HTML
         // Look for links with target="_blank" and rel="noopener" that have class="btn"
-        // These are the custom links (other links like AirNav, AOPA also have these attributes)
+        // These are the custom links (other standard links like AirNav also have these attributes)
         $customLinkPattern = '/<a[^>]*target=["\']_blank["\'][^>]*rel=["\']noopener["\'][^>]*class=["\'][^"\']*btn[^"\']*["\'][^>]*>/i';
         $hasCustomLinks = preg_match_all($customLinkPattern, $html, $customLinkMatches);
         

--- a/tests/Unit/PublicApiAirportTest.php
+++ b/tests/Unit/PublicApiAirportTest.php
@@ -140,7 +140,6 @@ class PublicApiAirportTest extends TestCase
 
         $labels = array_column($formatted['external_links'], 'label');
         $this->assertContains('AirNav', $labels);
-        $this->assertContains('AOPA', $labels);
         $this->assertContains('FAA Weather', $labels);
         $this->assertContains('ForeFlight', $labels);
 


### PR DESCRIPTION
## Summary
Removes the AOPA resource link from airport dashboard link rows and stops exposing AOPA in the v1 airport API (`external_links`) and in JSON-LD `sameAs`. Drops the `aopa_url` config field from validation, the config generator, the example config, and CONFIGURATION.md. Data was showing it had a very low clickthrough rate, so removing it. 

## User impact
- US airport dashboards no longer show an AOPA button.
- API `external_links` no longer includes `{ label: AOPA, url: ... }` for US airports.
- Structured data `sameAs` now only references AirNav for the primary identifier.

## Breaking change
Clients that relied on an AOPA entry in `external_links` must stop expecting it. Custom per-airport links are unchanged and still returned under `links`.

## Testing
- `make test-ci` (or targeted PHPUnit) recommended; unit tests for API and external links were updated.