### PR TITLE
Rename status health label to Airport Location Service

### DIFF
--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -427,7 +427,7 @@ function checkRunwayCacheHealth(?array $config): array {
  * @return array{name: string, status: string, message: string, lastChanged: int, details?: array<string, mixed>}
  */
 function computeAirportCountryResolutionHealth(?array $config, ?string $configSha256): array {
-    $name = 'Airport country resolution';
+    $name = 'Airport Location Service';
     $path = CACHE_AIRPORT_COUNTRY_RESOLUTION_FILE;
     $basename = basename($path);
 


### PR DESCRIPTION
## Summary
Renames the service health row on the status page from **Airport country resolution** to **Airport Location Service** for clearer user-facing copy.

## Changes
- `lib/status-checks.php`: update the display `name` returned by `computeAirportCountryResolutionHealth()` (same payload used by the status page and status health fetchers).

## Testing
- `make test-ci`