### PR TITLE
Fix embed host Public API v1 CORS, add production probes and CD nginx gates

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -456,6 +456,9 @@ jobs:
             "docker/sshd_config"
             "docker/docker-compose.prod.yml"
             "docker/Dockerfile"
+            "docker/nginx.conf"
+            "lib/nginx-embed-vhost-verify.php"
+            "scripts/verify-embed-nginx-conf.php"
           )
           
           for file in "${CRITICAL_FILES[@]}"; do
@@ -568,6 +571,16 @@ jobs:
             fi
           else
             echo "⚠ Guides directory not found - skipping validation"
+          fi
+          
+          # Validation 8: Embed host nginx must route Public API v1 on-host (CORS / iframe fetch)
+          echo ""
+          echo "8. Verifying embed.aviationwx.org nginx vhost (docker/nginx.conf)..."
+          if php scripts/verify-embed-nginx-conf.php docker/nginx.conf; then
+            echo "✓ Embed nginx Public API v1 routing checks passed"
+          else
+            VALIDATION_FAILED=true
+            FAILURE_REASONS+=("docker/nginx.conf embed vhost failed verification (run scripts/verify-embed-nginx-conf.php)")
           fi
           
           # Final check
@@ -1182,6 +1195,15 @@ jobs:
               "1. Check network connectivity: ping ${{ secrets.HOST }}\n2. Verify SSH connection: ssh ${{ secrets.USER }}@${{ secrets.HOST }} 'echo Connection OK'\n3. Check server disk space: ssh ${{ secrets.USER }}@${{ secrets.HOST }} 'df -h'\n4. Verify permissions on server: ssh ${{ secrets.USER }}@${{ secrets.HOST }} 'ls -la ~/aviationwx'\n5. Check rsync logs for specific errors\n6. Retry deployment after resolving issues"
           fi
           echo "✓ Repository synced successfully"
+
+      - name: Verify embed nginx vhost on server (post-rsync)
+        run: |
+          ssh ${{ secrets.USER }}@${{ secrets.HOST }} << 'EOF'
+          set -euo pipefail
+          cd ~/aviationwx
+          php scripts/verify-embed-nginx-conf.php docker/nginx.conf
+          echo "✓ Server copy of docker/nginx.conf passes embed Public API v1 checks"
+          EOF
 
       - name: Configure firewall ports
         run: |

--- a/.github/workflows/production-health-check.yml
+++ b/.github/workflows/production-health-check.yml
@@ -1,0 +1,45 @@
+name: Production health check
+
+run-name: "Production health (${{ github.event_name }})"
+
+on:
+  schedule:
+    # Daily 06:15 UTC (after weekly link-check Monday slot)
+    - cron: '15 6 * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: production-health-check
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: External HTTPS probes (production)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: curl
+          coverage: none
+
+      - name: Run production health checks
+        env:
+          HEALTH_CHECK_MAIN: https://aviationwx.org
+          HEALTH_CHECK_API: https://api.aviationwx.org
+          HEALTH_CHECK_EMBED: https://embed.aviationwx.org
+          HEALTH_CHECK_ICAO: kspb
+          HEALTH_CHECK_TIMEOUT: '25'
+        run: php scripts/production-health-check.php
+
+      - name: Built-in aviation HTTPS URLs
+        run: php scripts/check-builtin-aviation-links.php

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -468,7 +468,7 @@ const meters = AviationWX.units.feetToMeters(3000);
 
 When creating or modifying weather adapters:
 
-1. **Parse raw data** using the legacy parser function
+1. **Parse raw data** using the adapter's source-specific parser (per vendor/API shape)
 2. **Create WeatherSnapshot** using factory methods for each field
 3. **Document units** in the adapter's parseToSnapshot PHPDoc
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #
 # See docs/LOCAL_SETUP.md and docs/TESTING.md for complete documentation.
 
-.PHONY: help init build build-force up down down-prod restart logs shell test test-unit test-integration test-browser test-local test-error-detector metrics-test smoke clean config config-check dev update-leaflet test-up test-down test-shell test-logs test-e2e test-clean smoke-test station-power-fetch check-builtin-aviation-links
+.PHONY: help init build build-force up down down-prod restart logs shell test test-unit test-integration test-browser test-local test-error-detector metrics-test smoke clean config config-check dev update-leaflet test-up test-down test-shell test-logs test-e2e test-clean smoke-test station-power-fetch check-builtin-aviation-links production-health-check
 
 help: ## Show this help message
 	@echo ''
@@ -19,7 +19,7 @@ help: ## Show this help message
 	@grep -E '^(dev|up|down|down-prod|restart|logs|shell|station-power-fetch):.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
 	@echo ''
 	@echo '\033[1;33mTesting:\033[0m'
-	@grep -E '^(test|test-ci|test-unit|test-integration|test-e2e|test-browser|test-local|metrics-test|smoke|smoke-test|check-builtin-aviation-links):.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^(test|test-ci|test-unit|test-integration|test-e2e|test-browser|test-local|metrics-test|smoke|smoke-test|check-builtin-aviation-links|production-health-check):.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 	@echo ''
 	@echo '\033[1;33mTest Environment (Isolated):\033[0m'
 	@grep -E '^(test-up|test-down|test-shell|test-logs|test-clean):.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -214,6 +214,9 @@ test-ci: ## Run all tests that GitHub CI runs (comprehensive)
 
 check-builtin-aviation-links: ## HEAD-probe built-in aviation HTTPS URLs (networked; same as scheduled CI)
 	@php scripts/check-builtin-aviation-links.php
+
+production-health-check: ## HTTPS probes against production (networked; same as daily workflow)
+	@php scripts/production-health-check.php
 
 test-unit: ## Run unit tests only (fast, no Docker needed)
 	@echo "Running unit tests..."

--- a/api/weather.php
+++ b/api/weather.php
@@ -1,7 +1,11 @@
 <?php
 /**
- * Weather Data Fetcher
- * Fetches weather data from configured source for the specified airport
+ * Internal API -- Weather JSON endpoint for the dashboard and site UI.
+ *
+ * Documented as the Internal API in docs/API.md (paths under api/ on the main host).
+ * Distinct from the versioned Public API at api.aviationwx.org.
+ *
+ * Fetches weather data from configured sources for the specified airport.
  */
 
 require_once __DIR__ . '/../lib/config.php';

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -178,17 +178,31 @@ server {
     access_log /dev/stdout json_access;
     error_log /dev/stderr warn;
 
-    # Public API v1: redirect /api/v1/... to the canonical API base (docker default matches PHP default).
-    # Exact match for /api/v1 and /api/v1/; regex below for /api/v1/... .
-    # CD may inject redirect targets from deployment airports.json. Nginx does not read JSON at request time.
+    # Embed host: serve Public API v1 internally (no browser redirect to api.aviationwx.org).
+    # Third-party fetch() from iframe origins requires CORS on the first response; an off-host 301 breaks that.
     location = /api/v1 {
-        return 301 https://api.aviationwx.org/v1$is_args$args;
+        rewrite ^ /v1/ last;
     }
     location = /api/v1/ {
-        return 301 https://api.aviationwx.org/v1$is_args$args;
+        rewrite ^ /v1/ last;
     }
     location ~ ^/api/v1/(.*)$ {
-        return 301 https://api.aviationwx.org/v1/$1$is_args$args;
+        rewrite ^/api/v1/(.*)$ /v1/$1 last;
+    }
+
+    # API v1 endpoints - route to router.php (same pattern as api.aviationwx.org server block)
+    location /v1/ {
+        rewrite ^/v1/(.*)$ /api/v1/router.php break;
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Original-URI $request_uri;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
     }
 
     # Proxy to PHP application

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,8 @@
 
 This document describes the **Internal API** endpoints used by the AviationWX.org web interface. These endpoints are designed for the frontend and are not versioned. The Internal API is long-lived and distinct from the Public API.
 
+**Terminology:** Always refer to these routes as the **Internal API**. They are actively maintained first-party endpoints for the dashboard and site UI. **Do not** call them "legacy API" or "legacy endpoints" -- that wording is reserved for older file formats, optional query flags (e.g. `?legacy=1`), or vendor-specific cases (e.g. Davis legacy hardware), not for `api/weather.php` / `api/webcam.php` themselves.
+
 > **For Third-Party Developers:** If you're building an application that integrates with AviationWX, please use the [**Public API**](https://api.aviationwx.org) instead. The Public API provides:
 > - Stable, versioned endpoints (`/v1/...`)
 > - OpenAPI specification

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,20 +1,14 @@
 # Internal API Documentation
 
-This document describes the **Internal API** endpoints used by the AviationWX.org web interface. These endpoints are designed for the frontend and are not versioned. The Internal API is long-lived and distinct from the Public API.
+The **Internal API** is the set of first-party HTTP endpoints used by the AviationWX.org web interface (`api/*.php` on the main site host). Responses are tailored to the dashboard; endpoints are not versioned as a public contract.
 
-**Terminology:** Always refer to these routes as the **Internal API**. They are actively maintained first-party endpoints for the dashboard and site UI. **Do not** call them "legacy API" or "legacy endpoints" -- that wording is reserved for older file formats, optional query flags (e.g. `?legacy=1`), or vendor-specific cases (e.g. Davis legacy hardware), not for `api/weather.php` / `api/webcam.php` themselves.
+The **Public API** (`https://api.aviationwx.org/v1/...`) is the supported integration surface for third-party apps; see [api.aviationwx.org](https://api.aviationwx.org).
 
-> **For Third-Party Developers:** If you're building an application that integrates with AviationWX, please use the [**Public API**](https://api.aviationwx.org) instead. The Public API provides:
-> - Stable, versioned endpoints (`/v1/...`)
-> - OpenAPI specification
-> - Rate limit headers
-> - Consistent JSON responses
-> - Support for API keys with higher rate limits
->
-> Visit **[api.aviationwx.org](https://api.aviationwx.org)** for documentation.
->
+**Wording:** Use **Internal API** for these routes. Use **legacy** only for older file formats, optional flags such as `?legacy=1`, or vendor-specific hardware lines -- not as a label for `api/weather.php` / `api/webcam.php`.
+
+> **For third-party developers:** Use the [**Public API**](https://api.aviationwx.org): stable `/v1/...` paths, OpenAPI, rate-limit headers, and API keys.  
 > **Canonical Public API base URL (public deployment):** `https://api.aviationwx.org/v1`  
-> Integrations should call that base directly. Self-hosted deployments may set `config.public_api.canonical_base_url` so documentation matches their public origin.
+> Self-hosted deployments may set `config.public_api.canonical_base_url` so docs match their origin.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,6 +89,10 @@ aviationwx.org/
 
 ## Core Components
 
+### HTTP edge (`docker/nginx.conf`)
+
+TLS terminates in nginx. **`api.aviationwx.org`** exposes Public API v1; **`embed.aviationwx.org`** serves the embed generator and forwards `/api/v1/...` to **`api/v1/router.php`** on that host so `fetch()` from the embed origin receives CORS on the first hop. **`aviationwx.org`** and **`*.aviationwx.org`** serve the dashboard. The committed **`docker/nginx.conf`** is bind-mounted in production (see **`docs/DEPLOYMENT.md`**).
+
 ### Routing System (`index.php`)
 
 - **Purpose**: Routes requests to appropriate pages

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -100,7 +100,9 @@ aviationwx.org/
 
 ### Weather System (`api/weather.php`)
 
-- **Purpose**: Fetches and serves weather data as JSON API
+Part of the **Internal API** (see [API.md](API.md)): JSON for the web dashboard; distinct from the versioned Public API on `api.aviationwx.org`.
+
+- **Purpose**: Fetches and serves weather data as JSON for first-party consumers
 - **Key Features**:
   - Supports multiple weather sources (Tempest, Ambient, WeatherLink, PWSWeather, SynopticData, METAR, Nav Canada Weather for Canadian airports)
   - **Unified Fetcher** (default): Clean aggregation pipeline with predictable behavior
@@ -110,7 +112,7 @@ aviationwx.org/
   - Caching with stale-while-revalidate
   - Rate limiting
   - Debug endpoint (`?debug=1`) for troubleshooting
-  - Legacy fallback (`?legacy=1`) for backward compatibility
+  - Optional backward-compatible response shape (`?legacy=1` query flag; not related to "legacy API" terminology)
 
 **Wind direction**: All internal values use true north. Display layers use `wind_direction_magnetic`; fail closed (`---`) when missing. See [Wind Direction: True North](SAFETY_CRITICAL_CALCULATIONS.md#wind-direction-true-north) and [Wind Direction Conventions by Source](DATA_FLOW.md#wind-direction-conventions-by-source). Conversion in `lib/heading-conversion.php` (safety-critical).
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1546,7 +1546,7 @@ When `config.public_api.enabled` is true, the Public API and weather history fea
 |--------|---------|-------------|
 | `canonical_base_url` | `https://api.aviationwx.org/v1` | Optional. Absolute `http://` or `https://` base URL for Public API v1 with no trailing slash. Used by `getCanonicalPublicApiV1BaseUrl()` and the API docs page. Omit to use this default. Set when your deployment’s public API origin differs (self-hosted). |
 
-**Nginx:** `/api/v1/` redirect rules (if present) must target the same host and path prefix as this value. The committed `docker/nginx.conf` uses the public default; production CD may render or push the vhost from deployment `airports.json` so nginx stays aligned with PHP (nginx does not read JSON at request time).
+**Nginx:** `/api/v1/` redirect rules on **api.aviationwx.org** (if present) must target the same host and path prefix as this value. Production CD **rsyncs** `docker/nginx.conf` from the repo into `~/aviationwx/` and bind-mounts it into the nginx container (see `docker/docker-compose.prod.yml`); optional host overrides must keep `embed.aviationwx.org` routing consistent so browser `fetch()` to `/api/v1` on the embed host does not follow an off-host redirect before CORS applies. Deploy runs `scripts/verify-embed-nginx-conf.php` to gate bad configs.
 
 ### Rate limits
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -984,7 +984,7 @@ Stores recent frames for time-lapse playback. Webcam images are stored at `cache
 
 ### Configuration
 
-History retention is now time-based using `webcam_history_retention_hours`:
+History retention uses `webcam_history_retention_hours`:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
@@ -1144,7 +1144,7 @@ Both services are proxied through `/api/map-tiles.php` for server-side caching a
 
 The precipitation radar layer is always enabled and accessible through the map controls (☔).
 
-**Note (January 2026 API Changes)**: RainViewer's API now limits tile requests to zoom level 7 and 100 requests/IP/minute. The map automatically handles this by fetching tiles at zoom 7 and scaling them up when zoomed in further. Server-side caching ensures the rate limit is rarely a concern.
+RainViewer limits tile requests to zoom level **7** and **100 requests per IP per minute**. The map client requests tiles at zoom 7 and scales them at higher zoom. Server-side caching reduces pressure on that limit.
 
 ---
 
@@ -1546,7 +1546,7 @@ When `config.public_api.enabled` is true, the Public API and weather history fea
 |--------|---------|-------------|
 | `canonical_base_url` | `https://api.aviationwx.org/v1` | Optional. Absolute `http://` or `https://` base URL for Public API v1 with no trailing slash. Used by `getCanonicalPublicApiV1BaseUrl()` and the API docs page. Omit to use this default. Set when your deployment’s public API origin differs (self-hosted). |
 
-**Nginx:** `/api/v1/` redirect rules on **api.aviationwx.org** (if present) must target the same host and path prefix as this value. Production CD **rsyncs** `docker/nginx.conf` from the repo into `~/aviationwx/` and bind-mounts it into the nginx container (see `docker/docker-compose.prod.yml`); optional host overrides must keep `embed.aviationwx.org` routing consistent so browser `fetch()` to `/api/v1` on the embed host does not follow an off-host redirect before CORS applies. Deploy runs `scripts/verify-embed-nginx-conf.php` to gate bad configs.
+**Nginx:** On **api.aviationwx.org**, `/api/v1/` redirects must target the same host and path prefix as this value. CD installs **`docker/nginx.conf`** from the repository (see `docker/docker-compose.prod.yml`). Any manual nginx overlay must preserve **`embed.aviationwx.org`** on-host Public API v1 routing (rewrite + `/v1/` → `api/v1/router.php`) so cross-origin `fetch()` to `/api/v1` on the embed host does not hit an off-host redirect before CORS. Deploy runs **`scripts/verify-embed-nginx-conf.php`** against the synced file.
 
 ### Rate limits
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -382,7 +382,7 @@ curl https://aviationwx.org/health.php
 curl https://aviationwx.org/diagnostics.php
 ```
 
-**Public API v1 (nginx):** Committed `docker/nginx.conf` includes `/api/v1/` redirect rules toward the default canonical API base. Production should keep redirect targets aligned with `config.public_api.canonical_base_url` when set; deployment may generate or install nginx configuration from deployment `airports.json` (nginx does not read JSON at request time).
+**Nginx / Public API v1:** Production loads **`docker/nginx.conf`** from the deployed repository (CD copies it to the server and bind-mounts it for the nginx container). Routing layout and embed checks: [Nginx and `embed.aviationwx.org` (CD)](#nginx-and-embedaviationwxorg-cd).
 
 ### 5. Scheduler Daemon (Automatic)
 
@@ -518,7 +518,7 @@ See `.github/workflows/deploy-docker.yml` for workflow details.
 
 ### Nginx and `embed.aviationwx.org` (CD)
 
-Production CD **rsyncs** `docker/nginx.conf` from the repo to `~/aviationwx/` and bind-mounts it into the nginx container (`docker/docker-compose.prod.yml`). Host routing changes for **`embed.aviationwx.org`** therefore ship with application commits; there is no separate generated vhost in CD. The deploy workflow runs **`scripts/verify-embed-nginx-conf.php`** before deployment and again on the server after rsync so the embed server block keeps Public API v1 **on-host** routing (needed so third-party iframe `fetch()` sees CORS on the first response).
+CD **rsyncs** `docker/nginx.conf` to `~/aviationwx/` and bind-mounts it into the nginx container (`docker/docker-compose.prod.yml`). **`embed.aviationwx.org`** routing ships with application commits; nginx does not read `airports.json`. The deploy workflow runs **`scripts/verify-embed-nginx-conf.php`** on the Actions runner before SSH and again on the server after rsync. The embed server block keeps Public API v1 on-host (rewrite + `location /v1/`) so browsers get CORS on the first hop for `/api/v1/...` requests.
 
 ## Maintenance
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -516,6 +516,10 @@ git push origin main
 
 See `.github/workflows/deploy-docker.yml` for workflow details.
 
+### Nginx and `embed.aviationwx.org` (CD)
+
+Production CD **rsyncs** `docker/nginx.conf` from the repo to `~/aviationwx/` and bind-mounts it into the nginx container (`docker/docker-compose.prod.yml`). Host routing changes for **`embed.aviationwx.org`** therefore ship with application commits; there is no separate generated vhost in CD. The deploy workflow runs **`scripts/verify-embed-nginx-conf.php`** before deployment and again on the server after rsync so the embed server block keeps Public API v1 **on-host** routing (needed so third-party iframe `fetch()` sees CORS on the first response).
+
 ## Maintenance
 
 ### Update Application

--- a/docs/EMBED.md
+++ b/docs/EMBED.md
@@ -6,7 +6,7 @@ The Embed Generator allows you to create embeddable weather widgets for any Avia
 
 ### Option 1: Web Component (Recommended for Modern Sites)
 
-Use the [Embed Configurator](https://embed.aviationwx.org) to generate embed code—it includes a version query param (`?v=...`) for cache busting so embeds get updates within minutes of deploy.
+Use the [Embed Configurator](https://embed.aviationwx.org) to generate embed code; it includes a version query param (`?v=...`) for cache busting so embeds get updates within minutes of deploy.
 
 ```html
 <!-- Include the widget script once per page -->
@@ -32,17 +32,17 @@ A compact card showing essential weather data including wind, temperature, altim
 **Style Code:** `card`
 
 ### Webcam Only Single (450×380)
-Displays a single webcam feed with footer. Webcams and footer only—no weather metrics.
+Displays a single webcam feed with footer. Webcams and footer only (no weather metrics).
 
 **Style Code:** `webcam-only`
 
 ### Webcam Only Dual (600×250)
-Shows two webcams side by side with footer. Webcams and footer only—no weather metrics.
+Shows two webcams side by side with footer. Webcams and footer only (no weather metrics).
 
 **Style Code:** `dual-only`
 
 ### Webcam Only Quad (600×400)
-Displays up to four webcams in a compact grid with footer. Webcams and footer only—no weather metrics.
+Displays up to four webcams in a compact grid with footer. Webcams and footer only (no weather metrics).
 
 **Style Code:** `multi-only`
 
@@ -247,7 +247,9 @@ GET /api/v1/airports/{id}/embed?refresh=1
 - Airport topic includes: `id`, `name`, `icao`, `lat`, `lon`, `elevation_ft`, `timezone`, `webcams`, `runways`, `weather_sources` (all data needed for embed widgets)
 - Explicit observed times for staleness validation
 
-**CORS:** Permissive (`*`) for third-party embedding.
+**CORS:** Responses include permissive `Access-Control-Allow-Origin` for third-party embedding.
+
+**Embed host routing:** `widget.js` calls the Public API on **`embed.aviationwx.org`** (same origin as the script). Nginx maps `/api/v1/...` on that host to `api/v1/router.php` without redirecting the browser to **`api.aviationwx.org`** first, so the initial response carries CORS headers required by `fetch()` from embedded contexts. Configuration lives in **`docker/nginx.conf`** (embed `server` block).
 
 ## Local Development
 
@@ -269,23 +271,19 @@ http://localhost:8080/public/widget-demo.html
 
 ## Nginx Configuration
 
-The embed subdomain requires modified security headers to allow iframe embedding on third-party sites. Key differences from the main site:
-
-- No `X-Frame-Options` header (allows embedding anywhere)
-- Modified CSP `frame-ancestors *` (allows embedding from any origin)
-- Allows connections to `*.aviationwx.org` for webcam images
+Defined in **`docker/nginx.conf`**. The **`embed.aviationwx.org`** `server` block relaxes framing (`frame-ancestors *`, no `X-Frame-Options`) and CSP compared to the main site so widgets load in third-party iframes. Public API v1 paths use internal rewrite + **`location /v1/`** so embed-origin `fetch()` stays on the embed host (see [Embed API JSON](#embed-api-json)). Production deploy bind-mounts this file from the repository (see **`docs/DEPLOYMENT.md`**).
 
 ## Content Security Policy (CSP)
 
 If your site uses a Content Security Policy, add these directives so embeds work:
 
 **Web component** (script + fetch):
-- `script-src` — Include `https://aviationwx.org` and `https://embed.aviationwx.org` (widget script)
-- `connect-src` — Include `https://aviationwx.org` and `https://*.aviationwx.org` (API, webcam images)
-- `style-src` — Include `https://aviationwx.org` and `https://embed.aviationwx.org` (widget CSS)
+- **script-src**: include `https://aviationwx.org` and `https://embed.aviationwx.org` (widget script)
+- **connect-src**: include `https://aviationwx.org` and `https://*.aviationwx.org` (API, webcam images)
+- **style-src**: include `https://aviationwx.org` and `https://embed.aviationwx.org` (widget CSS)
 
 **iframe embed:**
-- `frame-src` — Include `https://embed.aviationwx.org`
+- **frame-src**: include `https://embed.aviationwx.org`
 
 **Example CSP additions** (append to your existing policy):
 ```
@@ -299,7 +297,7 @@ Sites without CSP (e.g., most WordPress, Squarespace) work without changes. Add 
 
 ## Caching and Updates
 
-The widget script uses short cache headers (`max-age=300`, `stale-while-revalidate=3600`) so updates propagate within ~5 minutes of deploy. For immediate cache busting, use the versioned URL from the [Embed Configurator](https://embed.aviationwx.org)—it appends `?v=<timestamp>` based on file modification time, so new embeds always fetch the latest script.
+The widget script uses short cache headers (`max-age=300`, `stale-while-revalidate=3600`) so updates propagate within ~5 minutes of deploy. For immediate cache busting, use the versioned URL from the [Embed Configurator](https://embed.aviationwx.org); it appends `?v=<timestamp>` based on file modification time, so new embeds fetch the latest script.
 
 ## Troubleshooting
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -93,6 +93,10 @@ Shows:
 | `/admin/diagnostics.php` | Detailed system info |
 | `/admin/metrics.php` | Prometheus-format metrics |
 
+### External probes (GitHub Actions)
+
+The **`production-health-check`** workflow runs **`scripts/production-health-check.php`** on a schedule against public HTTPS URLs (main site, Public API, embed host, internal-style routes). **`docs/TESTING.md`** lists the workflow and **`make production-health-check`** for manual runs.
+
 ### Scheduler Verification
 
 ```bash

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -196,7 +196,7 @@ form-action 'self';
 The CSP explicitly allows:
 - ✅ **Cloudflare Web Analytics** (`static.cloudflareinsights.com`, `cloudflareinsights.com`)
 - ✅ **Cloudflare Email Obfuscation** (via `/cdn-cgi/` paths covered by `'self'`)
-- ✅ **Inline scripts** (via `'unsafe-inline'` - required for legacy code)
+- ✅ **Inline scripts** (via `'unsafe-inline'` -- required for inline dashboard scripts)
 
 ### Weather Overlay Services
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -16,12 +16,12 @@ AviationWX uses a unified testing strategy based on `APP_ENV`:
 
 ## API terminology (Internal vs Public)
 
-Use consistent wording in docs, comments, and reviews:
+| Term | Meaning |
+|------|---------|
+| **Internal API** | First-party JSON and binary endpoints on the main site host (`api/weather.php`, `api/webcam.php`, `api/notam.php`, ...). Documented in [`docs/API.md`](API.md). Used by the dashboard and site UI; not versioned. |
+| **Public API** | Versioned JSON under `https://api.aviationwx.org/v1/...` for integrations, OpenAPI, and embed JSON contracts. |
 
-- **Internal API** -- First-party JSON and image endpoints on the main site host, e.g. [`api/weather.php`](../api/weather.php), [`api/webcam.php`](../api/webcam.php), [`api/notam.php`](../api/notam.php). Described in [`docs/API.md`](API.md). Actively maintained for the dashboard; **not** deprecated.
-- **Public API** -- Versioned JSON at `https://api.aviationwx.org/v1/...` for integrations and embed data contracts.
-
-**Do not** refer to Internal API routes as "legacy API." Reserve **legacy** for older *formats*, optional *flags* (e.g. `?legacy=1`), vendor *hardware* (e.g. Davis legacy devices), or unrelated code paths -- not for the main weather/webcam HTTP endpoints.
+Reserve **legacy** for older response formats, optional query flags such as `?legacy=1`, vendor hardware lines (e.g. Davis WeatherLink legacy devices), or unrelated features -- not for the Internal API weather/webcam routes.
 
 ## Quick Start
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -14,6 +14,15 @@ AviationWX uses a unified testing strategy based on `APP_ENV`:
 | Testing (Isolated Docker) | `testing` | tests/Fixtures/airports.json.test | Fully mocked | 9080 |
 | CI | `testing` | tests/Fixtures/airports.json.test | Fully mocked | 9080 |
 
+## API terminology (Internal vs Public)
+
+Use consistent wording in docs, comments, and reviews:
+
+- **Internal API** -- First-party JSON and image endpoints on the main site host, e.g. [`api/weather.php`](../api/weather.php), [`api/webcam.php`](../api/webcam.php), [`api/notam.php`](../api/notam.php). Described in [`docs/API.md`](API.md). Actively maintained for the dashboard; **not** deprecated.
+- **Public API** -- Versioned JSON at `https://api.aviationwx.org/v1/...` for integrations and embed data contracts.
+
+**Do not** refer to Internal API routes as "legacy API." Reserve **legacy** for older *formats*, optional *flags* (e.g. `?legacy=1`), vendor *hardware* (e.g. Davis legacy devices), or unrelated code paths -- not for the main weather/webcam HTTP endpoints.
+
 ## Quick Start
 
 **⚠️ IMPORTANT: Always run `make test-ci` before committing or pushing code.**
@@ -45,12 +54,14 @@ These jobs use the network and are **not** part of `make test-ci` (unit tests st
 |----------|----------------|
 | [`.github/workflows/weekly-link-check.yml`](../.github/workflows/weekly-link-check.yml) | Live dashboard URLs (`scripts/link-check.php`), then built-in aviation HTTPS targets (`scripts/check-builtin-aviation-links.php`, URL list from `lib/aviation-region-links.php`). |
 | [`.github/workflows/builtin-aviation-links.yml`](../.github/workflows/builtin-aviation-links.yml) | Same built-in probe on PRs and pushes to `main` when `lib/aviation-region-links.php`, the script, or this workflow file changes. |
+| [`.github/workflows/production-health-check.yml`](../.github/workflows/production-health-check.yml) | Daily HTTPS probes against production (`scripts/production-health-check.php`), then `check-builtin-aviation-links.php`. Requires outbound network; not part of `make test-ci`. |
 
-A red run usually means a third party moved or blocked a URL; confirm in a browser, then update the static `url` in profiles or the probe script (for example user-agent or HEAD vs GET behavior), and re-run the failed workflow or `make check-builtin-aviation-links`.
+Link-check and built-in URL failures usually mean a third party moved or blocked a URL; confirm in a browser, then update the static `url` in profiles or the probe script (for example user-agent or HEAD vs GET behavior), and re-run the failed workflow or `make check-builtin-aviation-links`.
 
-Local manual run (needs outbound HTTPS):
+Local manual runs (need outbound HTTPS):
 
 ```bash
+make production-health-check
 php scripts/check-builtin-aviation-links.php
 ```
 

--- a/lib/nginx-embed-vhost-verify.php
+++ b/lib/nginx-embed-vhost-verify.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Validates embed.aviationwx.org nginx server block for Public API v1 routing.
+ *
+ * Ensures third-party fetch() to /api/v1 on the embed host does not hit an off-host
+ * redirect before CORS headers apply (see docker/nginx.conf embed server block).
+ *
+ * @package AviationWX
+ */
+
+declare(strict_types=1);
+
+/**
+ * Extract the server { ... } block for embed.aviationwx.org from raw nginx config.
+ *
+ * @param string $content Full nginx.conf contents
+ * @return string Embed server block including outer braces, or empty string if not found
+ */
+function nginx_extract_embed_aviationwx_server_block(string $content): string
+{
+    $marker = 'server_name embed.aviationwx.org;';
+    $pos = strpos($content, $marker);
+    if ($pos === false) {
+        return '';
+    }
+    $slice = substr($content, 0, $pos);
+    $serverKw = strrpos($slice, 'server {');
+    if ($serverKw === false) {
+        return '';
+    }
+    $prefix = substr($content, $serverKw, 12);
+    $braceRel = strpos($prefix, '{');
+    if ($braceRel === false) {
+        return '';
+    }
+    $braceOpen = $serverKw + $braceRel;
+    $depth = 0;
+    $len = strlen($content);
+    for ($i = $braceOpen; $i < $len; $i++) {
+        $c = $content[$i];
+        if ($c === '{') {
+            $depth++;
+        } elseif ($c === '}') {
+            $depth--;
+            if ($depth === 0) {
+                return substr($content, $serverKw, $i - $serverKw + 1);
+            }
+        }
+    }
+
+    return '';
+}
+
+/**
+ * Verify the embed vhost routes Public API v1 on-host (rewrite + location /v1/), not via off-host 301.
+ *
+ * @param string $block Extracted embed.aviationwx.org server block
+ * @return array<int, string> Human-readable errors; empty when valid
+ */
+function nginx_verify_embed_server_block_public_api_v1(string $block): array
+{
+    $errors = [];
+    if ($block === '') {
+        $errors[] = 'Could not extract embed.aviationwx.org server block';
+
+        return $errors;
+    }
+
+    $bad = 'return 301 https://api.aviationwx.org/v1';
+    if (str_contains($block, $bad)) {
+        $errors[] = 'embed.aviationwx.org must not use off-host 301 for /api/v1 (use internal rewrite + location /v1/)';
+    }
+    if (!str_contains($block, 'location /v1/')) {
+        $errors[] = 'embed server block should include location /v1/ for Public API routing';
+    }
+    if (!str_contains($block, '/api/v1/router.php')) {
+        $errors[] = 'embed server block should rewrite /v1/ to api/v1/router.php';
+    }
+
+    return $errors;
+}

--- a/scripts/production-health-check.php
+++ b/scripts/production-health-check.php
@@ -114,7 +114,11 @@ function productionHealthCheckFormatHeaders(array $headers): array
 }
 
 /**
- * @return array{ok: bool, detail: string}
+ * Run a single named check and prefix output with timing.
+ *
+ * @param string $name Stable check identifier (used in logs and GitHub summary).
+ * @param callable(): array{ok: bool, detail?: string} $fn Check body.
+ * @return array{name: string, ok: bool, detail: string}
  */
 function runNamedCheck(string $name, callable $fn): array
 {
@@ -168,6 +172,10 @@ $checks = [
         return ['ok' => true, 'detail' => 'HTTP 200'];
     },
     'embed_api_cors' => static function () use ($embed, $icao, $timeout, $googleEmbedOrigin) {
+        $embedHost = parse_url($embed, PHP_URL_HOST);
+        if (!is_string($embedHost) || $embedHost === '') {
+            return ['ok' => false, 'detail' => 'invalid HEALTH_CHECK_EMBED host'];
+        }
         $url = $embed . '/api/v1/airports/' . rawurlencode($icao) . '/embed';
         $r = productionHealthCheckRequest(
             $url,
@@ -177,8 +185,12 @@ $checks = [
             ]),
             $timeout
         );
-        if (stripos($r['final_url'], 'embed.aviationwx.org') === false) {
-            return ['ok' => false, 'detail' => 'followed away from embed host: ' . $r['final_url']];
+        $finalHost = parse_url($r['final_url'], PHP_URL_HOST);
+        if (!is_string($finalHost) || strcasecmp($finalHost, $embedHost) !== 0) {
+            return ['ok' => false, 'detail' => 'expected final URL on embed host ' . $embedHost . ', got ' . $r['final_url']];
+        }
+        if ($r['code'] === 429) {
+            return ['ok' => true, 'detail' => 'HTTP 429 (rate limit)'];
         }
         if ($r['code'] !== 200) {
             return ['ok' => false, 'detail' => 'HTTP ' . $r['code'] . ' ' . $r['error']];
@@ -196,6 +208,9 @@ $checks = [
     'api_v1_embed' => static function () use ($api, $icao, $timeout) {
         $url = $api . '/v1/airports/' . rawurlencode($icao) . '/embed';
         $r = productionHealthCheckRequest($url, productionHealthCheckFormatHeaders(['Accept' => 'application/json']), $timeout);
+        if ($r['code'] === 429) {
+            return ['ok' => true, 'detail' => 'HTTP 429 (rate limit)'];
+        }
         if ($r['code'] !== 200) {
             return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
         }
@@ -228,6 +243,9 @@ $checks = [
     },
     'api_v1_airports' => static function () use ($api, $timeout) {
         $r = productionHealthCheckRequest($api . '/v1/airports', productionHealthCheckFormatHeaders(['Accept' => 'application/json']), $timeout);
+        if ($r['code'] === 429) {
+            return ['ok' => true, 'detail' => 'HTTP 429 (rate limit)'];
+        }
         if ($r['code'] !== 200) {
             return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
         }
@@ -242,6 +260,9 @@ $checks = [
         if ($r['code'] === 503) {
             return ['ok' => true, 'detail' => 'HTTP 503 (upstream)'];
         }
+        if ($r['code'] === 429) {
+            return ['ok' => true, 'detail' => 'HTTP 429 (rate limit)'];
+        }
         if ($r['code'] !== 200) {
             return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
         }
@@ -253,6 +274,9 @@ $checks = [
             productionHealthCheckFormatHeaders(['Accept' => 'application/json']),
             $timeout
         );
+        if ($r['code'] === 429) {
+            return ['ok' => true, 'detail' => 'HTTP 429 (rate limit)'];
+        }
         if ($r['code'] !== 200) {
             return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
         }

--- a/scripts/production-health-check.php
+++ b/scripts/production-health-check.php
@@ -1,0 +1,381 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Production external health checks: HTTPS probes against public AviationWX hosts.
+ *
+ * Read-only GET requests. Exit 0 when all checks pass, 1 on any failure.
+ * Used by .github/workflows/production-health-check.yml (daily schedule).
+ *
+ * Environment (optional overrides):
+ * - HEALTH_CHECK_MAIN     default https://aviationwx.org
+ * - HEALTH_CHECK_API      default https://api.aviationwx.org
+ * - HEALTH_CHECK_EMBED    default https://embed.aviationwx.org
+ * - HEALTH_CHECK_ICAO     default kspb (lowercase, listed airport)
+ * - HEALTH_CHECK_TIMEOUT  default 20 (seconds)
+ *
+ * @package AviationWX
+ */
+
+declare(strict_types=1);
+
+/**
+ * HTTP GET with optional request headers; follows redirects.
+ *
+ * @param array<int, string> $requestHeaders Raw header lines (e.g. "Origin: https://...")
+ * @return array{
+ *     code: int,
+ *     headers: array<string, string>,
+ *     body: string,
+ *     error: string,
+ *     final_url: string
+ * }
+ */
+function productionHealthCheckRequest(string $url, array $requestHeaders, int $timeoutSeconds): array
+{
+    if (!function_exists('curl_init')) {
+        return [
+            'code' => 0,
+            'headers' => [],
+            'body' => '',
+            'error' => 'PHP curl extension not available',
+            'final_url' => $url,
+        ];
+    }
+    $ch = curl_init($url);
+    if ($ch === false) {
+        return [
+            'code' => 0,
+            'headers' => [],
+            'body' => '',
+            'error' => 'curl_init failed',
+            'final_url' => $url,
+        ];
+    }
+    $headerLines = [];
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HEADER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_MAXREDIRS => 5,
+        CURLOPT_CONNECTTIMEOUT => $timeoutSeconds,
+        CURLOPT_TIMEOUT => $timeoutSeconds,
+        CURLOPT_SSL_VERIFYPEER => true,
+        CURLOPT_SSL_VERIFYHOST => 2,
+        CURLOPT_USERAGENT => 'AviationWX-production-health-check/1.0',
+        CURLOPT_HTTPHEADER => $requestHeaders,
+        CURLOPT_HEADERFUNCTION => static function ($ch, $header) use (&$headerLines) {
+            $len = strlen($header);
+            $parts = explode(':', $header, 2);
+            if (count($parts) === 2) {
+                $headerLines[strtolower(trim($parts[0]))] = trim($parts[1]);
+            }
+            return $len;
+        },
+    ]);
+    $raw = curl_exec($ch);
+    $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $headerSize = (int) curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+    $finalUrl = (string) curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+    $curlErr = curl_error($ch);
+    curl_close($ch);
+
+    if ($raw === false) {
+        return [
+            'code' => 0,
+            'headers' => $headerLines,
+            'body' => '',
+            'error' => $curlErr !== '' ? $curlErr : 'curl_exec failed',
+            'final_url' => $finalUrl,
+        ];
+    }
+
+    $body = substr($raw, $headerSize);
+
+    return [
+        'code' => $code,
+        'headers' => $headerLines,
+        'body' => $body,
+        'error' => $curlErr,
+        'final_url' => $finalUrl,
+    ];
+}
+
+/**
+ * @param array<string, string> $headers Associative name => value
+ * @return array<int, string>
+ */
+function productionHealthCheckFormatHeaders(array $headers): array
+{
+    $out = [];
+    foreach ($headers as $k => $v) {
+        $out[] = $k . ': ' . $v;
+    }
+    return $out;
+}
+
+/**
+ * @return array{ok: bool, detail: string}
+ */
+function runNamedCheck(string $name, callable $fn): array
+{
+    $start = microtime(true);
+    try {
+        /** @var array{ok: bool, detail?: string} $r */
+        $r = $fn();
+        $elapsed = round(microtime(true) - $start, 3);
+        $msg = $r['detail'] ?? ($r['ok'] ? 'OK' : 'failed');
+
+        return [
+            'name' => $name,
+            'ok' => (bool) $r['ok'],
+            'detail' => $name . ': ' . $msg . " ({$elapsed}s)",
+        ];
+    } catch (Throwable $e) {
+        $elapsed = round(microtime(true) - $start, 3);
+
+        return [
+            'name' => $name,
+            'ok' => false,
+            'detail' => $name . ': ' . $e->getMessage() . " ({$elapsed}s)",
+        ];
+    }
+}
+
+$main = rtrim((string) (getenv('HEALTH_CHECK_MAIN') ?: 'https://aviationwx.org'), '/');
+$api = rtrim((string) (getenv('HEALTH_CHECK_API') ?: 'https://api.aviationwx.org'), '/');
+$embed = rtrim((string) (getenv('HEALTH_CHECK_EMBED') ?: 'https://embed.aviationwx.org'), '/');
+$icao = strtolower(trim((string) (getenv('HEALTH_CHECK_ICAO') ?: 'kspb')));
+$timeout = max(5, (int) (getenv('HEALTH_CHECK_TIMEOUT') ?: '20'));
+$googleEmbedOrigin = 'https://1912747447-atari-embeds.googleusercontent.com';
+
+$checks = [
+    'embed_widget_js' => static function () use ($embed, $timeout) {
+        $r = productionHealthCheckRequest($embed . '/widget.js', [], $timeout);
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code'] . ' ' . $r['error']];
+        }
+        $ct = $r['headers']['content-type'] ?? '';
+        if (stripos($ct, 'javascript') === false && stripos($ct, 'application/javascript') === false && stripos($ct, 'text/javascript') === false) {
+            return ['ok' => false, 'detail' => 'unexpected content-type: ' . $ct];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'embed_css' => static function () use ($embed, $timeout) {
+        $r = productionHealthCheckRequest($embed . '/public/css/embed-widgets.css', [], $timeout);
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'embed_api_cors' => static function () use ($embed, $icao, $timeout, $googleEmbedOrigin) {
+        $url = $embed . '/api/v1/airports/' . rawurlencode($icao) . '/embed';
+        $r = productionHealthCheckRequest(
+            $url,
+            productionHealthCheckFormatHeaders([
+                'Origin' => $googleEmbedOrigin,
+                'Accept' => 'application/json',
+            ]),
+            $timeout
+        );
+        if (stripos($r['final_url'], 'embed.aviationwx.org') === false) {
+            return ['ok' => false, 'detail' => 'followed away from embed host: ' . $r['final_url']];
+        }
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code'] . ' ' . $r['error']];
+        }
+        $acao = $r['headers']['access-control-allow-origin'] ?? '';
+        if ($acao === '') {
+            return ['ok' => false, 'detail' => 'missing Access-Control-Allow-Origin'];
+        }
+        $json = json_decode($r['body'], true);
+        if (!is_array($json) || empty($json['success']) || empty($json['data']['embed'])) {
+            return ['ok' => false, 'detail' => 'invalid embed JSON payload'];
+        }
+        return ['ok' => true, 'detail' => '200 + CORS + embed JSON'];
+    },
+    'api_v1_embed' => static function () use ($api, $icao, $timeout) {
+        $url = $api . '/v1/airports/' . rawurlencode($icao) . '/embed';
+        $r = productionHealthCheckRequest($url, productionHealthCheckFormatHeaders(['Accept' => 'application/json']), $timeout);
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        $json = json_decode($r['body'], true);
+        if (!is_array($json) || empty($json['success'])) {
+            return ['ok' => false, 'detail' => 'invalid JSON'];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'api_v1_version' => static function () use ($api, $timeout) {
+        $r = productionHealthCheckRequest($api . '/v1/version.php', [], $timeout);
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        $json = json_decode($r['body'], true);
+        if (!is_array($json)) {
+            return ['ok' => false, 'detail' => 'not JSON'];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'api_v1_status' => static function () use ($api, $timeout) {
+        $r = productionHealthCheckRequest($api . '/v1/status', productionHealthCheckFormatHeaders(['Accept' => 'application/json']), $timeout);
+        if ($r['code'] === 429) {
+            return ['ok' => true, 'detail' => 'HTTP 429 (rate limit)'];
+        }
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'api_v1_airports' => static function () use ($api, $timeout) {
+        $r = productionHealthCheckRequest($api . '/v1/airports', productionHealthCheckFormatHeaders(['Accept' => 'application/json']), $timeout);
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'api_v1_weather' => static function () use ($api, $icao, $timeout) {
+        $r = productionHealthCheckRequest(
+            $api . '/v1/airports/' . rawurlencode($icao) . '/weather',
+            productionHealthCheckFormatHeaders(['Accept' => 'application/json']),
+            $timeout
+        );
+        if ($r['code'] === 503) {
+            return ['ok' => true, 'detail' => 'HTTP 503 (upstream)'];
+        }
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'api_v1_webcams' => static function () use ($api, $icao, $timeout) {
+        $r = productionHealthCheckRequest(
+            $api . '/v1/airports/' . rawurlencode($icao) . '/webcams',
+            productionHealthCheckFormatHeaders(['Accept' => 'application/json']),
+            $timeout
+        );
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'main_home' => static function () use ($main, $timeout) {
+        $r = productionHealthCheckRequest($main . '/', [], $timeout);
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'dashboard_subdomain' => static function () use ($icao, $timeout) {
+        $url = 'https://' . rawurlencode($icao) . '.aviationwx.org/';
+        $r = productionHealthCheckRequest($url, [], $timeout);
+        if (!in_array($r['code'], [200, 404], true)) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP ' . $r['code']];
+    },
+    'internal_weather_json' => static function () use ($main, $icao, $timeout) {
+        $r = productionHealthCheckRequest(
+            $main . '/api/weather.php?airport=' . rawurlencode($icao),
+            productionHealthCheckFormatHeaders(['Accept' => 'application/json']),
+            $timeout
+        );
+        if (in_array($r['code'], [503, 429], true)) {
+            return ['ok' => true, 'detail' => 'HTTP ' . $r['code']];
+        }
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'internal_webcam_image' => static function () use ($main, $icao, $timeout) {
+        $r = productionHealthCheckRequest($main . '/api/webcam.php?airport=' . rawurlencode($icao) . '&index=0', [], $timeout);
+        if (!in_array($r['code'], [200, 404], true)) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        if ($r['code'] === 200) {
+            $ct = $r['headers']['content-type'] ?? '';
+            if (stripos($ct, 'image/') !== 0) {
+                return ['ok' => false, 'detail' => 'expected image/*, got ' . $ct];
+            }
+        }
+        return ['ok' => true, 'detail' => 'HTTP ' . $r['code']];
+    },
+    'internal_partner_logo_error_shape' => static function () use ($main, $timeout) {
+        $r = productionHealthCheckRequest($main . '/api/partner-logo.php', [], $timeout);
+        if ($r['code'] === 500) {
+            return ['ok' => false, 'detail' => 'HTTP 500'];
+        }
+        if ($r['code'] !== 400) {
+            return ['ok' => false, 'detail' => 'expected HTTP 400, got ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 400'];
+    },
+    'internal_notam_json' => static function () use ($main, $icao, $timeout) {
+        $r = productionHealthCheckRequest(
+            $main . '/api/notam.php?airport=' . rawurlencode($icao),
+            productionHealthCheckFormatHeaders(['Accept' => 'application/json']),
+            $timeout
+        );
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'health_live' => static function () use ($main, $timeout) {
+        $r = productionHealthCheckRequest($main . '/health/health.php', [], $timeout);
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'health_ready' => static function () use ($main, $timeout) {
+        $r = productionHealthCheckRequest($main . '/health/ready.php', [], $timeout);
+        if (!in_array($r['code'], [200, 503], true)) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP ' . $r['code']];
+    },
+    'openapi_json' => static function () use ($api, $timeout) {
+        $r = productionHealthCheckRequest($api . '/openapi.json', productionHealthCheckFormatHeaders(['Accept' => 'application/json']), $timeout);
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
+    'map_tiles_proxy' => static function () use ($main, $timeout) {
+        $url = $main . '/api/map-tiles.php?layer=clouds_new&z=1&x=0&y=0';
+        $r = productionHealthCheckRequest($url, [], $timeout);
+        if ($r['code'] === 429) {
+            return ['ok' => true, 'detail' => 'HTTP 429'];
+        }
+        if ($r['code'] >= 500) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        return ['ok' => true, 'detail' => 'HTTP ' . $r['code']];
+    },
+];
+
+$failed = 0;
+$rows = [];
+foreach ($checks as $name => $fn) {
+    $row = runNamedCheck($name, $fn);
+    $rows[] = $row;
+    fwrite(STDOUT, ($row['ok'] ? '[OK] ' : '[FAIL] ') . $row['detail'] . PHP_EOL);
+    if (!$row['ok']) {
+        $failed++;
+    }
+}
+
+$summaryPath = getenv('GITHUB_STEP_SUMMARY');
+if ($summaryPath !== false && $summaryPath !== '') {
+    $dir = dirname($summaryPath);
+    if (is_dir($dir) && is_writable($dir)) {
+        $md = "\n## Production health check\n\n| Check | Result |\n|-------|--------|\n";
+        foreach ($rows as $row) {
+            $md .= '| `' . $row['name'] . '` | ' . ($row['ok'] ? 'pass' : '**fail**') . " |\n";
+        }
+        @file_put_contents($summaryPath, $md, FILE_APPEND);
+    }
+}
+
+exit($failed > 0 ? 1 : 0);

--- a/scripts/production-health-check.php
+++ b/scripts/production-health-check.php
@@ -51,10 +51,13 @@ function productionHealthCheckRequest(string $url, array $requestHeaders, int $t
             'final_url' => $url,
         ];
     }
+    // With CURLOPT_FOLLOWLOCATION, CURLOPT_HEADER + CURLINFO_HEADER_SIZE only describe the
+    // final hop; raw output would concatenate all redirect bodies incorrectly. Body-only return
+    // plus HEADERFUNCTION; reset headers on each HTTP status line so we keep the final response.
     $headerLines = [];
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_HEADER => true,
+        CURLOPT_HEADER => false,
         CURLOPT_FOLLOWLOCATION => true,
         CURLOPT_MAXREDIRS => 5,
         CURLOPT_CONNECTTIMEOUT => $timeoutSeconds,
@@ -65,21 +68,25 @@ function productionHealthCheckRequest(string $url, array $requestHeaders, int $t
         CURLOPT_HTTPHEADER => $requestHeaders,
         CURLOPT_HEADERFUNCTION => static function ($ch, $header) use (&$headerLines) {
             $len = strlen($header);
+            $trim = trim($header);
+            if ($trim !== '' && preg_match('/^HTTP\\/\\d/', $trim) === 1) {
+                $headerLines = [];
+            }
             $parts = explode(':', $header, 2);
             if (count($parts) === 2) {
                 $headerLines[strtolower(trim($parts[0]))] = trim($parts[1]);
             }
+
             return $len;
         },
     ]);
-    $raw = curl_exec($ch);
+    $body = curl_exec($ch);
     $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    $headerSize = (int) curl_getinfo($ch, CURLINFO_HEADER_SIZE);
     $finalUrl = (string) curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
     $curlErr = curl_error($ch);
     curl_close($ch);
 
-    if ($raw === false) {
+    if ($body === false) {
         return [
             'code' => 0,
             'headers' => $headerLines,
@@ -89,12 +96,10 @@ function productionHealthCheckRequest(string $url, array $requestHeaders, int $t
         ];
     }
 
-    $body = substr($raw, $headerSize);
-
     return [
         'code' => $code,
         'headers' => $headerLines,
-        'body' => $body,
+        'body' => (string) $body,
         'error' => $curlErr,
         'final_url' => $finalUrl,
     ];

--- a/scripts/verify-embed-nginx-conf.php
+++ b/scripts/verify-embed-nginx-conf.php
@@ -1,0 +1,46 @@
+#!/usr/bin/env php
+<?php
+/**
+ * CLI: verify docker/nginx.conf embed vhost has correct Public API v1 routing.
+ *
+ * Exit 0 when valid, 1 when validation fails, 2 when file/path error.
+ * Used by deploy-docker.yml (pre-deploy + post-rsync on server).
+ *
+ * Usage: php scripts/verify-embed-nginx-conf.php [path/to/nginx.conf]
+ *
+ * @package AviationWX
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/lib/nginx-embed-vhost-verify.php';
+
+$path = $argv[1] ?? 'docker/nginx.conf';
+if (!is_readable($path)) {
+    fwrite(STDERR, "Cannot read nginx config: {$path}\n");
+
+    exit(2);
+}
+
+$content = file_get_contents($path);
+if ($content === false) {
+    fwrite(STDERR, "Failed to read nginx config: {$path}\n");
+
+    exit(2);
+}
+
+$block = nginx_extract_embed_aviationwx_server_block($content);
+$errors = nginx_verify_embed_server_block_public_api_v1($block);
+
+if ($errors !== []) {
+    fwrite(STDERR, "Embed nginx vhost verification failed for {$path}:\n");
+    foreach ($errors as $msg) {
+        fwrite(STDERR, "  - {$msg}\n");
+    }
+
+    exit(1);
+}
+
+fwrite(STDOUT, "OK: embed.aviationwx.org server block passes Public API v1 routing checks ({$path})\n");
+
+exit(0);

--- a/tests/Integration/SmokeTest.php
+++ b/tests/Integration/SmokeTest.php
@@ -1,10 +1,13 @@
 <?php
 /**
  * Smoke Tests for Production Endpoint
- * 
+ *
  * Basic health checks and endpoint availability tests.
  * These tests verify that critical endpoints are accessible and functioning.
- * 
+ *
+ * Exercises the Internal API on the main host (for example api/weather.php, api/webcam.php),
+ * not exclusively Public API v1 on api.aviationwx.org. See docs/API.md for terminology.
+ *
  * These tests can be run against production to verify deployment health.
  */
 

--- a/tests/Integration/WebcamApiReliabilityTest.php
+++ b/tests/Integration/WebcamApiReliabilityTest.php
@@ -94,7 +94,7 @@ class WebcamApiReliabilityTest extends TestCase
         // Integrity headers (ETag, Content-Digest, Content-MD5)
         $this->assertArrayHasKey('etag', $response['headers'], 'Should have ETag for conditional requests');
         $this->assertArrayHasKey('content-digest', $response['headers'], 'Should have Content-Digest (RFC 9530)');
-        $this->assertArrayHasKey('content-md5', $response['headers'], 'Should have Content-MD5 for legacy clients');
+        $this->assertArrayHasKey('content-md5', $response['headers'], 'Should have Content-MD5 for clients that still validate MD5');
         $this->assertStringStartsWith('W/"', $response['headers']['etag'], 'ETag should be weak format');
         $this->assertStringStartsWith('sha-256=:', $response['headers']['content-digest'], 'Content-Digest should be RFC 9530 format');
     }

--- a/tests/Unit/NginxEmbedVhostConfigTest.php
+++ b/tests/Unit/NginxEmbedVhostConfigTest.php
@@ -8,6 +8,8 @@
  * @package AviationWX\Tests\Unit
  */
 
+require_once dirname(__DIR__, 2) . '/lib/nginx-embed-vhost-verify.php';
+
 use PHPUnit\Framework\TestCase;
 
 class NginxEmbedVhostConfigTest extends TestCase
@@ -21,88 +23,20 @@ class NginxEmbedVhostConfigTest extends TestCase
     }
 
     /**
-     * Extract the server { ... } block for embed.aviationwx.org from raw nginx config.
-     *
-     * @param string $content Full nginx.conf contents
-     * @return string Embed server block including outer braces
+     * Embed vhost must proxy Public API v1 through router.php on-host (no off-host 301).
      */
-    public static function extractEmbedServerBlock(string $content): string
-    {
-        $marker = 'server_name embed.aviationwx.org;';
-        $pos = strpos($content, $marker);
-        if ($pos === false) {
-            return '';
-        }
-        // Opening brace of this server block: search backward from marker for "server {"
-        $slice = substr($content, 0, $pos);
-        $serverKw = strrpos($slice, 'server {');
-        if ($serverKw === false) {
-            return '';
-        }
-        $prefix = substr($content, $serverKw, 12);
-        $braceRel = strpos($prefix, '{');
-        if ($braceRel === false) {
-            return '';
-        }
-        $braceOpen = $serverKw + $braceRel;
-        // $braceOpen points at '{'
-        $depth = 0;
-        $len = strlen($content);
-        for ($i = $braceOpen; $i < $len; $i++) {
-            $c = $content[$i];
-            if ($c === '{') {
-                $depth++;
-            } elseif ($c === '}') {
-                $depth--;
-                if ($depth === 0) {
-                    return substr($content, $serverKw, $i - $serverKw + 1);
-                }
-            }
-        }
-
-        return '';
-    }
-
-    /**
-     * Embed vhost must not redirect /api/v1 to api.aviationwx.org (breaks CORS on first hop).
-     */
-    public function testEmbedVhostDoesNotUseOffHost301ForApiV1(): void
+    public function testEmbedVhostPublicApiV1Routing(): void
     {
         $path = self::nginxConfPath();
         $this->assertFileExists($path, 'docker/nginx.conf must exist');
         $content = file_get_contents($path);
         $this->assertIsString($content);
-        $block = self::extractEmbedServerBlock($content);
-        $this->assertNotSame('', $block, 'Could not extract embed.aviationwx.org server block');
-
-        $bad = 'return 301 https://api.aviationwx.org/v1';
-        $this->assertStringNotContainsString(
-            $bad,
-            $block,
-            'embed.aviationwx.org must not use off-host 301 for /api/v1 (use internal rewrite + location /v1/)'
-        );
-    }
-
-    /**
-     * Embed vhost must proxy API v1 through router.php like api.aviationwx.org.
-     */
-    public function testEmbedVhostContainsInternalV1Routing(): void
-    {
-        $path = self::nginxConfPath();
-        $content = file_get_contents($path);
-        $this->assertIsString($content);
-        $block = self::extractEmbedServerBlock($content);
-        $this->assertNotSame('', $block);
-
-        $this->assertStringContainsString(
-            'location /v1/',
-            $block,
-            'embed server block should include location /v1/ for Public API routing'
-        );
-        $this->assertStringContainsString(
-            '/api/v1/router.php',
-            $block,
-            'embed server block should rewrite /v1/ to api/v1/router.php'
+        $block = nginx_extract_embed_aviationwx_server_block($content);
+        $errors = nginx_verify_embed_server_block_public_api_v1($block);
+        $this->assertSame(
+            [],
+            $errors,
+            $errors !== [] ? implode('; ', $errors) : ''
         );
     }
 }

--- a/tests/Unit/NginxEmbedVhostConfigTest.php
+++ b/tests/Unit/NginxEmbedVhostConfigTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Regression tests for docker/nginx.conf embed.aviationwx.org routing.
+ *
+ * Ensures Public API paths on the embed host are not served via off-host 301,
+ * which breaks cross-origin fetch() from third-party iframe origins (CORS).
+ *
+ * @package AviationWX\Tests\Unit
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class NginxEmbedVhostConfigTest extends TestCase
+{
+    /**
+     * Path to nginx config relative to repository root.
+     */
+    private static function nginxConfPath(): string
+    {
+        return dirname(__DIR__, 2) . '/docker/nginx.conf';
+    }
+
+    /**
+     * Extract the server { ... } block for embed.aviationwx.org from raw nginx config.
+     *
+     * @param string $content Full nginx.conf contents
+     * @return string Embed server block including outer braces
+     */
+    public static function extractEmbedServerBlock(string $content): string
+    {
+        $marker = 'server_name embed.aviationwx.org;';
+        $pos = strpos($content, $marker);
+        if ($pos === false) {
+            return '';
+        }
+        // Opening brace of this server block: search backward from marker for "server {"
+        $slice = substr($content, 0, $pos);
+        $serverKw = strrpos($slice, 'server {');
+        if ($serverKw === false) {
+            return '';
+        }
+        $prefix = substr($content, $serverKw, 12);
+        $braceRel = strpos($prefix, '{');
+        if ($braceRel === false) {
+            return '';
+        }
+        $braceOpen = $serverKw + $braceRel;
+        // $braceOpen points at '{'
+        $depth = 0;
+        $len = strlen($content);
+        for ($i = $braceOpen; $i < $len; $i++) {
+            $c = $content[$i];
+            if ($c === '{') {
+                $depth++;
+            } elseif ($c === '}') {
+                $depth--;
+                if ($depth === 0) {
+                    return substr($content, $serverKw, $i - $serverKw + 1);
+                }
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Embed vhost must not redirect /api/v1 to api.aviationwx.org (breaks CORS on first hop).
+     */
+    public function testEmbedVhostDoesNotUseOffHost301ForApiV1(): void
+    {
+        $path = self::nginxConfPath();
+        $this->assertFileExists($path, 'docker/nginx.conf must exist');
+        $content = file_get_contents($path);
+        $this->assertIsString($content);
+        $block = self::extractEmbedServerBlock($content);
+        $this->assertNotSame('', $block, 'Could not extract embed.aviationwx.org server block');
+
+        $bad = 'return 301 https://api.aviationwx.org/v1';
+        $this->assertStringNotContainsString(
+            $bad,
+            $block,
+            'embed.aviationwx.org must not use off-host 301 for /api/v1 (use internal rewrite + location /v1/)'
+        );
+    }
+
+    /**
+     * Embed vhost must proxy API v1 through router.php like api.aviationwx.org.
+     */
+    public function testEmbedVhostContainsInternalV1Routing(): void
+    {
+        $path = self::nginxConfPath();
+        $content = file_get_contents($path);
+        $this->assertIsString($content);
+        $block = self::extractEmbedServerBlock($content);
+        $this->assertNotSame('', $block);
+
+        $this->assertStringContainsString(
+            'location /v1/',
+            $block,
+            'embed server block should include location /v1/ for Public API routing'
+        );
+        $this->assertStringContainsString(
+            '/api/v1/router.php',
+            $block,
+            'embed server block should rewrite /v1/ to api/v1/router.php'
+        );
+    }
+}

--- a/tests/Unit/NginxEmbedVhostConfigTest.php
+++ b/tests/Unit/NginxEmbedVhostConfigTest.php
@@ -8,9 +8,9 @@
  * @package AviationWX\Tests\Unit
  */
 
-require_once dirname(__DIR__, 2) . '/lib/nginx-embed-vhost-verify.php';
-
 use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/lib/nginx-embed-vhost-verify.php';
 
 class NginxEmbedVhostConfigTest extends TestCase
 {


### PR DESCRIPTION
## Summary

Cross-origin `fetch()` from Google Sites (and similar) to `embed.aviationwx.org/api/v1/...` failed when nginx returned an off-host **301** to `api.aviationwx.org` before CORS headers applied. The embed `server` block in `docker/nginx.conf` now rewrites `/api/v1` to on-host `/v1/` and proxies through `api/v1/router.php`, matching the API host behavior without a browser-visible redirect.

Adds scheduled external HTTPS checks (`scripts/production-health-check.php`, workflow), embed nginx verification in CD (`lib/nginx-embed-vhost-verify.php`, `scripts/verify-embed-nginx-conf.php`, deploy workflow steps), PHPDoc and 429 tolerance improvements on the health script, Internal vs Public API terminology in docs, and atomic operational documentation updates.

## Technical changes

**Nginx**
- `docker/nginx.conf`: embed `server_name embed.aviationwx.org` serves Public API v1 via internal rewrite + `location /v1/` to `router.php`.

**Tests**
- `tests/Unit/NginxEmbedVhostConfigTest.php`: regression on embed block (shared helpers).

**Operations**
- `scripts/production-health-check.php`: `HEALTH_CHECK_EMBED`-aware final URL host check; HTTP 429 passthrough on relevant probes; `runNamedCheck` PHPDoc.
- `.github/workflows/production-health-check.yml`: daily schedule + dispatch.

**CD**
- `.github/workflows/deploy-docker.yml`: critical files; validation step + post-rsync `verify-embed-nginx-conf.php`.

**Docs**
- Internal API naming, `docs/DEPLOYMENT.md`, `docs/CONFIGURATION.md`, `docs/EMBED.md`, `docs/API.md`, `docs/TESTING.md`, `docs/ARCHITECTURE.md`, `docs/OPERATIONS.md`, `CODE_STYLE.md` / integration messages as in commits.

## Deploy notes

Production must ship `docker/nginx.conf` from this repo (existing CD rsync + bind mount). After merge, deploy applies nginx change; daily health check `embed_api_cors` validates behavior against production.

## Testing

- `make test-ci` passed locally before documentation commit.