### PR TITLE
Push FTP/SFTP upload inbox debris cleanup (config allowlist, hourly cron)

### DIFF
--- a/config/airports.json.example
+++ b/config/airports.json.example
@@ -60,6 +60,8 @@
     "webcam_history_preset_hours": [1, 3, 6, 24],
     
     "webcam_variant_heights": [1080, 720, 360],
+    "_comment_push_upload_cleanup": "Optional. FTP/SFTP push inbox debris cleanup keeps files with these extensions plus each push camera push_config.allowed_extensions (subset of jpg,jpeg,png,webp). Omit key entirely for the same default without listing it.",
+    "push_upload_allowed_extensions": ["jpg", "jpeg", "png", "webp"],
     "_comment_legacy": "The following image_* options are deprecated. Use webcam_variant_heights instead.",
     "image_primary_size": "1920x1080",
     "image_max_resolution": "3840x2160",

--- a/config/crontab
+++ b/config/crontab
@@ -32,6 +32,10 @@ CONFIG_PATH=/var/www/html/secrets/airports.json
 # (both push and pull) with per-camera refresh_seconds configuration.
 # This cron job has been removed as part of the unified webcam worker refactor.
 
+# Push FTP/SFTP upload inbox debris (non-image files older than CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS)
+# Runs hourly; daily cleanup-cache.php also includes this step as a safety net.
+17 * * * * www-data cd /var/www/html && /usr/local/bin/php scripts/cleanup-push-upload-debris.php >> /var/log/aviationwx/cleanup-push-upload-debris.log 2>&1
+
 # Cache Cleanup - Runs daily at 4 AM
 # Two-layer cleanup strategy (belt and suspenders):
 # - Layer 1: Primary cleanup for files without automatic cleanup (rate limits, error files)

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -332,6 +332,7 @@ if [ -d "${LOG_DIR}" ]; then
           "${LOG_DIR}/cron-weather.log" \
           "${LOG_DIR}/cron-push-webcams.log" \
           "${LOG_DIR}/cron-heartbeat.log" \
+          "${LOG_DIR}/cleanup-push-upload-debris.log" \
           "${LOG_DIR}/apache-access.log" \
           "${LOG_DIR}/apache-error.log" \
           "${LOG_DIR}/sshd.log" \

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -33,6 +33,7 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 | `dynamic_dns_refresh_seconds` | `0` | Re-resolve DNS periodically for DDNS (0=disabled, min 60) |
 | `webcam_refresh_default` | `60` | Default webcam refresh (seconds) |
 | `cache_file_max_size_mb` | `25` | Max size in MiB for webcam pipeline loads, HTTP/MJPEG pull downloads, partner logo fetches, and **default** push upload acceptance (integer **1--100**). |
+| `push_upload_allowed_extensions` | omit | Optional: extensions **preserved** during FTP/SFTP push inbox debris cleanup; merged with each push camera `push_config.allowed_extensions`. Values must be from **jpg, jpeg, png, webp**. Omit the key for the full default (all four). |
 | `weather_refresh_default` | `60` | Default weather refresh (seconds) |
 | `metar_refresh_seconds` | `60` | METAR refresh interval (min: 60) |
 | `notam_refresh_seconds` | `600` | NOTAM refresh interval |
@@ -166,7 +167,7 @@ Values are strings in MHz (e.g. `"122.8"`, `"123.05"`).
 | `push_config.username` | — | 14 alphanumeric chars |
 | `push_config.password` | — | 14 alphanumeric chars |
 | `push_config.max_file_size_mb` | *(inherit global)* | Optional per-camera cap (integer **1** through **`config.cache_file_max_size_mb`**). Omit to use the global `cache_file_max_size_mb` for FTP/SFTP acceptance. Set lower to limit a single camera (bandwidth or policy). |
-| `push_config.allowed_extensions` | `["jpg","jpeg","png"]` | Allowed file types |
+| `push_config.allowed_extensions` | `["jpg","jpeg","png","webp"]` | Allowed file types (subset of **jpg, jpeg, png, webp**) |
 | `push_config.upload_file_max_age_seconds` | `1800` | Max file age before abandonment (600-7200) |
 | `push_config.stability_check_timeout_seconds` | `15` | Stability check timeout (10-30) |
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1847,6 +1847,7 @@ This path is separate from weather, webcam, and NOTAM pipelines. It supplies **g
 
 ### Cache cleanup (`scripts/cleanup-cache.php`)
 
+- **Push FTP/SFTP inbox debris:** Same keep-list as above. **`scripts/cleanup-push-upload-debris.php`** runs **hourly** via cron; **`cleanup-cache.php`** still runs the same step daily as a backup.
 - Layer-2 age cleanup for the aggregate uses a **90-day** threshold so a healthy file is not deleted while the 30-day policy still considers it usable between scheduler passes.
 
 ---

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -38,6 +38,8 @@ All logs are in `/var/log/aviationwx/` inside the container (mounted from `/var/
 | `apache-error.log` | HTTP error logs |
 | `php-error.log` | PHP runtime errors |
 | `cron-heartbeat.log` | Cron daemon status |
+| `cleanup-push-upload-debris.log` | Hourly push FTP/SFTP inbox debris cleanup (stdout) |
+| `cleanup-cache.log` | Daily full cache cleanup (stdout) |
 | `scheduler-health-check.log` | Scheduler health checks |
 
 **Log rotation**: 1 rotated file, 100MB max per file.

--- a/lib/config.php
+++ b/lib/config.php
@@ -3504,7 +3504,7 @@ function validateAirportsJsonStructure(array $config): array {
                     $master = push_upload_master_image_extensions();
                     $masterList = implode(', ', $master);
                     foreach ($cfg['push_upload_allowed_extensions'] as $ext) {
-                        if (!is_string($ext) && !is_int($ext)) {
+                        if (!is_string($ext)) {
                             $errors[] = 'config.push_upload_allowed_extensions entries must be strings';
                             break;
                         }
@@ -4420,7 +4420,7 @@ function validateAirportsJsonStructure(array $config): array {
                                         } else {
                                             $masterList = push_upload_master_image_extensions();
                                             foreach ($pushConfig['allowed_extensions'] as $pex) {
-                                                if (!is_string($pex) && !is_int($pex)) {
+                                                if (!is_string($pex)) {
                                                     $errors[] = "Airport '{$airportCode}' webcam[{$idx}] push_config.allowed_extensions entries must be strings";
                                                     break;
                                                 }

--- a/lib/config.php
+++ b/lib/config.php
@@ -1376,6 +1376,105 @@ function getWebcamHistoryUIConfig(string $airportId): array {
 }
 
 /**
+ * Normalize and validate an extension against the push master allowlist.
+ *
+ * @param mixed             $ext        Extension string (may include leading dot)
+ * @param array<string,int> $masterFlip flip(push_upload_master_image_extensions())
+ */
+function push_upload_filter_extension_to_master($ext, array $masterFlip): ?string
+{
+    if (!is_string($ext) && !is_int($ext)) {
+        return null;
+    }
+    $e = strtolower(ltrim(trim((string) $ext), '.'));
+    if ($e === '' || !isset($masterFlip[$e])) {
+        return null;
+    }
+
+    return $e;
+}
+
+/**
+ * Sorted unique list for stable comparisons and logging.
+ *
+ * @param array<int, string> $exts
+ * @return array<int, string>
+ */
+function push_upload_sorted_unique_extensions_list(array $exts): array
+{
+    $exts = array_unique(array_map(static function ($x): string {
+        return strtolower((string) $x);
+    }, $exts));
+    sort($exts);
+
+    return array_values($exts);
+}
+
+/**
+ * Effective allowlist of push inbox image extensions for FTP/SFTP debris cleanup.
+ *
+ * Merges optional global `config.push_upload_allowed_extensions` with every push camera's
+ * `push_config.allowed_extensions`. Values are intersected with {@see push_upload_master_image_extensions()}.
+ *
+ * When nothing is configured (no global key and no push cameras contribute extensions), returns
+ * the full master list (jpg, jpeg, png, webp).
+ *
+ * @return array<int, string>
+ */
+function getPushUploadAllowedExtensionsForCleanup(): array
+{
+    $master = push_upload_master_image_extensions();
+    $masterFlip = array_flip($master);
+
+    $merged = [];
+
+    $config = loadConfig();
+    if ($config === null) {
+        return push_upload_sorted_unique_extensions_list($master);
+    }
+
+    $cfgBlock = $config['config'] ?? [];
+    if (isset($cfgBlock['push_upload_allowed_extensions'])
+        && is_array($cfgBlock['push_upload_allowed_extensions'])
+        && $cfgBlock['push_upload_allowed_extensions'] !== []) {
+        foreach ($cfgBlock['push_upload_allowed_extensions'] as $ext) {
+            $e = push_upload_filter_extension_to_master($ext, $masterFlip);
+            if ($e !== null) {
+                $merged[$e] = true;
+            }
+        }
+    }
+
+    if (isset($config['airports']) && is_array($config['airports'])) {
+        foreach ($config['airports'] as $airport) {
+            $webcams = $airport['webcams'] ?? [];
+            foreach ($webcams as $cam) {
+                $pc = $cam['push_config'] ?? null;
+                if (!is_array($pc)) {
+                    continue;
+                }
+                $ae = $pc['allowed_extensions'] ?? null;
+                if (!is_array($ae)) {
+                    continue;
+                }
+                foreach ($ae as $ext) {
+                    $e = push_upload_filter_extension_to_master($ext, $masterFlip);
+                    if ($e !== null) {
+                        $merged[$e] = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if ($merged === []) {
+        return push_upload_sorted_unique_extensions_list($master);
+    }
+
+    return push_upload_sorted_unique_extensions_list(array_keys($merged));
+}
+
+/**
  * Get HTTP integrity digest cache TTL in seconds
  *
  * Matches the oldest content we cache digests for: webcam history images
@@ -3394,6 +3493,28 @@ function validateAirportsJsonStructure(array $config): array {
                     $errors[] = "config.dynamic_dns_refresh_seconds must be >= 60 seconds when enabled (or 0 to disable)";
                 }
             }
+
+            // Optional global allowlist for push FTP/SFTP inbox debris cleanup (union with per-push-camera allowed_extensions)
+            if (isset($cfg['push_upload_allowed_extensions'])) {
+                if (!is_array($cfg['push_upload_allowed_extensions'])) {
+                    $errors[] = 'config.push_upload_allowed_extensions must be an array';
+                } elseif ($cfg['push_upload_allowed_extensions'] === []) {
+                    $errors[] = 'config.push_upload_allowed_extensions must be non-empty when set (omit the key to use defaults)';
+                } else {
+                    $master = push_upload_master_image_extensions();
+                    $masterList = implode(', ', $master);
+                    foreach ($cfg['push_upload_allowed_extensions'] as $ext) {
+                        if (!is_string($ext) && !is_int($ext)) {
+                            $errors[] = 'config.push_upload_allowed_extensions entries must be strings';
+                            break;
+                        }
+                        $e = strtolower(ltrim(trim((string) $ext), '.'));
+                        if (!in_array($e, $master, true)) {
+                            $errors[] = "config.push_upload_allowed_extensions: invalid extension '{$ext}' (allowed: {$masterList})";
+                        }
+                    }
+                }
+            }
             
             // Validate staleness thresholds (3-tier model)
             $stalenessKeys = [
@@ -4293,8 +4414,22 @@ function validateAirportsJsonStructure(array $config): array {
                                             $errors[] = "Airport '{$airportCode}' webcam index {$idx}: max_file_size_mb must be between 1 and {$upper} (global cache_file_max_size_mb is {$globalMb}; omit key to inherit)";
                                         }
                                     }
-                                    if (isset($pushConfig['allowed_extensions']) && !is_array($pushConfig['allowed_extensions'])) {
-                                        $errors[] = "Airport '{$airportCode}' webcam[{$idx}] push_config.allowed_extensions must be an array";
+                                    if (isset($pushConfig['allowed_extensions'])) {
+                                        if (!is_array($pushConfig['allowed_extensions'])) {
+                                            $errors[] = "Airport '{$airportCode}' webcam[{$idx}] push_config.allowed_extensions must be an array";
+                                        } else {
+                                            $masterList = push_upload_master_image_extensions();
+                                            foreach ($pushConfig['allowed_extensions'] as $pex) {
+                                                if (!is_string($pex) && !is_int($pex)) {
+                                                    $errors[] = "Airport '{$airportCode}' webcam[{$idx}] push_config.allowed_extensions entries must be strings";
+                                                    break;
+                                                }
+                                                $e = strtolower(ltrim(trim((string) $pex), '.'));
+                                                if (!in_array($e, $masterList, true)) {
+                                                    $errors[] = "Airport '{$airportCode}' webcam[{$idx}] push_config.allowed_extensions: invalid extension '{$pex}' (allowed: " . implode(', ', $masterList) . ')';
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -555,6 +555,11 @@ if (!defined('MAX_UPLOAD_FILE_MAX_AGE_SECONDS')) {
     define('MAX_UPLOAD_FILE_MAX_AGE_SECONDS', 7200); // 2 hours maximum (config override)
 }
 
+// Push FTP/SFTP inbox debris: max file age (mtime) before deletion (hourly + daily cleanup scripts)
+if (!defined('CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS')) {
+    define('CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS', 172800); // 48 hours
+}
+
 // Push webcam adaptive stability checking
 // How long to wait in stability checking loop for in-progress upload
 if (!defined('DEFAULT_STABILITY_CHECK_TIMEOUT_SECONDS')) {
@@ -969,5 +974,18 @@ if (!defined('WEBCAM_WEBP_COMPRESSION_LEVEL')) {
 // - 10+: Visible artifacts
 if (!defined('WEBCAM_JPEG_QUALITY')) {
     define('WEBCAM_JPEG_QUALITY', 1);
+}
+
+/**
+ * Master allowlist of push upload image file extensions (lowercase, no dot).
+ *
+ * The acquisition worker only globs these types; config and debris cleanup may use subsets
+ * but must not list extensions outside this set.
+ *
+ * @return array<int, string>
+ */
+function push_upload_master_image_extensions(): array
+{
+    return ['jpg', 'jpeg', 'png', 'webp'];
 }
 

--- a/lib/push-upload-debris-cleanup.php
+++ b/lib/push-upload-debris-cleanup.php
@@ -71,64 +71,64 @@ function cleanupPushUploadDebris(
                 new RecursiveDirectoryIterator($root, RecursiveDirectoryIterator::SKIP_DOTS),
                 RecursiveIteratorIterator::LEAVES_ONLY
             );
-        } catch (Exception $e) {
+
+            foreach ($iterator as $fileInfo) {
+                if (!$fileInfo->isFile()) {
+                    continue;
+                }
+
+                $path = $fileInfo->getPathname();
+                $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+                if ($ext !== '' && isset($allowedFlip[$ext])) {
+                    continue;
+                }
+
+                $stats['files_checked']++;
+                $mtime = @filemtime($path);
+                if ($mtime === false) {
+                    continue;
+                }
+
+                $age = $now - $mtime;
+                if ($age <= $maxAgeSeconds) {
+                    continue;
+                }
+
+                $size = @filesize($path);
+                if ($size === false) {
+                    $size = 0;
+                }
+
+                if ($verbose) {
+                    echo '  ' . ($dryRun ? 'Would delete' : 'Deleting') . ' ' . $path
+                        . ' (age: ' . formatPushUploadDebrisAge($age) . ", size: {$size} B)\n";
+                }
+
+                if ($dryRun) {
+                    $stats['files_deleted']++;
+                    $stats['bytes_freed'] += $size;
+                    $phaseDeleted++;
+                    $phaseBytes += $size;
+                    continue;
+                }
+
+                if (@unlink($path)) {
+                    $stats['files_deleted']++;
+                    $stats['bytes_freed'] += $size;
+                    $phaseDeleted++;
+                    $phaseBytes += $size;
+                } else {
+                    $stats['errors']++;
+                    echo "  Failed to delete: {$path}\n";
+                }
+            }
+        } catch (Throwable $e) {
             $stats['errors']++;
             aviationwx_log('warning', 'push upload debris cleanup: cannot iterate directory', [
                 'root' => $root,
                 'error' => $e->getMessage(),
             ], 'app');
             continue;
-        }
-
-        foreach ($iterator as $fileInfo) {
-            if (!$fileInfo->isFile()) {
-                continue;
-            }
-
-            $path = $fileInfo->getPathname();
-            $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
-            if ($ext !== '' && isset($allowedFlip[$ext])) {
-                continue;
-            }
-
-            $stats['files_checked']++;
-            $mtime = @filemtime($path);
-            if ($mtime === false) {
-                continue;
-            }
-
-            $age = $now - $mtime;
-            if ($age <= $maxAgeSeconds) {
-                continue;
-            }
-
-            $size = @filesize($path);
-            if ($size === false) {
-                $size = 0;
-            }
-
-            if ($verbose) {
-                echo '  ' . ($dryRun ? 'Would delete' : 'Deleting') . ' ' . $path
-                    . ' (age: ' . formatPushUploadDebrisAge($age) . ", size: {$size} B)\n";
-            }
-
-            if ($dryRun) {
-                $stats['files_deleted']++;
-                $stats['bytes_freed'] += $size;
-                $phaseDeleted++;
-                $phaseBytes += $size;
-                continue;
-            }
-
-            if (@unlink($path)) {
-                $stats['files_deleted']++;
-                $stats['bytes_freed'] += $size;
-                $phaseDeleted++;
-                $phaseBytes += $size;
-            } else {
-                $stats['errors']++;
-                echo "  Failed to delete: {$path}\n";
-            }
         }
     }
 

--- a/lib/push-upload-debris-cleanup.php
+++ b/lib/push-upload-debris-cleanup.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Push upload inbox debris cleanup (FTP/SFTP).
+ *
+ * Uses {@see getPushUploadAllowedExtensionsForCleanup()} so the keep-list matches
+ * `config.push_upload_allowed_extensions` (optional), each push camera's `allowed_extensions`,
+ * and defaults to {@see push_upload_master_image_extensions()}.
+ *
+ * Anything not in that effective allowlist (including extensionless files) is eligible for age-based
+ * deletion so disk cannot grow without bound when vendors upload video or sidecars.
+ */
+
+require_once __DIR__ . '/cache-paths.php';
+require_once __DIR__ . '/config.php';
+
+/**
+ * Collect roots to scan: FTP cache tree plus each SFTP user's files/ directory when present.
+ *
+ * @return array<int, string>
+ */
+function push_upload_debris_default_roots(): array
+{
+    $roots = [CACHE_UPLOADS_DIR];
+
+    if (is_dir(CACHE_SFTP_DIR) && is_readable(CACHE_SFTP_DIR)) {
+        $filesDirs = glob(rtrim(CACHE_SFTP_DIR, '/') . '/*/files', GLOB_ONLYDIR) ?: [];
+        foreach ($filesDirs as $dir) {
+            if (is_readable($dir)) {
+                $roots[] = $dir;
+            }
+        }
+    }
+
+    return $roots;
+}
+
+/**
+ * Remove stale files that are not in the effective push upload allowlist.
+ *
+ * @param int               $maxAgeSeconds Minimum age (mtime) before a file is eligible
+ * @param array<string, int> $stats Mutated: files_checked, files_deleted, bytes_freed, errors
+ * @param bool              $dryRun        When true, count only
+ * @param bool              $verbose       Extra per-file output
+ * @param array<int,string>|null $rootsOverride For tests; when null, uses {@see push_upload_debris_default_roots()}
+ * @param array<int,string>|null $allowedExtensionsOverride When non-null, extensions to keep (lowercase); when null, uses {@see getPushUploadAllowedExtensionsForCleanup()}
+ */
+function cleanupPushUploadDebris(
+    int $maxAgeSeconds,
+    array &$stats,
+    bool $dryRun,
+    bool $verbose,
+    ?array $rootsOverride = null,
+    ?array $allowedExtensionsOverride = null
+): void {
+    $roots = $rootsOverride ?? push_upload_debris_default_roots();
+    $allowedList = $allowedExtensionsOverride ?? getPushUploadAllowedExtensionsForCleanup();
+    $allowedFlip = array_flip($allowedList);
+
+    $now = time();
+    $phaseDeleted = 0;
+    $phaseBytes = 0;
+
+    foreach ($roots as $root) {
+        $root = rtrim($root, '/');
+        if ($root === '' || !is_dir($root) || !is_readable($root)) {
+            continue;
+        }
+
+        try {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($root, RecursiveDirectoryIterator::SKIP_DOTS),
+                RecursiveIteratorIterator::LEAVES_ONLY
+            );
+        } catch (Exception $e) {
+            $stats['errors']++;
+            aviationwx_log('warning', 'push upload debris cleanup: cannot iterate directory', [
+                'root' => $root,
+                'error' => $e->getMessage(),
+            ], 'app');
+            continue;
+        }
+
+        foreach ($iterator as $fileInfo) {
+            if (!$fileInfo->isFile()) {
+                continue;
+            }
+
+            $path = $fileInfo->getPathname();
+            $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+            if ($ext !== '' && isset($allowedFlip[$ext])) {
+                continue;
+            }
+
+            $stats['files_checked']++;
+            $mtime = @filemtime($path);
+            if ($mtime === false) {
+                continue;
+            }
+
+            $age = $now - $mtime;
+            if ($age <= $maxAgeSeconds) {
+                continue;
+            }
+
+            $size = @filesize($path);
+            if ($size === false) {
+                $size = 0;
+            }
+
+            if ($verbose) {
+                echo '  ' . ($dryRun ? 'Would delete' : 'Deleting') . ' ' . $path
+                    . ' (age: ' . formatPushUploadDebrisAge($age) . ", size: {$size} B)\n";
+            }
+
+            if ($dryRun) {
+                $stats['files_deleted']++;
+                $stats['bytes_freed'] += $size;
+                $phaseDeleted++;
+                $phaseBytes += $size;
+                continue;
+            }
+
+            if (@unlink($path)) {
+                $stats['files_deleted']++;
+                $stats['bytes_freed'] += $size;
+                $phaseDeleted++;
+                $phaseBytes += $size;
+            } else {
+                $stats['errors']++;
+                echo "  Failed to delete: {$path}\n";
+            }
+        }
+    }
+
+    if ($phaseDeleted > 0 || $verbose) {
+        $action = $dryRun ? 'Would delete' : 'Deleted';
+        $mb = round($phaseBytes / (1024 * 1024), 2);
+        echo "  Push upload debris (FTP/SFTP non-image files): {$action} {$phaseDeleted} files ({$mb} MB)\n";
+    }
+}
+
+/**
+ * Human-readable age for verbose debris cleanup output.
+ *
+ * @param int $ageSeconds Age in seconds
+ * @return string Short human-readable duration
+ */
+function formatPushUploadDebrisAge(int $ageSeconds): string
+{
+    if ($ageSeconds < 3600) {
+        return round($ageSeconds / 60, 1) . ' min';
+    }
+    if ($ageSeconds < 86400) {
+        return round($ageSeconds / 3600, 1) . ' h';
+    }
+
+    return round($ageSeconds / 86400, 1) . ' d';
+}

--- a/lib/push-webcam-validator.php
+++ b/lib/push-webcam-validator.php
@@ -5,6 +5,7 @@
  */
 
 require_once __DIR__ . '/logger.php';
+require_once __DIR__ . '/constants.php';
 
 /**
  * Validate push webcam configuration
@@ -88,7 +89,7 @@ function validatePushWebcamConfig($cam, $airportId, $camIndex, ?int $globalCache
         if (!is_array($pushConfig['allowed_extensions'])) {
             $errors[] = "Airport '{$airportId}' webcam index {$camIndex}: allowed_extensions must be an array";
         } else {
-            $validExtensions = ['jpg', 'jpeg', 'png'];
+            $validExtensions = push_upload_master_image_extensions();
             foreach ($pushConfig['allowed_extensions'] as $ext) {
                 if (!in_array(strtolower($ext), $validExtensions)) {
                     $errors[] = "Airport '{$airportId}' webcam index {$camIndex}: invalid extension '{$ext}' (allowed: " . implode(', ', $validExtensions) . ")";

--- a/pages/config-generator.php
+++ b/pages/config-generator.php
@@ -538,7 +538,7 @@ function generateConfigSnippet($formData) {
                     'password' => $cam['push_password'] ?? generateRandomCredential(),
                     'protocol' => strtolower($cam['protocol'] ?? 'sftp'),
                     'port' => intval($cam['port'] ?? ($cam['protocol'] === 'sftp' ? 2222 : ($cam['protocol'] === 'ftps' ? 2122 : 2121))),
-                    'allowed_extensions' => ['jpg', 'jpeg', 'png']
+                    'allowed_extensions' => ['jpg', 'jpeg', 'png', 'webp']
                 ];
                 $mfs = $cam['max_file_size_mb'] ?? '';
                 if ($mfs !== '' && $mfs !== null && is_numeric($mfs) && (int) $mfs > 0) {

--- a/scripts/cleanup-cache.php
+++ b/scripts/cleanup-cache.php
@@ -9,6 +9,7 @@
  * - Rate limit files older than 1 hour
  * - Webcam error files older than 7 days
  * - Outage state files older than 30 days
+ * - Push FTP/SFTP inbox debris (files not in the config-derived keep-list; see getPushUploadAllowedExtensionsForCleanup())
  * 
  * LAYER 2 - Backup cleanup for files WITH automatic cleanup:
  * More generous thresholds as a safety net in case primary cleanup fails.
@@ -83,6 +84,8 @@ require_once __DIR__ . '/../lib/cache-paths.php';
 define('CLEANUP_RATE_LIMIT_AGE', 86400);          // 24 hours
 define('CLEANUP_WEBCAM_ERROR_AGE', 604800);       // 7 days
 define('CLEANUP_OUTAGE_STATE_AGE', 2592000);      // 30 days
+// Push upload dirs: MP4/TXT etc. are never processed by acquisition (images only); remove after 48h
+// (shared with scripts/cleanup-push-upload-debris.php hourly job)
 
 // Layer 2: Backup cleanup (more generous - safety net)
 define('CLEANUP_WEATHER_HISTORY_AGE', 172800);    // 48 hours (primary: 24h)
@@ -198,6 +201,12 @@ cleanupFilesByPattern(
     'Public API rate limit files',
     $stats, $dryRun, $verbose
 );
+
+// Push FTP/SFTP upload debris (e.g. Reolink MP4 + sidecar TXT; worker only ingests images)
+require_once __DIR__ . '/../lib/push-upload-debris-cleanup.php';
+echo "Push upload debris (FTP/SFTP non-image files)...\n";
+cleanupPushUploadDebris(CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS, $stats, $dryRun, $verbose);
+echo "\n";
 
 // ============================================================================
 // LAYER 2: Backup cleanup (safety net for files with automatic cleanup)

--- a/scripts/cleanup-push-upload-debris.php
+++ b/scripts/cleanup-push-upload-debris.php
@@ -1,0 +1,62 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Hourly cleanup of push FTP/SFTP upload inbox debris.
+ *
+ * Removes stale files whose extensions are not in the config-derived keep-list
+ * (see getPushUploadAllowedExtensionsForCleanup()). Same behavior as the push debris
+ * step in scripts/cleanup-cache.php Layer 1.
+ *
+ * Usage:
+ *   php cleanup-push-upload-debris.php [--dry-run] [--verbose] [--help]
+ */
+
+if (php_sapi_name() !== 'cli') {
+    http_response_code(403);
+    die('This script must be run from the command line');
+}
+
+$options = getopt('', ['dry-run', 'verbose', 'help']);
+if (isset($options['help'])) {
+    echo "Usage: php cleanup-push-upload-debris.php [--dry-run] [--verbose]\n";
+    exit(0);
+}
+
+$dryRun = isset($options['dry-run']);
+$verbose = isset($options['verbose']);
+
+chdir(__DIR__ . '/..');
+
+require_once __DIR__ . '/../lib/push-upload-debris-cleanup.php';
+
+$stats = [
+    'files_checked' => 0,
+    'files_deleted' => 0,
+    'bytes_freed' => 0,
+    'errors' => 0,
+];
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n";
+echo 'Push upload debris cleanup - ' . gmdate('Y-m-d H:i:s') . " UTC\n";
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n";
+
+if ($dryRun) {
+    echo "DRY RUN - No files will be deleted\n\n";
+}
+
+cleanupPushUploadDebris(
+    (int) CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS,
+    $stats,
+    $dryRun,
+    $verbose
+);
+
+aviationwx_log('info', 'push upload debris cleanup finished', [
+    'files_checked' => $stats['files_checked'],
+    'files_deleted' => $stats['files_deleted'],
+    'bytes_freed' => $stats['bytes_freed'],
+    'errors' => $stats['errors'],
+    'dry_run' => $dryRun,
+], 'app');
+
+exit($stats['errors'] > 0 ? 1 : 0);

--- a/tests/Unit/PushUploadDebrisCleanupTest.php
+++ b/tests/Unit/PushUploadDebrisCleanupTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Tests for push FTP/SFTP upload debris cleanup (non-image files ignored by push worker).
+ */
+
+require_once __DIR__ . '/../../lib/push-upload-debris-cleanup.php';
+
+use PHPUnit\Framework\TestCase;
+
+final class PushUploadDebrisCleanupTest extends TestCase
+{
+    private string $tempRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempRoot = sys_get_temp_dir() . '/awx_push_debris_test_' . bin2hex(random_bytes(8));
+        mkdir($this->tempRoot . '/nested/2026/05/09', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTree($this->tempRoot);
+        parent::tearDown();
+    }
+
+    /**
+     * Old MP4 and TXT are removed; fresh MP4 and JPG remain.
+     */
+    public function testRemovesStaleVideoAndSidecarKeepsRecentAndImages(): void
+    {
+        $oldMp4 = $this->tempRoot . '/nested/old_clip.mp4';
+        $newMp4 = $this->tempRoot . '/nested/new_clip.mp4';
+        $oldTxt = $this->tempRoot . '/nested/sidecar.txt';
+        $jpg = $this->tempRoot . '/nested/frame.jpg';
+
+        file_put_contents($oldMp4, str_repeat('x', 100));
+        touch($oldMp4, time() - 200000);
+
+        file_put_contents($newMp4, 'small');
+        touch($newMp4, time() - 3600);
+
+        file_put_contents($oldTxt, 'meta');
+        touch($oldTxt, time() - 200000);
+
+        file_put_contents($jpg, 'jpeg');
+        touch($jpg, time() - 200000);
+
+        $stats = [
+            'files_checked' => 0,
+            'files_deleted' => 0,
+            'bytes_freed' => 0,
+            'errors' => 0,
+        ];
+
+        $maxAge = 172800;
+
+        cleanupPushUploadDebris($maxAge, $stats, false, false, [$this->tempRoot], push_upload_master_image_extensions());
+
+        $this->assertFileDoesNotExist($oldMp4);
+        $this->assertFileDoesNotExist($oldTxt);
+        $this->assertFileExists($newMp4);
+        $this->assertFileExists($jpg);
+        $this->assertSame(2, $stats['files_deleted']);
+        $this->assertSame(0, $stats['errors']);
+    }
+
+    /**
+     * Unknown extension is debris and is removed when stale.
+     */
+    public function testRemovesStaleUnknownExtension(): void
+    {
+        $junk = $this->tempRoot . '/nested/file.xyz';
+        file_put_contents($junk, 'x');
+        touch($junk, time() - 200000);
+
+        $stats = [
+            'files_checked' => 0,
+            'files_deleted' => 0,
+            'bytes_freed' => 0,
+            'errors' => 0,
+        ];
+
+        cleanupPushUploadDebris(172800, $stats, false, false, [$this->tempRoot], push_upload_master_image_extensions());
+
+        $this->assertFileDoesNotExist($junk);
+        $this->assertSame(1, $stats['files_deleted']);
+    }
+
+    /**
+     * Restrictive allowlist treats omitted types as debris.
+     */
+    public function testRestrictiveAllowlistDeletesStaleAllowedTypesNotInList(): void
+    {
+        $oldJpg = $this->tempRoot . '/nested/old_frame.jpg';
+        file_put_contents($oldJpg, 'jpeg');
+        touch($oldJpg, time() - 200000);
+
+        $stats = [
+            'files_checked' => 0,
+            'files_deleted' => 0,
+            'bytes_freed' => 0,
+            'errors' => 0,
+        ];
+
+        cleanupPushUploadDebris(172800, $stats, false, false, [$this->tempRoot], ['png']);
+
+        $this->assertFileDoesNotExist($oldJpg);
+        $this->assertSame(1, $stats['files_deleted']);
+    }
+
+    /**
+     * Dry run increments counts but does not unlink.
+     */
+    public function testDryRunDoesNotDelete(): void
+    {
+        $mp4 = $this->tempRoot . '/nested/stale.mp4';
+        file_put_contents($mp4, 'data');
+        touch($mp4, time() - 200000);
+
+        $stats = [
+            'files_checked' => 0,
+            'files_deleted' => 0,
+            'bytes_freed' => 0,
+            'errors' => 0,
+        ];
+
+        cleanupPushUploadDebris(172800, $stats, true, false, [$this->tempRoot], push_upload_master_image_extensions());
+
+        $this->assertFileExists($mp4);
+        $this->assertGreaterThanOrEqual(1, $stats['files_deleted']);
+    }
+
+    public function testGetPushUploadAllowedExtensionsForCleanupMatchesMasterByDefault(): void
+    {
+        $this->assertSame(
+            push_upload_sorted_unique_extensions_list(push_upload_master_image_extensions()),
+            getPushUploadAllowedExtensionsForCleanup()
+        );
+    }
+
+    public function testValidatePushUploadAllowedExtensionsRejectsUnknownExtension(): void
+    {
+        $config = [
+            'config' => [
+                'push_upload_allowed_extensions' => ['jpg', 'bmp'],
+            ],
+            'airports' => [],
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('bmp', implode(' ', $result['errors']));
+    }
+
+    public function testFormatPushUploadDebrisAge(): void
+    {
+        $this->assertStringEndsWith('min', formatPushUploadDebrisAge(120));
+        $this->assertStringEndsWith('h', formatPushUploadDebrisAge(7200));
+        $this->assertStringEndsWith('d', formatPushUploadDebrisAge(200000));
+    }
+
+    private function deleteTree(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $fileInfo) {
+            $p = $fileInfo->getPathname();
+            if ($fileInfo->isDir()) {
+                @rmdir($p);
+            } else {
+                @unlink($p);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/Unit/PushUploadDebrisCleanupTest.php
+++ b/tests/Unit/PushUploadDebrisCleanupTest.php
@@ -155,6 +155,22 @@ final class PushUploadDebrisCleanupTest extends TestCase
         $this->assertStringContainsString('bmp', implode(' ', $result['errors']));
     }
 
+    public function testValidatePushUploadAllowedExtensionsRejectsNonStringEntries(): void
+    {
+        $config = [
+            'config' => [
+                'push_upload_allowed_extensions' => ['jpg', 123],
+            ],
+            'airports' => [],
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString(
+            'config.push_upload_allowed_extensions entries must be strings',
+            implode(' ', $result['errors'])
+        );
+    }
+
     public function testFormatPushUploadDebrisAge(): void
     {
         $this->assertStringEndsWith('min', formatPushUploadDebrisAge(120));


### PR DESCRIPTION
## Summary
Adds cleanup for push FTP/SFTP upload inboxes so files that are **not** in the effective image extension allowlist (e.g. vendor MP4 and TXT alongside stills) are deleted once older than **48 hours** (mtime). Prevents unbounded growth when the acquisition worker only scans image globs.

The keep-list is **config-driven**: optional global `config.push_upload_allowed_extensions` merged with each push camera `push_config.allowed_extensions`, intersected with `push_upload_master_image_extensions()` (**jpg, jpeg, png, webp**).

## Implementation
- New `lib/push-upload-debris-cleanup.php` with `cleanupPushUploadDebris()`; `getPushUploadAllowedExtensionsForCleanup()` in `lib/config.php`.
- Layer 1 of `scripts/cleanup-cache.php` calls the same cleanup (daily safety net).
- New hourly CLI `scripts/cleanup-push-upload-debris.php`; cron `17 * * * *` logging to `cleanup-push-upload-debris.log`.
- Shared age threshold `CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS` in `lib/constants.php`.
- Structure validation for global `push_upload_allowed_extensions`; push cameras validate `allowed_extensions` against the master list. `lib/push-webcam-validator.php` aligned (includes **webp**).
- Tests: `tests/Unit/PushUploadDebrisCleanupTest.php`.
- Docs: `docs/CONFIGURATION.md`, `docs/DATA_FLOW.md`, `docs/OPERATIONS.md`; `config/airports.json.example`; `pages/config-generator.php`; `docker/docker-entrypoint.sh` log touch.

## Testing
- `make test-ci` passes locally.

## Deploy notes
- Refresh/rebuild the web image so `config/crontab` picks up the hourly job. Logrotate already covers `/var/log/aviationwx/*.log`.