### PR TITLE
Unify airports.json resolution and add country resolution status health

### DIFF
--- a/admin/config-validate.php
+++ b/admin/config-validate.php
@@ -146,7 +146,8 @@ if (!$configFilePath || !file_exists($configFilePath)) {
 
 // Check environment
 $info[] = "APP_ENV: " . (getenv('APP_ENV') ?: 'not set');
-$info[] = "CONFIG_PATH: " . (getenv('CONFIG_PATH') ?: 'not set');
+$info[] = 'CONFIG_PATH (env): ' . (getenv('CONFIG_PATH') !== false && getenv('CONFIG_PATH') !== '' ? getenv('CONFIG_PATH') : 'not set');
+$info[] = 'Resolved config: ' . ($configFilePath ?? 'NOT FOUND');
 $info[] = "Test mode: " . (isTestMode() ? 'YES' : 'NO');
 $info[] = "Mock mode: " . (shouldMockExternalServices() ? 'YES' : 'NO');
 $info[] = "Production: " . (isProduction() ? 'YES' : 'NO');

--- a/admin/diagnostics.php
+++ b/admin/diagnostics.php
@@ -5,6 +5,7 @@
  */
 
 require_once __DIR__ . '/../lib/cache-paths.php';
+require_once __DIR__ . '/../lib/config.php';
 header('Content-Type: text/html; charset=utf-8');
 
 $issues = [];
@@ -17,15 +18,16 @@ if (version_compare(PHP_VERSION, '7.4.0', '>=')) {
     $issues[] = "❌ PHP version too old: " . PHP_VERSION . " (needs 7.4+)";
 }
 
-// Check airports.json exists
-$configFile = __DIR__ . '/../config/airports.json';
-if (file_exists($configFile)) {
-    $success[] = "✅ airports.json exists";
-    
+// airports.json: path from getConfigFilePath()
+$resolvedConfigPath = getConfigFilePath();
+if ($resolvedConfigPath !== null && file_exists($resolvedConfigPath)) {
+    $configFile = $resolvedConfigPath;
+    $success[] = '✅ airports.json exists (' . htmlspecialchars($configFile, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . ')';
+
     // Check if readable
     if (is_readable($configFile)) {
         $success[] = "✅ airports.json is readable";
-        
+
         $config = json_decode(file_get_contents($configFile), true);
         if ($config && isset($config['airports'])) {
             $airportCount = count($config['airports']);
@@ -49,7 +51,7 @@ if (file_exists($configFile)) {
         $issues[] = "❌ airports.json is not readable (check permissions)";
     }
 } else {
-    $issues[] = "❌ airports.json does not exist. Copy from config/airports.json.example";
+    $issues[] = '❌ airports.json not found. Set CONFIG_PATH, mount /var/www/html/secrets/airports.json, or copy from config/airports.json.example';
 }
 
 // Check cache directory with actual write test
@@ -139,12 +141,16 @@ foreach ($importantFiles as $file) {
     }
 }
 
-// Check environment variables
+// CONFIG_PATH (informational) and resolved path from getConfigFilePath()
 $envConfigPath = getenv('CONFIG_PATH');
+$resolvedForEnv = getConfigFilePath();
 if ($envConfigPath) {
-    $success[] = "✅ CONFIG_PATH env var set: " . htmlspecialchars($envConfigPath);
+    $success[] = '✅ CONFIG_PATH env var set: ' . htmlspecialchars((string) $envConfigPath, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 } else {
-    $success[] = "ℹ️ CONFIG_PATH not set (using default)";
+    $success[] = 'ℹ️ CONFIG_PATH not set (see CONFIGURATION.md for resolver order)';
+}
+if ($resolvedForEnv !== null) {
+    $success[] = '✅ Resolved config path: ' . htmlspecialchars($resolvedForEnv, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 }
 
 // Show global config values (from airports.json config section)
@@ -418,10 +424,8 @@ if (is_dir($cacheDir)) {
 }
 
 // Check configuration cache status
-require_once __DIR__ . '/../lib/config.php';
-$envConfigPath = getenv('CONFIG_PATH');
-$configFilePath = ($envConfigPath && file_exists($envConfigPath)) ? $envConfigPath : (__DIR__ . '/../config/airports.json');
-if (file_exists($configFilePath)) {
+$configFilePath = getConfigFilePath();
+if ($configFilePath !== null && file_exists($configFilePath)) {
     $fileMtime = filemtime($configFilePath);
     $fileMtimeStr = date('Y-m-d H:i:s', $fileMtime);
     $success[] = "📄 Config file modified: {$fileMtimeStr}";

--- a/api/weather.php
+++ b/api/weather.php
@@ -243,14 +243,11 @@ function generateMockWeatherData($airportId, $airport) {
         exit;
     }
 
-    // Check if we should use mock weather data (only during tests or when explicitly enabled)
-    // Mock weather is enabled when:
-    // 1. Using test config (CONFIG_PATH contains airports.json.test), OR
-    // 2. Running in test environment (APP_ENV=testing, set by PHPUnit), OR
-    // 3. Explicitly enabled via MOCK_WEATHER=true (manual override), OR
-    // 4. shouldMockExternalServices() (test keys, example.com URLs - local dev with test fixture)
-    $envConfigPath = getenv('CONFIG_PATH');
-    $isTestConfig = ($envConfigPath && strpos($envConfigPath, 'airports.json.test') !== false);
+    // Check if we should use mock weather data
+    // Mock when: resolved config filename is airports.json.test, APP_ENV=testing, MOCK_WEATHER=true,
+    // or shouldMockExternalServices() (test keys / example.com URLs in config).
+    $resolvedPath = getConfigFilePath();
+    $isTestConfig = ($resolvedPath !== null && strpos($resolvedPath, 'airports.json.test') !== false);
     $isTestEnvironment = (getenv('APP_ENV') === 'testing');
     $useMockWeather = $isTestConfig || $isTestEnvironment || (getenv('MOCK_WEATHER') === 'true')
         || (function_exists('shouldMockExternalServices') && shouldMockExternalServices());

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,18 +222,23 @@ Optional **station power** telemetry on airport pages for `limited_availability`
   - Environment-aware config resolution
   - Mock mode detection for development
 
-**Configuration Resolution Order**:
-1. `APP_ENV=testing` → `tests/Fixtures/airports.json.test`
-2. `CONFIG_PATH` env var → specified file
-3. `secrets/airports.json` → Docker secrets mount
-4. `config/airports.json` → local development
+**Configuration Resolution Order** (single implementation: `resolveAirportsConfigFilePath()` in `lib/config.php`; used by `loadConfig()`, `getConfigFilePath()`, and status checks):
+
+1. `CONFIG_PATH` when set and the path exists as a regular file (PHPUnit/bootstrap sets this to `tests/Fixtures/airports.json.test`)
+2. `/var/www/html/secrets/airports.json` (Docker production mount)
+3. `config/airports.json` (repository default)
+4. Non-production only: adjacent `aviationwx.org-secrets` / `aviationwx-secrets` paths (local maintainer layout)
+5. `/var/www/html/airports.json` (host mount last resort)
+
+See [CONFIGURATION.md](CONFIGURATION.md) for the same list in the operator guide.
 
 **Key Functions**:
+- `resolveAirportsConfigFilePath()`: Locates `airports.json` without loading JSON
 - `loadConfig()`: Main entry point, returns validated config
 - `isTestMode()`: True when `APP_ENV=testing`
 - `isProduction()`: True in production environment
 - `shouldMockExternalServices()`: True when APIs should be mocked
-- `getConfigFilePath()`: Returns resolved config path
+- `getConfigFilePath()`: Alias of `resolveAirportsConfigFilePath()` (stable name for callers)
 
 **Country resolution (geometry aggregate)**:
 - `scripts/refresh-airport-country-resolution.php` builds `cache/airport_country_resolution.json` from airport coordinates and bundled Admin-0 polygons (`data/geo/ne_110m_admin_0_countries.geojson`, Natural Earth).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,6 +4,18 @@ All configuration lives in a single `airports.json` file with two sections:
 - **`config`** - Global defaults
 - **`airports`** - Per-airport settings
 
+### Which `airports.json` file is used?
+
+`resolveAirportsConfigFilePath()` in `lib/config.php` is the single resolver used by `loadConfig()`, `getConfigFilePath()`, and the status page. The first path that exists as a **regular file** wins:
+
+1. **`CONFIG_PATH`** (when set and the path is an existing file)
+2. **`/var/www/html/secrets/airports.json`** (Docker production mount)
+3. **`config/airports.json`** (repository default next to `lib/`)
+4. **Non-production only:** `../aviationwx.org-secrets/airports.json` then `../aviationwx-secrets/airports.json` (local maintainer layout)
+5. **`/var/www/html/airports.json`** (host mount last resort)
+
+If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candidates are evaluated in order.
+
 ---
 
 ## Quick Reference

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -229,16 +229,16 @@ make test-down
 ┌─────────────────────────────────────────────────────────────┐
 │                    Config Resolution                         │
 ├─────────────────────────────────────────────────────────────┤
-│ 1. APP_ENV=testing → tests/Fixtures/airports.json.test     │
+│ Single function: resolveAirportsConfigFilePath() (config.php)│
+│ Used by loadConfig(), getConfigFilePath(), status checks.    │
 │                                                              │
-│ 2. CONFIG_PATH env var → use specified file                 │
+│ 1. CONFIG_PATH when the path exists (phpunit.xml / bootstrap) │
+│ 2. /var/www/html/secrets/airports.json (Docker)             │
+│ 3. config/airports.json                                      │
+│ 4. Non-production: adjacent *-secrets/airports.json          │
+│ 5. /var/www/html/airports.json (last resort)                 │
 │                                                              │
-│ 3. secrets/airports.json exists → production mode           │
-│                                                              │
-│ 4. config/airports.json exists → development mode           │
-│    (auto-detects mock mode from config contents)            │
-│                                                              │
-│ 5. No config found → error with setup instructions          │
+│ See docs/CONFIGURATION.md for full detail.                   │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -254,7 +254,7 @@ See `lib/config.php:shouldMockExternalServices()` for implementation.
 ### Test Fixtures
 
 **`tests/Fixtures/airports.json.test`**
-- Used by all tests when `APP_ENV=testing`
+- Used by tests via `CONFIG_PATH` (see `phpunit.xml` / `tests/bootstrap.php`) and `resolveAirportsConfigFilePath()`
 - Contains airports with test API keys
 - Webcam URLs point to `example.com`
 - Designed for deterministic, reproducible tests

--- a/health/ready.php
+++ b/health/ready.php
@@ -1,18 +1,15 @@
 <?php
 require_once __DIR__ . '/../lib/logger.php';
 require_once __DIR__ . '/../lib/cache-paths.php';
+require_once __DIR__ . '/../lib/config.php';
 header('Content-Type: application/json');
 header('Cache-Control: no-cache, no-store, must-revalidate');
 
 $ok = true;
 $errors = [];
 
-// Config readable
-$configPath = getenv('CONFIG_PATH');
-if ($configPath === false || trim($configPath) === '') {
-    $configPath = __DIR__ . '/../config/airports.json';
-}
-if (!file_exists($configPath) || !is_readable($configPath)) {
+$resolvedConfig = getConfigFilePath();
+if ($resolvedConfig === null || !is_readable($resolvedConfig)) {
     $ok = false;
     $errors[] = 'config_unreadable';
 }

--- a/lib/config.php
+++ b/lib/config.php
@@ -358,39 +358,64 @@ function shouldMockExternalServices(): bool {
 }
 
 /**
- * Get the resolved config file path without loading config
- * 
- * Helper function to determine which config file would be used.
- * Used by shouldMockExternalServices() to avoid circular dependency.
- * 
- * @return string|null Path to config file, or null if not found
+ * Resolve the airports.json path used by loadConfig(), getConfigFilePath(), and status checks.
+ *
+ * One ordered list of candidates so every caller uses the same file for parse, SHA, and mtime.
+ * When multiple candidates exist, the first match in the list below is returned.
+ *
+ * Order:
+ * 1. CONFIG_PATH when set and points at an existing regular file
+ * 2. /var/www/html/secrets/airports.json (Docker production mount)
+ * 3. Repository default config/airports.json
+ * 4. Non-production only: adjacent aviationwx.org-secrets then aviationwx-secrets paths
+ * 5. /var/www/html/airports.json (host mount last resort)
+ *
+ * @return string|null Path to an existing regular file, or null if none match
  */
-function getConfigFilePath(): ?string {
-    // Check CONFIG_PATH environment variable first
+function resolveAirportsConfigFilePath(): ?string {
     $envConfigPath = getenv('CONFIG_PATH');
-    if ($envConfigPath && file_exists($envConfigPath) && is_file($envConfigPath)) {
+    if (is_string($envConfigPath) && $envConfigPath !== '' && file_exists($envConfigPath) && is_file($envConfigPath)) {
         return $envConfigPath;
     }
-    
-    // Check secrets path (Docker mount)
-    $secretsPath = '/var/www/html/secrets/airports.json';
-    if (file_exists($secretsPath)) {
-        return $secretsPath;
+
+    $dockerSecrets = '/var/www/html/secrets/airports.json';
+    if (file_exists($dockerSecrets) && is_file($dockerSecrets)) {
+        return $dockerSecrets;
     }
-    
-    // Check default config path
+
     $defaultPath = __DIR__ . '/../config/airports.json';
     if (file_exists($defaultPath) && is_file($defaultPath)) {
         return $defaultPath;
     }
-    
-    // Check adjacent secrets repo (local dev)
-    $adjacentSecrets = __DIR__ . '/../../aviationwx.org-secrets/airports.json';
-    if (file_exists($adjacentSecrets)) {
-        return $adjacentSecrets;
+
+    if (!isProduction()) {
+        $adjacentPrimary = __DIR__ . '/../../aviationwx.org-secrets/airports.json';
+        if (file_exists($adjacentPrimary) && is_file($adjacentPrimary)) {
+            return $adjacentPrimary;
+        }
+        $adjacentAlt = __DIR__ . '/../../aviationwx-secrets/airports.json';
+        if (file_exists($adjacentAlt) && is_file($adjacentAlt)) {
+            return $adjacentAlt;
+        }
     }
-    
+
+    $hostMount = '/var/www/html/airports.json';
+    if (file_exists($hostMount) && is_file($hostMount)) {
+        return $hostMount;
+    }
+
     return null;
+}
+
+/**
+ * Get the resolved airports.json path without loading or parsing it.
+ *
+ * {@see resolveAirportsConfigFilePath()}
+ *
+ * @return string|null Path to an existing regular file, or null if none match
+ */
+function getConfigFilePath(): ?string {
+    return resolveAirportsConfigFilePath();
 }
 
 /**
@@ -1868,32 +1893,20 @@ function validateRuntimeConfigSchema(array $config): array {
  */
 function loadConfig(bool $useCache = true): ?array {
     static $cachedConfig = null;
-    
-    // Get config file path
+
     $envConfigPath = getenv('CONFIG_PATH');
-    
-    // Check if CONFIG_PATH is set and is a file (not a directory)
-    if ($envConfigPath && file_exists($envConfigPath) && is_file($envConfigPath)) {
-        $configFile = $envConfigPath;
-    } else {
-        // Fall back to default path
-        $configFile = __DIR__ . '/../config/airports.json';
-        // If default path doesn't exist and not in production, try secrets path (for local dev)
-        if ((!file_exists($configFile) || is_dir($configFile)) && !isProduction()) {
-            $secretsPath = __DIR__ . '/../../aviationwx.org-secrets/airports.json';
-            $secretsPathAlt = __DIR__ . '/../../aviationwx-secrets/airports.json';
-            if (file_exists($secretsPath)) {
-                $configFile = $secretsPath;
-            } elseif (file_exists($secretsPathAlt)) {
-                $configFile = $secretsPathAlt;
-            }
+    $configFile = resolveAirportsConfigFilePath();
+
+    if ($configFile === null) {
+        if (!isProduction()) {
+            aviationwx_log('info', 'config file not found (no candidate airports.json)', [], 'app');
+        } else {
+            aviationwx_log('error', 'config file not found - PRODUCTION FAILURE', [], 'app', true);
+            error_log('CRITICAL: airports.json not found in production (resolveAirportsConfigFilePath returned null)');
         }
-        // Last resort: try /var/www/html/airports.json (production mount point)
-        if ((!file_exists($configFile) || is_dir($configFile))) {
-            $configFile = '/var/www/html/airports.json';
-        }
+        return null;
     }
-    
+
     // SECURITY: Prevent test data from being used in production
     $isProduction = isProduction();
     if ($isProduction) {
@@ -1918,25 +1931,14 @@ function loadConfig(bool $useCache = true): ?array {
         }
     }
     
-    // Validate file exists and is not a directory
-    // Note: In CI (GitHub Actions), airports.json doesn't exist - this is expected and handled gracefully
-    if (!file_exists($configFile)) {
-        // In CI, this is normal - tests use CONFIG_PATH pointing to test fixtures
-        // In production, this is a critical failure - airports.json MUST exist
+    // Validate path still usable (race: file removed after resolve)
+    if (!file_exists($configFile) || !is_file($configFile)) {
         if (!isProduction()) {
-            // Non-production: log as info (expected in CI/test environments)
             aviationwx_log('info', 'config file not found (using defaults)', ['path' => $configFile], 'app');
         } else {
-            // Production: CRITICAL ERROR - airports.json is required, fail immediately
             aviationwx_log('error', 'config file not found - PRODUCTION FAILURE', ['path' => $configFile], 'app', true);
             error_log('CRITICAL: airports.json not found in production at: ' . $configFile);
-            // In production, we cannot continue without airports.json - return null to fail fast
-            // The application should handle this gracefully by showing an error page
         }
-        return null;
-    }
-    if (is_dir($configFile)) {
-        aviationwx_log('error', 'config path is directory', ['path' => $configFile], 'app', true);
         return null;
     }
     

--- a/lib/sitemap.php
+++ b/lib/sitemap.php
@@ -37,8 +37,10 @@ function getSitemapUrls(): array
     
     $today = date('Y-m-d');
     
-    $configFile = __DIR__ . '/../config/airports.json';
-    $configLastmod = file_exists($configFile) ? date('Y-m-d', filemtime($configFile)) : $today;
+    $configFile = getConfigFilePath();
+    $configLastmod = ($configFile !== null && file_exists($configFile))
+        ? date('Y-m-d', (int) filemtime($configFile))
+        : $today;
     
     // Main pages
     $urls['main'][] = [

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -611,14 +611,14 @@ function airport_country_resolution_health_compute(?array $config, ?string $conf
  * Read-only health for the scheduler-built airport country resolution aggregate file.
  *
  * Non-testing: result is cached in APCu (getCachedData, TTL STATUS_HEALTH_CACHE_TTL); cache key includes
- * aggregate and config mtimes. APP_ENV=testing skips APCu for deterministic PHPUnit runs.
+ * aggregate and config mtimes. isTestMode() skips APCu for deterministic PHPUnit runs.
  *
  * @param array<string, mixed>|null $config Loaded config (for airport count sanity only)
  * @param string|null $configSha256 SHA-256 hex of raw airports.json when the caller already read the file (avoids a second read)
  * @return array{name: string, status: string, message: string, lastChanged: int, details?: array<string, mixed>}
  */
 function checkAirportCountryResolutionHealth(?array $config, ?string $configSha256 = null): array {
-    if (defined('APP_ENV') && APP_ENV === 'testing') {
+    if (isTestMode()) {
         return airport_country_resolution_health_compute($config, $configSha256);
     }
 

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -638,11 +638,17 @@ function checkAirportCountryResolutionHealth(?array $config, ?string $configSha2
     }
 
     $aggPath = CACHE_AIRPORT_COUNTRY_RESOLUTION_FILE;
-    $aggMtime = file_exists($aggPath) ? (int) filemtime($aggPath) : 0;
+    $aggMtime = 0;
+    if (file_exists($aggPath) && is_file($aggPath)) {
+        $mt = @filemtime($aggPath);
+        $aggMtime = ($mt !== false) ? (int) $mt : 0;
+    }
     $cfgPath = getConfigFilePath();
-    $cfgMtime = (is_string($cfgPath) && $cfgPath !== '' && file_exists($cfgPath))
-        ? (int) filemtime($cfgPath)
-        : 0;
+    $cfgMtime = 0;
+    if (is_string($cfgPath) && $cfgPath !== '' && file_exists($cfgPath) && is_file($cfgPath)) {
+        $mt = @filemtime($cfgPath);
+        $cfgMtime = ($mt !== false) ? (int) $mt : 0;
+    }
     $cacheBasis = $aggMtime . "\x1e" . $cfgMtime;
     $cacheKey = 'status_acr_health_' . substr(hash('sha256', $cacheBasis), 0, 16);
 

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -451,7 +451,8 @@ function computeAirportCountryResolutionHealth(?array $config, ?string $configSh
         ];
     }
 
-    $mtime = filemtime($path);
+    // @ below: TOCTOU if aggregate is removed or swapped after is_file / is_readable (same rationale as checkSystemHealth).
+    $mtime = @filemtime($path);
     if ($mtime === false) {
         $mtime = 0;
     }
@@ -466,7 +467,7 @@ function computeAirportCountryResolutionHealth(?array $config, ?string $configSh
         ];
     }
 
-    $raw = file_get_contents($path);
+    $raw = @file_get_contents($path);
     if ($raw === false || $raw === '') {
         return [
             'name' => $name,
@@ -544,7 +545,8 @@ function computeAirportCountryResolutionHealth(?array $config, ?string $configSh
     } else {
         $cfgPath = getConfigFilePath();
         if (is_string($cfgPath) && $cfgPath !== '' && is_readable($cfgPath)) {
-            $cfgRaw = file_get_contents($cfgPath);
+            // @: path can race unreadable between is_readable and read.
+            $cfgRaw = @file_get_contents($cfgPath);
             if ($cfgRaw !== false && $cfgRaw !== '') {
                 $currentSha = hash('sha256', $cfgRaw);
             }

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -438,6 +438,16 @@ function airport_country_resolution_health_compute(?array $config, ?string $conf
         ];
     }
 
+    if (!is_file($path)) {
+        return [
+            'name' => $name,
+            'status' => 'degraded',
+            'message' => 'Aggregate path exists but is not a regular file (' . $basename . ')',
+            'lastChanged' => 0,
+            'details' => ['file' => $basename],
+        ];
+    }
+
     $mtime = filemtime($path);
     if ($mtime === false) {
         $mtime = 0;

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -57,15 +57,18 @@ function checkSystemHealth(): array {
 
     $configSha256ForStatus = '';
     if ($resolvedConfigPath !== null && is_readable($resolvedConfigPath)) {
-        $rawCfgForSha = file_get_contents($resolvedConfigPath);
+        // @ suppresses fopen warnings if the path flips unreadable between is_readable and read (TOCTOU).
+        $rawCfgForSha = @file_get_contents($resolvedConfigPath);
         if ($rawCfgForSha !== false && $rawCfgForSha !== '') {
             $configSha256ForStatus = hash('sha256', $rawCfgForSha);
         }
     }
 
-    $configMtime = ($resolvedConfigPath !== null && file_exists($resolvedConfigPath))
-        ? (int) filemtime($resolvedConfigPath)
-        : 0;
+    $configMtime = 0;
+    if ($resolvedConfigPath !== null && file_exists($resolvedConfigPath)) {
+        $mt = @filemtime($resolvedConfigPath);
+        $configMtime = ($mt !== false) ? (int) $mt : 0;
+    }
     $health['components']['configuration'] = [
         'name' => 'Configuration',
         'status' => $configReadable && $configValid ? 'operational' : 'down',

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -423,7 +423,7 @@ function checkRunwayCacheHealth(?array $config): array {
  * @param string|null $configSha256 SHA-256 hex of raw airports.json; when null or empty, SHA is taken from getConfigFilePath()
  * @return array{name: string, status: string, message: string, lastChanged: int, details?: array<string, mixed>}
  */
-function airport_country_resolution_health_compute(?array $config, ?string $configSha256): array {
+function computeAirportCountryResolutionHealth(?array $config, ?string $configSha256): array {
     $name = 'Airport country resolution';
     $path = CACHE_AIRPORT_COUNTRY_RESOLUTION_FILE;
     $basename = basename($path);
@@ -629,7 +629,7 @@ function airport_country_resolution_health_compute(?array $config, ?string $conf
  */
 function checkAirportCountryResolutionHealth(?array $config, ?string $configSha256 = null): array {
     if (isTestMode()) {
-        return airport_country_resolution_health_compute($config, $configSha256);
+        return computeAirportCountryResolutionHealth($config, $configSha256);
     }
 
     $aggPath = CACHE_AIRPORT_COUNTRY_RESOLUTION_FILE;
@@ -643,7 +643,7 @@ function checkAirportCountryResolutionHealth(?array $config, ?string $configSha2
 
     return getCachedData(
         static function () use ($config, $configSha256): array {
-            return airport_country_resolution_health_compute($config, $configSha256);
+            return computeAirportCountryResolutionHealth($config, $configSha256);
         },
         $cacheKey,
         null,

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/constants.php';
 require_once __DIR__ . '/logger.php';
 require_once __DIR__ . '/cache-paths.php';
+require_once __DIR__ . '/cached-data-loader.php';
 require_once __DIR__ . '/process-utils.php';
 require_once __DIR__ . '/webcam-metadata.php';
 require_once __DIR__ . '/webcam-variant-manifest.php';
@@ -45,16 +46,26 @@ function checkSystemHealth(): array {
         'components' => []
     ];
     
-    $configPath = getenv('CONFIG_PATH') ?: __DIR__ . '/../config/airports.json';
-    $configReadable = file_exists($configPath) && is_readable($configPath);
+    $resolvedConfigPath = resolveAirportsConfigFilePath();
+    $configReadable = $resolvedConfigPath !== null && is_readable($resolvedConfigPath);
     $config = null;
     $configValid = false;
     if ($configReadable) {
         $config = loadConfig(false); // Don't use cache for status check
         $configValid = $config !== null;
     }
-    
-    $configMtime = $configReadable ? filemtime($configPath) : 0;
+
+    $configSha256ForStatus = '';
+    if ($resolvedConfigPath !== null && is_readable($resolvedConfigPath)) {
+        $rawCfgForSha = file_get_contents($resolvedConfigPath);
+        if ($rawCfgForSha !== false && $rawCfgForSha !== '') {
+            $configSha256ForStatus = hash('sha256', $rawCfgForSha);
+        }
+    }
+
+    $configMtime = ($resolvedConfigPath !== null && file_exists($resolvedConfigPath))
+        ? (int) filemtime($resolvedConfigPath)
+        : 0;
     $health['components']['configuration'] = [
         'name' => 'Configuration',
         'status' => $configReadable && $configValid ? 'operational' : 'down',
@@ -299,7 +310,11 @@ function checkSystemHealth(): array {
     // Runway cache (FAA/OurAirports)
     $runwayCacheHealth = checkRunwayCacheHealth($config);
     $health['components']['runway_cache'] = $runwayCacheHealth;
-    
+    $health['components']['airport_country_resolution'] = checkAirportCountryResolutionHealth(
+        $config,
+        $configSha256ForStatus !== '' ? $configSha256ForStatus : null
+    );
+
     // Magnetic declination (NOAA geomag) - only when geomag_api_key is configured
     $geomagKey = getGlobalConfig('geomag_api_key');
     if ($geomagKey !== null && $geomagKey !== '' && trim((string) $geomagKey) !== '') {
@@ -397,6 +412,233 @@ function checkRunwayCacheHealth(?array $config): array {
         'lastChanged' => $fetchedAt,
         'details' => $details,
     ];
+}
+
+/**
+ * Compute airport country resolution health (uncached).
+ *
+ * @internal Use checkAirportCountryResolutionHealth() from product code.
+ *
+ * @param array<string, mixed>|null $config Loaded config (for airport count sanity only)
+ * @param string|null $configSha256 SHA-256 hex of raw airports.json; when null or empty, SHA is taken from getConfigFilePath()
+ * @return array{name: string, status: string, message: string, lastChanged: int, details?: array<string, mixed>}
+ */
+function airport_country_resolution_health_compute(?array $config, ?string $configSha256): array {
+    $name = 'Airport country resolution';
+    $path = CACHE_AIRPORT_COUNTRY_RESOLUTION_FILE;
+    $basename = basename($path);
+
+    if (!file_exists($path)) {
+        return [
+            'name' => $name,
+            'status' => 'degraded',
+            'message' => 'Aggregate not present yet (scheduler writes ' . $basename . ')',
+            'lastChanged' => 0,
+            'details' => ['file' => $basename],
+        ];
+    }
+
+    $mtime = filemtime($path);
+    if ($mtime === false) {
+        $mtime = 0;
+    }
+
+    if (!is_readable($path)) {
+        return [
+            'name' => $name,
+            'status' => 'degraded',
+            'message' => 'Aggregate exists but is not readable',
+            'lastChanged' => $mtime,
+            'details' => ['file' => $basename],
+        ];
+    }
+
+    $raw = file_get_contents($path);
+    if ($raw === false || $raw === '') {
+        return [
+            'name' => $name,
+            'status' => 'degraded',
+            'message' => 'Aggregate file is empty or unreadable',
+            'lastChanged' => $mtime,
+            'details' => ['file' => $basename],
+        ];
+    }
+
+    try {
+        $data = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+    } catch (\JsonException) {
+        return [
+            'name' => $name,
+            'status' => 'degraded',
+            'message' => 'Aggregate is not valid JSON',
+            'lastChanged' => $mtime,
+            'details' => ['file' => $basename],
+        ];
+    }
+
+    if (!is_array($data)) {
+        return [
+            'name' => $name,
+            'status' => 'degraded',
+            'message' => 'Aggregate JSON is not an object',
+            'lastChanged' => $mtime,
+            'details' => ['file' => $basename],
+        ];
+    }
+
+    if (($data['version'] ?? null) !== COUNTRY_RESOLUTION_AGGREGATE_SCHEMA_VERSION) {
+        return [
+            'name' => $name,
+            'status' => 'degraded',
+            'message' => 'Aggregate schema version mismatch (worker should rewrite)',
+            'lastChanged' => $mtime,
+            'details' => [
+                'file' => $basename,
+                'version' => $data['version'] ?? null,
+                'expected' => COUNTRY_RESOLUTION_AGGREGATE_SCHEMA_VERSION,
+            ],
+        ];
+    }
+
+    if (!isset($data['airports']) || !is_array($data['airports'])) {
+        return [
+            'name' => $name,
+            'status' => 'degraded',
+            'message' => 'Aggregate missing airports map',
+            'lastChanged' => $mtime,
+            'details' => ['file' => $basename],
+        ];
+    }
+
+    $airportsMap = $data['airports'];
+    $nAgg = count($airportsMap);
+
+    $checked = 0;
+    $structureOk = true;
+    foreach ($airportsMap as $row) {
+        if (!is_array($row) || !array_key_exists('iso_country', $row)) {
+            $structureOk = false;
+            break;
+        }
+        if (++$checked >= 5) {
+            break;
+        }
+    }
+
+    $currentSha = '';
+    if ($configSha256 !== null && $configSha256 !== '') {
+        $currentSha = $configSha256;
+    } else {
+        $cfgPath = getConfigFilePath();
+        if (is_string($cfgPath) && $cfgPath !== '' && is_readable($cfgPath)) {
+            $cfgRaw = file_get_contents($cfgPath);
+            if ($cfgRaw !== false && $cfgRaw !== '') {
+                $currentSha = hash('sha256', $cfgRaw);
+            }
+        }
+    }
+
+    $aggSha = isset($data['config_sha256']) && is_string($data['config_sha256']) ? $data['config_sha256'] : '';
+    $shaComparable = $currentSha !== '' && $aggSha !== '';
+    $shaMatches = $shaComparable
+        && strlen($currentSha) === strlen($aggSha)
+        && hash_equals($currentSha, $aggSha);
+
+    $generatedAt = $data['generated_at'] ?? null;
+    $lastChanged = $mtime;
+    if (is_string($generatedAt)) {
+        $ts = strtotime($generatedAt);
+        if ($ts !== false && $ts > 0) {
+            $lastChanged = $ts;
+        }
+    }
+
+    $ageSec = $mtime > 0 ? time() - $mtime : 0;
+    $pastPolicyAge = $mtime > 0 && $ageSec >= COUNTRY_RESOLUTION_AGGREGATE_MAX_AGE_SECONDS;
+
+    $configAirportCount = 0;
+    if (is_array($config) && isset($config['airports']) && is_array($config['airports'])) {
+        $configAirportCount = count($config['airports']);
+    }
+
+    $issues = [];
+    if ($shaComparable && !$shaMatches) {
+        $issues[] = 'aggregate predates current airports.json (merge skipped until worker runs)';
+    }
+    if ($pastPolicyAge) {
+        $issues[] = 'file age past refresh policy (scheduler should rebuild)';
+    }
+    if (!$structureOk) {
+        $issues[] = 'sample rows missing iso_country field';
+    }
+    if ($nAgg === 0 && $configAirportCount > 0) {
+        $issues[] = 'aggregate empty while config lists airports';
+    }
+
+    $status = $issues === [] ? 'operational' : 'degraded';
+    $parts = [];
+    $parts[] = $nAgg . ' airports in aggregate';
+    if ($shaComparable) {
+        $parts[] = $shaMatches ? 'SHA matches current config' : 'SHA does not match current config';
+    }
+    if ($mtime > 0) {
+        $parts[] = 'file mtime ' . $ageSec . 's ago';
+    }
+    if (is_string($generatedAt) && $generatedAt !== '') {
+        $parts[] = 'generated_at ' . $generatedAt;
+    }
+    if ($issues !== []) {
+        $parts[] = implode('; ', $issues);
+    }
+
+    return [
+        'name' => $name,
+        'status' => $status,
+        'message' => implode(' • ', $parts),
+        'lastChanged' => $lastChanged,
+        'details' => [
+            'file' => $basename,
+            'airport_count' => $nAgg,
+            'file_mtime' => $mtime,
+            'generated_at' => is_string($generatedAt) ? $generatedAt : null,
+            'config_sha_matches' => $shaComparable ? $shaMatches : null,
+            'boundary_dataset' => $data['boundary_dataset'] ?? null,
+        ],
+    ];
+}
+
+/**
+ * Read-only health for the scheduler-built airport country resolution aggregate file.
+ *
+ * Non-testing: result is cached in APCu (getCachedData, TTL STATUS_HEALTH_CACHE_TTL); cache key includes
+ * aggregate and config mtimes. APP_ENV=testing skips APCu for deterministic PHPUnit runs.
+ *
+ * @param array<string, mixed>|null $config Loaded config (for airport count sanity only)
+ * @param string|null $configSha256 SHA-256 hex of raw airports.json when the caller already read the file (avoids a second read)
+ * @return array{name: string, status: string, message: string, lastChanged: int, details?: array<string, mixed>}
+ */
+function checkAirportCountryResolutionHealth(?array $config, ?string $configSha256 = null): array {
+    if (defined('APP_ENV') && APP_ENV === 'testing') {
+        return airport_country_resolution_health_compute($config, $configSha256);
+    }
+
+    $aggPath = CACHE_AIRPORT_COUNTRY_RESOLUTION_FILE;
+    $aggMtime = file_exists($aggPath) ? (int) filemtime($aggPath) : 0;
+    $cfgPath = getConfigFilePath();
+    $cfgMtime = (is_string($cfgPath) && $cfgPath !== '' && file_exists($cfgPath))
+        ? (int) filemtime($cfgPath)
+        : 0;
+    $cacheBasis = $aggMtime . "\x1e" . $cfgMtime;
+    $cacheKey = 'status_acr_health_' . substr(hash('sha256', $cacheBasis), 0, 16);
+
+    return getCachedData(
+        static function () use ($config, $configSha256): array {
+            return airport_country_resolution_health_compute($config, $configSha256);
+        },
+        $cacheKey,
+        null,
+        STATUS_HEALTH_CACHE_TTL
+    );
 }
 
 /**

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -65,7 +65,7 @@ function checkSystemHealth(): array {
     }
 
     $configMtime = 0;
-    if ($resolvedConfigPath !== null && file_exists($resolvedConfigPath)) {
+    if ($resolvedConfigPath !== null && file_exists($resolvedConfigPath) && is_file($resolvedConfigPath)) {
         $mt = @filemtime($resolvedConfigPath);
         $configMtime = ($mt !== false) ? (int) $mt : 0;
     }

--- a/pages/homepage.php
+++ b/pages/homepage.php
@@ -36,7 +36,8 @@ $pilotsServedToday = $cfAnalytics['unique_visitors_today'] ?? 0;
 
 if (is_readable($configFile)) {
     $config = null;
-    $configJson = file_get_contents($configFile);
+    // @: TOCTOU after is_readable; avoid notices leaking into HTML (same idea as checkSystemHealth).
+    $configJson = @file_get_contents($configFile);
     if ($configJson !== false && $configJson !== '') {
         $config = json_decode($configJson, true);
     }
@@ -1276,7 +1277,8 @@ Best regards,
             
             <?php if ($totalAirports > 0 && is_readable($configFile)): ?>
             <?php
-            $configJson = file_get_contents($configFile);
+            // @: TOCTOU after is_readable (same as top-of-page config read).
+            $configJson = @file_get_contents($configFile);
             $config = ($configJson !== false && $configJson !== '') ? json_decode($configJson, true) : null;
             // Only show listed airports (excludes unlisted airports from display)
             $airports = getListedAirports($config ?? []);

--- a/pages/homepage.php
+++ b/pages/homepage.php
@@ -19,9 +19,7 @@ function encodeEmailBody($text) {
     return implode('%0A', $encodedLines);
 }
 
-// Use CONFIG_PATH environment variable if set (for production), otherwise use default path
-$envConfigPath = getenv('CONFIG_PATH');
-$configFile = ($envConfigPath && file_exists($envConfigPath)) ? $envConfigPath : (__DIR__ . '/../config/airports.json');
+$configFile = getConfigFilePath() ?? (__DIR__ . '/../config/airports.json');
 $totalAirports = 0;
 $totalWebcams = 0;
 $totalWeatherStations = 0;
@@ -1274,9 +1272,7 @@ Best regards,
             
             <?php if ($totalAirports > 0 && file_exists($configFile)): ?>
             <?php
-            $envConfigPath = getenv('CONFIG_PATH');
-            $configFileForList = ($envConfigPath && file_exists($envConfigPath)) ? $envConfigPath : (__DIR__ . '/../config/airports.json');
-            $config = json_decode(file_get_contents($configFileForList), true);
+            $config = json_decode(file_get_contents($configFile), true);
             // Only show listed airports (excludes unlisted airports from display)
             $airports = getListedAirports($config ?? []);
             $airportsPerPage = 9;

--- a/pages/homepage.php
+++ b/pages/homepage.php
@@ -34,9 +34,13 @@ $imagesProcessed24h = $rolling24h['global']['variants_generated'] ?? 0;
 $cfAnalytics = getCloudflareAnalytics();
 $pilotsServedToday = $cfAnalytics['unique_visitors_today'] ?? 0;
 
-if (file_exists($configFile)) {
-    $config = json_decode(file_get_contents($configFile), true);
-    if (isset($config['airports'])) {
+if (is_readable($configFile)) {
+    $config = null;
+    $configJson = file_get_contents($configFile);
+    if ($configJson !== false && $configJson !== '') {
+        $config = json_decode($configJson, true);
+    }
+    if (is_array($config) && isset($config['airports'])) {
         // Only count enabled airports
         $enabledAirports = getEnabledAirports($config);
         $totalAirports = count($enabledAirports);
@@ -1270,9 +1274,10 @@ Best regards,
                 🗺️ <a href="https://airports.aviationwx.org" style="color: #0066cc; font-weight: 500; font-size: 1.05rem;">View All Airports on Interactive Map →</a>
             </p>
             
-            <?php if ($totalAirports > 0 && file_exists($configFile)): ?>
+            <?php if ($totalAirports > 0 && is_readable($configFile)): ?>
             <?php
-            $config = json_decode(file_get_contents($configFile), true);
+            $configJson = file_get_contents($configFile);
+            $config = ($configJson !== false && $configJson !== '') ? json_decode($configJson, true) : null;
             // Only show listed airports (excludes unlisted airports from display)
             $airports = getListedAirports($config ?? []);
             $airportsPerPage = 9;

--- a/scripts/compare-runways.php
+++ b/scripts/compare-runways.php
@@ -12,17 +12,19 @@
  *   php scripts/compare-runways.php [--config path] [--tolerance 0.0001]
  *
  * Options:
- *   --config path    Config file (default: CONFIG_PATH or config/airports.json)
+ *   --config path    Config file (default: getConfigFilePath() if non-null, else config/airports.json)
  *   --tolerance deg  Max diff to consider "match" in degrees (default: 0.0001 ≈ 11m)
  */
 
 error_reporting(E_ALL & ~E_DEPRECATED);
 
+require_once __DIR__ . '/../lib/config.php';
+
 $OURAIRPORTS_RUNWAYS_URL = 'https://davidmegginson.github.io/ourairports-data/runways.csv';
 $FAA_RUNWAYS_URL = 'https://ngda-transportation-geoplatform.hub.arcgis.com/api/download/v1/items/110af7b8a9424a59a3fb1d8fc69a2172/csv?layers=0';
 
 $options = getopt('', ['config:', 'tolerance:', 'help']);
-$configPath = $options['config'] ?? getenv('CONFIG_PATH') ?: __DIR__ . '/../config/airports.json';
+$configPath = $options['config'] ?? getConfigFilePath() ?? (__DIR__ . '/../config/airports.json');
 $tolerance = isset($options['tolerance']) ? (float) $options['tolerance'] : 0.0001;
 
 if (isset($options['help'])) {

--- a/tests/Integration/ExternalLinksTest.php
+++ b/tests/Integration/ExternalLinksTest.php
@@ -30,8 +30,7 @@ class ExternalLinksTest extends TestCase
             $this->markTestSkipped('cURL not available');
         }
         
-        // Load test airports configuration
-        $configPath = getenv('CONFIG_PATH') ?: __DIR__ . '/../Fixtures/airports.json.test';
+        $configPath = getConfigFilePath() ?? __DIR__ . '/../Fixtures/airports.json.test';
         if (!file_exists($configPath)) {
             $this->markTestSkipped("Airport configuration not found at: $configPath");
             return;

--- a/tests/Integration/HtmlOutputValidationTest.php
+++ b/tests/Integration/HtmlOutputValidationTest.php
@@ -289,7 +289,7 @@ class HtmlOutputValidationTest extends TestCase
         }
         
         // Load test config to check if links are configured
-        $configPath = getenv('CONFIG_PATH') ?: __DIR__ . '/../Fixtures/airports.json.test';
+        $configPath = getConfigFilePath() ?? __DIR__ . '/../Fixtures/airports.json.test';
         if (!file_exists($configPath)) {
             $this->markTestSkipped("Test configuration not found");
             return;
@@ -793,7 +793,7 @@ class HtmlOutputValidationTest extends TestCase
         }
         
         // Load test config to check services configuration
-        $configPath = getenv('CONFIG_PATH') ?: __DIR__ . '/../Fixtures/airports.json.test';
+        $configPath = getConfigFilePath() ?? __DIR__ . '/../Fixtures/airports.json.test';
         if (!file_exists($configPath)) {
             $this->markTestSkipped("Test configuration not found");
             return;
@@ -894,7 +894,7 @@ class HtmlOutputValidationTest extends TestCase
         }
         
         // Load test config to verify coordinates
-        $configPath = getenv('CONFIG_PATH') ?: __DIR__ . '/../Fixtures/airports.json.test';
+        $configPath = getConfigFilePath() ?? __DIR__ . '/../Fixtures/airports.json.test';
         if (!file_exists($configPath)) {
             $this->markTestSkipped("Test configuration not found");
             return;
@@ -961,7 +961,7 @@ class HtmlOutputValidationTest extends TestCase
         }
         
         // Load test config to verify address
-        $configPath = getenv('CONFIG_PATH') ?: __DIR__ . '/../Fixtures/airports.json.test';
+        $configPath = getConfigFilePath() ?? __DIR__ . '/../Fixtures/airports.json.test';
         if (!file_exists($configPath)) {
             $this->markTestSkipped("Test configuration not found");
             return;
@@ -999,7 +999,7 @@ class HtmlOutputValidationTest extends TestCase
         }
         
         // Load test config
-        $configPath = getenv('CONFIG_PATH') ?: __DIR__ . '/../Fixtures/airports.json.test';
+        $configPath = getConfigFilePath() ?? __DIR__ . '/../Fixtures/airports.json.test';
         if (!file_exists($configPath)) {
             $this->markTestSkipped("Test configuration not found");
             return;

--- a/tests/Integration/MultiIdentifierApiTest.php
+++ b/tests/Integration/MultiIdentifierApiTest.php
@@ -43,7 +43,7 @@ class MultiIdentifierApiTest extends TestCase
     public function testFindAirportByIdentifier_WithRealConfig()
     {
         // Use test fixture
-        $configPath = getenv('CONFIG_PATH') ?: __DIR__ . '/../Fixtures/airports.json.test';
+        $configPath = getConfigFilePath() ?? __DIR__ . '/../Fixtures/airports.json.test';
         if (!file_exists($configPath)) {
             $this->markTestSkipped("Test fixture not found: $configPath");
             return;

--- a/tests/Unit/ResolveAirportsConfigFilePathTest.php
+++ b/tests/Unit/ResolveAirportsConfigFilePathTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/config.php';
+
+/**
+ * Ensures resolveAirportsConfigFilePath() matches loadConfig() / getConfigFilePath() contract.
+ */
+final class ResolveAirportsConfigFilePathTest extends TestCase
+{
+    public function testResolve_MatchesGetConfigFilePath(): void
+    {
+        $a = resolveAirportsConfigFilePath();
+        $b = getConfigFilePath();
+        $this->assertSame($a, $b);
+    }
+
+    public function testResolve_WithPhpunitConfigPath_ReturnsReadableFile(): void
+    {
+        $resolved = resolveAirportsConfigFilePath();
+        $this->assertNotNull($resolved);
+        $this->assertFileExists($resolved);
+        $this->assertTrue(is_readable($resolved));
+    }
+
+    public function testResolve_LoadConfigUsesSameFile(): void
+    {
+        $resolved = resolveAirportsConfigFilePath();
+        $this->assertNotNull($resolved);
+        $config = loadConfig(false);
+        $this->assertNotNull($config);
+        $this->assertSame($resolved, $GLOBALS['AVIATIONWX_CONFIG_FILE_PATH'] ?? null);
+    }
+}

--- a/tests/Unit/StatusChecksCountryResolutionHealthTest.php
+++ b/tests/Unit/StatusChecksCountryResolutionHealthTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/status-checks.php';
+
+/**
+ * Unit tests for checkAirportCountryResolutionHealth() (status page aggregate sanity).
+ */
+final class StatusChecksCountryResolutionHealthTest extends TestCase
+{
+    private string $aggregatePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->aggregatePath = CACHE_AIRPORT_COUNTRY_RESOLUTION_FILE;
+        $base = dirname($this->aggregatePath);
+        if (!is_dir($base)) {
+            mkdir($base, 0755, true);
+        }
+        if (is_file($this->aggregatePath)) {
+            unlink($this->aggregatePath);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->aggregatePath)) {
+            unlink($this->aggregatePath);
+        }
+        parent::tearDown();
+    }
+
+    public function testCheckAirportCountryResolutionHealth_MissingFile_ReturnsDegraded(): void
+    {
+        $h = checkAirportCountryResolutionHealth(null);
+        $this->assertSame('degraded', $h['status']);
+        $this->assertStringContainsString('not present', $h['message']);
+    }
+
+    public function testCheckAirportCountryResolutionHealth_InvalidJson_ReturnsDegraded(): void
+    {
+        file_put_contents($this->aggregatePath, '{not json');
+        $h = checkAirportCountryResolutionHealth(null);
+        $this->assertSame('degraded', $h['status']);
+        $this->assertStringContainsString('valid JSON', $h['message']);
+    }
+
+    public function testCheckAirportCountryResolutionHealth_JsonScalarRoot_ReturnsDegraded(): void
+    {
+        file_put_contents($this->aggregatePath, '"not-an-object"');
+        $h = checkAirportCountryResolutionHealth(null);
+        $this->assertSame('degraded', $h['status']);
+        $this->assertStringContainsString('not an object', $h['message']);
+    }
+
+    public function testCheckAirportCountryResolutionHealth_SchemaMismatch_ReturnsDegraded(): void
+    {
+        $this->writeAggregate([
+            'version' => 99999,
+            'generated_at' => gmdate('c'),
+            'config_sha256' => '',
+            'airports' => ['kabc' => ['iso_country' => 'US']],
+        ]);
+        $h = checkAirportCountryResolutionHealth(null);
+        $this->assertSame('degraded', $h['status']);
+        $this->assertStringContainsString('schema version', $h['message']);
+    }
+
+    public function testCheckAirportCountryResolutionHealth_ValidAggregateAndSha_ReturnsOperational(): void
+    {
+        $cfgPath = getConfigFilePath();
+        $this->assertNotFalse($cfgPath);
+        $this->assertNotSame('', $cfgPath);
+        $raw = file_get_contents($cfgPath);
+        $this->assertNotFalse($raw);
+        $sha = hash('sha256', $raw);
+
+        $this->writeAggregate([
+            'version' => COUNTRY_RESOLUTION_AGGREGATE_SCHEMA_VERSION,
+            'generated_at' => gmdate('c'),
+            'config_sha256' => $sha,
+            'boundary_dataset' => 'test',
+            'airports' => [
+                'kabc' => ['iso_country' => 'US'],
+            ],
+        ]);
+
+        $config = loadConfig();
+        $h = checkAirportCountryResolutionHealth($config);
+        $this->assertSame('operational', $h['status']);
+        $this->assertSame(true, $h['details']['config_sha_matches']);
+    }
+
+    public function testCheckAirportCountryResolutionHealth_ShaMismatch_ReturnsDegraded(): void
+    {
+        $this->writeAggregate([
+            'version' => COUNTRY_RESOLUTION_AGGREGATE_SCHEMA_VERSION,
+            'generated_at' => gmdate('c'),
+            'config_sha256' => str_repeat('a', 64),
+            'airports' => [
+                'kabc' => ['iso_country' => 'US'],
+            ],
+        ]);
+
+        $cfgPath = getConfigFilePath();
+        $raw = file_get_contents($cfgPath);
+        $this->assertNotFalse($raw);
+
+        $config = loadConfig();
+        $h = checkAirportCountryResolutionHealth($config);
+        $this->assertSame('degraded', $h['status']);
+        $this->assertStringContainsString('predates', $h['message']);
+    }
+
+    public function testCheckAirportCountryResolutionHealth_MissingIsoCountryInSample_ReturnsDegraded(): void
+    {
+        $this->writeAggregate([
+            'version' => COUNTRY_RESOLUTION_AGGREGATE_SCHEMA_VERSION,
+            'generated_at' => gmdate('c'),
+            'config_sha256' => '',
+            'airports' => [
+                'kbad' => ['wrong' => true],
+                'kabc' => ['iso_country' => 'US'],
+            ],
+        ]);
+
+        $h = checkAirportCountryResolutionHealth(null);
+        $this->assertSame('degraded', $h['status']);
+        $this->assertStringContainsString('iso_country', $h['message']);
+    }
+
+    public function testCheckAirportCountryResolutionHealth_EmptyAggregateWithConfigAirports_ReturnsDegraded(): void
+    {
+        $this->writeAggregate([
+            'version' => COUNTRY_RESOLUTION_AGGREGATE_SCHEMA_VERSION,
+            'generated_at' => gmdate('c'),
+            'config_sha256' => '',
+            'airports' => [],
+        ]);
+
+        $config = loadConfig();
+        $this->assertNotEmpty($config['airports'] ?? []);
+
+        $h = checkAirportCountryResolutionHealth($config);
+        $this->assertSame('degraded', $h['status']);
+        $this->assertStringContainsString('empty', $h['message']);
+    }
+
+    public function testCheckAirportCountryResolutionHealth_FilePastMaxAge_ReturnsDegraded(): void
+    {
+        $cfgPath = getConfigFilePath();
+        $raw = file_get_contents($cfgPath);
+        $this->assertNotFalse($raw);
+        $sha = hash('sha256', $raw);
+
+        $this->writeAggregate([
+            'version' => COUNTRY_RESOLUTION_AGGREGATE_SCHEMA_VERSION,
+            'generated_at' => gmdate('c', time() - 86400 * 400),
+            'config_sha256' => $sha,
+            'airports' => [
+                'kabc' => ['iso_country' => 'US'],
+            ],
+        ]);
+
+        $oldMtime = time() - COUNTRY_RESOLUTION_AGGREGATE_MAX_AGE_SECONDS - 3600;
+        touch($this->aggregatePath, $oldMtime);
+
+        $config = loadConfig();
+        $h = checkAirportCountryResolutionHealth($config);
+        $this->assertSame('degraded', $h['status']);
+        $this->assertStringContainsString('refresh policy', $h['message']);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function writeAggregate(array $data): void
+    {
+        $json = json_encode($data, JSON_THROW_ON_ERROR);
+        file_put_contents($this->aggregatePath, $json);
+        touch($this->aggregatePath, time());
+    }
+}

--- a/tests/Unit/StatusChecksCountryResolutionHealthTest.php
+++ b/tests/Unit/StatusChecksCountryResolutionHealthTest.php
@@ -72,9 +72,7 @@ final class StatusChecksCountryResolutionHealthTest extends TestCase
 
     public function testCheckAirportCountryResolutionHealth_ValidAggregateAndSha_ReturnsOperational(): void
     {
-        $cfgPath = getConfigFilePath();
-        $this->assertNotFalse($cfgPath);
-        $this->assertNotSame('', $cfgPath);
+        $cfgPath = $this->resolvedAirportsConfigPathForShaTests();
         $raw = file_get_contents($cfgPath);
         $this->assertNotFalse($raw);
         $sha = hash('sha256', $raw);
@@ -105,10 +103,6 @@ final class StatusChecksCountryResolutionHealthTest extends TestCase
                 'kabc' => ['iso_country' => 'US'],
             ],
         ]);
-
-        $cfgPath = getConfigFilePath();
-        $raw = file_get_contents($cfgPath);
-        $this->assertNotFalse($raw);
 
         $config = loadConfig();
         $h = checkAirportCountryResolutionHealth($config);
@@ -152,7 +146,7 @@ final class StatusChecksCountryResolutionHealthTest extends TestCase
 
     public function testCheckAirportCountryResolutionHealth_FilePastMaxAge_ReturnsDegraded(): void
     {
-        $cfgPath = getConfigFilePath();
+        $cfgPath = $this->resolvedAirportsConfigPathForShaTests();
         $raw = file_get_contents($cfgPath);
         $this->assertNotFalse($raw);
         $sha = hash('sha256', $raw);
@@ -183,5 +177,18 @@ final class StatusChecksCountryResolutionHealthTest extends TestCase
         $json = json_encode($data, JSON_THROW_ON_ERROR);
         file_put_contents($this->aggregatePath, $json);
         touch($this->aggregatePath, time());
+    }
+
+    /**
+     * SHA-based tests need a readable resolved airports.json; skip if resolver returns null/empty (PHP 8+ would TypeError on file_get_contents).
+     */
+    private function resolvedAirportsConfigPathForShaTests(): string
+    {
+        $cfgPath = getConfigFilePath();
+        if (!is_string($cfgPath) || $cfgPath === '' || !is_file($cfgPath)) {
+            self::markTestSkipped('No resolved airports.json path for this environment');
+        }
+
+        return $cfgPath;
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -110,6 +110,7 @@ function cleanTestCache(): void {
         CACHE_BACKOFF_FILE,
         CACHE_PEAK_GUSTS_FILE,
         CACHE_TEMP_EXTREMES_FILE,
+        CACHE_AIRPORT_COUNTRY_RESOLUTION_FILE,
     ];
     
     // Patterns to clean (weather in CACHE_WEATHER_DIR, outage in CACHE_BASE_DIR)


### PR DESCRIPTION
## Summary
Introduces `resolveAirportsConfigFilePath()` in `lib/config.php` as the single resolver for which `airports.json` file exists, used by `loadConfig()`, `getConfigFilePath()`, and `checkSystemHealth()`. Migrates PHP entrypoints that previously duplicated `CONFIG_PATH` fallbacks to `getConfigFilePath()`.

Adds an **Airport country resolution** row to system health: read-only checks on `airport_country_resolution.json` (presence, JSON, schema version, config SHA, sample row shape, max age), with APCu caching outside `APP_ENV=testing`.

## Breaking / behavior notes
- When **both** `/var/www/html/secrets/airports.json` and `config/airports.json` exist, **Docker secrets win** (aligned with prior `getConfigFilePath()` behavior, not the old `loadConfig()` order that preferred default first).

## Files touched
- **Core:** `lib/config.php`, `lib/status-checks.php`, `lib/cached-data-loader.php` (require only), `lib/sitemap.php`
- **Call sites:** `pages/homepage.php`, `health/ready.php`, `admin/diagnostics.php`, `admin/config-validate.php`, `api/weather.php`, `scripts/compare-runways.php`
- **Tests:** `tests/Unit/ResolveAirportsConfigFilePathTest.php`, `tests/Unit/StatusChecksCountryResolutionHealthTest.php`, `tests/bootstrap.php`, integration tests using resolver
- **Docs:** `docs/CONFIGURATION.md`, `docs/ARCHITECTURE.md`, `docs/TESTING.md`

## Tests
- `make test-ci` (full suite) passes locally.

## Assignee / labels
Assignee: @alexwitherspoon. Labels: `enhancement`, `documentation`.