### PR TITLE
Status page: simplify airport view counts (drop UTC /d, local day as /d)

### DIFF
--- a/pages/status.php
+++ b/pages/status.php
@@ -1025,11 +1025,11 @@ if (php_sapi_name() === 'cli') {
                     </h2>
                 </div>
                 <div class="airport-header-col airport-header-col--views">
-                    <div class="airport-views-summary airport-views-summary-compact" title="View counts: live partial hour from server; /loc is your local calendar day; /wk is a rolling UTC week.">
+                    <div class="airport-views-summary airport-views-summary-compact" title="View counts: live partial hour from server; /d is your local calendar day; /wk is a rolling UTC week.">
                         <span class="views-label">Views</span>
                         <span class="views-period" title="<?php echo htmlspecialchars($titleHourViews); ?>"><?php echo number_format($hourViews); ?>/hr</span>
                         <span class="views-sep">·</span>
-                        <span class="views-period views-local-calendar-day" data-airport="<?php echo htmlspecialchars(strtolower($airport['id'])); ?>" title="Your local calendar day (summed from UTC hour buckets). Waiting for hourly cache if shown as ---.">---/loc</span>
+                        <span class="views-period views-local-calendar-day" data-airport="<?php echo htmlspecialchars(strtolower($airport['id'])); ?>" title="Your local calendar day (summed from UTC hour buckets). Waiting for hourly cache if shown as ---.">---/d</span>
                         <span class="views-sep">·</span>
                         <span class="views-period" title="<?php echo htmlspecialchars($titleWeekViews); ?>"><?php echo number_format($weekViews); ?>/wk</span>
                     </div>

--- a/pages/status.php
+++ b/pages/status.php
@@ -1009,11 +1009,9 @@ if (php_sapi_name() === 'cli') {
         $airportPeriodMetrics = $multiPeriodMetrics[$airportIdLower] ?? null;
         // Get view counts (default to 0 if no metrics)
         $hourViews = $airportPeriodMetrics['hour']['page_views'] ?? 0;
-        $dayViews = $airportPeriodMetrics['day']['page_views'] ?? 0;
         $weekViews = $airportPeriodMetrics['week']['page_views'] ?? 0;
-        $titleHourViews = 'Live: current UTC hour (persisted file plus counters not yet flushed to disk).';
-        $titleDayViews = 'Today UTC from persisted hourly files; may trail the hour figure briefly until counters flush. Bundle cache can lag a few minutes.';
-        $titleWeekViews = 'Rolling calendar window: seven prior UTC days (daily files) plus today hourly; bundle cache can lag a few minutes.';
+        $titleHourViews = 'Views so far in the current metrics hour (partial hour until it completes).';
+        $titleWeekViews = 'Rolling week in UTC (seven prior UTC days plus today hourly); bundle cache can lag a few minutes.';
         ?>
         <div class="status-card">
             <div class="status-card-header airport-card-header"
@@ -1027,13 +1025,11 @@ if (php_sapi_name() === 'cli') {
                     </h2>
                 </div>
                 <div class="airport-header-col airport-header-col--views">
-                    <div class="airport-views-summary airport-views-summary-compact" title="View counts: UTC hour/day/week from server; /loc sums UTC buckets into your browser timezone.">
+                    <div class="airport-views-summary airport-views-summary-compact" title="View counts: live partial hour from server; /loc is your local calendar day; /wk is a rolling UTC week.">
                         <span class="views-label">Views</span>
                         <span class="views-period" title="<?php echo htmlspecialchars($titleHourViews); ?>"><?php echo number_format($hourViews); ?>/hr</span>
                         <span class="views-sep">·</span>
-                        <span class="views-period" title="<?php echo htmlspecialchars($titleDayViews); ?>"><?php echo number_format($dayViews); ?>/d</span>
-                        <span class="views-sep">·</span>
-                        <span class="views-period views-local-calendar-day" data-airport="<?php echo htmlspecialchars(strtolower($airport['id'])); ?>" title="Local calendar day (browser). Waiting for hourly cache if shown as ---.">---/loc</span>
+                        <span class="views-period views-local-calendar-day" data-airport="<?php echo htmlspecialchars(strtolower($airport['id'])); ?>" title="Your local calendar day (summed from UTC hour buckets). Waiting for hourly cache if shown as ---.">---/loc</span>
                         <span class="views-sep">·</span>
                         <span class="views-period" title="<?php echo htmlspecialchars($titleWeekViews); ?>"><?php echo number_format($weekViews); ?>/wk</span>
                     </div>

--- a/public/js/status-local-calendar.js
+++ b/public/js/status-local-calendar.js
@@ -116,7 +116,7 @@
     const TITLE_STALE =
         'Metrics cache not warmed yet (scheduler will populate). Local sum unavailable until hourly buckets load.';
     const TITLE_OK =
-        'Your calendar day in %TZ%, summed from UTC hour buckets on the server. Current UTC hour uses the same live partial totals as /hour.';
+        'Page views for your local calendar day in %TZ% (summed from UTC hour buckets on the server).';
 
     /**
      * Update .views-local-calendar-day nodes from hourly_profile.

--- a/public/js/status-local-calendar.js
+++ b/public/js/status-local-calendar.js
@@ -135,7 +135,7 @@
             const tz = resolvedTimeZone();
             for (let i = 0; i < nodes.length; i++) {
                 nodes[i].classList.add('views-local-stale');
-                nodes[i].textContent = '---/loc';
+                nodes[i].textContent = '---/d';
                 nodes[i].setAttribute('title', TITLE_STALE);
                 nodes[i].setAttribute('data-local-tz', tz);
             }
@@ -153,7 +153,7 @@
                 continue;
             }
             const n = sumLocalDayViewsForAirport(profile, aid, tz, nowMs, dayStartMs);
-            el.textContent = n.toLocaleString() + '/loc';
+            el.textContent = n.toLocaleString() + '/d';
             el.setAttribute('title', TITLE_OK.replace('%TZ%', tz));
             el.setAttribute('data-local-tz', tz);
         }


### PR DESCRIPTION
Removes the UTC calendar-day column from each airport row so hour remains partial-hour server totals, day is the viewer local calendar day (summed from hourly buckets), and week stays the rolling UTC window.

Follow-up: label that local-day figure as /d instead of /loc for clearer reading.