### PR TITLE
Skip weather and webcam workers when not configured

### DIFF
--- a/.github/instructions/weather.instructions.md
+++ b/.github/instructions/weather.instructions.md
@@ -2,7 +2,7 @@
 applyTo: "lib/weather/**/*.php,api/weather.php"
 ---
 
-# Weather Subsystem -- Safety-Critical
+# Weather Subsystem - Safety-Critical
 
 ## Data Flow
 

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -621,7 +621,7 @@ lib/constants/
 Use adapter pattern for each API provider with versioning:
 
 ```php
-// lib/weather/adapter/tempest-v1.php -- TempestAdapter + parseTempestResponse(); device fallback when station obs empty
+// lib/weather/adapter/tempest-v1.php - TempestAdapter + parseTempestResponse(); device fallback when station obs empty
 class TempestAdapter {
     public static function buildUrl(array $config): ?string { /* ... */ }
 }

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ AviationWX provides a free public API for developers to integrate aviation weath
 
 - **Documentation:** [api.aviationwx.org](https://api.aviationwx.org)
 - **OpenAPI Spec:** [api.aviationwx.org/openapi.json](https://api.aviationwx.org/openapi.json)
-- **Canonical base URL (v1):** `https://api.aviationwx.org/v1` -- default for Public API v1. Self-hosted: set `config.public_api.canonical_base_url` in `airports.json` when your origin differs.
+- **Canonical base URL (v1):** `https://api.aviationwx.org/v1` - default for Public API v1. Self-hosted: set `config.public_api.canonical_base_url` in `airports.json` when your origin differs.
 
 ### Quick Start
 

--- a/api/weather.php
+++ b/api/weather.php
@@ -587,7 +587,7 @@ function generateMockWeatherData($airportId, $airport) {
         http_response_code(HTTP_STATUS_SERVICE_UNAVAILABLE);
         aviationwx_log('info', 'no weather source configured', ['airport' => $airportId], 'app');
         ob_clean();
-        echo json_encode(['success' => false, 'error' => 'Weather source not configured']);
+        echo json_encode(['success' => false, 'error' => WEATHER_INTERNAL_API_ERROR_SOURCE_NOT_CONFIGURED]);
         exit;
     }
     

--- a/data/geo/README.md
+++ b/data/geo/README.md
@@ -2,6 +2,6 @@
 
 ## Admin-0 countries (110m)
 
-`ne_110m_admin_0_countries.geojson` is [Natural Earth](https://www.naturalearthdata.com/) Admin 0 -- Countries (110m), distributed under the [Natural Earth terms of use](https://www.naturalearthdata.com/about/terms-of-use/). It is used offline to derive geometry-only ISO 3166-1 alpha-2 hints for airports (see `scripts/refresh-airport-country-resolution.php`).
+`ne_110m_admin_0_countries.geojson` is [Natural Earth](https://www.naturalearthdata.com/) Admin 0 - Countries (110m), distributed under the [Natural Earth terms of use](https://www.naturalearthdata.com/about/terms-of-use/). It is used offline to derive geometry-only ISO 3166-1 alpha-2 hints for airports (see `scripts/refresh-airport-country-resolution.php`).
 
 Update this file only when intentionally refreshing boundaries (infrequent); bump `COUNTRY_RESOLUTION_BOUNDARY_DATASET_ID` in `lib/constants.php` if the dataset identity changes.

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,7 +4,7 @@ The **Internal API** is the set of first-party HTTP endpoints used by the Aviati
 
 The **Public API** (`https://api.aviationwx.org/v1/...`) is the supported integration surface for third-party apps; see [api.aviationwx.org](https://api.aviationwx.org).
 
-**Wording:** Use **Internal API** for these routes. Use **legacy** only for older file formats, optional flags such as `?legacy=1`, or vendor-specific hardware lines -- not as a label for `api/weather.php` / `api/webcam.php`.
+**Wording:** Use **Internal API** for these routes. Use **legacy** only for older file formats, optional flags such as `?legacy=1`, or vendor-specific hardware lines - not as a label for `api/weather.php` / `api/webcam.php`.
 
 > **For third-party developers:** Use the [**Public API**](https://api.aviationwx.org): stable `/v1/...` paths, OpenAPI, rate-limit headers, and API keys.  
 > **Canonical Public API base URL (public deployment):** `https://api.aviationwx.org/v1`  

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -180,6 +180,8 @@ Values are strings in MHz (e.g. `"122.8"`, `"123.05"`).
 
 **Scheduling:** The scheduler only runs acquisition for cameras with `enabled !== false` and enough configuration to fetch: pull cameras need a non-empty `url`, except `type: aviationwx_api`, which uses `base_url` instead; push cameras need `push_config.username`. Placeholder slots (`enabled: false` or missing acquisition fields) are skipped, matching the weather pipeline rule for airports without `weather_sources`.
 
+**Config hygiene:** Use JSON boolean `true` / `false` for `enabled` (a string like `"false"` is not treated as disabled). For non-push cameras, omit `push_config` entirely. If `push_config` is present, the slot is treated as a push camera for scheduling and validation, even when `type` is something else. Remove stale `push_config` blocks when switching a slot to pull or `aviationwx_api`.
+
 ### Configuration Hierarchy
 
 Settings resolve in this order (first match wins):

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,10 +26,10 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 |--------|---------|-------------|
 | `default_timezone` | `UTC` | Fallback timezone for airports |
 | `base_domain` | `aviationwx.org` | Base domain for subdomains. Used for CORS allowlist on M2M API (*.aviationwx.org). |
-| `public_ip` | — | Optional: explicit IPv4 for FTP passive mode (use only if DNS unavailable at startup) |
-| `public_ipv6` | — | Optional: reserved for future IPv6 support |
+| `public_ip` | --- | Optional: explicit IPv4 for FTP passive mode (use only if DNS unavailable at startup) |
+| `public_ipv6` | --- | Optional: reserved for future IPv6 support |
 | `upload_hostname` | `upload.{base_domain}` | Hostname for FTP/SFTP uploads (recommended) |
-| `network_ports` | — | Optional (self-hosted prod): TCP ports for the app stack, UFW, and in-container services; see [Network configuration](#network-configuration). |
+| `network_ports` | --- | Optional (self-hosted prod): TCP ports for the app stack, UFW, and in-container services; see [Network configuration](#network-configuration). |
 | `dynamic_dns_refresh_seconds` | `0` | Re-resolve DNS periodically for DDNS (0=disabled, min 60) |
 | `webcam_refresh_default` | `60` | Default webcam refresh (seconds) |
 | `cache_file_max_size_mb` | `25` | Max size in MiB for webcam pipeline loads, HTTP/MJPEG pull downloads, partner logo fetches, and **default** push upload acceptance (integer **1--100**). |
@@ -51,20 +51,20 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 | `webcam_history_retention_hours` | `24` | Hours of history to retain (preferred) |
 | `webcam_history_default_hours` | `3` | Default period shown in UI |
 | `webcam_history_preset_hours` | `[1, 3, 6, 24]` | Period options in UI |
-| `webcam_history_max_frames` | — | *Deprecated* - use retention_hours |
+| `webcam_history_max_frames` | --- | *Deprecated* - use retention_hours |
 | `http_integrity_digest_cache_ttl_seconds` | max(webcam_history, weather_history) | APCu TTL for Content-Digest/MD5 cache; defaults to longest retention (images + weather) |
-| `default_preferences` | — | Default unit toggle settings (see below) |
+| `default_preferences` | --- | Default unit toggle settings (see below) |
 | `magnetic_declination` | `0` | Default magnetic declination (degrees) for runway diagram and `wind_direction_magnetic`; overridable per-airport |
-| `geomag_api_key` | — | NOAA NCEI geomagnetic API key for automatic declination lookup. [Register](https://www.ngdc.noaa.gov/geomag/CalcSurvey.shtml) for free. When set, declination is fetched for airports without manual override. |
+| `geomag_api_key` | --- | NOAA NCEI geomagnetic API key for automatic declination lookup. [Register](https://www.ngdc.noaa.gov/geomag/CalcSurvey.shtml) for free. When set, declination is fetched for airports without manual override. |
 | `notam_cache_ttl_seconds` | `3600` | NOTAM cache TTL |
-| `notam_api_client_id` | — | NOTAM API client ID |
-| `notam_api_client_secret` | — | NOTAM API client secret |
+| `notam_api_client_id` | --- | NOTAM API client ID |
+| `notam_api_client_secret` | --- | NOTAM API client secret |
 | **OpenWeatherMap Integration** |||
-| `openweathermap_api_key` | — | API key for cloud layer tiles (optional, [free at openweathermap.org](https://home.openweathermap.org/api_keys)) |
+| `openweathermap_api_key` | --- | API key for cloud layer tiles (optional, [free at openweathermap.org](https://home.openweathermap.org/api_keys)) |
 | **Cloudflare Analytics** |||
-| `cloudflare.api_token` | — | Cloudflare API token (Analytics:Read) |
-| `cloudflare.zone_id` | — | Cloudflare Zone ID |
-| `cloudflare.account_id` | — | Cloudflare Account ID |
+| `cloudflare.api_token` | --- | Cloudflare API token (Analytics:Read) |
+| `cloudflare.zone_id` | --- | Cloudflare Zone ID |
+| `cloudflare.account_id` | --- | Cloudflare Account ID |
 | **Client Version Management** |||
 | `dead_man_switch_days` | `7` | Days without update before cleanup (0 = disabled) |
 | `force_cleanup` | `false` | Emergency flag to force all clients to cleanup |
@@ -87,26 +87,26 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 | Option | Default | Description |
 |--------|---------|-------------|
 | **Required** |||
-| `name` | — | Display name |
+| `name` | --- | Display name |
 | `enabled` | `false` | Must be `true` to activate |
-| `lat` | — | Latitude |
-| `lon` | — | Longitude |
+| `lat` | --- | Latitude |
+| `lon` | --- | Longitude |
 | **Identifiers** |||
-| `icao` | — | ICAO code (e.g., `KSPB`) |
-| `iata` | — | IATA code (e.g., `SPB`) |
-| `faa` | — | FAA LID (e.g., `03S`) |
-| `iso_country` | — | Optional ISO 3166-1 alpha-2 (two letters, validated). Highest-precedence hint for effective country, Public API `iso_country`, and aviation-region link selection. |
+| `icao` | --- | ICAO code (e.g., `KSPB`) |
+| `iata` | --- | IATA code (e.g., `SPB`) |
+| `faa` | --- | FAA LID (e.g., `03S`) |
+| `iso_country` | --- | Optional ISO 3166-1 alpha-2 (two letters, validated). Highest-precedence hint for effective country, Public API `iso_country`, and aviation-region link selection. |
 | `formerly` | `[]` | Previous identifiers for NOTAM matching |
 | **Location** |||
-| `address` | — | City, State display |
-| `elevation_ft` | — | Field elevation in feet |
+| `address` | --- | City, State display |
+| `elevation_ft` | --- | Field elevation in feet |
 | `timezone` | global default | Timezone (e.g., `America/Los_Angeles`) |
 | **Status** |||
 | `maintenance` | `false` | Show maintenance banner |
-| `unlisted` | `false` | Hide from discovery (map, search, sitemap). When true, worker failures (webcam/weather/NOTAM) are treated as expected during commissioning—logged at info, exit 2 (skip) so process pool does not log "worker failed". |
+| `unlisted` | `false` | Hide from discovery (map, search, sitemap). When true, worker failures (webcam/weather/NOTAM) are treated as expected during commissioning; logged at info, exit 2 (skip) so process pool does not log "worker failed". |
 | `limited_availability` | `false` | Off-grid/solar/battery site; shows informational banner when data unavailable |
 | `limited_availability_outage_seconds` | `1800` | When to show outage banner for limited_availability sites (default 30 min); override per-airport or globally |
-| `station_power` | — | Optional facility power telemetry for `limited_availability` sites. Object shape: `provider` (string, e.g. `vrm`) and `config` (provider-specific). **Requires** `limited_availability: true`. Staleness for this block is **not** tied to METAR/weather fail-closed rules. The dashboard uses neutral **Station Power** labels only (no vendor branding in the UI). **Manual refresh:** same command as the scheduler: `php scripts/fetch-station-power.php --worker <airport_id>`; with local Docker: `make station-power-fetch AIRPORT=<airport_id>` (containers must be running). |
+| `station_power` | --- | Optional facility power telemetry for `limited_availability` sites. Object shape: `provider` (string, e.g. `vrm`) and `config` (provider-specific). **Requires** `limited_availability: true`. Staleness for this block is **not** tied to METAR/weather fail-closed rules. The dashboard uses neutral **Station Power** labels only (no vendor branding in the UI). **Manual refresh:** same command as the scheduler: `php scripts/fetch-station-power.php --worker <airport_id>`; with local Docker: `make station-power-fetch AIRPORT=<airport_id>` (containers must be running). |
 | `station_power_refresh_seconds` | `config.station_power_refresh_seconds` or 900 | Per-airport override for how often the browser polls `/api/station-power.php` (minimum 60). Scheduler fetch interval for upstream data is separate (`STATION_POWER_FETCH_INTERVAL_SECONDS`, default 10 minutes). |
 | **Refresh Overrides** |||
 | `webcam_refresh_seconds` | global default | Override webcam refresh for this airport |
@@ -129,8 +129,8 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 | **Link Overrides** |||
 | `airnav_url` | auto | Override AirNav link |
 | `faa_weather_url` | auto | Override FAA Weather link (US link bundle only) |
-| `regional_weather_url` | — | Override the primary built-in regional authority URL for that airport's link region |
-| `regional_weather_label` | — | Label for regional weather link (e.g., "NAV Canada WxCam") |
+| `regional_weather_url` | --- | Override the primary built-in regional authority URL for that airport's link region |
+| `regional_weather_label` | --- | Label for regional weather link (e.g., "NAV Canada WxCam") |
 | `foreflight_url` | auto | Override ForeFlight link |
 
 **Regional link behavior:** Built-in external links use a **data-driven profile** per link region derived from effective country (ISO 3166-1 alpha-2): optional `iso_country` → `inferIso3166Alpha2FromIcaoPrefix()` (K/C/Y-style ICAO hints) → FAA LID (implies US) → merged geometry aggregate in `airport_country_resolution.json` when `config_sha256` matches (otherwise merge skipped) → US or Canada from `address` parsing. First-pass regions include **us** (built-in rows: AirNav, FAA Weather, ForeFlight; no SkyVector row in that profile), **ca**, **au**, **nz**, **gb**, **eu** (EU members, EEA, CH, and listed microstates), **mx**, **br**, **jp**, with US territories grouped under **us**. When the region is **unknown**, only explicit overrides (`airnav_url`, `faa_weather_url`, `regional_weather_url`, `foreflight_url`) produce built-ins; use custom `links` for anything else. The scheduler rebuilds the geometry aggregate when `airports.json` changes, the aggregate is missing or invalid, or it is older than the configured max age (30 days by default).
@@ -142,7 +142,7 @@ The `frequencies` object maps service names to MHz strings. Align keys with char
 | Key | When to use |
 |-----|-------------|
 | `tower`, `ground`, `atis`, `clearance_delivery`, `approach`, `departure` | As published for controlled airports. |
-| `ctaf` | Common traffic frequency at non-towered airports. When the source lists **CTAF/UNICOM** on **one** frequency, use **`ctaf` only**—do not also add `unicom` with the same MHz (duplicate line in the UI, not two services). |
+| `ctaf` | Common traffic frequency at non-towered airports. When the source lists **CTAF/UNICOM** on **one** frequency, use **`ctaf` only**. Do not also add `unicom` with the same MHz (duplicate line in the UI, not two services). |
 | `unicom` | When UNICOM is **distinct** from CTAF (e.g. towered field FBO/airport advisory on 122.8 while traffic uses tower), or when only UNICOM is given without a separate CTAF. |
 | `awos`, `asos` | Automated weather as published. |
 
@@ -152,45 +152,51 @@ Values are strings in MHz (e.g. `"122.8"`, `"123.05"`).
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| **Required** |||
-| `name` | — | Display name |
-| `url` | — | Stream/image URL (not for push type) |
+| **Common** |||
+| `name` | --- | Display name |
+| `enabled` | `true` | When `false`, the slot stays in config/UI but acquisition fields such as `url`, `push_config`, and `base_url` are not required and workers do not run for this camera |
+| **Conditional** |||
+| `url` | --- | Stream/image URL for pull types (`http` / `mjpeg` / `static_jpeg` / `static_png` / `rtsp`). Not used for `push` (credentials live under `push_config`) or for `aviationwx_api` (use `base_url`). Omit for `enabled: false` placeholders. |
 | **Optional** |||
-| `type` | auto-detect | `rtsp`, `mjpeg`, `static_jpeg`, `static_png`, `push` |
+| `type` | auto-detect | `rtsp`, `mjpeg`, `static_jpeg`, `static_png`, `push`, `aviationwx_api` |
 | `refresh_seconds` | airport default | Override refresh for this camera |
-| `enabled` | `true` | When `false`, the slot stays in config/UI but fetch workers do not run for this camera |
 | `crop_margins` | global default | FAA profile crop margins override (percentages) |
 | **RTSP Options** |||
 | `rtsp_transport` | `tcp` | `tcp` or `udp` |
 | `rtsp_fetch_timeout` | `10` | Frame capture timeout (seconds) |
 | `rtsp_max_runtime` | `6` | Max ffmpeg runtime (seconds) |
 | **Push Options** |||
-| `push_config.username` | — | 14 alphanumeric chars |
-| `push_config.password` | — | 14 alphanumeric chars |
+| `push_config.username` | --- | 14 alphanumeric chars |
+| `push_config.password` | --- | 14 alphanumeric chars |
 | `push_config.max_file_size_mb` | *(inherit global)* | Optional per-camera cap (integer **1** through **`config.cache_file_max_size_mb`**). Omit to use the global `cache_file_max_size_mb` for FTP/SFTP acceptance. Set lower to limit a single camera (bandwidth or policy). |
 | `push_config.allowed_extensions` | `["jpg","jpeg","png","webp"]` | Allowed file types (subset of **jpg, jpeg, png, webp**) |
 | `push_config.upload_file_max_age_seconds` | `1800` | Max file age before abandonment (600-7200) |
 | `push_config.stability_check_timeout_seconds` | `15` | Stability check timeout (10-30) |
+| **aviationwx_api (federated)** |||
+| `base_url` | --- | Required when `type` is `aviationwx_api`: root URL of the Public API host |
+| `api_key` | --- | Optional API key when the remote endpoint requires authentication |
+| `timeout_seconds` | *(inherit)* | Optional HTTP timeout in seconds (integer **1**-**300**) |
+| `camera_index` | --- | Optional remote camera index (integer **0**-**99**) |
 
-**Scheduling:** The scheduler only runs acquisition for cameras that have enough configuration to fetch: non-push cameras need a non-empty `url` (or `type: aviationwx_api` with `base_url`); push cameras need `push_config.username`. Empty placeholder slots are skipped, matching the weather pipeline rule for airports without `weather_sources`.
+**Scheduling:** The scheduler only runs acquisition for cameras with `enabled !== false` and enough configuration to fetch: pull cameras need a non-empty `url`, except `type: aviationwx_api`, which uses `base_url` instead; push cameras need `push_config.username`. Placeholder slots (`enabled: false` or missing acquisition fields) are skipped, matching the weather pipeline rule for airports without `weather_sources`.
 
 ### Configuration Hierarchy
 
 Settings resolve in this order (first match wins):
 
-1. **Per-webcam** — `webcams[].refresh_seconds`
-2. **Per-airport** — `airport.webcam_refresh_seconds` or `airport.weather_refresh_seconds`
-3. **Global** — `config.webcam_refresh_default` or `config.weather_refresh_default`
-4. **Built-in default** — 60 seconds
+1. **Per-webcam** -- `webcams[].refresh_seconds`
+2. **Per-airport** -- `airport.webcam_refresh_seconds` or `airport.weather_refresh_seconds`
+3. **Global** -- `config.webcam_refresh_default` or `config.weather_refresh_default`
+4. **Built-in default** -- 60 seconds
 
 ### Default Preferences Hierarchy
 
 Unit toggle defaults resolve in this order (first match wins):
 
-1. **User preference** — stored in browser cookie/localStorage
-2. **Per-airport** — `airport.default_preferences`
-3. **Global** — `config.default_preferences`
-4. **Built-in default** — US aviation standards (12hr, °F, ft, inHg, kts)
+1. **User preference** -- stored in browser cookie/localStorage
+2. **Per-airport** -- `airport.default_preferences`
+3. **Global** -- `config.default_preferences`
+4. **Built-in default** -- US aviation standards (12hr, °F, ft, inHg, kts)
 
 ---
 
@@ -240,7 +246,7 @@ Unit toggle defaults resolve in this order (first match wins):
 }
 ```
 
-The `config` section is optional—sensible defaults apply if omitted.
+The `config` section is optional; sensible defaults apply if omitted.
 
 ### Network Configuration
 
@@ -255,14 +261,14 @@ Configure the server's public network identity for FTP/SFTP services and URL gen
 | `network_ports` | object | Optional object defining TCP ports for self-hosted production (all port values must be JSON **numbers**, not strings). `deploy-configure-firewall.sh` applies host UFW/iptables/NAT; the web container entrypoint sets **vsftpd** `listen_port` from **`ftp_control`** only (passive range from the map), **sshd** (SFTP on `sftp`), and **fail2ban** jails. Omitted keys use defaults: `http` 80, `https` 443, `ftp_control` 2121, `ftps_explicit_tls` 2122, `sftp` 2222, `ftp_passive_min`/`max` 50000–51000, `ssh` 22, `ftps_alt` null. **`ftps_explicit_tls`** is used for host firewall/fail2ban when that inbound port differs from `ftp_control`; vsftpd still binds a single control port (`ftp_control`). **`ssh`** opens the host admin SSH port in UFW only. **`ftps_alt`**: optional extra inbound control port on the host; NAT REDIRECT targets **`ftp_control`**. |
 | `dynamic_dns_refresh_seconds` | integer | Re-resolve DNS periodically (0=disabled, min 60 when enabled) |
 
-**Network ports (`network_ports`):** When `network_ports` is present, it must be a JSON **object** (not an array), and each set port field must be a JSON **number** (not a quoted string); config validation, `deploy-configure-firewall.sh`, and `docker-entrypoint.sh` enforce this. On deploy, `deploy-configure-firewall.sh` reads `~/airports.json` (or `AIRPORTS_JSON`). At container start, `docker-entrypoint.sh` reads `config.network_ports` from `CONFIG_PATH` / `config/airports.json` and configures **vsftpd** with a **single** control listener on **`ftp_control`** (plus passive ports), **sshd** (SFTP on `sftp`), and **fail2ban**. Host-facing ports such as **`ftps_explicit_tls`** and **`ftps_alt`** are for UFW/NAT/fail2ban when inbound ports differ from the container bind—they do not add a second vsftpd listener. **Nginx** uses `docker/nginx.conf`; keep its `listen` ports consistent with `network_ports.http` and `network_ports.https` when you customize them. **Apache** listens on `127.0.0.1:8080` behind nginx and is not configured through `network_ports`.
+**Network ports (`network_ports`):** When `network_ports` is present, it must be a JSON **object** (not an array), and each set port field must be a JSON **number** (not a quoted string); config validation, `deploy-configure-firewall.sh`, and `docker-entrypoint.sh` enforce this. On deploy, `deploy-configure-firewall.sh` reads `~/airports.json` (or `AIRPORTS_JSON`). At container start, `docker-entrypoint.sh` reads `config.network_ports` from `CONFIG_PATH` / `config/airports.json` and configures **vsftpd** with a **single** control listener on **`ftp_control`** (plus passive ports), **sshd** (SFTP on `sftp`), and **fail2ban**. Host-facing ports such as **`ftps_explicit_tls`** and **`ftps_alt`** are for UFW/NAT/fail2ban when inbound ports differ from the container bind; they do not add a second vsftpd listener. **Nginx** uses `docker/nginx.conf`; keep its `listen` ports consistent with `network_ports.http` and `network_ports.https` when you customize them. **Apache** listens on `127.0.0.1:8080` behind nginx and is not configured through `network_ports`.
 
 **FTP Passive Mode Resolution Priority:**
 
-1. **`public_ip`** — If set, use explicit IP (no DNS lookup). Use only when DNS is unavailable at startup.
-2. **`upload_hostname`** — If `public_ip` not set, resolve via DNS (recommended; survives IP changes)
-3. **`upload.{base_domain}`** — Default fallback if `upload_hostname` not set
-4. **`upload.aviationwx.org`** — Final fallback
+1. **`public_ip`** -- If set, use explicit IP (no DNS lookup). Use only when DNS is unavailable at startup.
+2. **`upload_hostname`** -- If `public_ip` not set, resolve via DNS (recommended; survives IP changes)
+3. **`upload.{base_domain}`** -- Default fallback if `upload_hostname` not set
+4. **`upload.aviationwx.org`** -- Final fallback
 
 **Recommended: Hostname (default)**
 
@@ -293,7 +299,7 @@ Set `public_ip` only if DNS is unavailable or unreliable at container startup (e
 
 **Dynamic DNS (DDNS) Support:**
 
-For self-hosted instances with dynamic IPs (e.g., home internet with DDNS), use hostname only—vsftpd resolves at connection time:
+For self-hosted instances with dynamic IPs (e.g., home internet with DDNS), use hostname only -- vsftpd resolves at connection time:
 
 ```json
 {
@@ -432,10 +438,10 @@ For self-hosted instances, configure your own domain. Hostname is recommended:
 ### Airport Identifiers
 
 Priority order for URL routing (highest first):
-1. **ICAO** — `KSPB` → `kspb.aviationwx.org`
-2. **IATA** — `SPB` → redirects to ICAO
-3. **FAA** — `03S` → `03s.aviationwx.org` (if no ICAO)
-4. **Airport ID** — JSON key as fallback
+1. **ICAO** -- `KSPB` → `kspb.aviationwx.org`
+2. **IATA** -- `SPB` → redirects to ICAO
+3. **FAA** -- `03S` → `03s.aviationwx.org` (if no ICAO)
+4. **Airport ID** -- JSON key as fallback
 
 All identifiers are case-insensitive. Non-primary identifiers 301 redirect to primary.
 
@@ -478,7 +484,7 @@ Affects daily statistics reset (midnight), sunrise/sunset display, and local tim
 
 ## Weather Sources
 
-All weather sources are configured in a unified `weather_sources` array. Sources are fetched in parallel and aggregated—the freshest data from any source wins for each field. METAR typically provides ceiling and cloud_cover (other sources do not provide these fields).
+All weather sources are configured in a unified `weather_sources` array. Sources are fetched in parallel and aggregated; the freshest data from any source wins for each field. METAR typically provides ceiling and cloud_cover (other sources do not provide these fields).
 
 ### Source Types
 
@@ -525,7 +531,7 @@ All weather sources are configured in a unified `weather_sources` array. Sources
 ]
 ```
 
-`mac_address` is optional—uses first device if omitted.
+`mac_address` is optional and uses the first device if omitted.
 
 ### Davis WeatherLink v2 (Newer Devices)
 
@@ -1051,11 +1057,11 @@ The old `webcam_history_max_frames` setting is deprecated but still supported:
 
 ### Player URLs
 
-- `https://kspb.aviationwx.org/?cam=0` — Opens player
-- `https://kspb.aviationwx.org/?cam=0&autoplay` — Auto-plays
-- `https://kspb.aviationwx.org/?cam=0&autoplay&hideui` — Kiosk mode
-- `https://kspb.aviationwx.org/?cam=0&period=3h` — Opens with 3-hour period selected
-- `https://kspb.aviationwx.org/?cam=0&period=all` — Opens with all history
+- `https://kspb.aviationwx.org/?cam=0` -- Opens player
+- `https://kspb.aviationwx.org/?cam=0&autoplay` -- Auto-plays
+- `https://kspb.aviationwx.org/?cam=0&autoplay&hideui` -- Kiosk mode
+- `https://kspb.aviationwx.org/?cam=0&period=3h` -- Opens with 3-hour period selected
+- `https://kspb.aviationwx.org/?cam=0&period=all` -- Opens with all history
 
 ### Keyboard Shortcuts
 
@@ -1116,10 +1122,10 @@ Configure default units for the airport page toggle buttons. User preferences (s
 
 ### Priority Order
 
-1. **User preference** — stored in browser cookie/localStorage (persists across visits)
-2. **Per-airport** — `airport.default_preferences`
-3. **Global** — `config.default_preferences`
-4. **Built-in** — US aviation standards (12hr, °F, ft, inHg, kts)
+1. **User preference** -- stored in browser cookie/localStorage (persists across visits)
+2. **Per-airport** -- `airport.default_preferences`
+3. **Global** -- `config.default_preferences`
+4. **Built-in** -- US aviation standards (12hr, °F, ft, inHg, kts)
 
 Only include preferences you want to change from defaults. Users who have previously set a preference will keep their choice.
 
@@ -1587,12 +1593,12 @@ Example:
 
 ## Validation
 
-The validator uses strict checking—unknown fields are rejected.
+The validator uses strict checking: unknown fields are rejected.
 
 ### Adding New Fields
 
-1. Update `lib/config.php` — add to allowed fields, add validation
-2. Update `tests/Unit/ConfigValidationTest.php` — add tests
+1. Update `lib/config.php` -- add to allowed fields, add validation
+2. Update `tests/Unit/ConfigValidationTest.php` -- add tests
 3. Update this documentation
 4. Update `config/airports.json.example`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,10 +26,10 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 |--------|---------|-------------|
 | `default_timezone` | `UTC` | Fallback timezone for airports |
 | `base_domain` | `aviationwx.org` | Base domain for subdomains. Used for CORS allowlist on M2M API (*.aviationwx.org). |
-| `public_ip` | --- | Optional: explicit IPv4 for FTP passive mode (use only if DNS unavailable at startup) |
-| `public_ipv6` | --- | Optional: reserved for future IPv6 support |
+| `public_ip` | - | Optional: explicit IPv4 for FTP passive mode (use only if DNS unavailable at startup) |
+| `public_ipv6` | - | Optional: reserved for future IPv6 support |
 | `upload_hostname` | `upload.{base_domain}` | Hostname for FTP/SFTP uploads (recommended) |
-| `network_ports` | --- | Optional (self-hosted prod): TCP ports for the app stack, UFW, and in-container services; see [Network configuration](#network-configuration). |
+| `network_ports` | - | Optional (self-hosted prod): TCP ports for the app stack, UFW, and in-container services; see [Network configuration](#network-configuration). |
 | `dynamic_dns_refresh_seconds` | `0` | Re-resolve DNS periodically for DDNS (0=disabled, min 60) |
 | `webcam_refresh_default` | `60` | Default webcam refresh (seconds) |
 | `cache_file_max_size_mb` | `25` | Max size in MiB for webcam pipeline loads, HTTP/MJPEG pull downloads, partner logo fetches, and **default** push upload acceptance (integer **1--100**). |
@@ -51,20 +51,20 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 | `webcam_history_retention_hours` | `24` | Hours of history to retain (preferred) |
 | `webcam_history_default_hours` | `3` | Default period shown in UI |
 | `webcam_history_preset_hours` | `[1, 3, 6, 24]` | Period options in UI |
-| `webcam_history_max_frames` | --- | *Deprecated* - use retention_hours |
+| `webcam_history_max_frames` | - | *Deprecated* - use retention_hours |
 | `http_integrity_digest_cache_ttl_seconds` | max(webcam_history, weather_history) | APCu TTL for Content-Digest/MD5 cache; defaults to longest retention (images + weather) |
-| `default_preferences` | --- | Default unit toggle settings (see below) |
+| `default_preferences` | - | Default unit toggle settings (see below) |
 | `magnetic_declination` | `0` | Default magnetic declination (degrees) for runway diagram and `wind_direction_magnetic`; overridable per-airport |
-| `geomag_api_key` | --- | NOAA NCEI geomagnetic API key for automatic declination lookup. [Register](https://www.ngdc.noaa.gov/geomag/CalcSurvey.shtml) for free. When set, declination is fetched for airports without manual override. |
+| `geomag_api_key` | - | NOAA NCEI geomagnetic API key for automatic declination lookup. [Register](https://www.ngdc.noaa.gov/geomag/CalcSurvey.shtml) for free. When set, declination is fetched for airports without manual override. |
 | `notam_cache_ttl_seconds` | `3600` | NOTAM cache TTL |
-| `notam_api_client_id` | --- | NOTAM API client ID |
-| `notam_api_client_secret` | --- | NOTAM API client secret |
+| `notam_api_client_id` | - | NOTAM API client ID |
+| `notam_api_client_secret` | - | NOTAM API client secret |
 | **OpenWeatherMap Integration** |||
-| `openweathermap_api_key` | --- | API key for cloud layer tiles (optional, [free at openweathermap.org](https://home.openweathermap.org/api_keys)) |
+| `openweathermap_api_key` | - | API key for cloud layer tiles (optional, [free at openweathermap.org](https://home.openweathermap.org/api_keys)) |
 | **Cloudflare Analytics** |||
-| `cloudflare.api_token` | --- | Cloudflare API token (Analytics:Read) |
-| `cloudflare.zone_id` | --- | Cloudflare Zone ID |
-| `cloudflare.account_id` | --- | Cloudflare Account ID |
+| `cloudflare.api_token` | - | Cloudflare API token (Analytics:Read) |
+| `cloudflare.zone_id` | - | Cloudflare Zone ID |
+| `cloudflare.account_id` | - | Cloudflare Account ID |
 | **Client Version Management** |||
 | `dead_man_switch_days` | `7` | Days without update before cleanup (0 = disabled) |
 | `force_cleanup` | `false` | Emergency flag to force all clients to cleanup |
@@ -87,26 +87,26 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 | Option | Default | Description |
 |--------|---------|-------------|
 | **Required** |||
-| `name` | --- | Display name |
+| `name` | - | Display name |
 | `enabled` | `false` | Must be `true` to activate |
-| `lat` | --- | Latitude |
-| `lon` | --- | Longitude |
+| `lat` | - | Latitude |
+| `lon` | - | Longitude |
 | **Identifiers** |||
-| `icao` | --- | ICAO code (e.g., `KSPB`) |
-| `iata` | --- | IATA code (e.g., `SPB`) |
-| `faa` | --- | FAA LID (e.g., `03S`) |
-| `iso_country` | --- | Optional ISO 3166-1 alpha-2 (two letters, validated). Highest-precedence hint for effective country, Public API `iso_country`, and aviation-region link selection. |
+| `icao` | - | ICAO code (e.g., `KSPB`) |
+| `iata` | - | IATA code (e.g., `SPB`) |
+| `faa` | - | FAA LID (e.g., `03S`) |
+| `iso_country` | - | Optional ISO 3166-1 alpha-2 (two letters, validated). Highest-precedence hint for effective country, Public API `iso_country`, and aviation-region link selection. |
 | `formerly` | `[]` | Previous identifiers for NOTAM matching |
 | **Location** |||
-| `address` | --- | City, State display |
-| `elevation_ft` | --- | Field elevation in feet |
+| `address` | - | City, State display |
+| `elevation_ft` | - | Field elevation in feet |
 | `timezone` | global default | Timezone (e.g., `America/Los_Angeles`) |
 | **Status** |||
 | `maintenance` | `false` | Show maintenance banner |
 | `unlisted` | `false` | Hide from discovery (map, search, sitemap). When true, worker failures (webcam/weather/NOTAM) are treated as expected during commissioning; logged at info, exit 2 (skip) so process pool does not log "worker failed". |
 | `limited_availability` | `false` | Off-grid/solar/battery site; shows informational banner when data unavailable |
 | `limited_availability_outage_seconds` | `1800` | When to show outage banner for limited_availability sites (default 30 min); override per-airport or globally |
-| `station_power` | --- | Optional facility power telemetry for `limited_availability` sites. Object shape: `provider` (string, e.g. `vrm`) and `config` (provider-specific). **Requires** `limited_availability: true`. Staleness for this block is **not** tied to METAR/weather fail-closed rules. The dashboard uses neutral **Station Power** labels only (no vendor branding in the UI). **Manual refresh:** same command as the scheduler: `php scripts/fetch-station-power.php --worker <airport_id>`; with local Docker: `make station-power-fetch AIRPORT=<airport_id>` (containers must be running). |
+| `station_power` | - | Optional facility power telemetry for `limited_availability` sites. Object shape: `provider` (string, e.g. `vrm`) and `config` (provider-specific). **Requires** `limited_availability: true`. Staleness for this block is **not** tied to METAR/weather fail-closed rules. The dashboard uses neutral **Station Power** labels only (no vendor branding in the UI). **Manual refresh:** same command as the scheduler: `php scripts/fetch-station-power.php --worker <airport_id>`; with local Docker: `make station-power-fetch AIRPORT=<airport_id>` (containers must be running). |
 | `station_power_refresh_seconds` | `config.station_power_refresh_seconds` or 900 | Per-airport override for how often the browser polls `/api/station-power.php` (minimum 60). Scheduler fetch interval for upstream data is separate (`STATION_POWER_FETCH_INTERVAL_SECONDS`, default 10 minutes). |
 | **Refresh Overrides** |||
 | `webcam_refresh_seconds` | global default | Override webcam refresh for this airport |
@@ -129,8 +129,8 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 | **Link Overrides** |||
 | `airnav_url` | auto | Override AirNav link |
 | `faa_weather_url` | auto | Override FAA Weather link (US link bundle only) |
-| `regional_weather_url` | --- | Override the primary built-in regional authority URL for that airport's link region |
-| `regional_weather_label` | --- | Label for regional weather link (e.g., "NAV Canada WxCam") |
+| `regional_weather_url` | - | Override the primary built-in regional authority URL for that airport's link region |
+| `regional_weather_label` | - | Label for regional weather link (e.g., "NAV Canada WxCam") |
 | `foreflight_url` | auto | Override ForeFlight link |
 
 **Regional link behavior:** Built-in external links use a **data-driven profile** per link region derived from effective country (ISO 3166-1 alpha-2): optional `iso_country` → `inferIso3166Alpha2FromIcaoPrefix()` (K/C/Y-style ICAO hints) → FAA LID (implies US) → merged geometry aggregate in `airport_country_resolution.json` when `config_sha256` matches (otherwise merge skipped) → US or Canada from `address` parsing. First-pass regions include **us** (built-in rows: AirNav, FAA Weather, ForeFlight; no SkyVector row in that profile), **ca**, **au**, **nz**, **gb**, **eu** (EU members, EEA, CH, and listed microstates), **mx**, **br**, **jp**, with US territories grouped under **us**. When the region is **unknown**, only explicit overrides (`airnav_url`, `faa_weather_url`, `regional_weather_url`, `foreflight_url`) produce built-ins; use custom `links` for anything else. The scheduler rebuilds the geometry aggregate when `airports.json` changes, the aggregate is missing or invalid, or it is older than the configured max age (30 days by default).
@@ -153,10 +153,10 @@ Values are strings in MHz (e.g. `"122.8"`, `"123.05"`).
 | Option | Default | Description |
 |--------|---------|-------------|
 | **Common** |||
-| `name` | --- | Display name |
+| `name` | - | Display name |
 | `enabled` | `true` | When `false`, the slot stays in config/UI but acquisition fields such as `url`, `push_config`, and `base_url` are not required and workers do not run for this camera |
 | **Conditional** |||
-| `url` | --- | Stream/image URL for pull types (`http` / `mjpeg` / `static_jpeg` / `static_png` / `rtsp`). Not used for `push` (credentials live under `push_config`) or for `aviationwx_api` (use `base_url`). Omit for `enabled: false` placeholders. |
+| `url` | - | Stream/image URL for pull types (`http` / `mjpeg` / `static_jpeg` / `static_png` / `rtsp`). Not used for `push` (credentials live under `push_config`) or for `aviationwx_api` (use `base_url`). Omit for `enabled: false` placeholders. |
 | **Optional** |||
 | `type` | auto-detect | `rtsp`, `mjpeg`, `static_jpeg`, `static_png`, `push`, `aviationwx_api` |
 | `refresh_seconds` | airport default | Override refresh for this camera |
@@ -166,17 +166,17 @@ Values are strings in MHz (e.g. `"122.8"`, `"123.05"`).
 | `rtsp_fetch_timeout` | `10` | Frame capture timeout (seconds) |
 | `rtsp_max_runtime` | `6` | Max ffmpeg runtime (seconds) |
 | **Push Options** |||
-| `push_config.username` | --- | 14 alphanumeric chars |
-| `push_config.password` | --- | 14 alphanumeric chars |
+| `push_config.username` | - | 14 alphanumeric chars |
+| `push_config.password` | - | 14 alphanumeric chars |
 | `push_config.max_file_size_mb` | *(inherit global)* | Optional per-camera cap (integer **1** through **`config.cache_file_max_size_mb`**). Omit to use the global `cache_file_max_size_mb` for FTP/SFTP acceptance. Set lower to limit a single camera (bandwidth or policy). |
 | `push_config.allowed_extensions` | `["jpg","jpeg","png","webp"]` | Allowed file types (subset of **jpg, jpeg, png, webp**) |
 | `push_config.upload_file_max_age_seconds` | `1800` | Max file age before abandonment (600-7200) |
 | `push_config.stability_check_timeout_seconds` | `15` | Stability check timeout (10-30) |
 | **aviationwx_api (federated)** |||
-| `base_url` | --- | Required when `type` is `aviationwx_api`: root URL of the Public API host |
-| `api_key` | --- | Optional API key when the remote endpoint requires authentication |
+| `base_url` | - | Required when `type` is `aviationwx_api`: root URL of the Public API host |
+| `api_key` | - | Optional API key when the remote endpoint requires authentication |
 | `timeout_seconds` | *(inherit)* | Optional HTTP timeout in seconds (integer **1**-**300**) |
-| `camera_index` | --- | Optional remote camera index (integer **0**-**99**) |
+| `camera_index` | - | Optional remote camera index (integer **0**-**99**) |
 
 **Scheduling:** The scheduler only runs acquisition for cameras with `enabled !== false` and enough configuration to fetch: pull cameras need a non-empty `url`, except `type: aviationwx_api`, which uses `base_url` instead; push cameras need `push_config.username`. Placeholder slots (`enabled: false` or missing acquisition fields) are skipped, matching the weather pipeline rule for airports without `weather_sources`.
 
@@ -184,19 +184,19 @@ Values are strings in MHz (e.g. `"122.8"`, `"123.05"`).
 
 Settings resolve in this order (first match wins):
 
-1. **Per-webcam** -- `webcams[].refresh_seconds`
-2. **Per-airport** -- `airport.webcam_refresh_seconds` or `airport.weather_refresh_seconds`
-3. **Global** -- `config.webcam_refresh_default` or `config.weather_refresh_default`
-4. **Built-in default** -- 60 seconds
+1. **Per-webcam** - `webcams[].refresh_seconds`
+2. **Per-airport** - `airport.webcam_refresh_seconds` or `airport.weather_refresh_seconds`
+3. **Global** - `config.webcam_refresh_default` or `config.weather_refresh_default`
+4. **Built-in default** - 60 seconds
 
 ### Default Preferences Hierarchy
 
 Unit toggle defaults resolve in this order (first match wins):
 
-1. **User preference** -- stored in browser cookie/localStorage
-2. **Per-airport** -- `airport.default_preferences`
-3. **Global** -- `config.default_preferences`
-4. **Built-in default** -- US aviation standards (12hr, °F, ft, inHg, kts)
+1. **User preference** - stored in browser cookie/localStorage
+2. **Per-airport** - `airport.default_preferences`
+3. **Global** - `config.default_preferences`
+4. **Built-in default** - US aviation standards (12hr, °F, ft, inHg, kts)
 
 ---
 
@@ -265,10 +265,10 @@ Configure the server's public network identity for FTP/SFTP services and URL gen
 
 **FTP Passive Mode Resolution Priority:**
 
-1. **`public_ip`** -- If set, use explicit IP (no DNS lookup). Use only when DNS is unavailable at startup.
-2. **`upload_hostname`** -- If `public_ip` not set, resolve via DNS (recommended; survives IP changes)
-3. **`upload.{base_domain}`** -- Default fallback if `upload_hostname` not set
-4. **`upload.aviationwx.org`** -- Final fallback
+1. **`public_ip`** - If set, use explicit IP (no DNS lookup). Use only when DNS is unavailable at startup.
+2. **`upload_hostname`** - If `public_ip` not set, resolve via DNS (recommended; survives IP changes)
+3. **`upload.{base_domain}`** - Default fallback if `upload_hostname` not set
+4. **`upload.aviationwx.org`** - Final fallback
 
 **Recommended: Hostname (default)**
 
@@ -299,7 +299,7 @@ Set `public_ip` only if DNS is unavailable or unreliable at container startup (e
 
 **Dynamic DNS (DDNS) Support:**
 
-For self-hosted instances with dynamic IPs (e.g., home internet with DDNS), use hostname only -- vsftpd resolves at connection time:
+For self-hosted instances with dynamic IPs (e.g., home internet with DDNS), use hostname only - vsftpd resolves at connection time:
 
 ```json
 {
@@ -438,10 +438,10 @@ For self-hosted instances, configure your own domain. Hostname is recommended:
 ### Airport Identifiers
 
 Priority order for URL routing (highest first):
-1. **ICAO** -- `KSPB` → `kspb.aviationwx.org`
-2. **IATA** -- `SPB` → redirects to ICAO
-3. **FAA** -- `03S` → `03s.aviationwx.org` (if no ICAO)
-4. **Airport ID** -- JSON key as fallback
+1. **ICAO** - `KSPB` → `kspb.aviationwx.org`
+2. **IATA** - `SPB` → redirects to ICAO
+3. **FAA** - `03S` → `03s.aviationwx.org` (if no ICAO)
+4. **Airport ID** - JSON key as fallback
 
 All identifiers are case-insensitive. Non-primary identifiers 301 redirect to primary.
 
@@ -1057,11 +1057,11 @@ The old `webcam_history_max_frames` setting is deprecated but still supported:
 
 ### Player URLs
 
-- `https://kspb.aviationwx.org/?cam=0` -- Opens player
-- `https://kspb.aviationwx.org/?cam=0&autoplay` -- Auto-plays
-- `https://kspb.aviationwx.org/?cam=0&autoplay&hideui` -- Kiosk mode
-- `https://kspb.aviationwx.org/?cam=0&period=3h` -- Opens with 3-hour period selected
-- `https://kspb.aviationwx.org/?cam=0&period=all` -- Opens with all history
+- `https://kspb.aviationwx.org/?cam=0` - Opens player
+- `https://kspb.aviationwx.org/?cam=0&autoplay` - Auto-plays
+- `https://kspb.aviationwx.org/?cam=0&autoplay&hideui` - Kiosk mode
+- `https://kspb.aviationwx.org/?cam=0&period=3h` - Opens with 3-hour period selected
+- `https://kspb.aviationwx.org/?cam=0&period=all` - Opens with all history
 
 ### Keyboard Shortcuts
 
@@ -1122,10 +1122,10 @@ Configure default units for the airport page toggle buttons. User preferences (s
 
 ### Priority Order
 
-1. **User preference** -- stored in browser cookie/localStorage (persists across visits)
-2. **Per-airport** -- `airport.default_preferences`
-3. **Global** -- `config.default_preferences`
-4. **Built-in** -- US aviation standards (12hr, °F, ft, inHg, kts)
+1. **User preference** - stored in browser cookie/localStorage (persists across visits)
+2. **Per-airport** - `airport.default_preferences`
+3. **Global** - `config.default_preferences`
+4. **Built-in** - US aviation standards (12hr, °F, ft, inHg, kts)
 
 Only include preferences you want to change from defaults. Users who have previously set a preference will keep their choice.
 
@@ -1597,8 +1597,8 @@ The validator uses strict checking: unknown fields are rejected.
 
 ### Adding New Fields
 
-1. Update `lib/config.php` -- add to allowed fields, add validation
-2. Update `tests/Unit/ConfigValidationTest.php` -- add tests
+1. Update `lib/config.php` - add to allowed fields, add validation
+2. Update `tests/Unit/ConfigValidationTest.php` - add tests
 3. Update this documentation
 4. Update `config/airports.json.example`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -158,6 +158,7 @@ Values are strings in MHz (e.g. `"122.8"`, `"123.05"`).
 | **Optional** |||
 | `type` | auto-detect | `rtsp`, `mjpeg`, `static_jpeg`, `static_png`, `push` |
 | `refresh_seconds` | airport default | Override refresh for this camera |
+| `enabled` | `true` | When `false`, the slot stays in config/UI but fetch workers do not run for this camera |
 | `crop_margins` | global default | FAA profile crop margins override (percentages) |
 | **RTSP Options** |||
 | `rtsp_transport` | `tcp` | `tcp` or `udp` |
@@ -170,6 +171,8 @@ Values are strings in MHz (e.g. `"122.8"`, `"123.05"`).
 | `push_config.allowed_extensions` | `["jpg","jpeg","png","webp"]` | Allowed file types (subset of **jpg, jpeg, png, webp**) |
 | `push_config.upload_file_max_age_seconds` | `1800` | Max file age before abandonment (600-7200) |
 | `push_config.stability_check_timeout_seconds` | `15` | Stability check timeout (10-30) |
+
+**Scheduling:** The scheduler only runs acquisition for cameras that have enough configuration to fetch: non-push cameras need a non-empty `url` (or `type: aviationwx_api` with `base_url`); push cameras need `push_config.username`. Empty placeholder slots are skipped, matching the weather pipeline rule for airports without `weather_sources`.
 
 ### Configuration Hierarchy
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -68,9 +68,9 @@ All weather sources are configured in a unified `weather_sources` array. Each so
 - **Primary endpoint (federated station snapshot)**: `https://swd.weatherflow.com/swd/rest/observations/station/{station_id}?token={api_key}`
   - WeatherFlow builds this from devices on the station; it can be empty while a physical sensor still has data (federation gap).
 - **Automatic device fallback** (when the primary response does not parse, or parses to a timestamp-only / sensor-empty federated row with no temperature, humidity, pressure, dew point, wind, or non-zero precip):
-  1. `GET https://swd.weatherflow.com/swd/rest/stations/{station_id}?token={api_key}` -- response lists devices (typically hub `HB` plus one Tempest unit `ST`).
+  1. `GET https://swd.weatherflow.com/swd/rest/stations/{station_id}?token={api_key}` - response lists devices (typically hub `HB` plus one Tempest unit `ST`).
   2. The integration selects the **first device with `device_type` `ST`** (the Tempest unit that publishes `obs_st` rows).
-  3. `GET https://swd.weatherflow.com/swd/rest/observations/device/{device_id}?token={api_key}` -- latest observation uses the **`obs_st` numeric row layout** from WeatherFlow's API docs.
+  3. `GET https://swd.weatherflow.com/swd/rest/observations/device/{device_id}?token={api_key}` - latest observation uses the **`obs_st` numeric row layout** from WeatherFlow's API docs.
   4. The adapter maps that row into the same internal shape as federated `obs[0]`, then applies the same unit conversions. **Dew point** is not present on raw `obs_st` rows; it may be derived later from temperature and humidity when both exist (same as any missing dew point path).
   5. **Pressure**: device index 6 is station pressure in mb and is run through the same mb → inHg path as federated `sea_level_pressure`; when only the device path is used, treat displayed pressure as sensor-reported pressure, not a guaranteed sea-level reduction.
   6. **Logging**: when the device path is used, an internal structured log records `airport_id`, `station_id`, and `device_id` (no secrets).
@@ -637,7 +637,7 @@ Sunrise, sunset, and twilight times for display and night mode. Uses NOAA Solar 
 
 **References**:
 - [NOAA Solar Calculator Equations](https://gml.noaa.gov/grad/solcalc/solareqns.PDF)
-- [FAA 14 CFR §1.1](https://www.ecfr.gov/current/title-14/chapter-I/subchapter-A/part-1/subpart-A/section-1.1) — "Night" definition
+- [FAA 14 CFR §1.1](https://www.ecfr.gov/current/title-14/chapter-I/subchapter-A/part-1/subpart-A/section-1.1) - "Night" definition
 
 ---
 
@@ -1655,7 +1655,7 @@ The `/api/notam.php` endpoint serves cached NOTAM data:
 - **Format**: JPEG or WebP (based on browser support)
 - **Refresh**: Automatic refresh based on cache age
 - **Loading State**: Shown during fetch
-- **Stale Overlay**: When image exceeds fail-closed threshold but history has frames—shows last image dimmed with overlay "Live image unavailable. Tap for time-lapse history." and timestamp; user can tap to open history player
+- **Stale Overlay**: When image exceeds fail-closed threshold but history has frames, shows last image dimmed with overlay "Live image unavailable. Tap for time-lapse history." and timestamp; user can tap to open history player
 - **Placeholder**: Shown when no image exists or history unavailable (no frames, history disabled)
 
 #### Timestamp Display

--- a/docs/LINK_CHECK.md
+++ b/docs/LINK_CHECK.md
@@ -7,7 +7,7 @@ The link check workflow discovers external links on airport dashboards, validate
 1. **Discovery:** Fetches `https://aviationwx.org/sitemap.xml`, extracts airport dashboard URLs
 2. **Scrape:** Fetches each dashboard HTML, extracts external `<a href>` links
 3. **Check:** HEAD request to each URL; treats 301/302/4xx/5xx/timeout as unhealthy
-4. **Issues:** Per-link GitHub issues—create when broken, update with comment each run, close when healthy
+4. **Issues:** Per-link GitHub issues - create when broken, update with comment each run, close when healthy
 
 ## Setup Requirements
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -87,6 +87,10 @@ Shows:
 - **Per-airport weather**: based on observation timestamps in the weather cache (same family of values as the public API).
 - **Per-airport webcams**: freshness uses **last completed frame** time on disk (aligned with the image pipeline and API), not the `current.jpg` symlink mtime alone.
 
+**Schedulers and missing sensors**
+
+When an airport has no `weather_sources` or a webcam slot has no acquisition settings, schedulers **skip those workers** on purpose. Cron noise goes down, but you should still watch **staleness on the dashboard** and **status page per-airport rows**. Silence from `fetch-weather.php` / unified webcam workers does not prove observations are fresh; it means nothing was queued for that slot.
+
 ### Health Endpoints
 
 | Endpoint | Purpose |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -196,7 +196,7 @@ form-action 'self';
 The CSP explicitly allows:
 - ✅ **Cloudflare Web Analytics** (`static.cloudflareinsights.com`, `cloudflareinsights.com`)
 - ✅ **Cloudflare Email Obfuscation** (via `/cdn-cgi/` paths covered by `'self'`)
-- ✅ **Inline scripts** (via `'unsafe-inline'` -- required for inline dashboard scripts)
+- ✅ **Inline scripts** (via `'unsafe-inline'` - required for inline dashboard scripts)
 
 ### Weather Overlay Services
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -21,7 +21,7 @@ AviationWX uses a unified testing strategy based on `APP_ENV`:
 | **Internal API** | First-party JSON and binary endpoints on the main site host (`api/weather.php`, `api/webcam.php`, `api/notam.php`, ...). Documented in [`docs/API.md`](API.md). Used by the dashboard and site UI; not versioned. |
 | **Public API** | Versioned JSON under `https://api.aviationwx.org/v1/...` for integrations, OpenAPI, and embed JSON contracts. |
 
-Reserve **legacy** for older response formats, optional query flags such as `?legacy=1`, vendor hardware lines (e.g. Davis WeatherLink legacy devices), or unrelated features -- not for the Internal API weather/webcam routes.
+Reserve **legacy** for older response formats, optional query flags such as `?legacy=1`, vendor hardware lines (e.g. Davis WeatherLink legacy devices), or unrelated features - not for the Internal API weather/webcam routes.
 
 ## Quick Start
 

--- a/guides/08-camera-configuration.md
+++ b/guides/08-camera-configuration.md
@@ -426,7 +426,7 @@ UniFi Protect can be a great fit if the airport/FBO already has a UniFi ecosyste
 
 ### UniFi Protect RTSP URL (Local RTSP only)
 
-UniFi Protect exposes an RTSP stream that works when the Bridge is on the same network as the NVR. UniFi's UI gives you an RTSPS URL—you must convert it to Local RTSP format.
+UniFi Protect exposes an RTSP stream that works when the Bridge is on the same network as the NVR. UniFi's UI gives you an RTSPS URL; you must convert it to Local RTSP format.
 
 **Step 1: Get the stream URL from UniFi Protect**
 
@@ -458,7 +458,7 @@ rtsp://192.168.1.1:7447/QxJCVMefFHfBnqrp
 
 **Step 3: Use in the AviationWX Bridge**
 
-Enter the converted URL in the Bridge web console. The Bridge must be on the same local network as the NVR. Leave the username and password fields empty—UniFi Local RTSP does not use authentication.
+Enter the converted URL in the Bridge web console. The Bridge must be on the same local network as the NVR. Leave the username and password fields empty - UniFi Local RTSP does not use authentication.
 
 ---
 

--- a/guides/10-aviationwx-bridge.md
+++ b/guides/10-aviationwx-bridge.md
@@ -319,12 +319,12 @@ UniFi Protect doesn't offer scheduled FTP uploads. The Bridge connects to the RT
 
 1. **Get the URL from UniFi Protect:** Home → Protect → UniFi Devices → (select camera) → Settings → Advanced → toggle the resolution you want → copy the URL (e.g., `rtsps://192.168.1.1:7441/QxJCVMefFHfBnqrp?enableSrtp`)
 
-2. **Convert it** — UniFi's URL needs a few adjustments. Apply these three changes:
+2. **Convert it** - UniFi's URL needs a few adjustments. Apply these three changes:
    - Change `rtsps://` to `rtsp://` (remove the second `s`)
    - Change port `7441` to `7447`
    - Remove `?enableSrtp` from the end
 
-3. **Use in the Bridge:** Enter the converted URL in the Bridge web console. Leave the username and password fields empty—UniFi Local RTSP does not use authentication.
+3. **Use in the Bridge:** Enter the converted URL in the Bridge web console. Leave the username and password fields empty - UniFi Local RTSP does not use authentication.
 
 **Example:**
 ```
@@ -362,13 +362,13 @@ At remote sites where reliability matters most:
 ## Troubleshooting
 
 ### "Camera captures are failing"
-- **Test RTSP separately:** To confirm the feed is reachable, try it from a computer on the same network as the camera or NVR. Open **VLC** (Media → Open Network Stream) and paste your RTSP URL. If VLC can play the stream, the Bridge should be able to reach it too. If VLC fails, the issue is likely with the network or camera configuration—troubleshoot that first.
+- **Test RTSP separately:** To confirm the feed is reachable, try it from a computer on the same network as the camera or NVR. Open **VLC** (Media → Open Network Stream) and paste your RTSP URL. If VLC can play the stream, the Bridge should be able to reach it too. If VLC fails, the issue is likely with the network or camera configuration - troubleshoot that first.
 - Verify the camera URL is reachable from the Bridge device
 - For RTSP, confirm the stream path (and that username/password are empty for UniFi Local RTSP)
 - Check the Bridge logs via the web console
 
 ### "Uploads aren't happening"
-- **Test SFTP/FTPS separately:** Use **FileZilla** (or similar) to connect to `upload.aviationwx.org` with your credentials. If FileZilla can connect and upload a test file, the Bridge should be able to as well. If FileZilla fails, the issue is likely with credentials or network connectivity—check those first.
+- **Test SFTP/FTPS separately:** Use **FileZilla** (or similar) to connect to `upload.aviationwx.org` with your credentials. If FileZilla can connect and upload a test file, the Bridge should be able to as well. If FileZilla fails, the issue is likely with credentials or network connectivity - check those first.
 - Verify internet connectivity from the Bridge device
 - Check upload credentials in the web console
 - Look for queue buildup (images waiting to upload)

--- a/guides/13-using-the-airport-dashboard.md
+++ b/guides/13-using-the-airport-dashboard.md
@@ -243,7 +243,7 @@ Tap (or click) any webcam image to open the **24-hour history player**:
 +-----------------------------------------------------------------------------+
 |                                                                             |
 |                              SWIPE LEFT/RIGHT                               |
-|                           <-- -- -- -- -- -- -->                            |
+|                           <-- - - - - - -->                            |
 |                              Navigate frames                                |
 |                                                                             |
 |          +-----------------------------------------------+                  |
@@ -430,7 +430,7 @@ If data sources experience issues, you'll see a banner at the top of the page:
 
 ```
 +-----------------------------------------------------------------------------+
-|  ! WEATHER DATA OUTAGE -- Last successful update: 45 min ago                |
+|  ! WEATHER DATA OUTAGE - Last successful update: 45 min ago                |
 |    Some readings may be outdated. Check official sources.                   |
 +-----------------------------------------------------------------------------+
 ```
@@ -441,7 +441,7 @@ Active NOTAMs for the airport appear at the top:
 
 ```
 +-----------------------------------------------------------------------------+
-|  ! ACTIVE NOTAM -- Runway 15/33 closed for maintenance                      |
+|  ! ACTIVE NOTAM - Runway 15/33 closed for maintenance                      |
 |    Effective: Dec 20 0800Z - Dec 20 1700Z                                   |
 +-----------------------------------------------------------------------------+
 ```
@@ -453,8 +453,8 @@ Active NOTAMs for the airport appear at the top:
 Want to display an AviationWX dashboard on your own website, FBO lobby screen, or flight school? Use the **Embed Generator** at [embed.aviationwx.org](https://embed.aviationwx.org).
 
 **What you get:**
-- **Web component** (default) — Best for modern sites. Paste a script tag and a custom element. Responsive by default.
-- **iframe** — For platforms that restrict JavaScript (e.g., some CMS blocks). Add `responsive=1` to the URL for auto-height.
+- **Web component** (default) - Best for modern sites. Paste a script tag and a custom element. Responsive by default.
+- **iframe** - For platforms that restrict JavaScript (e.g., some CMS blocks). Add `responsive=1` to the URL for auto-height.
 
 ```
 +-----------------------------------------------------------------------------+
@@ -527,7 +527,7 @@ The real power of AviationWX is **visual verification**. Use the dashboard like 
 
 ```
 +-----------------------------------------------------------------------------+
-|  AVIATIONWX DASHBOARD -- QUICK REFERENCE                                    |
+|  AVIATIONWX DASHBOARD - QUICK REFERENCE                                    |
 +-----------------------------------------------------------------------------+
 |                                                                             |
 |  WEBCAM PLAYER KEYS                   FLIGHT CATEGORIES                     |

--- a/lib/config.php
+++ b/lib/config.php
@@ -4380,6 +4380,22 @@ function validateAirportsJsonStructure(array $config): array {
                         // Reserved UI slots: no pull URL / push_config required (matches scheduler skip)
                         $skipAcquisitionValidation = isset($webcam['enabled']) && $webcam['enabled'] === false;
 
+                        // Still reject unknown top-level keys so typos cannot slip through (e.g. refesh_seconds)
+                        if ($skipAcquisitionValidation) {
+                            $allowedDisabledWebcamFields = [
+                                'api_key', 'base_url', 'camera_index', 'crop_margins', 'enabled', 'name',
+                                'push_config', 'refresh_seconds', 'rtsp_fetch_timeout', 'rtsp_max_runtime',
+                                'rtsp_transport', 'timeout_seconds', 'transcode_timeout', 'type', 'url',
+                                'variant_heights',
+                            ];
+                            foreach ($webcam as $key => $_val) {
+                                if (!in_array($key, $allowedDisabledWebcamFields, true)) {
+                                    $errors[] = "Airport '{$airportCode}' webcam[{$idx}] (disabled placeholder) has unknown field '{$key}'. Allowed fields: "
+                                        . implode(', ', $allowedDisabledWebcamFields);
+                                }
+                            }
+                        }
+
                         if (!$skipAcquisitionValidation) {
                             $webcamType = $webcam['type'] ?? 'http';
                         

--- a/lib/config.php
+++ b/lib/config.php
@@ -4373,11 +4373,14 @@ function validateAirportsJsonStructure(array $config): array {
                     if (!is_array($webcam)) {
                         $errors[] = "Airport '{$airportCode}' webcam[{$idx}] must be an object";
                     } else {
+                        if (isset($webcam['enabled']) && !is_bool($webcam['enabled'])) {
+                            $errors[] = "Airport '{$airportCode}' webcam[{$idx}] enabled must be a boolean";
+                        }
                         $webcamType = $webcam['type'] ?? 'http';
                         
                         if ($webcamType === 'push') {
                             // Define allowed fields for push cameras
-                            $allowedPushWebcamFields = ['name', 'type', 'push_config', 'refresh_seconds', 'variant_heights', 'crop_margins'];
+                            $allowedPushWebcamFields = ['name', 'type', 'push_config', 'refresh_seconds', 'variant_heights', 'crop_margins', 'enabled'];
                             
                             // Check for unknown fields in push webcam
                             foreach ($webcam as $key => $value) {
@@ -4435,7 +4438,7 @@ function validateAirportsJsonStructure(array $config): array {
                             }
                         } elseif ($webcamType === 'rtsp') {
                             // Define allowed fields for RTSP cameras
-                            $allowedRtspWebcamFields = ['name', 'type', 'url', 'rtsp_transport', 'refresh_seconds', 'rtsp_fetch_timeout', 'rtsp_max_runtime', 'transcode_timeout', 'variant_heights', 'crop_margins'];
+                            $allowedRtspWebcamFields = ['name', 'type', 'url', 'rtsp_transport', 'refresh_seconds', 'rtsp_fetch_timeout', 'rtsp_max_runtime', 'transcode_timeout', 'variant_heights', 'crop_margins', 'enabled'];
                             
                             // Check for unknown fields in RTSP webcam
                             foreach ($webcam as $key => $value) {
@@ -4452,7 +4455,7 @@ function validateAirportsJsonStructure(array $config): array {
                             }
                         } else {
                             // Define allowed fields for pull cameras (http/mjpeg/static_jpeg/static_png)
-                            $allowedPullWebcamFields = ['name', 'type', 'url', 'refresh_seconds', 'variant_heights', 'crop_margins'];
+                            $allowedPullWebcamFields = ['name', 'type', 'url', 'refresh_seconds', 'variant_heights', 'crop_margins', 'enabled'];
                             
                             // Check for unknown fields in pull webcam
                             foreach ($webcam as $key => $value) {

--- a/lib/config.php
+++ b/lib/config.php
@@ -4376,7 +4376,12 @@ function validateAirportsJsonStructure(array $config): array {
                         if (isset($webcam['enabled']) && !is_bool($webcam['enabled'])) {
                             $errors[] = "Airport '{$airportCode}' webcam[{$idx}] enabled must be a boolean";
                         }
-                        $webcamType = $webcam['type'] ?? 'http';
+
+                        // Reserved UI slots: no pull URL / push_config required (matches scheduler skip)
+                        $skipAcquisitionValidation = isset($webcam['enabled']) && $webcam['enabled'] === false;
+
+                        if (!$skipAcquisitionValidation) {
+                            $webcamType = $webcam['type'] ?? 'http';
                         
                         if ($webcamType === 'push') {
                             // Define allowed fields for push cameras
@@ -4453,6 +4458,33 @@ function validateAirportsJsonStructure(array $config): array {
                             if (!isset($webcam['url'])) {
                                 $errors[] = "Airport '{$airportCode}' webcam[{$idx}] (rtsp type) missing 'url' field";
                             }
+                        } elseif ($webcamType === 'aviationwx_api') {
+                            $allowedFederatedWebcamFields = [
+                                'name', 'type', 'base_url', 'api_key', 'timeout_seconds',
+                                'camera_index', 'refresh_seconds', 'variant_heights', 'crop_margins', 'enabled',
+                            ];
+                            foreach ($webcam as $key => $value) {
+                                if (!in_array($key, $allowedFederatedWebcamFields, true)) {
+                                    $errors[] = "Airport '{$airportCode}' webcam[{$idx}] (aviationwx_api) has unknown field '{$key}'. Allowed fields: " . implode(', ', $allowedFederatedWebcamFields);
+                                }
+                            }
+                            if (!isset($webcam['base_url']) || trim((string) $webcam['base_url']) === '') {
+                                $errors[] = "Airport '{$airportCode}' webcam[{$idx}] (aviationwx_api) missing 'base_url'";
+                            } elseif (!$validateUrl($webcam['base_url'])) {
+                                $errors[] = "Airport '{$airportCode}' webcam[{$idx}] (aviationwx_api) has invalid base_url: must be a valid URL";
+                            }
+                            if (isset($webcam['timeout_seconds'])) {
+                                $ts = $webcam['timeout_seconds'];
+                                if (!is_int($ts) || $ts < 1 || $ts > 300) {
+                                    $errors[] = "Airport '{$airportCode}' webcam[{$idx}] (aviationwx_api) timeout_seconds must be integer 1-300";
+                                }
+                            }
+                            if (isset($webcam['camera_index'])) {
+                                $ci = $webcam['camera_index'];
+                                if (!is_int($ci) || $ci < 0 || $ci > 99) {
+                                    $errors[] = "Airport '{$airportCode}' webcam[{$idx}] (aviationwx_api) camera_index must be integer 0-99";
+                                }
+                            }
                         } else {
                             // Define allowed fields for pull cameras (http/mjpeg/static_jpeg/static_png)
                             $allowedPullWebcamFields = ['name', 'type', 'url', 'refresh_seconds', 'variant_heights', 'crop_margins', 'enabled'];
@@ -4468,7 +4500,8 @@ function validateAirportsJsonStructure(array $config): array {
                                 $errors[] = "Airport '{$airportCode}' webcam[{$idx}] missing required 'url' field";
                             }
                         }
-                        
+                        }
+
                         if (isset($webcam['url']) && !$validateUrl($webcam['url'])) {
                             $errors[] = "Airport '{$airportCode}' webcam[{$idx}] has invalid url: must be a valid URL";
                         }

--- a/lib/config.php
+++ b/lib/config.php
@@ -3446,7 +3446,7 @@ function validateAirportsJsonStructure(array $config): array {
                 $errors[] = 'config.host_firewall is not a valid key; TCP ports are configured in config.network_ports';
             }
             if (isset($cfg['network_ports'])) {
-                // JSON objects decode to associative arrays; JSON arrays decode to list arrays — reject lists.
+                // JSON objects decode to associative arrays; JSON arrays decode to list arrays -- reject lists.
                 if (!is_array($cfg['network_ports']) || array_is_list($cfg['network_ports'])) {
                     $errors[] = 'config.network_ports must be an object';
                 } else {

--- a/lib/config.php
+++ b/lib/config.php
@@ -3446,7 +3446,7 @@ function validateAirportsJsonStructure(array $config): array {
                 $errors[] = 'config.host_firewall is not a valid key; TCP ports are configured in config.network_ports';
             }
             if (isset($cfg['network_ports'])) {
-                // JSON objects decode to associative arrays; JSON arrays decode to list arrays -- reject lists.
+                // JSON objects decode to associative arrays; JSON arrays decode to list arrays - reject lists.
                 if (!is_array($cfg['network_ports']) || array_is_list($cfg['network_ports'])) {
                     $errors[] = 'config.network_ports must be an object';
                 } else {

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -29,6 +29,12 @@ if (!defined('DEFAULT_WEATHER_REFRESH')) {
     define('DEFAULT_WEATHER_REFRESH', 60);
 }
 
+// Internal api/weather.php JSON `error` when the airport has no `weather_sources`.
+// scripts/fetch-weather.php must recognize the same value with HTTP 503 so cron workers do not fail closed.
+if (!defined('WEATHER_INTERNAL_API_ERROR_SOURCE_NOT_CONFIGURED')) {
+    define('WEATHER_INTERNAL_API_ERROR_SOURCE_NOT_CONFIGURED', 'Weather source not configured');
+}
+
 // RTSP/ffmpeg timeouts
 if (!defined('RTSP_DEFAULT_TIMEOUT')) {
     define('RTSP_DEFAULT_TIMEOUT', 10);

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -255,10 +255,10 @@ if (!defined('STATUS_PAGE_CACHE_TTL')) {
     define('STATUS_PAGE_CACHE_TTL', 600); // 10 minutes
 }
 if (!defined('STATUS_PAGE_BACKGROUND_FETCH_INTERVAL')) {
-    define('STATUS_PAGE_BACKGROUND_FETCH_INTERVAL', 120); // 2 minutes — refresh well before TTL
+    define('STATUS_PAGE_BACKGROUND_FETCH_INTERVAL', 120); // 2 minutes -- refresh well before TTL
 }
 
-// Legacy aliases — same values (health, metrics bundle, performance JSON caches)
+// Legacy aliases -- same values (health, metrics bundle, performance JSON caches)
 if (!defined('STATUS_HEALTH_CACHE_TTL')) {
     define('STATUS_HEALTH_CACHE_TTL', STATUS_PAGE_CACHE_TTL);
 }

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -255,10 +255,10 @@ if (!defined('STATUS_PAGE_CACHE_TTL')) {
     define('STATUS_PAGE_CACHE_TTL', 600); // 10 minutes
 }
 if (!defined('STATUS_PAGE_BACKGROUND_FETCH_INTERVAL')) {
-    define('STATUS_PAGE_BACKGROUND_FETCH_INTERVAL', 120); // 2 minutes -- refresh well before TTL
+    define('STATUS_PAGE_BACKGROUND_FETCH_INTERVAL', 120); // 2 minutes - refresh well before TTL
 }
 
-// Legacy aliases -- same values (health, metrics bundle, performance JSON caches)
+// Legacy aliases - same values (health, metrics bundle, performance JSON caches)
 if (!defined('STATUS_HEALTH_CACHE_TTL')) {
     define('STATUS_HEALTH_CACHE_TTL', STATUS_PAGE_CACHE_TTL);
 }
@@ -427,7 +427,7 @@ if (!defined('SECONDS_PER_DAY')) {
     define('SECONDS_PER_DAY', 86400);
 }
 
-// Station power (facility metrics; not flight-safety tier -- separate staleness from weather/METAR)
+// Station power (facility metrics; not flight-safety tier - separate staleness from weather/METAR)
 if (!defined('STATION_POWER_FETCH_INTERVAL_SECONDS')) {
     define('STATION_POWER_FETCH_INTERVAL_SECONDS', 600); // 10 minutes
 }

--- a/lib/data/README.md
+++ b/lib/data/README.md
@@ -1,3 +1,3 @@
 # Static data files
 
-- **`iso3166-alpha2-codes.txt`** -- One ISO 3166-1 alpha-2 code per line, derived from [lukes/ISO-3166-Countries-with-Regional-Codes](https://github.com/lukes/ISO-3166-Countries-with-Regional-Codes) (MIT). Used to validate optional `iso_country` in `airports.json` and related fields.
+- **`iso3166-alpha2-codes.txt`** - One ISO 3166-1 alpha-2 code per line, derived from [lukes/ISO-3166-Countries-with-Regional-Codes](https://github.com/lukes/ISO-3166-Countries-with-Regional-Codes) (MIT). Used to validate optional `iso_country` in `airports.json` and related fields.

--- a/lib/push-webcam-validator.php
+++ b/lib/push-webcam-validator.php
@@ -69,7 +69,7 @@ function validatePushWebcamConfig($cam, $airportId, $camIndex, ?int $globalCache
         }
     }
     
-    // Port is informational only — not enforced by the server (listeners are config.network_ports / defaults).
+    // Port is informational only -- not enforced by the server (listeners are config.network_ports / defaults).
     
     // max_file_size_mb: optional (omit = inherit global cache_file_max_size_mb at runtime)
     if (isset($pushConfig['max_file_size_mb'])) {

--- a/lib/push-webcam-validator.php
+++ b/lib/push-webcam-validator.php
@@ -69,7 +69,7 @@ function validatePushWebcamConfig($cam, $airportId, $camIndex, ?int $globalCache
         }
     }
     
-    // Port is informational only -- not enforced by the server (listeners are config.network_ports / defaults).
+    // Port is informational only - not enforced by the server (listeners are config.network_ports / defaults).
     
     // max_file_size_mb: optional (omit = inherit global cache_file_max_size_mb at runtime)
     if (isset($pushConfig['max_file_size_mb'])) {

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -785,7 +785,7 @@ function getSchedulerStatus(): array {
 
 /**
  * Resolved listener ports for status display (defaults merged with config.network_ports).
- * List-shaped or invalid values are ignored (defaults) — same integer-only rule as validateAirportsJsonStructure.
+ * List-shaped or invalid values are ignored (defaults) -- same integer-only rule as validateAirportsJsonStructure.
  *
  * @return array{ftp_control:int,ftps_explicit_tls:int,sftp:int}
  */

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -785,7 +785,7 @@ function getSchedulerStatus(): array {
 
 /**
  * Resolved listener ports for status display (defaults merged with config.network_ports).
- * List-shaped or invalid values are ignored (defaults) -- same integer-only rule as validateAirportsJsonStructure.
+ * List-shaped or invalid values are ignored (defaults) - same integer-only rule as validateAirportsJsonStructure.
  *
  * @return array{ftp_control:int,ftps_explicit_tls:int,sftp:int}
  */

--- a/lib/webcam-acquisition.php
+++ b/lib/webcam-acquisition.php
@@ -1030,11 +1030,6 @@ class PushAcquisitionStrategy extends BaseAcquisitionStrategy
             return AcquisitionResult::failure('webcam_not_configured', 'push');
         }
 
-        $username = $this->camConfig['push_config']['username'] ?? null;
-        if (!$username) {
-            return AcquisitionResult::failure('no_username_configured', 'push');
-        }
-
         if (empty($this->uploadDirs)) {
             return AcquisitionResult::skip('no_upload_dir', 'push');
         }

--- a/lib/webcam-acquisition.php
+++ b/lib/webcam-acquisition.php
@@ -11,6 +11,7 @@
 require_once __DIR__ . '/constants.php';
 require_once __DIR__ . '/cache-paths.php';
 require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/webcam-source-validation.php';
 require_once __DIR__ . '/logger.php';
 require_once __DIR__ . '/circuit-breaker.php';
 require_once __DIR__ . '/exif-utils.php';
@@ -325,6 +326,10 @@ class PullAcquisitionStrategy extends BaseAcquisitionStrategy
         // Check for mock mode
         if (function_exists('shouldMockExternalServices') && shouldMockExternalServices()) {
             return $this->acquireMock();
+        }
+
+        if (!hasWebcamAcquisitionConfigured($this->camConfig)) {
+            return AcquisitionResult::failure('webcam_not_configured', $this->sourceType);
         }
 
         $stagingPath = $this->getStagingPath();
@@ -1021,6 +1026,10 @@ class PushAcquisitionStrategy extends BaseAcquisitionStrategy
 
     public function acquire(): AcquisitionResult
     {
+        if (!hasWebcamAcquisitionConfigured($this->camConfig)) {
+            return AcquisitionResult::failure('webcam_not_configured', 'push');
+        }
+
         $username = $this->camConfig['push_config']['username'] ?? null;
         if (!$username) {
             return AcquisitionResult::failure('no_username_configured', 'push');

--- a/lib/webcam-schedule-queue.php
+++ b/lib/webcam-schedule-queue.php
@@ -15,6 +15,7 @@
 
 require_once __DIR__ . '/constants.php';
 require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/webcam-source-validation.php';
 
 /**
  * Camera entry in the schedule queue
@@ -118,8 +119,9 @@ class WebcamScheduleQueue
     /**
      * Initialize queue from airport configuration
      * 
-     * Populates the queue with all configured cameras.
-     * All cameras start as immediately due (dueTime = now).
+     * Populates the queue with configured cameras that have acquisition inputs (pull URL or push username).
+     * Placeholder slots and `enabled: false` entries are omitted so workers are not scheduled.
+     * All queued cameras start as immediately due (dueTime = now).
      * 
      * @param array $airports Airport configuration array
      * @param array $globalConfig Global configuration
@@ -141,6 +143,10 @@ class WebcamScheduleQueue
             }
 
             foreach ($webcams as $camIndex => $webcam) {
+                if (!is_array($webcam) || !hasWebcamAcquisitionConfigured($webcam)) {
+                    continue;
+                }
+
                 $refreshSeconds = $this->getRefreshSeconds($webcam, $airport, $globalConfig);
                 $isPush = $this->isPushCamera($webcam);
 
@@ -274,6 +280,10 @@ class WebcamScheduleQueue
 
             $webcams = $airport['webcams'] ?? [];
             foreach ($webcams as $camIndex => $webcam) {
+                if (!is_array($webcam) || !hasWebcamAcquisitionConfigured($webcam)) {
+                    continue;
+                }
+
                 $key = $airportId . '_' . $camIndex;
                 $refreshSeconds = $this->getRefreshSeconds($webcam, $airport, $globalConfig);
                 $isPush = $this->isPushCamera($webcam);

--- a/lib/webcam-source-validation.php
+++ b/lib/webcam-source-validation.php
@@ -28,7 +28,11 @@ function hasWebcamAcquisitionConfigured(array $webcam): bool
         || isset($webcam['push_config']);
 
     if ($isPush) {
-        $user = $webcam['push_config']['username'] ?? '';
+        $pushConfig = $webcam['push_config'] ?? null;
+        if (!is_array($pushConfig)) {
+            return false;
+        }
+        $user = $pushConfig['username'] ?? '';
         return is_string($user) && trim($user) !== '';
     }
 

--- a/lib/webcam-source-validation.php
+++ b/lib/webcam-source-validation.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Webcam acquisition configuration gate (parallel to hasWeatherSources() for weather).
+ *
+ * Used by the scheduler queue and workers so reserved webcam slots without pull URLs
+ * or push credentials do not run acquisition or appear as pool failures.
+ */
+
+/**
+ * Whether this webcam entry has the minimum configuration for acquisition to be attempted.
+ *
+ * Rules:
+ * - Optional `enabled: false` on the webcam object disables scheduling (placeholder slot).
+ * - Push cameras require a non-empty `push_config.username`.
+ * - `type: aviationwx_api` requires non-empty `base_url`.
+ * - All other pull cameras require a non-empty `url` (RTSP, MJPEG, static, legacy http).
+ *
+ * @param array $webcam Single camera object from airport `webcams[]`
+ * @return bool True when the worker should run acquisition for this slot
+ */
+function hasWebcamAcquisitionConfigured(array $webcam): bool
+{
+    if (array_key_exists('enabled', $webcam) && $webcam['enabled'] === false) {
+        return false;
+    }
+
+    $isPush = (isset($webcam['type']) && $webcam['type'] === 'push')
+        || isset($webcam['push_config']);
+
+    if ($isPush) {
+        $user = $webcam['push_config']['username'] ?? '';
+        return is_string($user) && trim($user) !== '';
+    }
+
+    if (isset($webcam['type'])) {
+        $explicitType = strtolower(trim((string) $webcam['type']));
+        if ($explicitType === 'aviationwx_api') {
+            $base = $webcam['base_url'] ?? '';
+            return is_string($base) && trim($base) !== '';
+        }
+    }
+
+    $url = $webcam['url'] ?? '';
+    return is_string($url) && trim($url) !== '';
+}

--- a/lib/webcam-worker.php
+++ b/lib/webcam-worker.php
@@ -224,11 +224,28 @@ class WebcamWorker
             $reason = $acquisitionResult->errorReason;
             $isCommissioning = isAirportUnlisted($this->airportConfig);
 
-            // Expected/configuration issues - log as info (camera not set up yet)
+            $configurationNotReadyReasons = [
+                'webcam_not_configured',
+                'missing_base_url',
+                'no_username_configured',
+            ];
+            if (in_array($reason, $configurationNotReadyReasons, true)) {
+                aviationwx_log('info', 'Webcam acquisition skipped (not configured)', [
+                    'airport' => $this->airportId,
+                    'cam' => $this->camIndex,
+                    'reason' => $reason,
+                    'source' => $acquisitionResult->sourceType,
+                    'metadata' => $acquisitionResult->metadata
+                ], 'app');
+                return WorkerResult::skip($reason, [
+                    'source' => $acquisitionResult->sourceType,
+                    'metadata' => $acquisitionResult->metadata
+                ]);
+            }
+
+            // Expected environment or setup issues (not a remote camera fault)
             $expectedReasons = [
-                'no_username_configured',  // Push camera not set up
                 'ffmpeg_not_available',    // RTSP not supported on this system
-                'missing_base_url'         // Federation not configured
             ];
 
             // Transient network/camera issues - log as warning (camera may come online)

--- a/lib/webcam-worker.php
+++ b/lib/webcam-worker.php
@@ -227,7 +227,6 @@ class WebcamWorker
             $configurationNotReadyReasons = [
                 'webcam_not_configured',
                 'missing_base_url',
-                'no_username_configured',
             ];
             if (in_array($reason, $configurationNotReadyReasons, true)) {
                 aviationwx_log('info', 'Webcam acquisition skipped (not configured)', [

--- a/pages/embed-configurator.php
+++ b/pages/embed-configurator.php
@@ -1225,11 +1225,11 @@ $shouldNoIndex = $hasQueryParams;
                     <div class="size-mode-toggle">
                         <label class="radio-item size-mode-option">
                             <input type="radio" name="size_mode" value="responsive" checked>
-                            <span><strong>Responsive</strong> — Fills container width, height adjusts automatically</span>
+                            <span><strong>Responsive</strong>: Fills container width, height adjusts automatically</span>
                         </label>
                         <label class="radio-item size-mode-option">
                             <input type="radio" name="size_mode" value="fixed">
-                            <span><strong>Fixed size</strong> — Set exact width and height in pixels</span>
+                            <span><strong>Fixed size</strong>: Set exact width and height in pixels</span>
                         </label>
                     </div>
                     <div id="size-fixed-inputs" class="size-inputs" style="display: none;">

--- a/scripts/fetch-weather.php
+++ b/scripts/fetch-weather.php
@@ -46,8 +46,8 @@ function getWeatherBaseUrl(): string {
  * When expectFailures is true (maintenance or unlisted/commissioning), failures
  * are logged at info level so process pool does not treat as errors.
  *
- * Returns true when the airport has no weather sources configured (503 + known message):
- * refresh is a no-op and must not count as a worker failure.
+ * Returns true when the airport has no weather sources configured (503 + JSON error
+ * WEATHER_INTERNAL_API_ERROR_SOURCE_NOT_CONFIGURED): refresh is a no-op and must not count as a worker failure.
  *
  * @param string $airportId Airport ID (e.g., 'kspb')
  * @param string $baseUrl Base URL for weather API (e.g., 'http://localhost')
@@ -115,7 +115,7 @@ function processAirportWeather(string $airportId, string $baseUrl, string $invoc
         $errorMessage = is_array($data) ? ($data['error'] ?? null) : null;
 
         // Unconfigured airport: success so the process pool does not treat this as a worker failure
-        if ($httpCode === 503 && $errorMessage === 'Weather source not configured') {
+        if ($httpCode === 503 && $errorMessage === WEATHER_INTERNAL_API_ERROR_SOURCE_NOT_CONFIGURED) {
             aviationwx_log('info', 'weather refresh skipped (not configured)', [
                 'invocation_id' => $invocationId,
                 'trigger' => $triggerType,

--- a/scripts/fetch-weather.php
+++ b/scripts/fetch-weather.php
@@ -110,9 +110,9 @@ function processAirportWeather(string $airportId, string $baseUrl, string $invoc
             $success = false;
         }
     } else {
-        // Parse error response to determine log level
-        $data = json_decode($response, true);
-        $errorMessage = $data['error'] ?? null;
+        // Parse error response to determine log level (curl may return false; decode yields null)
+        $data = json_decode(is_string($response) ? $response : '', true);
+        $errorMessage = is_array($data) ? ($data['error'] ?? null) : null;
         
         // If not configured, treat as successful no-op (scheduler should skip these; belt-and-suspenders)
         if ($httpCode === 503 && $errorMessage === 'Weather source not configured') {

--- a/scripts/fetch-weather.php
+++ b/scripts/fetch-weather.php
@@ -230,12 +230,12 @@ if ($isWeb) {
         .info { color: #666; }
     </style></head><body>";
     echo "<div class='header'><h1>AviationWX Weather Fetcher</h1></div>";
-    echo "<p>Processing " . count($config['airports']) . " airports with {$poolSize} workers...</p>";
+    echo "<p>Queueing weather refresh for airports with configured sources (of " . count($config['airports']) . " in config) using {$poolSize} workers...</p>";
 } else {
     // Write progress to stderr for CLI/cron visibility
     @fwrite(STDERR, "AviationWX Weather Fetcher\n");
     @fwrite(STDERR, "========================\n\n");
-    @fwrite(STDERR, "Processing " . count($config['airports']) . " airports with {$poolSize} workers...\n\n");
+    @fwrite(STDERR, "Queueing weather refresh for airports with configured sources (of " . count($config['airports']) . " in config) using {$poolSize} workers...\n\n");
 }
 
 $pool = new ProcessPool($poolSize, $workerTimeout, basename(__FILE__), $invocationId);
@@ -244,6 +244,7 @@ register_shutdown_function(function() use ($pool) {
 });
 
 $skipped = 0;
+$weatherJobsEligible = 0;
 foreach ($config['airports'] as $airportId => $airport) {
     // Only process enabled airports; skip malformed entries
     if (!is_array($airport) || !isAirportEnabled($airport)) {
@@ -253,7 +254,8 @@ foreach ($config['airports'] as $airportId => $airport) {
     if (!hasWeatherSources($airport)) {
         continue;
     }
-    
+
+    $weatherJobsEligible++;
     if (!$pool->addJob([$airportId])) {
         $skipped++;
     }
@@ -287,7 +289,8 @@ aviationwx_log('info', 'weather fetch script completed', [
     'trigger' => $triggerType,
     'trigger_context' => $triggerContext,
     'duration_ms' => $scriptDuration,
-    'airports_processed' => $totalAirports,
+    'airports_in_config' => $totalAirports,
+    'weather_jobs_eligible' => $weatherJobsEligible,
     'stats' => $stats
 ], 'app');
 

--- a/scripts/fetch-weather.php
+++ b/scripts/fetch-weather.php
@@ -110,11 +110,11 @@ function processAirportWeather(string $airportId, string $baseUrl, string $invoc
             $success = false;
         }
     } else {
-        // Parse error response to determine log level (curl may return false; decode yields null)
+        // Failed curl or invalid JSON must not trigger array offset warnings on decoded values
         $data = json_decode(is_string($response) ? $response : '', true);
         $errorMessage = is_array($data) ? ($data['error'] ?? null) : null;
-        
-        // If not configured, treat as successful no-op (scheduler should skip these; belt-and-suspenders)
+
+        // Unconfigured airport: success so the process pool does not treat this as a worker failure
         if ($httpCode === 503 && $errorMessage === 'Weather source not configured') {
             aviationwx_log('info', 'weather refresh skipped (not configured)', [
                 'invocation_id' => $invocationId,

--- a/scripts/fetch-weather.php
+++ b/scripts/fetch-weather.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/../lib/config.php';
 require_once __DIR__ . '/../lib/internal-http-url.php';
 require_once __DIR__ . '/../lib/logger.php';
 require_once __DIR__ . '/../lib/process-pool.php';
+require_once __DIR__ . '/../lib/weather/utils.php';
 
 // Check for worker mode
 $isWorkerMode = false;
@@ -45,12 +46,15 @@ function getWeatherBaseUrl(): string {
  * When expectFailures is true (maintenance or unlisted/commissioning), failures
  * are logged at info level so process pool does not treat as errors.
  *
+ * Returns true when the airport has no weather sources configured (503 + known message):
+ * refresh is a no-op and must not count as a worker failure.
+ *
  * @param string $airportId Airport ID (e.g., 'kspb')
  * @param string $baseUrl Base URL for weather API (e.g., 'http://localhost')
  * @param string $invocationId Invocation ID for log correlation
  * @param string $triggerType Trigger type ('cron_job', 'web_request', 'manual_cli')
  * @param bool $expectFailures True if failures are expected (maintenance or commissioning/unlisted)
- * @return bool True on success, false on failure
+ * @return bool True on success or intentional skip (no sources), false on failure
  */
 function processAirportWeather(string $airportId, string $baseUrl, string $invocationId, string $triggerType, bool $expectFailures = false): bool
 {
@@ -110,13 +114,14 @@ function processAirportWeather(string $airportId, string $baseUrl, string $invoc
         $data = json_decode($response, true);
         $errorMessage = $data['error'] ?? null;
         
-        // If not configured, log as info (expected state), not error
+        // If not configured, treat as successful no-op (scheduler should skip these; belt-and-suspenders)
         if ($httpCode === 503 && $errorMessage === 'Weather source not configured') {
             aviationwx_log('info', 'weather refresh skipped (not configured)', [
                 'invocation_id' => $invocationId,
                 'trigger' => $triggerType,
                 'airport' => $airportId
             ], 'app');
+            $success = true;
         } else {
             $logLevel = $expectFailures ? 'info' : 'error';
             aviationwx_log($logLevel, 'weather refresh failed', [
@@ -126,8 +131,8 @@ function processAirportWeather(string $airportId, string $baseUrl, string $invoc
                 'http_code' => $httpCode,
                 'error' => $error ?: $errorMessage
             ], 'app');
+            $success = false;
         }
-        $success = false;
     }
     
     return $success;
@@ -163,6 +168,13 @@ if ($isWorkerMode) {
     }
     // Downgrade errors for maintenance (repairs) or unlisted (commissioning - new airport setup)
     $expectFailures = isAirportInMaintenance($airport) || isAirportUnlisted($airport);
+
+    if (!hasWeatherSources($airport)) {
+        aviationwx_log('info', 'weather worker skipped (no weather sources in config)', [
+            'airport' => $workerAirportId,
+        ], 'app');
+        exit(0);
+    }
 
     $baseUrl = getWeatherBaseUrl();
     $invocationId = aviationwx_get_invocation_id();
@@ -235,6 +247,10 @@ $skipped = 0;
 foreach ($config['airports'] as $airportId => $airport) {
     // Only process enabled airports; skip malformed entries
     if (!is_array($airport) || !isAirportEnabled($airport)) {
+        continue;
+    }
+
+    if (!hasWeatherSources($airport)) {
         continue;
     }
     

--- a/scripts/link-check.php
+++ b/scripts/link-check.php
@@ -254,7 +254,7 @@ function createOrUpdateIssue(
     $title = '[Link Check] ' . strtoupper($airportId) . ' - ' . $label;
     $statusText = $error !== '' ? $error : "HTTP {$status}";
     $redirectNote = ($status >= 301 && $status < 400) ? "\n\n**Suggested fix:** Update config URL to: {$finalUrl}" : '';
-    $body = "{$mentionUser} -- Broken link detected.\n\n"
+    $body = "{$mentionUser} - Broken link detected.\n\n"
         . "## Link Details\n"
         . "- **Airport:** " . strtoupper($airportId) . "\n"
         . "- **Link label:** {$label}\n"

--- a/scripts/link-check.php
+++ b/scripts/link-check.php
@@ -254,7 +254,7 @@ function createOrUpdateIssue(
     $title = '[Link Check] ' . strtoupper($airportId) . ' - ' . $label;
     $statusText = $error !== '' ? $error : "HTTP {$status}";
     $redirectNote = ($status >= 301 && $status < 400) ? "\n\n**Suggested fix:** Update config URL to: {$finalUrl}" : '';
-    $body = "{$mentionUser} — Broken link detected.\n\n"
+    $body = "{$mentionUser} -- Broken link detected.\n\n"
         . "## Link Details\n"
         . "- **Airport:** " . strtoupper($airportId) . "\n"
         . "- **Link label:** {$label}\n"

--- a/scripts/scheduler.php
+++ b/scripts/scheduler.php
@@ -718,7 +718,7 @@ while ($running) {
         }
 
         // 10. Status page caches pre-warm (every STATUS_PAGE_BACKGROUND_FETCH_INTERVAL, non-blocking)
-        // Health, metrics bundle, performance JSON — aligned TTL (STATUS_PAGE_CACHE_TTL)
+        // Health, metrics bundle, performance JSON -- aligned TTL (STATUS_PAGE_CACHE_TTL)
         if (($now - $lastStatusPageCachesFetch) >= STATUS_PAGE_BACKGROUND_FETCH_INTERVAL) {
             $statusScripts = [
                 'fetch-status-health.php',

--- a/scripts/scheduler.php
+++ b/scripts/scheduler.php
@@ -33,6 +33,7 @@ require_once __DIR__ . '/../lib/worker-timeout.php';
 require_once __DIR__ . '/../lib/webcam-schedule-queue.php';
 require_once __DIR__ . '/../lib/runways.php';
 require_once __DIR__ . '/../lib/airport-country-resolution-merge.php';
+require_once __DIR__ . '/../lib/weather/utils.php';
 // Note: variant-health flush uses variant_health_flush_via_http(); metrics use spill aggregator CLI
 
 // Lock file location
@@ -398,6 +399,11 @@ while ($running) {
         if ($weatherPool !== null && isset($config['airports'])) {
             foreach ($config['airports'] as $airportId => $airport) {
                 if (!is_array($airport) || !isAirportEnabled($airport)) {
+                    continue;
+                }
+
+                // No sensor / no weather_sources: nothing to refresh (matches api/weather.php gate)
+                if (!hasWeatherSources($airport)) {
                     continue;
                 }
                 

--- a/scripts/scheduler.php
+++ b/scripts/scheduler.php
@@ -718,7 +718,7 @@ while ($running) {
         }
 
         // 10. Status page caches pre-warm (every STATUS_PAGE_BACKGROUND_FETCH_INTERVAL, non-blocking)
-        // Health, metrics bundle, performance JSON -- aligned TTL (STATUS_PAGE_CACHE_TTL)
+        // Health, metrics bundle, performance JSON - aligned TTL (STATUS_PAGE_CACHE_TTL)
         if (($now - $lastStatusPageCachesFetch) >= STATUS_PAGE_BACKGROUND_FETCH_INTERVAL) {
             $statusScripts = [
                 'fetch-status-health.php',

--- a/scripts/unified-webcam-worker.php
+++ b/scripts/unified-webcam-worker.php
@@ -344,7 +344,7 @@ function runSingleMode(string $airportId, int $camIndex): int
 /**
  * Run all cameras mode
  * 
- * @return int Exit code (0 if any succeeded, 1 if all failed)
+ * @return int Exit code (success unless every attempted camera failed)
  */
 function runAllMode(): int
 {
@@ -387,6 +387,7 @@ function runAllMode(): int
         foreach ($webcams as $camIndex => $cam) {
             if (!is_array($cam) || !hasWebcamAcquisitionConfigured($cam)) {
                 echo "  [{$camIndex}] (not configured): skipped\n";
+                $skipped++;
                 continue;
             }
 
@@ -431,8 +432,12 @@ function runAllMode(): int
     echo "  Failed: {$failed}\n";
     echo "  Duration: {$elapsed}ms\n";
 
-    // Return success if any succeeded or all skipped (no failures)
-    return ($failed === $totalCameras) ? WorkerResult::FAILURE : WorkerResult::SUCCESS;
+    // FAILURE only when nothing succeeded and at least one configured worker reported failure
+    if ($totalCameras === 0) {
+        return WorkerResult::SUCCESS;
+    }
+
+    return ($failed === $totalCameras && $processed === 0) ? WorkerResult::FAILURE : WorkerResult::SUCCESS;
 }
 
 // =============================================================================

--- a/scripts/unified-webcam-worker.php
+++ b/scripts/unified-webcam-worker.php
@@ -40,6 +40,7 @@ require_once __DIR__ . '/../lib/worker-timeout.php';
 require_once __DIR__ . '/../lib/webcam-worker.php';
 require_once __DIR__ . '/../lib/variant-health.php';
 require_once __DIR__ . '/../lib/metrics.php';
+require_once __DIR__ . '/../lib/webcam-source-validation.php';
 
 // Verify exiftool is available (required for EXIF handling)
 require_once __DIR__ . '/../lib/exif-utils.php';
@@ -238,6 +239,29 @@ function runWorkerMode(string $airportId, int $camIndex): int
         return WorkerResult::FAILURE;
     }
 
+    $config = loadConfig(false);
+    if ($config === null || !isset($config['airports'][$airportId])) {
+        aviationwx_log('error', 'unified-webcam-worker: airport not found', [
+            'airport' => $airportId
+        ], 'app');
+        return WorkerResult::FAILURE;
+    }
+    $airportCfg = $config['airports'][$airportId];
+    if (!is_array($airportCfg)) {
+        aviationwx_log('error', 'unified-webcam-worker: malformed airport config', [
+            'airport' => $airportId
+        ], 'app');
+        return WorkerResult::FAILURE;
+    }
+    $slot = $airportCfg['webcams'][$camIndex] ?? null;
+    if (!is_array($slot) || !hasWebcamAcquisitionConfigured($slot)) {
+        aviationwx_log('info', 'unified-webcam-worker: skipped (webcam not configured)', [
+            'airport' => $airportId,
+            'cam' => $camIndex,
+        ], 'app');
+        return WorkerResult::SKIP;
+    }
+
     try {
         $worker = WebcamWorkerFactory::create($airportId, $camIndex);
         $result = $worker->run();
@@ -361,6 +385,11 @@ function runAllMode(): int
         echo str_repeat('-', 40) . "\n";
 
         foreach ($webcams as $camIndex => $cam) {
+            if (!is_array($cam) || !hasWebcamAcquisitionConfigured($cam)) {
+                echo "  [{$camIndex}] (not configured): skipped\n";
+                continue;
+            }
+
             $totalCameras++;
             $camName = $cam['name'] ?? "Camera {$camIndex}";
             echo "  [{$camIndex}] {$camName}: ";

--- a/tests/Integration/ProcessPoolIntegrationTest.php
+++ b/tests/Integration/ProcessPoolIntegrationTest.php
@@ -39,7 +39,7 @@ class ProcessPoolIntegrationTest extends TestCase
         exec($cmd, $output, $exitCode);
         $outputStr = implode("\n", $output);
         
-        $this->assertStringContainsString('Processing', $outputStr, 'Should show process pool output');
+        $this->assertStringContainsString('Queueing', $outputStr, 'Should show queueing / pool output');
         $this->assertStringContainsString('workers', $outputStr, 'Should mention workers');
         $this->assertStringContainsString('Done!', $outputStr, 'Should show completion message');
     }

--- a/tests/Integration/ProcessPoolOutputTest.php
+++ b/tests/Integration/ProcessPoolOutputTest.php
@@ -37,7 +37,7 @@ class ProcessPoolOutputTest extends TestCase
         $outputStr = implode("\n", $output);
         
         $this->assertStringContainsString('AviationWX Weather Fetcher', $outputStr, 'Should show header');
-        $this->assertStringContainsString('Processing', $outputStr, 'Should show processing message');
+        $this->assertStringContainsString('Queueing', $outputStr, 'Should show queueing message');
         $this->assertStringContainsString('airports', $outputStr, 'Should mention airports');
         $this->assertStringContainsString('workers', $outputStr, 'Should mention workers');
     }
@@ -84,7 +84,7 @@ class ProcessPoolOutputTest extends TestCase
         exec($cmd, $output, $exitCode);
         $outputStr = implode("\n", $output);
         
-        $this->assertStringNotContainsString('Processing', $outputStr, 'Worker mode should not show processing message');
+        $this->assertStringNotContainsString('Queueing', $outputStr, 'Worker mode should not show queueing message');
         $this->assertStringNotContainsString('workers', $outputStr, 'Worker mode should not mention workers');
         $this->assertStringNotContainsString('Done!', $outputStr, 'Worker mode should not show done message');
     }

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -1305,6 +1305,64 @@ class ConfigValidationTest extends TestCase
     }
 
     /**
+     * Reserved webcam slots may use enabled:false without URL or push_config (UI placeholder).
+     */
+    public function testWebcam_DisabledReservedSlotPassesWithoutAcquisitionFields(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Reserved camera slot',
+                            'enabled' => false,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], 'Disabled placeholder webcam should pass without url or push_config');
+    }
+
+    /**
+     * Federated pull webcam uses base_url instead of url (matches PullAcquisitionStrategy).
+     */
+    public function testWebcam_ValidAviationwxApiCamera(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Federated runway cam',
+                            'type' => 'aviationwx_api',
+                            'base_url' => 'https://weather.example.com',
+                            'api_key' => 'ak_test_partner_key',
+                            'camera_index' => 0,
+                            'timeout_seconds' => 15,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], 'aviationwx_api webcam should validate with base_url');
+    }
+
+    /**
      * Test webcam validation - Invalid configurations
      */
     public function testWebcam_MissingUrlForPullCamera()

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -1332,6 +1332,36 @@ class ConfigValidationTest extends TestCase
     }
 
     /**
+     * Disabled placeholders still reject unknown top-level keys (strict field vocabulary).
+     */
+    public function testWebcam_DisabledPlaceholderRejectsUnknownField(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Reserved camera slot',
+                            'enabled' => false,
+                            'refesh_seconds' => 60,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('unknown field', implode(' ', $result['errors']));
+        $this->assertStringContainsString('refesh_seconds', implode(' ', $result['errors']));
+    }
+
+    /**
      * Federated pull webcam uses base_url instead of url (matches PullAcquisitionStrategy).
      */
     public function testWebcam_ValidAviationwxApiCamera(): void

--- a/tests/Unit/UnifiedWebcamWorkerFlowTest.php
+++ b/tests/Unit/UnifiedWebcamWorkerFlowTest.php
@@ -449,7 +449,7 @@ class UnifiedWebcamWorkerFlowTest extends TestCase
     // ========================================
 
     /**
-     * Push strategy fails gracefully without username
+     * Push strategy fails gracefully without username (same gate as scheduler skip)
      */
     public function testPushStrategy_FailsWithoutUsername()
     {
@@ -457,7 +457,7 @@ class UnifiedWebcamWorkerFlowTest extends TestCase
         $result = $strategy->acquire();
 
         $this->assertFalse($result->success);
-        $this->assertEquals('no_username_configured', $result->errorReason);
+        $this->assertEquals('webcam_not_configured', $result->errorReason);
     }
 
     /**

--- a/tests/Unit/WeatherInternalApiNoSourcesContractTest.php
+++ b/tests/Unit/WeatherInternalApiNoSourcesContractTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks the contract between api/weather.php (503 + JSON error) and
+ * scripts/fetch-weather.php (treat as success for process pool).
+ */
+final class WeatherInternalApiNoSourcesContractTest extends TestCase
+{
+    /**
+     * Error text must be defined once in lib/constants.php.
+     */
+    public function testConstantMatchesHistoricalMessage(): void
+    {
+        require_once __DIR__ . '/../../lib/constants.php';
+        $this->assertSame(
+            'Weather source not configured',
+            WEATHER_INTERNAL_API_ERROR_SOURCE_NOT_CONFIGURED
+        );
+    }
+
+    /**
+     * Both call sites must use the constant so message changes cannot drift.
+     */
+    public function testApiAndFetcherUseConstantNotDuplicateLiteral(): void
+    {
+        $apiPath = __DIR__ . '/../../api/weather.php';
+        $fetchPath = __DIR__ . '/../../scripts/fetch-weather.php';
+        $this->assertFileExists($apiPath);
+        $this->assertFileExists($fetchPath);
+
+        $apiSrc = (string) file_get_contents($apiPath);
+        $fetchSrc = (string) file_get_contents($fetchPath);
+
+        $this->assertStringContainsString(
+            'WEATHER_INTERNAL_API_ERROR_SOURCE_NOT_CONFIGURED',
+            $apiSrc,
+            'api/weather.php must emit JSON error via WEATHER_INTERNAL_API_ERROR_SOURCE_NOT_CONFIGURED'
+        );
+        $this->assertStringContainsString(
+            'WEATHER_INTERNAL_API_ERROR_SOURCE_NOT_CONFIGURED',
+            $fetchSrc,
+            'fetch-weather.php must compare 503 body using WEATHER_INTERNAL_API_ERROR_SOURCE_NOT_CONFIGURED'
+        );
+
+        $literalInQuotes = "'Weather source not configured'";
+        $this->assertStringNotContainsString(
+            $literalInQuotes,
+            $apiSrc,
+            'Duplicate literal in api/weather.php risks drift from lib/constants.php'
+        );
+        $this->assertStringNotContainsString(
+            $literalInQuotes,
+            $fetchSrc,
+            'Duplicate literal in fetch-weather.php risks drift from lib/constants.php'
+        );
+    }
+}

--- a/tests/Unit/WeatherSourceNormalizationTest.php
+++ b/tests/Unit/WeatherSourceNormalizationTest.php
@@ -47,6 +47,9 @@ class WeatherSourceNormalizationTest extends TestCase
     
     /**
      * Test hasWeatherSources - Returns false when sources array is empty
+     *
+     * Scheduler and fetch-weather.php use this to avoid weather workers when an airport is
+     * enabled for webcams or display only and has no `weather_sources` (matches api/weather.php).
      */
     public function testHasWeatherSources_EmptySources_ReturnsFalse()
     {

--- a/tests/Unit/WebcamScheduleQueueTest.php
+++ b/tests/Unit/WebcamScheduleQueueTest.php
@@ -50,6 +50,50 @@ class WebcamScheduleQueueTest extends TestCase
     }
 
     /**
+     * Test placeholder webcams without pull URL or push username are not scheduled
+     */
+    public function testSkipsUnconfiguredWebcamSlots()
+    {
+        $airports = [
+            'kspb' => [
+                'name' => 'Test Airport',
+                'enabled' => true,
+                'webcams' => [
+                    ['url' => 'http://example.com/cam1.mjpg'],
+                    ['name' => 'Reserved slot'],
+                ],
+            ],
+        ];
+
+        $this->queue->initialize($airports);
+
+        $this->assertEquals(1, $this->queue->count(), 'Only configured cameras should be queued');
+    }
+
+    /**
+     * Optional per-webcam enabled:false skips scheduling (reserved UI slot)
+     */
+    public function testSkipsExplicitlyDisabledWebcam()
+    {
+        $airports = [
+            'kspb' => [
+                'name' => 'Test Airport',
+                'enabled' => true,
+                'webcams' => [
+                    ['url' => 'http://example.com/a.mjpg'],
+                    ['url' => 'http://example.com/b.mjpg', 'enabled' => false],
+                ],
+            ],
+        ];
+
+        $this->queue->initialize($airports);
+
+        $this->assertEquals(1, $this->queue->count());
+        $this->assertNotNull($this->queue->getEntry('kspb', 0));
+        $this->assertNull($this->queue->getEntry('kspb', 1));
+    }
+
+    /**
      * Test that disabled airports are skipped
      */
     public function testSkipsDisabledAirports()

--- a/tests/Unit/WebcamSourceValidationTest.php
+++ b/tests/Unit/WebcamSourceValidationTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Unit tests for hasWebcamAcquisitionConfigured()
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/webcam-source-validation.php';
+
+class WebcamSourceValidationTest extends TestCase
+{
+    public function testPullRequiresNonEmptyUrl(): void
+    {
+        $this->assertFalse(hasWebcamAcquisitionConfigured(['name' => 'Cam']));
+        $this->assertTrue(hasWebcamAcquisitionConfigured(['url' => 'https://example.com/x.mjpg']));
+    }
+
+    public function testExplicitDisabledSkips(): void
+    {
+        $cam = ['url' => 'https://example.com/x.mjpg', 'enabled' => false];
+        $this->assertFalse(hasWebcamAcquisitionConfigured($cam));
+    }
+
+    public function testPushRequiresUsername(): void
+    {
+        $this->assertFalse(hasWebcamAcquisitionConfigured([
+            'type' => 'push',
+            'push_config' => [],
+        ]));
+        $this->assertTrue(hasWebcamAcquisitionConfigured([
+            'type' => 'push',
+            'push_config' => ['username' => 'camuser'],
+        ]));
+    }
+
+    public function testAviationwxApiRequiresBaseUrl(): void
+    {
+        $this->assertFalse(hasWebcamAcquisitionConfigured([
+            'type' => 'aviationwx_api',
+        ]));
+        $this->assertTrue(hasWebcamAcquisitionConfigured([
+            'type' => 'aviationwx_api',
+            'base_url' => 'https://partner.example.com',
+        ]));
+    }
+}

--- a/tests/Unit/WebcamSourceValidationTest.php
+++ b/tests/Unit/WebcamSourceValidationTest.php
@@ -33,6 +33,25 @@ class WebcamSourceValidationTest extends TestCase
         ]));
     }
 
+    public function testPushWithoutPushConfigArrayIsNotConfigured(): void
+    {
+        $this->assertFalse(hasWebcamAcquisitionConfigured([
+            'type' => 'push',
+            'name' => 'Incomplete push slot',
+        ]));
+    }
+
+    /**
+     * Usernames are strings; "0" must not be treated as missing (PHP falsy pitfall).
+     */
+    public function testPushUsernameStringZeroIsConfigured(): void
+    {
+        $this->assertTrue(hasWebcamAcquisitionConfigured([
+            'type' => 'push',
+            'push_config' => ['username' => '0'],
+        ]));
+    }
+
     public function testAviationwxApiRequiresBaseUrl(): void
     {
         $this->assertFalse(hasWebcamAcquisitionConfigured([

--- a/tests/Unit/WebcamWorkerTest.php
+++ b/tests/Unit/WebcamWorkerTest.php
@@ -148,7 +148,7 @@ class WebcamWorkerTest extends TestCase
     }
 
     /**
-     * Test PushAcquisitionStrategy returns failure for missing username
+     * Test PushAcquisitionStrategy returns failure when push credentials are absent
      */
     public function testPushStrategyFailsWithoutUsername()
     {
@@ -156,7 +156,7 @@ class WebcamWorkerTest extends TestCase
         $result = $strategy->acquire();
 
         $this->assertFalse($result->success, 'Should fail without username');
-        $this->assertEquals('no_username_configured', $result->errorReason, 'Error reason should indicate missing username');
+        $this->assertEquals('webcam_not_configured', $result->errorReason, 'Error reason should indicate webcam not configured');
     }
 
     /**


### PR DESCRIPTION
## Summary

Aligns scheduler and worker behavior with "nothing to fetch": airports without weather sources and webcam slots without pull/push configuration no longer spawn failing workers or noisy process-pool warnings.

## Weather

- `scripts/scheduler.php`: only enqueue weather jobs when `hasWeatherSources()` is true.
- `scripts/fetch-weather.php`: skip those airports in the pool; worker exits early when no sources; `503` + `Weather source not configured` counts as success for exit status.

## Webcam

- New `hasWebcamAcquisitionConfigured()` in `lib/webcam-source-validation.php` (parallel to weather gate).
- `WebcamScheduleQueue` `initialize` / `rebuild`: omit placeholders and `enabled: false` slots.
- `scripts/unified-webcam-worker.php`: worker mode logs info and exits skip when unconfigured; `--all` skips with a clear line.
- `lib/webcam-acquisition.php` / `lib/webcam-worker.php`: configuration gaps (`webcam_not_configured`, `missing_base_url`, `no_username_configured`) return worker skip, not failure.

## Config and docs

- Optional boolean `enabled` on `webcams[]`; validation and CONFIGURATION.md scheduling note.

## Tests

- `WebcamSourceValidationTest`, queue tests, updated push acquisition expectations.

**CI:** `make test-ci` passes locally.