### PR TITLE
Public API: rename airport detail links to custom_links

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ AviationWX provides a free public API for developers to integrate aviation weath
 
 - **Documentation:** [api.aviationwx.org](https://api.aviationwx.org)
 - **OpenAPI Spec:** [api.aviationwx.org/openapi.json](https://api.aviationwx.org/openapi.json)
-- **Canonical base URL (v1):** `https://api.aviationwx.org/v1` -- default for Public API v1 against the public service. Legacy `/api/v1/` paths on AviationWX hostnames redirect here (HTTP 301). Self-hosted: set `config.public_api.canonical_base_url` in `airports.json` when your origin differs.
+- **Canonical base URL (v1):** `https://api.aviationwx.org/v1` -- default for Public API v1. Self-hosted: set `config.public_api.canonical_base_url` in `airports.json` when your origin differs.
 
 ### Quick Start
 

--- a/api/docs/index.php
+++ b/api/docs/index.php
@@ -454,7 +454,7 @@ $attribution = getPublicApiAttributionText();
             <h3>Canonical base URL (v1)</h3>
             <p>Use this HTTP(S) base URL and <code>/v1</code> prefix for Public API v1 requests to this deployment.</p>
             <p class="canonical-url"><code><?= htmlspecialchars($canonicalV1, ENT_QUOTES, 'UTF-8') ?></code></p>
-            <p class="canonical-note">Example: <code><?= htmlspecialchars($canonicalV1, ENT_QUOTES, 'UTF-8') ?>/airports/kspb/weather</code>. Legacy <code>/api/v1/</code> paths on <code>aviationwx.org</code>, <code>*.aviationwx.org</code>, <code>embed.aviationwx.org</code>, or <code>api.aviationwx.org</code> redirect here (HTTP 301). Override with <code>config.public_api.canonical_base_url</code> in <code>airports.json</code> when your public origin differs.</p>
+            <p class="canonical-note">Example: <code><?= htmlspecialchars($canonicalV1, ENT_QUOTES, 'UTF-8') ?>/airports/kspb/weather</code>. Override the documented base with <code>config.public_api.canonical_base_url</code> in <code>airports.json</code> when your deployment’s public origin differs.</p>
         </div>
         
         <div class="quick-start">

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "AviationWX.org Public API",
-    "description": "Real-time aviation weather data, webcam images, and airport information. Free access with rate limiting. Partner API keys available for higher limits.\n\nPublic deployment server URL: https://api.aviationwx.org/v1. Paths in this spec are relative to that base. Legacy /api/v1/ URLs on aviationwx.org, *.aviationwx.org, embed.aviationwx.org, and api.aviationwx.org receive HTTP 301 to this host. Optional config.public_api.canonical_base_url overrides the documented base for self-hosted installs.",
+    "description": "Real-time aviation weather data, webcam images, and airport information. Free access with rate limiting. Partner API keys available for higher limits.\n\nPublic deployment server URL: https://api.aviationwx.org/v1. Paths in this spec are relative to that base. Requests to /api/v1/ on aviationwx.org, *.aviationwx.org, embed.aviationwx.org, and api.aviationwx.org receive HTTP 301 to this host. Optional config.public_api.canonical_base_url overrides the documented base for self-hosted installs.",
     "version": "1.0.0",
     "contact": {
       "name": "AviationWX.org",
@@ -72,7 +72,7 @@
     "/airports/{id}": {
       "get": {
         "summary": "Get airport details",
-        "description": "Returns detailed metadata for a single airport including runways, frequencies, and services.",
+        "description": "Returns detailed metadata for a single airport including runways, frequencies, services, custom_links, external_links, and related fields.",
         "operationId": "getAirport",
         "tags": ["Airports"],
         "parameters": [
@@ -840,7 +840,7 @@
               },
               "custom_links": {
                 "type": "array",
-                "description": "Operator-defined links from airport config (the `links` array in airports.json). Distinct from `external_links`, which are built-in resolved URLs.",
+                "description": "Operator-defined links from airport config (the `links` array in airports.json). Built-in resolved URLs are listed in `external_links`.",
                 "items": {
                   "type": "object",
                   "properties": {

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -838,9 +838,9 @@
                   }
                 }
               },
-              "links": {
+              "custom_links": {
                 "type": "array",
-                "description": "Custom links from airport config",
+                "description": "Operator-defined links from airport config (the `links` array in airports.json). Distinct from `external_links`, which are built-in resolved URLs.",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -851,7 +851,7 @@
               },
               "external_links": {
                 "type": "array",
-                "description": "Resolved external links (AirNav, FAA Weather, regional cameras, ForeFlight, etc.)",
+                "description": "Built-in resolved links (AirNav, FAA Weather, regional cameras, ForeFlight, etc.)",
                 "items": {
                   "type": "object",
                   "properties": {

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "AviationWX.org Public API",
-    "description": "Real-time aviation weather data, webcam images, and airport information. Free access with rate limiting. Partner API keys available for higher limits.\n\nPublic deployment server URL: https://api.aviationwx.org/v1. Paths in this spec are relative to that base. Requests to /api/v1/ on aviationwx.org, *.aviationwx.org, embed.aviationwx.org, and api.aviationwx.org receive HTTP 301 to this host. Optional config.public_api.canonical_base_url overrides the documented base for self-hosted installs.",
+    "description": "Real-time aviation weather data, webcam images, and airport information. Free access with rate limiting. Partner API keys available for higher limits.\n\nPublic deployment server URL: https://api.aviationwx.org/v1. Paths in this spec are relative to that base. Optional config.public_api.canonical_base_url overrides the documented base for self-hosted installs.",
     "version": "1.0.0",
     "contact": {
       "name": "AviationWX.org",

--- a/api/v1/airport.php
+++ b/api/v1/airport.php
@@ -159,9 +159,9 @@ function formatAirportDetails(string $airportId, array $airport): array
         $formatted['partners'] = [];
     }
 
-    // Custom links from config
+    // Custom links from config (`links` in airports.json; `custom_links` in API for clarity)
     if (isset($airport['links']) && is_array($airport['links'])) {
-        $formatted['links'] = array_values(array_filter(array_map(function ($link) {
+        $formatted['custom_links'] = array_values(array_filter(array_map(function ($link) {
             if (!is_array($link) || empty($link['label']) || empty($link['url'])) {
                 return null;
             }
@@ -171,7 +171,7 @@ function formatAirportDetails(string $airportId, array $airport): array
             ];
         }, $airport['links'])));
     } else {
-        $formatted['links'] = [];
+        $formatted['custom_links'] = [];
     }
 
     // Resolved external links (same logic as dashboard - AirNav, FAA Weather, etc.)
@@ -190,7 +190,7 @@ function formatAirportDetails(string $airportId, array $airport): array
  *
  * Matches the dashboard links section: AirNav, FAA Weather (US or override),
  * regional weather when applicable, ForeFlight. Per-airport custom links are
- * returned separately in the v1 airport detail payload under `links`.
+ * returned separately in the v1 airport detail payload under `custom_links`.
  *
  * Uses config helpers only (no network I/O).
  *

--- a/api/v1/airport.php
+++ b/api/v1/airport.php
@@ -5,7 +5,7 @@
  * GET /v1/airports/{id}
  * 
  * Returns detailed metadata for a single airport including
- * runways, frequencies, services, access info, and external links.
+ * runways, frequencies, services, access info, custom_links, external_links, and related fields.
  */
 
 require_once __DIR__ . '/../../lib/public-api/middleware.php';
@@ -66,7 +66,8 @@ function handleGetAirport(array $params, array $context): void
  * 
  * @param string $airportId Airport ID
  * @param array $airport Airport configuration
- * @return array Formatted airport details
+ * @return array<string, mixed> Formatted airport detail payload. Operator-defined URLs from
+ *         config `links` appear as `custom_links`; built-in resolved URLs as `external_links`.
  */
 function formatAirportDetails(string $airportId, array $airport): array
 {
@@ -159,7 +160,7 @@ function formatAirportDetails(string $airportId, array $airport): array
         $formatted['partners'] = [];
     }
 
-    // Custom links from config (`links` in airports.json; `custom_links` in API for clarity)
+    // Config key is links[]; API uses custom_links[] to distinguish from external_links[].
     if (isset($airport['links']) && is_array($airport['links'])) {
         $formatted['custom_links'] = array_values(array_filter(array_map(function ($link) {
             if (!is_array($link) || empty($link['label']) || empty($link['url'])) {
@@ -174,7 +175,7 @@ function formatAirportDetails(string $airportId, array $airport): array
         $formatted['custom_links'] = [];
     }
 
-    // Resolved external links (same logic as dashboard - AirNav, FAA Weather, etc.)
+    // Built-in link targets only (operator links are custom_links above).
     $formatted['external_links'] = buildResolvedExternalLinks($airport);
     
     // Add availability flags
@@ -186,11 +187,11 @@ function formatAirportDetails(string $airportId, array $airport): array
 }
 
 /**
- * Build resolved external link URLs for dashboard parity.
+ * Build resolved URLs for standard dashboard resources (not operator custom links).
  *
- * Matches the dashboard links section: AirNav, FAA Weather (US or override),
- * regional weather when applicable, ForeFlight. Per-airport custom links are
- * returned separately in the v1 airport detail payload under `custom_links`.
+ * Order matches the built-in link row on the airport dashboard (AirNav, FAA Weather,
+ * regional when applicable, ForeFlight). Config `links` are exposed separately as
+ * `custom_links` in formatAirportDetails().
  *
  * Uses config helpers only (no network I/O).
  *

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -79,9 +79,9 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Public API v1: HTTP 301 from legacy /api/v1 paths to https://api.aviationwx.org/v1/...
+    # Public API v1: redirect /api/v1/... to the canonical API base (docker default matches PHP default).
     # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... .
-    # Redirect host matches DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL; CD may inject from deployment airports.json. Nginx does not read JSON at request time.
+    # CD may inject redirect targets from deployment airports.json. Nginx does not read JSON at request time.
     location = /api/v1 {
         return 301 https://api.aviationwx.org/v1$is_args$args;
     }
@@ -178,9 +178,9 @@ server {
     access_log /dev/stdout json_access;
     error_log /dev/stderr warn;
 
-    # Public API v1: HTTP 301 from legacy /api/v1 paths to https://api.aviationwx.org/v1/...
+    # Public API v1: redirect /api/v1/... to the canonical API base (docker default matches PHP default).
     # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... .
-    # Redirect host matches DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL; CD may inject from deployment airports.json. Nginx does not read JSON at request time.
+    # CD may inject redirect targets from deployment airports.json. Nginx does not read JSON at request time.
     location = /api/v1 {
         return 301 https://api.aviationwx.org/v1$is_args$args;
     }
@@ -321,9 +321,9 @@ server {
         proxy_read_timeout 60s;
     }
     
-    # Public API v1: HTTP 301 from legacy /api/v1 paths to https://api.aviationwx.org/v1/...
+    # Public API v1: redirect /api/v1/... to the canonical API base (docker default matches PHP default).
     # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... .
-    # Redirect host matches DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL; CD may inject from deployment airports.json. Nginx does not read JSON at request time.
+    # CD may inject redirect targets from deployment airports.json. Nginx does not read JSON at request time.
     location = /api/v1 {
         return 301 https://api.aviationwx.org/v1$is_args$args;
     }

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,7 +12,7 @@ This document describes the **Internal API** endpoints used by the AviationWX.or
 > Visit **[api.aviationwx.org](https://api.aviationwx.org)** for documentation.
 >
 > **Canonical Public API base URL (public deployment):** `https://api.aviationwx.org/v1`  
-> Requests to `/api/v1/...` on `aviationwx.org`, `*.aviationwx.org`, `embed.aviationwx.org`, or `api.aviationwx.org` receive **HTTP 301** to the matching path under that base. Integrations should call `https://api.aviationwx.org/v1/...` directly. Self-hosted deployments may set `config.public_api.canonical_base_url` so documentation matches their public origin.
+> Integrations should call that base directly. Self-hosted deployments may set `config.public_api.canonical_base_url` so documentation matches their public origin.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1533,7 +1533,7 @@ When `config.public_api.enabled` is true, the Public API and weather history fea
 |--------|---------|-------------|
 | `canonical_base_url` | `https://api.aviationwx.org/v1` | Optional. Absolute `http://` or `https://` base URL for Public API v1 with no trailing slash. Used by `getCanonicalPublicApiV1BaseUrl()` and the API docs page. Omit to use this default. Set when your deployment’s public API origin differs (self-hosted). |
 
-**Nginx:** Legacy `/api/v1/` redirects must target the same host and path prefix as this value. The committed `docker/nginx.conf` uses the public default; production CD may render or push the vhost from deployment `airports.json` so nginx stays aligned with PHP (nginx does not read JSON at request time).
+**Nginx:** `/api/v1/` redirect rules (if present) must target the same host and path prefix as this value. The committed `docker/nginx.conf` uses the public default; production CD may render or push the vhost from deployment `airports.json` so nginx stays aligned with PHP (nginx does not read JSON at request time).
 
 ### Rate limits
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1321,7 +1321,7 @@ Logos are cached locally for 30 days. Text fallback if logo fails.
 
 ### Custom Links
 
-Appear after standard links (AirNav, FAA Weather, etc.):
+Appear in the dashboard link row after built-in links (AirNav, FAA Weather, regional, ForeFlight when shown). In the Public API, the same entries are returned under `custom_links` on `GET /v1/airports/{id}` (config file key remains `links`).
 
 ```json
 "links": [

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -111,7 +111,7 @@ All configuration lives in a single `airports.json` file with two sections:
 | `frequencies` | `{}` | Radio frequencies (see [Radio frequencies](#radio-frequencies)) |
 | `services` | `{}` | Available services |
 | `partners` | `[]` | Partner organizations |
-| `links` | `[]` | Custom external links |
+| `links` | `[]` | Custom external links (Public API `GET /v1/airports/{id}` returns these as `custom_links`; built-in links are `external_links`). |
 | **Link Overrides** |||
 | `airnav_url` | auto | Override AirNav link |
 | `faa_weather_url` | auto | Override FAA Weather link (US airports only by default) |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -382,7 +382,7 @@ curl https://aviationwx.org/health.php
 curl https://aviationwx.org/diagnostics.php
 ```
 
-**Public API v1 (nginx):** Committed `docker/nginx.conf` defines HTTP 301 redirects from legacy `/api/v1/` paths to the canonical API host. Production should keep redirect targets aligned with `config.public_api.canonical_base_url` when set; deployment may generate or install nginx configuration from deployment `airports.json` (nginx does not read JSON at request time).
+**Public API v1 (nginx):** Committed `docker/nginx.conf` includes `/api/v1/` redirect rules toward the default canonical API base. Production should keep redirect targets aligned with `config.public_api.canonical_base_url` when set; deployment may generate or install nginx configuration from deployment `airports.json` (nginx does not read JSON at request time).
 
 ### 5. Scheduler Daemon (Automatic)
 

--- a/lib/public-api/config.php
+++ b/lib/public-api/config.php
@@ -54,8 +54,6 @@ function getPublicApiVersion(): string
  * Optional `config.public_api.canonical_base_url` in `airports.json` overrides the default. Values must be absolute
  * `http://` or `https://` URLs; validation is in `validatePublicApiConfig()`. Otherwise returns DEFAULT_CANONICAL_PUBLIC_API_V1_BASE_URL.
  *
- * Production serves HTTP 301 for legacy `/api/v1/` paths on `aviationwx.org`, `*.aviationwx.org`,
- * `embed.aviationwx.org`, and `api.aviationwx.org` toward the canonical API host (`https://api.aviationwx.org/v1/...` by default).
  * The running vhost should stay aligned with `canonical_base_url` when set. Deployment may generate or install nginx
  * configuration from the same `airports.json` as the application. Committed `docker/nginx.conf` is the local Docker default; see `docs/LOCAL_SETUP.md`.
  *

--- a/tests/Integration/PublicApiIntegrationTest.php
+++ b/tests/Integration/PublicApiIntegrationTest.php
@@ -216,6 +216,30 @@ class PublicApiIntegrationTest extends TestCase
             );
         }
     }
+
+    /**
+     * GET /v1/airports/{id} uses custom_links (config links) and external_links (built-ins); not `links`.
+     */
+    public function testGetAirport_CustomLinksAndExternalLinksKeys(): void
+    {
+        $this->skipIfApiDisabled();
+
+        $response = $this->apiRequest('/airports/kspb');
+
+        if ($response['code'] !== 200) {
+            $this->markTestSkipped('Airport kspb not available (got ' . $response['code'] . ')');
+            return;
+        }
+
+        $airport = $response['json']['airport'] ?? null;
+        $this->assertNotNull($airport, 'Response should include airport');
+
+        $this->assertArrayHasKey('custom_links', $airport);
+        $this->assertArrayHasKey('external_links', $airport);
+        $this->assertIsArray($airport['custom_links']);
+        $this->assertIsArray($airport['external_links']);
+        $this->assertArrayNotHasKey('links', $airport, 'Legacy `links` key removed; use custom_links');
+    }
     
     /**
      * Unknown endpoint should return 404

--- a/tests/Integration/PublicApiIntegrationTest.php
+++ b/tests/Integration/PublicApiIntegrationTest.php
@@ -218,7 +218,7 @@ class PublicApiIntegrationTest extends TestCase
     }
 
     /**
-     * GET /v1/airports/{id} uses custom_links (config links) and external_links (built-ins); not `links`.
+     * GET /v1/airports/{id} exposes custom_links and external_links; legacy top-level links key is absent.
      */
     public function testGetAirport_CustomLinksAndExternalLinksKeys(): void
     {
@@ -238,7 +238,7 @@ class PublicApiIntegrationTest extends TestCase
         $this->assertArrayHasKey('external_links', $airport);
         $this->assertIsArray($airport['custom_links']);
         $this->assertIsArray($airport['external_links']);
-        $this->assertArrayNotHasKey('links', $airport, 'Legacy `links` key removed; use custom_links');
+        $this->assertArrayNotHasKey('links', $airport, 'Response must not use legacy links key; use custom_links');
     }
     
     /**

--- a/tests/Unit/PublicApiAirportTest.php
+++ b/tests/Unit/PublicApiAirportTest.php
@@ -4,7 +4,7 @@
  *
  * Tests formatAirportDetails and buildResolvedExternalLinks to ensure
  * API response matches dashboard data (access_type, tower_status,
- * partners, links, external_links).
+ * partners, custom_links, external_links).
  */
 
 use PHPUnit\Framework\TestCase;
@@ -108,11 +108,11 @@ class PublicApiAirportTest extends TestCase
         $airport = $this->getTestAirport('kspb');
         $formatted = formatAirportDetails('kspb', $airport);
 
-        $this->assertArrayHasKey('links', $formatted);
-        $this->assertIsArray($formatted['links']);
-        $this->assertCount(2, $formatted['links']);
-        $this->assertSame('Airport Website', $formatted['links'][0]['label']);
-        $this->assertSame('https://example.com/airport', $formatted['links'][0]['url']);
+        $this->assertArrayHasKey('custom_links', $formatted);
+        $this->assertIsArray($formatted['custom_links']);
+        $this->assertCount(2, $formatted['custom_links']);
+        $this->assertSame('Airport Website', $formatted['custom_links'][0]['label']);
+        $this->assertSame('https://example.com/airport', $formatted['custom_links'][0]['url']);
     }
 
     public function testFormatAirportDetails_IncludesTimezoneDisplay(): void
@@ -180,8 +180,8 @@ class PublicApiAirportTest extends TestCase
         $airport = $this->getTestAirport('pdx');
         $formatted = formatAirportDetails('pdx', $airport);
 
-        $this->assertArrayHasKey('links', $formatted);
-        $this->assertSame([], $formatted['links']);
+        $this->assertArrayHasKey('custom_links', $formatted);
+        $this->assertSame([], $formatted['custom_links']);
     }
 
     public function testFormatAirportDetails_ServicesAndFrequenciesReturnObjectWhenEmpty(): void


### PR DESCRIPTION
## Summary
Renames the operator-defined link list on `GET /v1/airports/{id}` from `links` to `custom_links` so it reads clearly alongside `external_links` (built-in resolved URLs). Config and dashboards keep the `links` key in `airports.json`.

## Breaking change
Clients must read `airport.custom_links` instead of `airport.links`. OpenAPI and CONFIGURATION.md are updated.

## Implementation notes
- `formatAirportDetails()` maps config `links` to response `custom_links`.
- PHPDoc and Custom Links docs aligned; integration test asserts the legacy top-level `links` key is absent on the airport object.

## Testing
- PHPUnit: `PublicApiAirportTest`, `PublicApiIntegrationTest` (latter skips when Public API disabled in env).