### PR TITLE
feat(public-api): density and pressure altitude on weather history

### DIFF
--- a/api/docs/index.php
+++ b/api/docs/index.php
@@ -530,7 +530,7 @@ $attribution = getPublicApiAttributionText();
                 <span class="endpoint-path">/v1/airports/{id}/weather/history</span>
             </div>
             <div class="endpoint-body">
-                <p class="endpoint-desc">Get 24-hour rolling weather history. Supports <code>hours</code>, <code>resolution</code> parameters.</p>
+                <p class="endpoint-desc">Get 24-hour rolling weather history. Supports <code>hours</code>, <code>resolution</code> parameters. Each observation includes <code>density_altitude</code> and <code>pressure_altitude</code> as integers when available, otherwise <code>null</code>.</p>
             </div>
         </div>
         

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -1220,6 +1220,16 @@
             "enum": ["VFR", "MVFR", "IFR", "LIFR"],
             "nullable": true
           },
+          "density_altitude": {
+            "type": "integer",
+            "description": "Density altitude in feet (null when not computed or unavailable)",
+            "nullable": true
+          },
+          "pressure_altitude": {
+            "type": "integer",
+            "description": "Pressure altitude in feet (null when not computed or unavailable)",
+            "nullable": true
+          },
           "field_sources": {
             "type": "object",
             "description": "Source attribution for each field",

--- a/api/v1/weather-history.php
+++ b/api/v1/weather-history.php
@@ -18,7 +18,6 @@ require_once __DIR__ . '/../../lib/public-api/response.php';
 require_once __DIR__ . '/../../lib/public-api/config.php';
 require_once __DIR__ . '/../../lib/public-api/weather-format.php';
 require_once __DIR__ . '/../../lib/weather/history.php';
-require_once __DIR__ . '/../../lib/heading-conversion.php';
 require_once __DIR__ . '/../../lib/config.php';
 
 /**
@@ -76,49 +75,12 @@ function handleGetWeatherHistory(array $params, array $context): void
     // Get weather history
     $history = getWeatherHistory($airportId, $startTime, $endTime, $resolution);
     
-    // Format observations for response (wind_direction object)
+    // Format observations for response (wind_direction object, DA/PA when stored)
     $decl = getMagneticDeclination($airport);
-    $observations = array_map(function ($obs) use ($decl) {
-        $wdRaw = $obs['wind_direction'] ?? null;
-        $isVRB = (is_string($wdRaw) && strtoupper($wdRaw) === 'VRB');
-        $trueNorth = $isVRB ? null : toApiHeading($wdRaw);
-        $magneticNorth = null;
-        if ($trueNorth !== null) {
-            $magVal = (int) round(convertTrueToMagnetic((float) $trueNorth, $decl));
-            $magneticNorth = toApiHeading($magVal);
-        }
-
-        $formatted = [
-            'obs_time' => $obs['obs_time'] ?? null,
-            'obs_time_iso' => $obs['obs_time_iso'] ?? null,
-            'temperature' => $obs['temperature'] ?? null,
-            'temperature_f' => $obs['temperature_f'] ?? null,
-            'dewpoint' => $obs['dewpoint'] ?? null,
-            'humidity' => $obs['humidity'] ?? null,
-            'wind_speed' => toApiInteger($obs['wind_speed'] ?? null),
-            'wind_direction' => [
-                'true_north' => $isVRB ? null : $trueNorth,
-                'magnetic_north' => $isVRB ? null : $magneticNorth,
-                'variable' => $isVRB,
-            ],
-            'gust_speed' => toApiInteger($obs['gust_speed'] ?? null),
-            'pressure' => $obs['pressure'] ?? null,
-            'visibility' => $obs['visibility'] ?? null,
-            'ceiling' => toApiInteger($obs['ceiling'] ?? null),
-            'cloud_cover' => $obs['cloud_cover'] ?? null,
-            'flight_category' => $obs['flight_category'] ?? null,
-        ];
-
-        // Add source attribution if available
-        if (isset($obs['field_sources']) && is_array($obs['field_sources'])) {
-            $formatted['field_sources'] = $obs['field_sources'];
-        }
-        if (isset($obs['sources']) && is_array($obs['sources'])) {
-            $formatted['sources'] = $obs['sources'];
-        }
-
-        return $formatted;
-    }, $history['observations']);
+    $observations = array_map(
+        static fn (array $obs): array => formatWeatherHistoryObservationForApi($obs, $decl),
+        $history['observations']
+    );
     
     // Build metadata
     $meta = [

--- a/lib/public-api/weather-format.php
+++ b/lib/public-api/weather-format.php
@@ -154,3 +154,60 @@ function formatWeatherResponse(array $weather, array $airport): array
         'metar_ceiling_reported' => $weather['metar_ceiling_reported'] ?? null,
     ];
 }
+
+/**
+ * Format one cached weather history observation for Public API JSON.
+ *
+ * Wind uses true degrees from storage and derives magnetic using declination.
+ * Density and pressure altitude use {@see toApiInteger()}; null when missing
+ * or non-numeric (fail closed per field).
+ *
+ * @param array $observation Raw observation from {@see getWeatherHistory()} / cache file
+ * @param float $declinationDegrees Airport magnetic declination (positive = East)
+ * @return array<string, mixed> API-shaped observation (includes field_sources and sources when present)
+ */
+function formatWeatherHistoryObservationForApi(array $observation, float $declinationDegrees): array
+{
+    require_once __DIR__ . '/../heading-conversion.php';
+
+    $wdRaw = $observation['wind_direction'] ?? null;
+    $isVRB = (is_string($wdRaw) && strtoupper($wdRaw) === 'VRB');
+    $trueNorth = $isVRB ? null : toApiHeading($wdRaw);
+    $magneticNorth = null;
+    if ($trueNorth !== null) {
+        $magVal = (int) round(convertTrueToMagnetic((float) $trueNorth, $declinationDegrees));
+        $magneticNorth = toApiHeading($magVal);
+    }
+
+    $formatted = [
+        'obs_time' => $observation['obs_time'] ?? null,
+        'obs_time_iso' => $observation['obs_time_iso'] ?? null,
+        'temperature' => $observation['temperature'] ?? null,
+        'temperature_f' => $observation['temperature_f'] ?? null,
+        'dewpoint' => $observation['dewpoint'] ?? null,
+        'humidity' => $observation['humidity'] ?? null,
+        'wind_speed' => toApiInteger($observation['wind_speed'] ?? null),
+        'wind_direction' => [
+            'true_north' => $isVRB ? null : $trueNorth,
+            'magnetic_north' => $isVRB ? null : $magneticNorth,
+            'variable' => $isVRB,
+        ],
+        'gust_speed' => toApiInteger($observation['gust_speed'] ?? null),
+        'pressure' => $observation['pressure'] ?? null,
+        'visibility' => $observation['visibility'] ?? null,
+        'ceiling' => toApiInteger($observation['ceiling'] ?? null),
+        'cloud_cover' => $observation['cloud_cover'] ?? null,
+        'flight_category' => $observation['flight_category'] ?? null,
+        'density_altitude' => toApiInteger($observation['density_altitude'] ?? null),
+        'pressure_altitude' => toApiInteger($observation['pressure_altitude'] ?? null),
+    ];
+
+    if (isset($observation['field_sources']) && is_array($observation['field_sources'])) {
+        $formatted['field_sources'] = $observation['field_sources'];
+    }
+    if (isset($observation['sources']) && is_array($observation['sources'])) {
+        $formatted['sources'] = $observation['sources'];
+    }
+
+    return $formatted;
+}

--- a/tests/Integration/PublicApiIntegrationTest.php
+++ b/tests/Integration/PublicApiIntegrationTest.php
@@ -318,6 +318,16 @@ class PublicApiIntegrationTest extends TestCase
             $this->assertArrayHasKey('true_north', $wd);
             $this->assertArrayHasKey('magnetic_north', $wd);
             $this->assertArrayHasKey('variable', $wd);
+            $this->assertArrayHasKey('density_altitude', $obs);
+            $this->assertArrayHasKey('pressure_altitude', $obs);
+            $this->assertTrue(
+                $obs['density_altitude'] === null || is_int($obs['density_altitude']),
+                'density_altitude should be int or null'
+            );
+            $this->assertTrue(
+                $obs['pressure_altitude'] === null || is_int($obs['pressure_altitude']),
+                'pressure_altitude should be int or null'
+            );
         }
     }
 }

--- a/tests/Unit/FormatWeatherHistoryObservationTest.php
+++ b/tests/Unit/FormatWeatherHistoryObservationTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Public API: formatWeatherHistoryObservationForApi (history observations)
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/public-api/weather-format.php';
+
+class FormatWeatherHistoryObservationTest extends TestCase
+{
+    /**
+     * Stored DA/PA are rounded to integers like the live weather payload
+     */
+    public function testDensityAndPressureAltitude_RoundedIntegers(): void
+    {
+        $obs = [
+            'obs_time' => 1700000000,
+            'obs_time_iso' => gmdate('c', 1700000000),
+            'wind_direction' => 270,
+            'wind_speed' => 10,
+            'temperature' => 15.0,
+            'pressure' => 30.12,
+            'density_altitude' => 1234.6,
+            'pressure_altitude' => 99.4,
+        ];
+
+        $out = formatWeatherHistoryObservationForApi($obs, 0.0);
+
+        $this->assertSame(1235, $out['density_altitude']);
+        $this->assertSame(99, $out['pressure_altitude']);
+    }
+
+    /**
+     * Missing or invalid stored values fail closed to null
+     */
+    public function testDensityPressureAltitude_InvalidOrMissing_ReturnsNull(): void
+    {
+        $base = [
+            'obs_time' => 1700000000,
+            'obs_time_iso' => gmdate('c', 1700000000),
+            'wind_direction' => 360,
+            'wind_speed' => 0,
+        ];
+
+        $outMissing = formatWeatherHistoryObservationForApi($base, 0.0);
+        $this->assertNull($outMissing['density_altitude']);
+        $this->assertNull($outMissing['pressure_altitude']);
+
+        $base['density_altitude'] = 'n/a';
+        $base['pressure_altitude'] = null;
+        $outBad = formatWeatherHistoryObservationForApi($base, 0.0);
+        $this->assertNull($outBad['density_altitude']);
+        $this->assertNull($outBad['pressure_altitude']);
+    }
+
+    /**
+     * VRB wind: variable true, headings null (unchanged from prior history behavior)
+     */
+    public function testVRBWind_VariableTrue(): void
+    {
+        $obs = [
+            'obs_time' => 1700000000,
+            'obs_time_iso' => gmdate('c', 1700000000),
+            'wind_direction' => 'VRB',
+            'wind_speed' => 3,
+        ];
+
+        $out = formatWeatherHistoryObservationForApi($obs, 14.0);
+
+        $this->assertTrue($out['wind_direction']['variable']);
+        $this->assertNull($out['wind_direction']['true_north']);
+        $this->assertNull($out['wind_direction']['magnetic_north']);
+    }
+
+    /**
+     * field_sources and sources pass through when present
+     */
+    public function testFieldSourcesAndSources_Preserved(): void
+    {
+        $obs = [
+            'obs_time' => 1700000000,
+            'obs_time_iso' => gmdate('c', 1700000000),
+            'wind_direction' => 180,
+            'wind_speed' => 5,
+            'field_sources' => ['temperature' => 'tempest'],
+            'sources' => ['tempest'],
+        ];
+
+        $out = formatWeatherHistoryObservationForApi($obs, 0.0);
+
+        $this->assertSame(['temperature' => 'tempest'], $out['field_sources']);
+        $this->assertSame(['tempest'], $out['sources']);
+    }
+}

--- a/tests/Unit/WeatherHistoryTest.php
+++ b/tests/Unit/WeatherHistoryTest.php
@@ -321,6 +321,8 @@ class WeatherHistoryTest extends TestCase
         $this->assertEquals(8, $obs['wind_speed']);
         $this->assertEquals(270, $obs['wind_direction']);
         $this->assertEquals('VFR', $obs['flight_category']);
+        $this->assertSame(1234, $obs['density_altitude']);
+        $this->assertSame(100, $obs['pressure_altitude']);
     }
     
     /**


### PR DESCRIPTION
## Summary

Expose `density_altitude` and `pressure_altitude` on `GET /v1/airports/{id}/weather/history` when they were stored for that observation (same integer-or-null behavior as live weather). Adds `formatWeatherHistoryObservationForApi()` in `lib/public-api/weather-format.php`, OpenAPI and API docs index updates, and tests.

## Tests

- `make test-ci` (full suite) passed locally before push.