### PR TITLE
feat: Push FTP/SFTP inbox debris default retention 3 hours (configurable)

### DIFF
--- a/config/airports.json.example
+++ b/config/airports.json.example
@@ -62,6 +62,7 @@
     "webcam_variant_heights": [1080, 720, 360],
     "_comment_push_upload_cleanup": "Optional. FTP/SFTP push inbox debris cleanup keeps files with these extensions plus each push camera push_config.allowed_extensions (subset of jpg,jpeg,png,webp). Omit key entirely for the same default without listing it.",
     "push_upload_allowed_extensions": ["jpg", "jpeg", "png", "webp"],
+    "_comment_cleanup_push_upload_debris_max_age_seconds": "Optional. Seconds before deleting push inbox files outside the keep-list (default 10800 = 3 hours; allowed range 600--604800). Omit key for default.",
     "_comment_legacy": "The following image_* options are deprecated. Use webcam_variant_heights instead.",
     "image_primary_size": "1920x1080",
     "image_max_resolution": "3840x2160",

--- a/config/crontab
+++ b/config/crontab
@@ -32,7 +32,7 @@ CONFIG_PATH=/var/www/html/secrets/airports.json
 # (both push and pull) with per-camera refresh_seconds configuration.
 # This cron job has been removed as part of the unified webcam worker refactor.
 
-# Push FTP/SFTP upload inbox debris (non-image files older than CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS)
+# Push FTP/SFTP upload inbox debris (non-image files older than getCleanupPushUploadDebrisMaxAgeSeconds(); default 3h)
 # Runs hourly; daily cleanup-cache.php also includes this step as a safety net.
 17 * * * * www-data cd /var/www/html && /usr/local/bin/php scripts/cleanup-push-upload-debris.php >> /var/log/aviationwx/cleanup-push-upload-debris.log 2>&1
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,6 +34,7 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 | `webcam_refresh_default` | `60` | Default webcam refresh (seconds) |
 | `cache_file_max_size_mb` | `25` | Max size in MiB for webcam pipeline loads, HTTP/MJPEG pull downloads, partner logo fetches, and **default** push upload acceptance (integer **1--100**). |
 | `push_upload_allowed_extensions` | omit | Optional: extensions **preserved** during FTP/SFTP push inbox debris cleanup; merged with each push camera `push_config.allowed_extensions`. Values must be from **jpg, jpeg, png, webp**. Omit the key for the full default (all four). |
+| `cleanup_push_upload_debris_max_age_seconds` | `10800` (3 hours) | Optional: minimum file age (mtime) before a non-allowed extension is deleted from push FTP/SFTP inboxes. Integer **600--604800** (10 minutes to 7 days). Hourly `scripts/cleanup-push-upload-debris.php` and the daily `cleanup-cache.php` step use this value. |
 | `weather_refresh_default` | `60` | Default weather refresh (seconds) |
 | `metar_refresh_seconds` | `60` | METAR refresh interval (min: 60) |
 | `notam_refresh_seconds` | `600` | NOTAM refresh interval |

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1847,7 +1847,7 @@ This path is separate from weather, webcam, and NOTAM pipelines. It supplies **g
 
 ### Cache cleanup (`scripts/cleanup-cache.php`)
 
-- **Push FTP/SFTP inbox debris:** Same keep-list as above. **`scripts/cleanup-push-upload-debris.php`** runs **hourly** via cron; **`cleanup-cache.php`** still runs the same step daily as a backup.
+- **Push FTP/SFTP inbox debris:** Same keep-list as above. Non-image debris is deleted when older than `config.cleanup_push_upload_debris_max_age_seconds` (default **3 hours**). **`scripts/cleanup-push-upload-debris.php`** runs **hourly** via cron; **`cleanup-cache.php`** still runs the same step daily as a backup.
 - Layer-2 age cleanup for the aggregate uses a **90-day** threshold so a healthy file is not deleted while the 30-day policy still considers it usable between scheduler passes.
 
 ---

--- a/lib/config.php
+++ b/lib/config.php
@@ -596,6 +596,27 @@ function isDynamicDnsEnabled(): bool {
     return getDynamicDnsRefreshSeconds() > 0;
 }
 
+/**
+ * Max mtime age in seconds before non-allowlisted push FTP/SFTP inbox files are deleted.
+ *
+ * Uses `config.cleanup_push_upload_debris_max_age_seconds` when it is an integer
+ * (clamped to min/max). Otherwise {@see CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS}.
+ * Used by `scripts/cleanup-push-upload-debris.php` (hourly) and `scripts/cleanup-cache.php` (daily).
+ *
+ * @return int Effective threshold in seconds
+ */
+function getCleanupPushUploadDebrisMaxAgeSeconds(): int {
+    $raw = getGlobalConfig('cleanup_push_upload_debris_max_age_seconds');
+    if ($raw === null || !is_int($raw)) {
+        return (int) CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS;
+    }
+
+    return min(
+        MAX_CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS,
+        max(MIN_CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS, $raw)
+    );
+}
+
 // =============================================================================
 // STALENESS THRESHOLD HELPERS (3-Tier Model)
 // =============================================================================
@@ -3513,6 +3534,22 @@ function validateAirportsJsonStructure(array $config): array {
                             $errors[] = "config.push_upload_allowed_extensions: invalid extension '{$ext}' (allowed: {$masterList})";
                         }
                     }
+                }
+            }
+
+            if (isset($cfg['cleanup_push_upload_debris_max_age_seconds'])) {
+                $v = $cfg['cleanup_push_upload_debris_max_age_seconds'];
+                if (!is_int($v)) {
+                    $errors[] = 'config.cleanup_push_upload_debris_max_age_seconds must be an integer';
+                } elseif (
+                    $v < MIN_CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS
+                    || $v > MAX_CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS
+                ) {
+                    $errors[] = sprintf(
+                        'config.cleanup_push_upload_debris_max_age_seconds must be between %d and %d seconds',
+                        MIN_CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS,
+                        MAX_CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS
+                    );
                 }
             }
             

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -562,8 +562,14 @@ if (!defined('MAX_UPLOAD_FILE_MAX_AGE_SECONDS')) {
 }
 
 // Push FTP/SFTP inbox debris: max file age (mtime) before deletion (hourly + daily cleanup scripts)
+if (!defined('MIN_CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS')) {
+    define('MIN_CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS', 600); // 10 minutes (config override floor)
+}
+if (!defined('MAX_CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS')) {
+    define('MAX_CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS', 604800); // 7 days (config override ceiling)
+}
 if (!defined('CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS')) {
-    define('CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS', 172800); // 48 hours
+    define('CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS', 10800); // 3 hours default when config omits override
 }
 
 // Push webcam adaptive stability checking

--- a/scripts/cleanup-cache.php
+++ b/scripts/cleanup-cache.php
@@ -9,7 +9,7 @@
  * - Rate limit files older than 1 hour
  * - Webcam error files older than 7 days
  * - Outage state files older than 30 days
- * - Push FTP/SFTP inbox debris (files not in the config-derived keep-list; see getPushUploadAllowedExtensionsForCleanup())
+ * - Push FTP/SFTP inbox debris (files not in the config-derived keep-list; age threshold from getCleanupPushUploadDebrisMaxAgeSeconds(), default 3 hours)
  * 
  * LAYER 2 - Backup cleanup for files WITH automatic cleanup:
  * More generous thresholds as a safety net in case primary cleanup fails.
@@ -84,7 +84,8 @@ require_once __DIR__ . '/../lib/cache-paths.php';
 define('CLEANUP_RATE_LIMIT_AGE', 86400);          // 24 hours
 define('CLEANUP_WEBCAM_ERROR_AGE', 604800);       // 7 days
 define('CLEANUP_OUTAGE_STATE_AGE', 2592000);      // 30 days
-// Push upload dirs: MP4/TXT etc. are never processed by acquisition (images only); remove after 48h
+// Push upload dirs: MP4/TXT etc. are never processed by acquisition (images only); remove when older than
+// getCleanupPushUploadDebrisMaxAgeSeconds() (default 3h; optional config.cleanup_push_upload_debris_max_age_seconds)
 // (shared with scripts/cleanup-push-upload-debris.php hourly job)
 
 // Layer 2: Backup cleanup (more generous - safety net)
@@ -205,7 +206,7 @@ cleanupFilesByPattern(
 // Push FTP/SFTP upload debris (e.g. Reolink MP4 + sidecar TXT; worker only ingests images)
 require_once __DIR__ . '/../lib/push-upload-debris-cleanup.php';
 echo "Push upload debris (FTP/SFTP non-image files)...\n";
-cleanupPushUploadDebris(CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS, $stats, $dryRun, $verbose);
+cleanupPushUploadDebris(getCleanupPushUploadDebrisMaxAgeSeconds(), $stats, $dryRun, $verbose);
 echo "\n";
 
 // ============================================================================

--- a/scripts/cleanup-push-upload-debris.php
+++ b/scripts/cleanup-push-upload-debris.php
@@ -45,7 +45,7 @@ if ($dryRun) {
 }
 
 cleanupPushUploadDebris(
-    (int) CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS,
+    getCleanupPushUploadDebrisMaxAgeSeconds(),
     $stats,
     $dryRun,
     $verbose

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -638,6 +638,13 @@ class ConfigTest extends TestCase {
     }
 
     /**
+     * Fixture omits cleanup_push_upload_debris_max_age_seconds; getter uses built-in default (3 hours).
+     */
+    public function testGetCleanupPushUploadDebrisMaxAgeSeconds_DefaultWhenUnset(): void {
+        $this->assertSame((int) CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS, getCleanupPushUploadDebrisMaxAgeSeconds());
+    }
+
+    /**
      * normalizeCacheFileMaxSizeMb() clamps to 1--100 MiB and treats non-numeric input as 25 MiB.
      */
     public function testNormalizeCacheFileMaxSizeMb_ClampsAndDefaults(): void {

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -3360,6 +3360,77 @@ class ConfigValidationTest extends TestCase
         $this->assertTrue($result['valid'], 'Valid cache_file_max_size_mb should pass validation');
     }
 
+    public function testGlobalConfig_InvalidCleanupPushUploadDebrisMaxAgeSeconds_NotInteger(): void
+    {
+        $config = [
+            'config' => [
+                'cleanup_push_upload_debris_max_age_seconds' => '10800',
+            ],
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString(
+            'config.cleanup_push_upload_debris_max_age_seconds must be an integer',
+            implode(' ', $result['errors'])
+        );
+    }
+
+    public function testGlobalConfig_InvalidCleanupPushUploadDebrisMaxAgeSeconds_OutOfRange(): void
+    {
+        $config = [
+            'config' => [
+                'cleanup_push_upload_debris_max_age_seconds' => 300,
+            ],
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString(
+            'config.cleanup_push_upload_debris_max_age_seconds must be between',
+            implode(' ', $result['errors'])
+        );
+    }
+
+    public function testGlobalConfig_ValidCleanupPushUploadDebrisMaxAgeSeconds(): void
+    {
+        $config = [
+            'config' => [
+                'cleanup_push_upload_debris_max_age_seconds' => 21600,
+            ],
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid']);
+    }
+
     public function testGlobalConfig_InvalidWeatherRefreshDefault()
     {
         $config = [

--- a/tests/Unit/PushUploadDebrisCleanupTest.php
+++ b/tests/Unit/PushUploadDebrisCleanupTest.php
@@ -56,7 +56,7 @@ final class PushUploadDebrisCleanupTest extends TestCase
             'errors' => 0,
         ];
 
-        $maxAge = 172800;
+        $maxAge = (int) CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS;
 
         cleanupPushUploadDebris($maxAge, $stats, false, false, [$this->tempRoot], push_upload_master_image_extensions());
 
@@ -84,7 +84,7 @@ final class PushUploadDebrisCleanupTest extends TestCase
             'errors' => 0,
         ];
 
-        cleanupPushUploadDebris(172800, $stats, false, false, [$this->tempRoot], push_upload_master_image_extensions());
+        cleanupPushUploadDebris((int) CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS, $stats, false, false, [$this->tempRoot], push_upload_master_image_extensions());
 
         $this->assertFileDoesNotExist($junk);
         $this->assertSame(1, $stats['files_deleted']);
@@ -106,7 +106,7 @@ final class PushUploadDebrisCleanupTest extends TestCase
             'errors' => 0,
         ];
 
-        cleanupPushUploadDebris(172800, $stats, false, false, [$this->tempRoot], ['png']);
+        cleanupPushUploadDebris((int) CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS, $stats, false, false, [$this->tempRoot], ['png']);
 
         $this->assertFileDoesNotExist($oldJpg);
         $this->assertSame(1, $stats['files_deleted']);
@@ -128,7 +128,7 @@ final class PushUploadDebrisCleanupTest extends TestCase
             'errors' => 0,
         ];
 
-        cleanupPushUploadDebris(172800, $stats, true, false, [$this->tempRoot], push_upload_master_image_extensions());
+        cleanupPushUploadDebris((int) CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS, $stats, true, false, [$this->tempRoot], push_upload_master_image_extensions());
 
         $this->assertFileExists($mp4);
         $this->assertGreaterThanOrEqual(1, $stats['files_deleted']);


### PR DESCRIPTION
## Summary

Reduces the default maximum age for **push FTP/SFTP inbox debris** (non-allowlisted extensions such as vendor MP4/sidecars) from **48 hours** to **3 hours**, aligned with hourly cron cleanup.

## Behavior

- **Default:** `CLEANUP_PUSH_UPLOAD_DEBRIS_MAX_AGE_SECONDS` is now **10800** (3 hours).
- **Optional override:** `config.cleanup_push_upload_debris_max_age_seconds` (integer **600--604800**, validated in `validateAirportsJsonStructure()`).
- **Call sites:** `getCleanupPushUploadDebrisMaxAgeSeconds()` is used by both `scripts/cleanup-push-upload-debris.php` (hourly) and the matching step in `scripts/cleanup-cache.php` (daily backup).

## Operational note

Deployments that relied on the previous **48-hour** implicit grace period should set `cleanup_push_upload_debris_max_age_seconds` to **172800** (or another value in range) if they need longer retention for troubleshooting uploads.

## Tests

- `make test-ci` passed locally before merge-oriented review.
- Added/updated unit tests for validation and default getter; debris cleanup tests use the named constant.

## Documentation

- `docs/CONFIGURATION.md` quick reference
- `docs/DATA_FLOW.md`, `config/crontab`, `config/airports.json.example` comments

---
Labels: `enhancement`, `documentation` (docs-only additions alongside behavior change).