### PR TITLE
Status metrics bundle: hourly profile, local calendar views, centered header layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,9 @@ test-ci: ## Run all tests that GitHub CI runs (comprehensive)
 	@echo "5a1b️⃣  Runway Label Layout Tests (JS)..."
 	@node tests/js/runway-label-layout.test.js || { echo "❌ Runway label layout JS tests failed"; exit 1; }
 	@echo ""
+	@echo "5a1c️⃣  Status local calendar Tests (JS)..."
+	@node tests/js/status-local-calendar.test.js || { echo "❌ Status local calendar JS tests failed"; exit 1; }
+	@echo ""
 	@echo "5a2️⃣  Webcam Player Cache Tests (JS)..."
 	@node tests/js/webcam-player-cache.test.js || { echo "❌ Webcam player cache JS tests failed"; exit 1; }
 	@echo ""

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -378,6 +378,14 @@ if (!defined('METRICS_FLUSH_INTERVAL_SECONDS')) {
 if (!defined('METRICS_STATUS_PAGE_DAYS')) {
     define('METRICS_STATUS_PAGE_DAYS', 7); // Show 7-day rolling window on status page
 }
+/** Completed UTC hour slices before current hour in {@see metrics_get_status_hourly_profile()} (plus one partial hour). */
+if (!defined('METRICS_STATUS_HOURLY_PROFILE_COMPLETED_HOURS')) {
+    define('METRICS_STATUS_HOURLY_PROFILE_COMPLETED_HOURS', 26);
+}
+/** Bump when hourly_profile JSON shape changes (invalidates APCu bundle mirror). */
+if (!defined('METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION')) {
+    define('METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION', 1);
+}
 if (!defined('METRICS_STATUS_BUNDLE_MIRROR_TTL_SECONDS')) {
     // APCu snapshot of metrics_get_status_bundle() after flush; best-effort telemetry only
     define('METRICS_STATUS_BUNDLE_MIRROR_TTL_SECONDS', 120);

--- a/lib/metrics.php
+++ b/lib/metrics.php
@@ -1451,6 +1451,7 @@ function metrics_get_empty_status_bundle(): array {
  *
  * Returns rolling7, rolling1, today from disk aggregation, plus sparse UTC hourly_profile (completed
  * hours from disk, current hour file + APCu). Uses one Unix snapshot for live hour merges.
+ * `multiPeriod` is built from those same merged `$today` / `$rolling7` / `$liveHour` structures (no second file pass).
  * An APCu mirror may short-circuit file reads when fresh.
  *
  * @return array {
@@ -1562,11 +1563,8 @@ function metrics_get_status_bundle(): array {
     metrics_merge_webcams($today['webcams'], $liveHour['webcams'] ?? []);
     metrics_merge_global($today['global'], $liveHour['global'] ?? []);
 
-    $multiPeriod = metrics_build_multi_period_from_periods(
-        $liveHour,
-        metrics_get_today($liveHour, $now),
-        metrics_get_rolling(METRICS_STATUS_PAGE_DAYS, $liveHour, $now)
-    );
+    // Reuse aggregates merged above; avoids re-reading the same daily/hour files for multiPeriod.
+    $multiPeriod = metrics_build_multi_period_from_periods($liveHour, $today, $rolling7);
 
     $bundle = [
         'rolling7' => $rolling7,

--- a/lib/metrics.php
+++ b/lib/metrics.php
@@ -527,7 +527,22 @@ function metrics_try_get_status_bundle_mirror(): ?array {
     if ($raw['today_bucket_id'] !== gmdate('Y-m-d', $now)) {
         return null;
     }
-    return is_array($raw['bundle']) ? $raw['bundle'] : null;
+    $bundle = is_array($raw['bundle']) ? $raw['bundle'] : null;
+    if ($bundle === null) {
+        return null;
+    }
+    // Invalidate mirrors from before hourly_profile / multiPeriod were embedded
+    if (!isset($bundle['hourly_profile']['hours']) || !is_array($bundle['hourly_profile']['hours'])) {
+        return null;
+    }
+    if ((int) ($bundle['hourly_profile']['schema_version'] ?? 0) < METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION) {
+        return null;
+    }
+    if (!array_key_exists('multiPeriod', $bundle) || !is_array($bundle['multiPeriod'])) {
+        return null;
+    }
+
+    return $bundle;
 }
 
 /**
@@ -545,7 +560,7 @@ function metrics_invalidate_status_bundle_mirror(): void {
 /**
  * Store status bundle snapshot in APCu for fast status page reads (telemetry only).
  *
- * @param array $bundle Same shape as metrics_get_status_bundle() return value
+ * @param array $bundle Same shape as metrics_get_status_bundle() return value (includes hourly_profile)
  * @return void
  */
 function metrics_store_status_bundle_mirror(array $bundle): void {
@@ -1367,9 +1382,33 @@ function metrics_get_today(?array $liveHourOverride = null, ?int $atTimestamp = 
 }
 
 /**
+ * Empty hourly profile shape (matches metrics_get_status_hourly_profile() keys).
+ *
+ * @param int|null $generatedAt Unix time for generated_at (default now)
+ * @return array{generated_at:int,current_hour_id:string,window_completed_hours:int,schema_version:int,hours:array}
+ */
+function metrics_get_empty_hourly_profile(?int $generatedAt = null): array {
+    $t = $generatedAt ?? time();
+
+    return [
+        'generated_at' => $t,
+        'current_hour_id' => '',
+        'window_completed_hours' => (int) METRICS_STATUS_HOURLY_PROFILE_COMPLETED_HOURS,
+        'schema_version' => METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION,
+        'hours' => [],
+    ];
+}
+
+/**
  * Empty status bundle shape for cold cache when web requests skip synchronous aggregation.
  *
- * @return array{rolling7: array, rolling1: array, today: array} Empty metrics structure matching metrics_get_status_bundle()
+ * @return array{
+ *   rolling7: array,
+ *   rolling1: array,
+ *   today: array,
+ *   hourly_profile: array,
+ *   multiPeriod: array
+ * }
  */
 function metrics_get_empty_status_bundle(): array {
     $now = time();
@@ -1402,20 +1441,25 @@ function metrics_get_empty_status_bundle(): array {
             'global' => metrics_get_empty_global(),
             'generated_at' => $now,
         ],
+        'hourly_profile' => metrics_get_empty_hourly_profile($now),
+        'multiPeriod' => [],
     ];
 }
 
 /**
- * Get status page metrics bundle - reads each file once
+ * Get status page metrics bundle - reads metrics files and attaches hourly_profile
  *
- * Returns rolling7, rolling1, and today from a single pass over metrics files.
- * The live merge uses metrics_get_current_hour() at the same Unix time as the start of the pass
- * so bucket boundaries match the file aggregation.
- * Multi-period is built separately via metrics_get_multi_period(). An APCu mirror may short-circuit
- * this read when present and fresh (same TTL as METRICS_STATUS_BUNDLE_MIRROR_TTL_SECONDS). After a
- * cold build from disk, the result is stored in APCu for subsequent requests.
+ * Returns rolling7, rolling1, today from disk aggregation, plus sparse UTC hourly_profile (completed
+ * hours from disk, current hour file + APCu). Uses one Unix snapshot for live hour merges.
+ * An APCu mirror may short-circuit file reads when fresh.
  *
- * @return array {rolling7: array, rolling1: array, today: array}
+ * @return array {
+ *   rolling7: array,
+ *   rolling1: array,
+ *   today: array,
+ *   hourly_profile: array,
+ *   multiPeriod: array
+ * }
  */
 function metrics_get_status_bundle(): array {
     $mirrored = metrics_try_get_status_bundle_mirror();
@@ -1453,6 +1497,9 @@ function metrics_get_status_bundle(): array {
         'global' => metrics_get_empty_global(),
         'generated_at' => $now
     ];
+
+    /** @var array<string,array<string,int>> $hourSparseDiskCache */
+    $hourSparseDiskCache = [];
 
     for ($d = 1; $d <= 7; $d++) {
         $dateId = gmdate('Y-m-d', $now - ($d * 86400));
@@ -1492,6 +1539,7 @@ function metrics_get_status_bundle(): array {
         if (!is_array($hourData)) {
             continue;
         }
+        $hourSparseDiskCache[$hourId] = metrics_sparse_page_views_from_hour_aggregate($hourData);
         metrics_merge_airports($rolling7['airports'], $hourData['airports'] ?? []);
         metrics_merge_webcams($rolling7['webcams'], $hourData['webcams'] ?? []);
         metrics_merge_global($rolling7['global'], $hourData['global'] ?? []);
@@ -1514,7 +1562,19 @@ function metrics_get_status_bundle(): array {
     metrics_merge_webcams($today['webcams'], $liveHour['webcams'] ?? []);
     metrics_merge_global($today['global'], $liveHour['global'] ?? []);
 
-    $bundle = ['rolling7' => $rolling7, 'rolling1' => $rolling1, 'today' => $today];
+    $multiPeriod = metrics_build_multi_period_from_periods(
+        $liveHour,
+        metrics_get_today($liveHour, $now),
+        metrics_get_rolling(METRICS_STATUS_PAGE_DAYS, $liveHour, $now)
+    );
+
+    $bundle = [
+        'rolling7' => $rolling7,
+        'rolling1' => $rolling1,
+        'today' => $today,
+        'hourly_profile' => metrics_get_status_hourly_profile($now, $liveHour, $hourSparseDiskCache),
+        'multiPeriod' => $multiPeriod,
+    ];
     metrics_store_status_bundle_mirror($bundle);
 
     return $bundle;
@@ -1571,15 +1631,19 @@ function metrics_build_multi_period_from_periods(array $hourly, array $daily, ar
 }
 
 /**
- * Build multi-period metrics for the status page (same result as metrics_get_multi_period()).
+ * Build multi-period metrics for the status page (same result as metrics_get_multi_period() when bundle is fresh).
  *
- * The bundle argument is ignored; it exists so getStatusMetricsBundle() can keep a stable shape.
- * Day and week values always come from a single live snapshot so they stay consistent with /hour.
+ * When {@see metrics_get_status_bundle()} populated multiPeriod, returns it so hour/day/week stay aligned
+ * with hourly_profile.generated_at and the same live hour merge.
  *
- * @param array $_bundle Ignored (pass metrics_get_status_bundle() output for API compatibility)
+ * @param array $_bundle Ignored unless it contains multiPeriod (pass metrics_get_status_bundle() output)
  * @return array Multi-period metrics indexed by airport
  */
 function metrics_build_multi_period_from_bundle(array $_bundle): array {
+    if (array_key_exists('multiPeriod', $_bundle) && is_array($_bundle['multiPeriod'])) {
+        return $_bundle['multiPeriod'];
+    }
+
     return metrics_get_multi_period();
 }
 
@@ -1601,6 +1665,98 @@ function metrics_get_multi_period(): array {
         metrics_get_today($live, $snapshot),
         metrics_get_rolling(METRICS_STATUS_PAGE_DAYS, $live, $snapshot)
     );
+}
+
+/**
+ * Sparse airport_id => page_views for status hourly profile JSON (non-zero only).
+ *
+ * @param array $hourAggregate Hour bucket with optional `airports` map
+ * @return array<string,int> Lowercase airport id => page views
+ */
+function metrics_sparse_page_views_from_hour_aggregate(array $hourAggregate): array {
+    $out = [];
+    foreach ($hourAggregate['airports'] ?? [] as $airportId => $row) {
+        if (!is_array($row)) {
+            continue;
+        }
+        $pv = (int) ($row['page_views'] ?? 0);
+        if ($pv > 0) {
+            $out[strtolower((string) $airportId)] = $pv;
+        }
+    }
+
+    return $out;
+}
+
+/**
+ * UTC hourly profile for status page local-calendar presentation.
+ *
+ * Includes METRICS_STATUS_HOURLY_PROFILE_COMPLETED_HOURS completed UTC hours read from disk only,
+ * plus the current UTC hour from {@see metrics_get_current_hour()} (hourly file + APCu) so the
+ * partial hour matches `/hour` and today UTC totals.
+ *
+ * @param int|null                       $atTimestamp        Single Unix snapshot for ids (default now)
+ * @param array|null                     $liveHourOverride   Output of metrics_get_current_hour($atTimestamp) when
+ *                                                          already computed (avoids duplicate APCu merge when building bundle)
+ * @param array<string,array<string,int>> $diskSparseByHourId Optional hour_id => sparse page_views map for
+ *                                                          hours already read from disk (e.g. today's hours during bundle build).
+ * @return array{
+ *   generated_at:int,
+ *   current_hour_id:string,
+ *   window_completed_hours:int,
+ *   schema_version:int,
+ *   hours:list<array{hour_id:string,complete:bool,views:array<string,int>}>
+ * }
+ */
+function metrics_get_status_hourly_profile(
+    ?int $atTimestamp = null,
+    ?array $liveHourOverride = null,
+    array $diskSparseByHourId = []
+): array {
+    $now = $atTimestamp ?? time();
+    $completed = (int) METRICS_STATUS_HOURLY_PROFILE_COMPLETED_HOURS;
+    $live = $liveHourOverride ?? metrics_get_current_hour($now);
+    $currentHourId = metrics_get_hour_id($now);
+
+    $hours = [];
+    for ($offset = $completed; $offset >= 1; $offset--) {
+        $t = $now - ($offset * 3600);
+        $hourId = metrics_get_hour_id($t);
+        $views = [];
+        if (array_key_exists($hourId, $diskSparseByHourId)) {
+            $views = $diskSparseByHourId[$hourId];
+        } else {
+            $path = getMetricsHourlyPath($hourId);
+            if (file_exists($path)) {
+                $content = @file_get_contents($path);
+                if ($content !== false) {
+                    $hourData = @json_decode($content, true);
+                    if (is_array($hourData)) {
+                        $views = metrics_sparse_page_views_from_hour_aggregate($hourData);
+                    }
+                }
+            }
+        }
+        $hours[] = [
+            'hour_id' => $hourId,
+            'complete' => true,
+            'views' => $views,
+        ];
+    }
+
+    $hours[] = [
+        'hour_id' => $currentHourId,
+        'complete' => false,
+        'views' => metrics_sparse_page_views_from_hour_aggregate($live),
+    ];
+
+    return [
+        'generated_at' => $now,
+        'current_hour_id' => $currentHourId,
+        'window_completed_hours' => $completed,
+        'schema_version' => METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION,
+        'hours' => $hours,
+    ];
 }
 
 // =============================================================================

--- a/lib/status-metrics.php
+++ b/lib/status-metrics.php
@@ -3,8 +3,9 @@
  * Status Page Metrics Loading
  *
  * Provides optimized access to metrics data for the status page with APCu caching.
- * Uses single bundle read (rolling7, rolling1, today) to eliminate duplicate file reads.
- * Multi-period uses metrics_get_multi_period() (one live snapshot per request for hour/day/week).
+ * Single bundle read (rolling7, rolling1, today, hourly_profile, multiPeriod) via warm JSON + APCu.
+ * multiPeriod is embedded in the warm bundle so it aligns with hourly_profile.generated_at; legacy caches
+ * fall back to metrics_build_multi_period_from_bundle().
  */
 
 require_once __DIR__ . '/cached-data-loader.php';
@@ -13,15 +14,16 @@ require_once __DIR__ . '/cache-paths.php';
 require_once __DIR__ . '/constants.php';
 
 /**
- * Get status metrics bundle (rolling7, rolling1, multiPeriod)
+ * Get status metrics bundle (rolling7, rolling1, today, hourly_profile, multiPeriod)
  *
- * Reads each metrics file once for rolling7/rolling1/today. multiPeriod is computed via
- * metrics_get_multi_period() so hour/day/week share one APCu snapshot.
+ * metrics_get_status_bundle() includes sparse UTC hourly_profile and multiPeriod aligned to the same snapshot.
  *
- * @return array {
- *   rolling7: array 7-day rolling metrics,
- *   rolling1: array 1-day rolling metrics,
- *   multiPeriod: array per-airport hour/day/week metrics
+ * @return array{
+ *   rolling7: array,
+ *   rolling1: array,
+ *   today: array,
+ *   hourly_profile: array,
+ *   multiPeriod: array
  * }
  */
 function getStatusMetricsBundle(): array {
@@ -33,7 +35,10 @@ function getStatusMetricsBundle(): array {
         $ttl,
         metrics_get_empty_status_bundle()
     );
-    $bundle['multiPeriod'] = metrics_build_multi_period_from_bundle($bundle);
+    if (!array_key_exists('multiPeriod', $bundle)) {
+        $bundle['multiPeriod'] = metrics_build_multi_period_from_bundle($bundle);
+    }
+
     return $bundle;
 }
 

--- a/pages/status.php
+++ b/pages/status.php
@@ -57,9 +57,15 @@ $multiPeriodMetrics = $metricsBundle['multiPeriod'];
 $rolling1Calendar = $metricsBundle['rolling1'];
 
 $statusLocalCalendarJsPath = __DIR__ . '/../public/js/status-local-calendar.js';
-$statusLocalCalendarJsVer = is_readable($statusLocalCalendarJsPath)
-    ? (string) filemtime($statusLocalCalendarJsPath)
-    : (string) time();
+$statusLocalCalendarJsReadable = is_readable($statusLocalCalendarJsPath);
+if (!$statusLocalCalendarJsReadable) {
+    aviationwx_log(
+        'warning',
+        'status page: status-local-calendar.js is not readable',
+        ['path' => $statusLocalCalendarJsPath],
+        'app'
+    );
+}
 
 // Get local performance metrics (STATUS_PAGE_CACHE_TTL; scheduler pre-warms every STATUS_PAGE_BACKGROUND_FETCH_INTERVAL)
 require_once __DIR__ . '/../lib/performance-metrics.php';
@@ -1338,7 +1344,9 @@ if (php_sapi_name() === 'cli') {
         </div>
     </div>
     
-    <script src="/public/js/status-local-calendar.js?v=<?php echo htmlspecialchars($statusLocalCalendarJsVer, ENT_QUOTES, 'UTF-8'); ?>"></script>
+    <?php if ($statusLocalCalendarJsReadable): ?>
+    <script src="/public/js/status-local-calendar.js?v=<?php echo htmlspecialchars((string) filemtime($statusLocalCalendarJsPath), ENT_QUOTES, 'UTF-8'); ?>"></script>
+    <?php endif; ?>
     <script>
         (function() {
             'use strict';

--- a/pages/status.php
+++ b/pages/status.php
@@ -47,13 +47,19 @@ if ($config === null) {
     die('Service Unavailable: Configuration cannot be loaded');
 }
 
-// Load usage metrics bundle (single read for rolling7/rolling1/multiPeriod)
+// Load usage metrics bundle (rolling7, rolling1, today, hourly_profile, multiPeriod)
 require_once __DIR__ . '/../lib/status-metrics.php';
 $metricsBundle = getStatusMetricsBundle();
+$hourlyProfileMetrics = $metricsBundle['hourly_profile'] ?? metrics_get_empty_hourly_profile();
 $usageMetrics = $metricsBundle['rolling7'];
 $multiPeriodMetrics = $metricsBundle['multiPeriod'];
 // Calendar rollup: full prior UTC day (daily file) + today hourly -- not metrics_get_rolling_hours(24)
 $rolling1Calendar = $metricsBundle['rolling1'];
+
+$statusLocalCalendarJsPath = __DIR__ . '/../public/js/status-local-calendar.js';
+$statusLocalCalendarJsVer = is_readable($statusLocalCalendarJsPath)
+    ? (string) filemtime($statusLocalCalendarJsPath)
+    : (string) time();
 
 // Get local performance metrics (STATUS_PAGE_CACHE_TTL; scheduler pre-warms every STATUS_PAGE_BACKGROUND_FETCH_INTERVAL)
 require_once __DIR__ . '/../lib/performance-metrics.php';
@@ -243,14 +249,6 @@ if (php_sapi_name() === 'cli') {
             color: #999;
             margin-top: 0.25rem;
         }
-            margin-bottom: 0.5rem;
-            color: #1a1a1a;
-        }
-        
-        .header .subtitle {
-            color: #555;
-            font-size: 0.9rem;
-        }
         
         .status-indicator {
             font-size: 1.5rem;
@@ -300,6 +298,32 @@ if (php_sapi_name() === 'cli') {
         .airport-card-header:hover {
             background-color: #f9fafb;
         }
+
+        /* Three columns: equal outer tracks keep the views block visually centered. */
+        .status-card-header.airport-card-header {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+            align-items: center;
+            column-gap: 1rem;
+        }
+
+        .airport-header-col {
+            min-width: 0;
+        }
+
+        .airport-header-col--title {
+            justify-self: start;
+        }
+
+        .airport-header-col--views {
+            justify-self: center;
+        }
+
+        .airport-header-col--status {
+            justify-self: end;
+            display: flex;
+            justify-content: flex-end;
+        }
         
         .airport-card-header h2 {
             font-size: 1.25rem;
@@ -310,21 +334,13 @@ if (php_sapi_name() === 'cli') {
             gap: 0.75rem;
         }
         
-        .airport-header-content {
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-            gap: 1.5rem;
-            flex: 1;
-        }
-        
         .airport-views-summary {
             font-size: 0.75rem;
             color: #888;
             display: flex;
             align-items: center;
             gap: 0.35rem;
-            flex: 1;
+            flex-wrap: wrap;
             justify-content: center;
         }
         
@@ -340,10 +356,10 @@ if (php_sapi_name() === 'cli') {
         .airport-views-summary .views-sep {
             color: #ccc;
         }
-        
-        .usage-metrics-block {
-            font-size: 0.85rem;
-            color: #666;
+
+        .airport-views-summary .views-local-stale {
+            color: #999;
+            font-style: italic;
         }
         
         .usage-metrics-block .metrics-line {
@@ -565,16 +581,16 @@ if (php_sapi_name() === 'cli') {
             
             /* Airport header stacks vertically on mobile */
             .status-card-header.airport-card-header {
-                flex-direction: column;
+                grid-template-columns: 1fr;
                 align-items: flex-start;
-                gap: 0.75rem;
+                justify-items: stretch;
+                row-gap: 0.75rem;
             }
-            
-            .airport-header-content {
-                flex-direction: column;
-                align-items: flex-start;
-                gap: 0.5rem;
-                width: 100%;
+
+            .airport-header-col--title,
+            .airport-header-col--views,
+            .airport-header-col--status {
+                justify-self: stretch;
             }
             
             .airport-views-summary {
@@ -670,6 +686,10 @@ if (php_sapi_name() === 'cli') {
         
         body.dark-mode .airport-views-summary .views-sep {
             color: #555;
+        }
+
+        body.dark-mode .airport-views-summary .views-local-stale {
+            color: #666;
         }
         
         body.dark-mode .usage-metrics-block .metric-label {
@@ -992,21 +1012,26 @@ if (php_sapi_name() === 'cli') {
         <div class="status-card">
             <div class="status-card-header airport-card-header" 
                  onclick="toggleAirport('<?php echo htmlspecialchars($airport['id']); ?>')">
-                <div class="airport-header-content">
+                <div class="airport-header-col airport-header-col--title">
                     <h2>
                         <span class="expand-icon">▶</span>
                         <?php echo htmlspecialchars($airport['id']); ?>
                     </h2>
-                    <div class="airport-views-summary">
-                        <span class="views-label">Views:</span>
-                        <span class="views-period" title="<?php echo htmlspecialchars($titleHourViews); ?>"><?php echo number_format($hourViews); ?>/hour</span>
+                </div>
+                <div class="airport-header-col airport-header-col--views">
+                    <div class="airport-views-summary airport-views-summary-compact" title="View counts: UTC hour/day/week from server; /loc sums UTC buckets into your browser timezone.">
+                        <span class="views-label">Views</span>
+                        <span class="views-period" title="<?php echo htmlspecialchars($titleHourViews); ?>"><?php echo number_format($hourViews); ?>/hr</span>
                         <span class="views-sep">·</span>
-                        <span class="views-period" title="<?php echo htmlspecialchars($titleDayViews); ?>"><?php echo number_format($dayViews); ?>/day</span>
+                        <span class="views-period" title="<?php echo htmlspecialchars($titleDayViews); ?>"><?php echo number_format($dayViews); ?>/d</span>
                         <span class="views-sep">·</span>
-                        <span class="views-period" title="<?php echo htmlspecialchars($titleWeekViews); ?>"><?php echo number_format($weekViews); ?>/week</span>
+                        <span class="views-period views-local-calendar-day" data-airport="<?php echo htmlspecialchars(strtolower($airport['id'])); ?>" title="Local calendar day (browser). Waiting for hourly cache if shown as ---.">---/loc</span>
+                        <span class="views-sep">·</span>
+                        <span class="views-period" title="<?php echo htmlspecialchars($titleWeekViews); ?>"><?php echo number_format($weekViews); ?>/wk</span>
                     </div>
                 </div>
-                <span class="status-badge">
+                <div class="airport-header-col airport-header-col--status">
+                    <span class="status-badge">
                     <?php if ($airport['status'] === 'maintenance'): ?>
                         Under Maintenance <span class="status-indicator <?php echo getStatusColor($airport['status']); ?>"><?php echo getStatusIcon($airport['status']); ?></span>
                     <?php elseif ($airport['status'] === 'down' && !empty($airport['limited_availability']) && !empty($airport['all_sources_down'])): ?>
@@ -1018,7 +1043,8 @@ if (php_sapi_name() === 'cli') {
                         </span>
                         <?php echo ucfirst($airport['status']); ?>
                     <?php endif; ?>
-                </span>
+                    </span>
+                </div>
             </div>
             <div class="status-card-body airport-card-body collapsed" 
                  id="airport-<?php echo htmlspecialchars($airport['id']); ?>-body">
@@ -1312,10 +1338,21 @@ if (php_sapi_name() === 'cli') {
         </div>
     </div>
     
+    <script src="/public/js/status-local-calendar.js?v=<?php echo htmlspecialchars($statusLocalCalendarJsVer, ENT_QUOTES, 'UTF-8'); ?>"></script>
     <script>
         (function() {
             'use strict';
-            
+            var profile = <?php
+            $profileJson = json_encode(
+                $hourlyProfileMetrics,
+                JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES
+            );
+            echo $profileJson !== false ? $profileJson : '{}';
+            ?>;
+            if (window.AviationWX && AviationWX.statusLocalCalendar) {
+                AviationWX.statusLocalCalendar.applyLocalCalendarDayViewsToDom(profile);
+            }
+
             function toggleAirport(airportId) {
                 const header = document.querySelector(`[onclick="toggleAirport('${airportId}')"]`);
                 const body = document.getElementById(`airport-${airportId}-body`);

--- a/pages/status.php
+++ b/pages/status.php
@@ -1016,8 +1016,10 @@ if (php_sapi_name() === 'cli') {
         $titleWeekViews = 'Rolling calendar window: seven prior UTC days (daily files) plus today hourly; bundle cache can lag a few minutes.';
         ?>
         <div class="status-card">
-            <div class="status-card-header airport-card-header" 
-                 onclick="toggleAirport('<?php echo htmlspecialchars($airport['id']); ?>')">
+            <div class="status-card-header airport-card-header"
+                 role="button"
+                 tabindex="0"
+                 data-airport-toggle="<?php echo htmlspecialchars($airport['id'], ENT_QUOTES, 'UTF-8'); ?>">
                 <div class="airport-header-col airport-header-col--title">
                     <h2>
                         <span class="expand-icon">▶</span>
@@ -1362,12 +1364,20 @@ if (php_sapi_name() === 'cli') {
             }
 
             function toggleAirport(airportId) {
-                const header = document.querySelector(`[onclick="toggleAirport('${airportId}')"]`);
-                const body = document.getElementById(`airport-${airportId}-body`);
-                
+                var headers = document.querySelectorAll('.airport-card-header[data-airport-toggle]');
+                var header = null;
+                var i;
+                for (i = 0; i < headers.length; i++) {
+                    if (headers[i].getAttribute('data-airport-toggle') === airportId) {
+                        header = headers[i];
+                        break;
+                    }
+                }
+                var body = document.getElementById('airport-' + airportId + '-body');
+
                 if (header && body) {
-                    const isExpanded = header.classList.contains('expanded');
-                    
+                    var isExpanded = header.classList.contains('expanded');
+
                     if (isExpanded) {
                         header.classList.remove('expanded');
                         body.classList.remove('expanded');
@@ -1379,9 +1389,26 @@ if (php_sapi_name() === 'cli') {
                     }
                 }
             }
-            
-            // Expose to global scope for onclick handlers
+
             window.toggleAirport = toggleAirport;
+
+            document.querySelectorAll('.airport-card-header[data-airport-toggle]').forEach(function (hdr) {
+                hdr.addEventListener('click', function () {
+                    var id = hdr.getAttribute('data-airport-toggle');
+                    if (id) {
+                        toggleAirport(id);
+                    }
+                });
+                hdr.addEventListener('keydown', function (ev) {
+                    if (ev.key === 'Enter' || ev.key === ' ') {
+                        ev.preventDefault();
+                        var id = hdr.getAttribute('data-airport-toggle');
+                        if (id) {
+                            toggleAirport(id);
+                        }
+                    }
+                });
+            });
         })();
     </script>
 </body>

--- a/pages/status.php
+++ b/pages/status.php
@@ -58,7 +58,7 @@ $rolling1Calendar = $metricsBundle['rolling1'];
 
 $statusLocalCalendarJsPath = __DIR__ . '/../public/js/status-local-calendar.js';
 $statusLocalCalendarJsReadable = is_readable($statusLocalCalendarJsPath);
-if (!$statusLocalCalendarJsReadable) {
+if (!$statusLocalCalendarJsReadable && metrics_should_log_warning('status_local_calendar_js_unreadable', 300)) {
     aviationwx_log(
         'warning',
         'status page: status-local-calendar.js is not readable',

--- a/public/js/status-local-calendar.js
+++ b/public/js/status-local-calendar.js
@@ -75,11 +75,15 @@
      * @param {string} airportId lowercase airport id
      * @param {string} timeZone IANA zone
      * @param {number} [nowMs]
+     * @param {number} [dayStartMsOpt] If set, skips recomputing {@link startOfLocalCalendarDayMs} (batch DOM updates)
      * @returns {number}
      */
-    function sumLocalDayViewsForAirport(profile, airportId, timeZone, nowMs) {
+    function sumLocalDayViewsForAirport(profile, airportId, timeZone, nowMs, dayStartMsOpt) {
         const end = typeof nowMs === 'number' ? nowMs : Date.now();
-        const dayStart = startOfLocalCalendarDayMs(timeZone, end);
+        const dayStart =
+            typeof dayStartMsOpt === 'number'
+                ? dayStartMsOpt
+                : startOfLocalCalendarDayMs(timeZone, end);
         const rows = profile && profile.hours ? profile.hours : [];
         let sum = 0;
         for (let i = 0; i < rows.length; i++) {
@@ -139,6 +143,8 @@
         }
 
         const tz = resolvedTimeZone();
+        const nowMs = Date.now();
+        const dayStartMs = startOfLocalCalendarDayMs(tz, nowMs);
         for (let i = 0; i < nodes.length; i++) {
             const el = nodes[i];
             el.classList.remove('views-local-stale');
@@ -146,7 +152,7 @@
             if (!aid) {
                 continue;
             }
-            const n = sumLocalDayViewsForAirport(profile, aid, tz);
+            const n = sumLocalDayViewsForAirport(profile, aid, tz, nowMs, dayStartMs);
             el.textContent = n.toLocaleString() + '/loc';
             el.setAttribute('title', TITLE_OK.replace('%TZ%', tz));
             el.setAttribute('data-local-tz', tz);

--- a/public/js/status-local-calendar.js
+++ b/public/js/status-local-calendar.js
@@ -1,0 +1,173 @@
+/**
+ * Status page: sum sparse UTC hourly buckets into the viewer's local calendar day.
+ *
+ * Used by pages/status.php. Airport ids must be lowercase (matches server sparse maps).
+ *
+ * @see METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION in PHP
+ */
+(function (global) {
+    'use strict';
+
+    /**
+     * UTC hour bucket bounds from metrics hour id (YYYY-MM-DD-HH).
+     *
+     * @param {string} hourId
+     * @returns {{start: number, end: number}}
+     */
+    function hourIdToUtcRangeMs(hourId) {
+        const p = String(hourId).split('-');
+        if (p.length !== 4) {
+            return { start: NaN, end: NaN };
+        }
+        const y = parseInt(p[0], 10);
+        const mo = parseInt(p[1], 10);
+        const d = parseInt(p[2], 10);
+        const h = parseInt(p[3], 10);
+        const start = Date.UTC(y, mo - 1, d, h, 0, 0);
+        return { start: start, end: start + 3600000 };
+    }
+
+    /**
+     * Start of local calendar day containing nowMs (binary search).
+     * Lower bound covers local midnight even when far behind UTC (52h window).
+     *
+     * @param {string} timeZone IANA zone
+     * @param {number} nowMs
+     * @returns {number}
+     */
+    function startOfLocalCalendarDayMs(timeZone, nowMs) {
+        const fmt = new Intl.DateTimeFormat('en-CA', {
+            timeZone: timeZone,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit'
+        });
+        const today = fmt.format(new Date(nowMs));
+        let lo = nowMs - 52 * 3600000;
+        let hi = nowMs + 1;
+        while (lo < hi) {
+            const mid = Math.floor((lo + hi) / 2);
+            if (fmt.format(new Date(mid)) === today) {
+                hi = mid;
+            } else {
+                lo = mid + 1;
+            }
+        }
+        return lo;
+    }
+
+    /**
+     * @param {string} hourId
+     * @param {number} localStartMs
+     * @param {number} localEndMs
+     * @returns {boolean}
+     */
+    function utcHourOverlapsLocalWindow(hourId, localStartMs, localEndMs) {
+        const r = hourIdToUtcRangeMs(hourId);
+        if (Number.isNaN(r.start)) {
+            return false;
+        }
+        return r.start < localEndMs && r.end > localStartMs;
+    }
+
+    /**
+     * @param {object} profile hourly_profile payload from server
+     * @param {string} airportId lowercase airport id
+     * @param {string} timeZone IANA zone
+     * @param {number} [nowMs]
+     * @returns {number}
+     */
+    function sumLocalDayViewsForAirport(profile, airportId, timeZone, nowMs) {
+        const end = typeof nowMs === 'number' ? nowMs : Date.now();
+        const dayStart = startOfLocalCalendarDayMs(timeZone, end);
+        const rows = profile && profile.hours ? profile.hours : [];
+        let sum = 0;
+        for (let i = 0; i < rows.length; i++) {
+            const row = rows[i];
+            if (!row || !row.hour_id) {
+                continue;
+            }
+            if (!utcHourOverlapsLocalWindow(row.hour_id, dayStart, end)) {
+                continue;
+            }
+            const v = row.views && row.views[airportId] ? row.views[airportId] : 0;
+            sum += typeof v === 'number' ? v : 0;
+        }
+        return sum;
+    }
+
+    /**
+     * Resolve IANA timezone for Intl (fallback UTC).
+     *
+     * @returns {string}
+     */
+    function resolvedTimeZone() {
+        try {
+            return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+        } catch {
+            return 'UTC';
+        }
+    }
+
+    const TITLE_STALE =
+        'Metrics cache not warmed yet (scheduler will populate). Local sum unavailable until hourly buckets load.';
+    const TITLE_OK =
+        'Your calendar day in %TZ%, summed from UTC hour buckets on the server. Current UTC hour uses the same live partial totals as /hour.';
+
+    /**
+     * Update .views-local-calendar-day nodes from hourly_profile.
+     *
+     * @param {object|null} profile
+     * @returns {void}
+     */
+    function applyLocalCalendarDayViewsToDom(profile) {
+        const nodes = document.querySelectorAll('.views-local-calendar-day[data-airport]');
+        if (!nodes.length) {
+            return;
+        }
+
+        const hours = profile && profile.hours ? profile.hours : [];
+        if (!hours.length) {
+            const tz = resolvedTimeZone();
+            for (let i = 0; i < nodes.length; i++) {
+                nodes[i].classList.add('views-local-stale');
+                nodes[i].textContent = '---/loc';
+                nodes[i].setAttribute('title', TITLE_STALE);
+                nodes[i].setAttribute('data-local-tz', tz);
+            }
+            return;
+        }
+
+        const tz = resolvedTimeZone();
+        for (let i = 0; i < nodes.length; i++) {
+            const el = nodes[i];
+            el.classList.remove('views-local-stale');
+            const aid = el.getAttribute('data-airport');
+            if (!aid) {
+                continue;
+            }
+            const n = sumLocalDayViewsForAirport(profile, aid, tz);
+            el.textContent = n.toLocaleString() + '/loc';
+            el.setAttribute('title', TITLE_OK.replace('%TZ%', tz));
+            el.setAttribute('data-local-tz', tz);
+        }
+    }
+
+    const api = {
+        hourIdToUtcRangeMs: hourIdToUtcRangeMs,
+        startOfLocalCalendarDayMs: startOfLocalCalendarDayMs,
+        utcHourOverlapsLocalWindow: utcHourOverlapsLocalWindow,
+        sumLocalDayViewsForAirport: sumLocalDayViewsForAirport,
+        resolvedTimeZone: resolvedTimeZone,
+        applyLocalCalendarDayViewsToDom: applyLocalCalendarDayViewsToDom
+    };
+
+    /* eslint-disable no-undef -- Node runs tests via module.exports; browser has no module */
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    } else {
+        global.AviationWX = global.AviationWX || {};
+        global.AviationWX.statusLocalCalendar = api;
+    }
+    /* eslint-enable no-undef */
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/scripts/fetch-status-metrics.php
+++ b/scripts/fetch-status-metrics.php
@@ -2,7 +2,8 @@
 /**
  * Status Metrics Pre-warm Worker
  *
- * Computes metrics bundle (rolling7, rolling1, today) and writes to file cache.
+ * Computes metrics bundle (rolling7, rolling1, today, hourly_profile) for status page
+ * and writes to file cache in getCachedData envelope format.
  * Invoked by scheduler every STATUS_PAGE_BACKGROUND_FETCH_INTERVAL seconds.
  * Page loads read from APCu/file cache for fast access.
  *
@@ -17,6 +18,12 @@ require_once __DIR__ . '/../lib/cached-data-loader.php';
 require_once __DIR__ . '/../lib/metrics.php';
 
 $bundle = metrics_get_status_bundle();
+if (!isset($bundle['hourly_profile']['schema_version'], $bundle['multiPeriod'])) {
+    aviationwx_log('warning', 'fetch-status-metrics: bundle missing expected keys', [
+        'has_schema' => isset($bundle['hourly_profile']['schema_version']),
+        'has_multi_period' => isset($bundle['multiPeriod']),
+    ], 'app');
+}
 
 $fileData = [
     'cached_at' => time(),

--- a/scripts/fetch-status-metrics.php
+++ b/scripts/fetch-status-metrics.php
@@ -2,7 +2,7 @@
 /**
  * Status Metrics Pre-warm Worker
  *
- * Computes metrics bundle (rolling7, rolling1, today, hourly_profile) for status page
+ * Computes metrics bundle (rolling7, rolling1, today, hourly_profile, multiPeriod) for status page
  * and writes to file cache in getCachedData envelope format.
  * Invoked by scheduler every STATUS_PAGE_BACKGROUND_FETCH_INTERVAL seconds.
  * Page loads read from APCu/file cache for fast access.

--- a/scripts/fetch-status-metrics.php
+++ b/scripts/fetch-status-metrics.php
@@ -19,10 +19,12 @@ require_once __DIR__ . '/../lib/metrics.php';
 
 $bundle = metrics_get_status_bundle();
 if (!isset($bundle['hourly_profile']['schema_version'], $bundle['multiPeriod'])) {
-    aviationwx_log('warning', 'fetch-status-metrics: bundle missing expected keys', [
-        'has_schema' => isset($bundle['hourly_profile']['schema_version']),
-        'has_multi_period' => isset($bundle['multiPeriod']),
-    ], 'app');
+    if (metrics_should_log_warning('fetch_status_metrics_bundle_shape', 3600)) {
+        aviationwx_log('warning', 'fetch-status-metrics: bundle missing expected keys', [
+            'has_schema' => isset($bundle['hourly_profile']['schema_version']),
+            'has_multi_period' => isset($bundle['multiPeriod']),
+        ], 'app');
+    }
 }
 
 $fileData = [

--- a/scripts/lint-javascript.js
+++ b/scripts/lint-javascript.js
@@ -26,7 +26,8 @@ const DEFAULT_FILES = [
   'public/js/webcam-player-utils.js',
   'public/js/webcam-player-scroll-lock.js',
   'public/js/weather-timestamp-utils.js',
-  'public/js/runway-label-layout.js'
+  'public/js/runway-label-layout.js',
+  'public/js/status-local-calendar.js'
 ];
 
 // Parse command line arguments

--- a/tests/Unit/FetchStatusMetricsTest.php
+++ b/tests/Unit/FetchStatusMetricsTest.php
@@ -67,5 +67,16 @@ class FetchStatusMetricsTest extends TestCase
         $this->assertArrayHasKey('rolling7', $data);
         $this->assertArrayHasKey('rolling1', $data);
         $this->assertArrayHasKey('today', $data);
+        $this->assertArrayHasKey('hourly_profile', $data);
+        $this->assertArrayHasKey('multiPeriod', $data);
+        $this->assertIsArray($data['multiPeriod']);
+
+        $hp = $data['hourly_profile'];
+        $this->assertArrayHasKey('schema_version', $hp);
+        $this->assertSame(METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION, $hp['schema_version']);
+        $this->assertArrayHasKey('hours', $hp);
+        $this->assertArrayHasKey('current_hour_id', $hp);
+        $this->assertArrayHasKey('window_completed_hours', $hp);
+        $this->assertCount(METRICS_STATUS_HOURLY_PROFILE_COMPLETED_HOURS + 1, $hp['hours']);
     }
 }

--- a/tests/Unit/MetricsStatusBundleMirrorLegacyTest.php
+++ b/tests/Unit/MetricsStatusBundleMirrorLegacyTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Tests APCu status bundle mirror rejects pre-schema bundles (forces rebuild).
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/cache-paths.php';
+require_once __DIR__ . '/../../lib/constants.php';
+require_once __DIR__ . '/../../lib/metrics.php';
+
+class MetricsStatusBundleMirrorLegacyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (function_exists('apcu_clear_cache')) {
+            @apcu_clear_cache();
+        }
+        metrics_invalidate_status_bundle_mirror();
+    }
+
+    public function testMirrorWithoutSchemaVersionIsRejected(): void
+    {
+        if (!function_exists('apcu_store') || !function_exists('apcu_fetch')) {
+            $this->markTestSkipped('APCu not available');
+        }
+
+        $legacyBundle = [
+            'rolling7' => ['period_days' => 7, 'airports' => [], 'webcams' => [], 'global' => metrics_get_empty_global(), 'generated_at' => time()],
+            'rolling1' => ['period_days' => 1, 'airports' => [], 'webcams' => [], 'global' => metrics_get_empty_global(), 'generated_at' => time()],
+            'today' => ['bucket_type' => 'today', 'bucket_id' => gmdate('Y-m-d'), 'airports' => [], 'webcams' => [], 'global' => metrics_get_empty_global(), 'generated_at' => time()],
+            'hourly_profile' => [
+                'generated_at' => time(),
+                'hours' => [['hour_id' => '2000-01-01-00', 'complete' => true, 'views' => []]],
+                // schema_version intentionally omitted (legacy)
+            ],
+            'multiPeriod' => [],
+        ];
+
+        $payload = [
+            'generated_at' => time(),
+            'today_bucket_id' => gmdate('Y-m-d'),
+            'bundle' => $legacyBundle,
+        ];
+        @apcu_store(METRICS_STATUS_BUNDLE_MIRROR_APCU_KEY, $payload, METRICS_STATUS_BUNDLE_MIRROR_TTL_SECONDS);
+
+        $hit = metrics_try_get_status_bundle_mirror();
+        $this->assertNull($hit, 'Legacy mirror without hourly_profile.schema_version must miss');
+    }
+}

--- a/tests/Unit/MetricsStatusBundleMirrorStoreTest.php
+++ b/tests/Unit/MetricsStatusBundleMirrorStoreTest.php
@@ -38,6 +38,10 @@ class MetricsStatusBundleMirrorStoreTest extends TestCase
         $this->assertIsArray($raw);
         $this->assertArrayHasKey('bundle', $raw);
         $this->assertSame(gmdate('Y-m-d'), $raw['today_bucket_id'] ?? null);
+        $b = $raw['bundle'];
+        $this->assertArrayHasKey('hourly_profile', $b);
+        $this->assertSame(METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION, $b['hourly_profile']['schema_version'] ?? null);
+        $this->assertArrayHasKey('multiPeriod', $b);
 
         $again = metrics_get_status_bundle();
         $this->assertSame($bundle['today']['bucket_id'] ?? null, $again['today']['bucket_id'] ?? null);

--- a/tests/Unit/StatusHourlyProfileTest.php
+++ b/tests/Unit/StatusHourlyProfileTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Unit tests for UTC hourly profile used by the status page local-calendar views.
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/config.php';
+require_once __DIR__ . '/../../lib/cache-paths.php';
+require_once __DIR__ . '/../../lib/metrics.php';
+
+class StatusHourlyProfileTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        @mkdir(CACHE_METRICS_HOURLY_DIR, 0755, true);
+        $this->cleanMetricsDir(CACHE_METRICS_HOURLY_DIR);
+        if (function_exists('apcu_clear_cache')) {
+            @apcu_clear_cache();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanMetricsDir(CACHE_METRICS_HOURLY_DIR);
+        parent::tearDown();
+    }
+
+    private function cleanMetricsDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*.json') ?: [] as $file) {
+            @unlink($file);
+        }
+    }
+
+    private function createHourlyFile(string $hourId, string $airportId, int $pageViews): void
+    {
+        $file = CACHE_METRICS_HOURLY_DIR . '/' . $hourId . '.json';
+        file_put_contents($file, json_encode([
+            'bucket_type' => 'hourly',
+            'bucket_id' => $hourId,
+            'airports' => [
+                $airportId => ['page_views' => $pageViews, 'weather_requests' => 0, 'webcam_requests' => 0],
+            ],
+            'webcams' => [],
+            'global' => metrics_get_empty_global(),
+        ], JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * Profile shape: 26 completed hours + 1 partial; partial matches metrics_get_current_hour sparse extract.
+     */
+    public function testMetricsGetStatusHourlyProfile_CompletedFromDiskPartialFromLive(): void
+    {
+        $snapshot = strtotime('2025-06-15 14:22:00 UTC');
+        $prevHourId = '2025-06-15-13';
+        $currentHourId = '2025-06-15-14';
+        $this->createHourlyFile($prevHourId, 'kspb', 100);
+        // Current hour bucket on disk (scheduler-flushed); APCu optional for this assertion.
+        $this->createHourlyFile($currentHourId, 'kspb', 42);
+
+        $live = metrics_get_current_hour($snapshot);
+        $liveSparse = metrics_sparse_page_views_from_hour_aggregate($live);
+
+        $profile = metrics_get_status_hourly_profile($snapshot);
+
+        $this->assertSame(METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION, $profile['schema_version']);
+        $this->assertSame($snapshot, $profile['generated_at']);
+        $this->assertSame((int) METRICS_STATUS_HOURLY_PROFILE_COMPLETED_HOURS, $profile['window_completed_hours']);
+        $this->assertSame('2025-06-15-14', $profile['current_hour_id']);
+        $this->assertCount(
+            METRICS_STATUS_HOURLY_PROFILE_COMPLETED_HOURS + 1,
+            $profile['hours'],
+            '26 completed UTC hours plus one partial hour'
+        );
+
+        $prevRow = null;
+        foreach ($profile['hours'] as $row) {
+            if ($row['hour_id'] === $prevHourId) {
+                $prevRow = $row;
+                break;
+            }
+        }
+        $this->assertNotNull($prevRow);
+        $this->assertTrue($prevRow['complete']);
+        $this->assertSame(['kspb' => 100], $prevRow['views']);
+
+        $last = $profile['hours'][count($profile['hours']) - 1];
+        $this->assertSame('2025-06-15-14', $last['hour_id']);
+        $this->assertFalse($last['complete']);
+        $this->assertSame($liveSparse, $last['views']);
+        $this->assertSame(42, $last['views']['kspb'] ?? 0);
+    }
+
+    /**
+     * Zero views are omitted from sparse maps.
+     */
+    public function testMetricsSparsePageViewsFromHourAggregate_OmitsZero(): void
+    {
+        $agg = [
+            'airports' => [
+                'kfoo' => ['page_views' => 0, 'weather_requests' => 1, 'webcam_requests' => 0],
+                'kbar' => ['page_views' => 3, 'weather_requests' => 0, 'webcam_requests' => 0],
+            ],
+        ];
+        $sparse = metrics_sparse_page_views_from_hour_aggregate($agg);
+        $this->assertSame(['kbar' => 3], $sparse);
+    }
+
+    /**
+     * Disk sparse map skips re-reading hourly JSON when bundle already decoded the hour.
+     */
+    public function testMetricsGetStatusHourlyProfile_ReusesDiskSparseMap(): void
+    {
+        $snapshot = strtotime('2025-06-15 14:22:00 UTC');
+        $hourId = '2025-06-15-13';
+        $this->createHourlyFile($hourId, 'kspb', 77);
+        $diskSparse = [
+            $hourId => ['kspb' => 77],
+        ];
+
+        $profile = metrics_get_status_hourly_profile($snapshot, null, $diskSparse);
+
+        foreach ($profile['hours'] as $row) {
+            if ($row['hour_id'] === $hourId) {
+                $this->assertSame(['kspb' => 77], $row['views']);
+
+                return;
+            }
+        }
+        $this->fail('Expected hour row not found');
+    }
+}

--- a/tests/Unit/StatusMetricsBundleShapeTest.php
+++ b/tests/Unit/StatusMetricsBundleShapeTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Shape tests for status metrics bundle JSON (no HTTP server).
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/constants.php';
+require_once __DIR__ . '/../../lib/cache-paths.php';
+require_once __DIR__ . '/../../lib/metrics.php';
+
+class StatusMetricsBundleShapeTest extends TestCase
+{
+    public function testEmbeddedProfileMatchesPageJsonEncodeFlags(): void
+    {
+        $profile = [
+            'generated_at' => 1700000000,
+            'current_hour_id' => '2025-06-15-14',
+            'window_completed_hours' => METRICS_STATUS_HOURLY_PROFILE_COMPLETED_HOURS,
+            'schema_version' => METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION,
+            'hours' => [
+                ['hour_id' => '2025-06-15-13', 'complete' => true, 'views' => ['kspb' => 1]],
+            ],
+        ];
+        $json = json_encode(
+            $profile,
+            JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES
+        );
+        $this->assertIsString($json);
+        $back = json_decode($json, true);
+        $this->assertIsArray($back);
+        $this->assertSame(METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION, $back['schema_version']);
+    }
+
+    public function testMetricsGetStatusBundleIncludesMultiPeriodAndSchema(): void
+    {
+        @mkdir(CACHE_METRICS_HOURLY_DIR, 0755, true);
+        @mkdir(CACHE_METRICS_DAILY_DIR, 0755, true);
+        if (function_exists('apcu_clear_cache')) {
+            @apcu_clear_cache();
+        }
+        metrics_invalidate_status_bundle_mirror();
+
+        $bundle = metrics_get_status_bundle();
+        $this->assertArrayHasKey('multiPeriod', $bundle);
+        $this->assertArrayHasKey('hourly_profile', $bundle);
+        $this->assertSame(METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION, $bundle['hourly_profile']['schema_version']);
+    }
+}

--- a/tests/Unit/StatusMetricsBundleTest.php
+++ b/tests/Unit/StatusMetricsBundleTest.php
@@ -108,6 +108,9 @@ class StatusMetricsBundleTest extends TestCase
         $this->assertArrayHasKey('rolling7', $bundle);
         $this->assertArrayHasKey('rolling1', $bundle);
         $this->assertArrayHasKey('multiPeriod', $bundle);
+        $this->assertArrayHasKey('hourly_profile', $bundle);
+        $this->assertArrayHasKey('schema_version', $bundle['hourly_profile']);
+        $this->assertSame(METRICS_STATUS_HOURLY_PROFILE_SCHEMA_VERSION, $bundle['hourly_profile']['schema_version']);
 
         $this->assertArrayHasKey('airports', $bundle['rolling7']);
         $this->assertArrayHasKey('global', $bundle['rolling7']);
@@ -198,12 +201,21 @@ class StatusMetricsBundleTest extends TestCase
     }
 
     /**
-     * Status multi-period path must match full live aggregation (today + rolling include APCu).
+     * Bundled multiPeriod must match a rebuild at the same snapshot as hourly_profile.
      */
     public function testMetricsBuildMultiPeriodFromBundle_MatchesFromPeriods(): void
     {
         $bundle = metrics_get_status_bundle();
         $fromBundle = metrics_build_multi_period_from_bundle($bundle);
-        $this->assertEquals(metrics_get_multi_period(), $fromBundle);
+        $this->assertSame($bundle['multiPeriod'], $fromBundle);
+
+        $snapshot = (int) ($bundle['hourly_profile']['generated_at'] ?? time());
+        $live = metrics_get_current_hour($snapshot);
+        $expected = metrics_build_multi_period_from_periods(
+            $live,
+            metrics_get_today($live, $snapshot),
+            metrics_get_rolling(METRICS_STATUS_PAGE_DAYS, $live, $snapshot)
+        );
+        $this->assertEquals($expected, $fromBundle);
     }
 }

--- a/tests/Unit/StatusPageTest.php
+++ b/tests/Unit/StatusPageTest.php
@@ -9,7 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../lib/process-utils.php';
 require_once __DIR__ . '/../../lib/cache-paths.php';
-require_once __DIR__ . '/../../pages/status.php';
+require_once __DIR__ . '/../../lib/status-utils.php';
+require_once __DIR__ . '/../../lib/status-checks.php';
 require_once __DIR__ . '/../../lib/weather/utils.php';
 
 class StatusPageTest extends TestCase

--- a/tests/js/status-local-calendar.test.js
+++ b/tests/js/status-local-calendar.test.js
@@ -1,0 +1,100 @@
+/**
+ * Status page local calendar view sums (JavaScript)
+ *
+ * Run: node tests/js/status-local-calendar.test.js
+ */
+
+const {
+    hourIdToUtcRangeMs,
+    startOfLocalCalendarDayMs,
+    utcHourOverlapsLocalWindow,
+    sumLocalDayViewsForAirport,
+    resolvedTimeZone
+} = require('../../public/js/status-local-calendar.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`  ✓ ${name}`);
+        passed++;
+    } catch (e) {
+        console.error(`  ✗ ${name}`);
+        console.error(`    ${e.message}`);
+        failed++;
+    }
+}
+
+function assertStrictEqual(actual, expected, message) {
+    if (actual !== expected) {
+        throw new Error(`${message}: expected ${expected}, got ${actual}`);
+    }
+}
+
+function runTests() {
+    console.log('\nStatus local calendar (hour buckets → local day)\n' + '='.repeat(50));
+
+    test('hourIdToUtcRangeMs: parses metrics hour id', () => {
+        const r = hourIdToUtcRangeMs('2025-06-15-14');
+        assertStrictEqual(r.end - r.start, 3600000, 'one hour');
+        assertStrictEqual(r.start, Date.UTC(2025, 5, 15, 14, 0, 0), 'start');
+    });
+
+    test('hourIdToUtcRangeMs: invalid id yields NaN start', () => {
+        const r = hourIdToUtcRangeMs('bad');
+        assertStrictEqual(Number.isNaN(r.start), true, 'nan');
+    });
+
+    test('startOfLocalCalendarDayMs: America/Los_Angeles is consistent with en-CA day', () => {
+        const tz = 'America/Los_Angeles';
+        const nowMs = Date.UTC(2025, 5, 15, 20, 0, 0);
+        const start = startOfLocalCalendarDayMs(tz, nowMs);
+        const fmt = new Intl.DateTimeFormat('en-CA', {
+            timeZone: tz,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit'
+        });
+        assertStrictEqual(fmt.format(new Date(start)), fmt.format(new Date(nowMs)), 'same calendar day');
+        assertStrictEqual(start <= nowMs, true, 'start not after now');
+    });
+
+    test('utcHourOverlapsLocalWindow: overlapping boundary', () => {
+        const hourStart = Date.UTC(2025, 5, 15, 10, 0, 0);
+        const ok = utcHourOverlapsLocalWindow(
+            '2025-06-15-10',
+            hourStart + 1000,
+            hourStart + 7200000
+        );
+        assertStrictEqual(ok, true, 'overlap');
+    });
+
+    test('sumLocalDayViewsForAirport: sums overlapping buckets only', () => {
+        const tz = 'UTC';
+        const fixedNow = Date.UTC(2025, 5, 15, 14, 30, 0);
+        const profile = {
+            hours: [
+                { hour_id: '2025-06-15-13', complete: true, views: { kspb: 2 } },
+                { hour_id: '2025-06-15-14', complete: false, views: { kspb: 5 } }
+            ]
+        };
+        const sum = sumLocalDayViewsForAirport(profile, 'kspb', tz, fixedNow);
+        assertStrictEqual(sum, 7, '2+5');
+    });
+
+    test('resolvedTimeZone: returns a non-empty string', () => {
+        const z = resolvedTimeZone();
+        if (typeof z !== 'string' || z.length < 2) {
+            throw new Error('expected IANA or UTC string');
+        }
+    });
+
+    console.log('\n' + (failed === 0 ? 'All passed' : 'Some failed') + ` (${passed} ok, ${failed} failed)\n`);
+    if (failed > 0) {
+        process.exit(1);
+    }
+}
+
+runTests();

--- a/tests/js/status-local-calendar.test.js
+++ b/tests/js/status-local-calendar.test.js
@@ -84,6 +84,22 @@ function runTests() {
         assertStrictEqual(sum, 7, '2+5');
     });
 
+    test('sumLocalDayViewsForAirport: precomputed dayStartMs matches one-call path', () => {
+        const tz = 'UTC';
+        const fixedNow = Date.UTC(2025, 5, 15, 14, 30, 0);
+        const profile = {
+            hours: [
+                { hour_id: '2025-06-15-13', complete: true, views: { kspb: 2 } },
+                { hour_id: '2025-06-15-14', complete: false, views: { kspb: 5 } }
+            ]
+        };
+        const dayStartMs = startOfLocalCalendarDayMs(tz, fixedNow);
+        const implicit = sumLocalDayViewsForAirport(profile, 'kspb', tz, fixedNow);
+        const explicit = sumLocalDayViewsForAirport(profile, 'kspb', tz, fixedNow, dayStartMs);
+        assertStrictEqual(explicit, implicit, 'batch path equals single-call');
+        assertStrictEqual(explicit, 7, 'total unchanged');
+    });
+
     test('resolvedTimeZone: returns a non-empty string', () => {
         const z = resolvedTimeZone();
         if (typeof z !== 'string' || z.length < 2) {


### PR DESCRIPTION
## Summary

Combines status metrics improvements with status page UX polish.

### Metrics and data
- Extends the status metrics bundle with `hourly_profile` (schema version), `multiPeriod` aligned with the same clock as hourly data, APCu mirror compatibility, and reuse of hourly disk reads where applicable.
- Metrics remain stored in UTC; sparse hourly data supports summing **local calendar day** views in the browser via `public/js/status-local-calendar.js`.
- `scripts/fetch-status-metrics.php` warns when bundle fields are missing.

### Status page UI
- Airport card headers use a three-column CSS grid so **view counts stay visually centered** regardless of ICAO width; narrow viewports keep the stacked layout.

### Tests
- New and updated PHPUnit coverage for bundle shape, mirror legacy behavior, and hourly profile.
- JS unit tests for local calendar logic; CI wired via Makefile / `scripts/lint-javascript.js`.

### Verification
`make test-ci` passes locally.