### PR TITLE
Public API: GET /v1/operations scheduler snapshot

### DIFF
--- a/api/docs/index.php
+++ b/api/docs/index.php
@@ -584,6 +584,16 @@ $attribution = getPublicApiAttributionText();
             </div>
         </div>
         
+        <div class="endpoint">
+            <div class="endpoint-header">
+                <span class="method">GET</span>
+                <span class="endpoint-path">/v1/operations</span>
+            </div>
+            <div class="endpoint-body">
+                <p class="endpoint-desc">Get a scheduler-built production operations snapshot (aggregated health caches and scrubbed log summaries).</p>
+            </div>
+        </div>
+        
         <h2>Response Format</h2>
         <p>All endpoints return JSON responses with consistent structure:</p>
         <pre><code>{

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -474,6 +474,32 @@
         }
       }
     },
+    "/operations": {
+      "get": {
+        "summary": "Get operations snapshot",
+        "description": "Returns a scheduler-built production health snapshot (aggregated status caches and scrubbed log fingerprints). Verbose detail blocks may be omitted when all subsystems are operational.",
+        "operationId": "getOperations",
+        "tags": ["Status"],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
     "/status": {
       "get": {
         "summary": "Get API status",
@@ -1517,6 +1543,22 @@
                 }
               }
             }
+          }
+        }
+      },
+      "OperationsResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "operations": {
+            "type": "object",
+            "description": "Snapshot payload: snapshot_meta, uptime_layer, data_plane, capacity_layer, edge_layer, pipeline_meta, and optional details.",
+            "additionalProperties": true
           }
         }
       },

--- a/api/v1/operations.php
+++ b/api/v1/operations.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Public API - Operations snapshot
+ *
+ * GET /v1/operations
+ *
+ * Returns a scheduler-built production health snapshot (see lib/operations-snapshot.php).
+ */
+
+require_once __DIR__ . '/../../lib/public-api/middleware.php';
+require_once __DIR__ . '/../../lib/public-api/response.php';
+require_once __DIR__ . '/../../lib/public-api/config.php';
+require_once __DIR__ . '/../../lib/operations-snapshot.php';
+
+/**
+ * Handle GET /v1/operations
+ *
+ * @param array<int, string> $params Path parameters (unused)
+ * @param array<string, mixed> $context Request context from middleware
+ * @return void
+ */
+function handleGetOperations(array $params, array $context): void
+{
+    unset($params, $context);
+    $payload = operations_snapshot_get_api_payload();
+    sendPublicApiCacheHeaders('live');
+    sendPublicApiSuccess($payload, []);
+}

--- a/api/v1/router.php
+++ b/api/v1/router.php
@@ -93,6 +93,9 @@ function routePublicApiRequest(string $path, array $context): void
         
         // GET /v1/status
         '#^/status$#' => ['file' => 'status.php', 'handler' => 'handleGetStatus'],
+
+        // GET /v1/operations
+        '#^/operations$#' => ['file' => 'operations.php', 'handler' => 'handleGetOperations'],
     ];
     
     // Try to match the path to a route

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,6 +10,8 @@ The **Public API** (`https://api.aviationwx.org/v1/...`) is the supported integr
 > **Canonical Public API base URL (public deployment):** `https://api.aviationwx.org/v1`  
 > Self-hosted deployments may set `config.public_api.canonical_base_url` so docs match their origin.
 
+**Production health snapshot:** `GET /v1/operations` returns a scheduler-built JSON summary (system and Public API health caches, weather and variant health, capacity metrics, optional scrubbed log fingerprints). It is intended for operators and support tooling, not for flight-critical minute-by-minute data. The scheduler writes `cache/operations_snapshot.json`; if the job stalls, responses may be served with `snapshot_meta.freshness` set to `stale` for up to 30 minutes.
+
 ---
 
 ## Internal Endpoints

--- a/lib/cache-paths.php
+++ b/lib/cache-paths.php
@@ -38,6 +38,7 @@
  * │   └── {prefix}/                # First 2 chars of hash (git-style sharding)
  * │       └── {hash}.json          # Rate limit state files
  * ├── backoff.json                 # Circuit breaker state
+ * ├── operations_snapshot.json   # Public API GET /v1/operations (scheduler)
  * ├── peak_gusts/                  # Per-airport daily peak gust tracking
  * │   └── {airport}.json
  * ├── temp_extremes/               # Per-airport daily temperature extremes
@@ -726,6 +727,10 @@ if (!defined('CACHE_IMAGE_PROCESSING_METRICS_FILE')) {
 }
 if (!defined('CACHE_PAGE_RENDER_METRICS_FILE')) {
     define('CACHE_PAGE_RENDER_METRICS_FILE', CACHE_BASE_DIR . '/status_page_render.json');
+}
+
+if (!defined('CACHE_OPERATIONS_SNAPSHOT_FILE')) {
+    define('CACHE_OPERATIONS_SNAPSHOT_FILE', CACHE_BASE_DIR . '/operations_snapshot.json');
 }
 
 /**

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -284,6 +284,14 @@ if (!defined('PERFORMANCE_METRICS_FETCH_INTERVAL')) {
     define('PERFORMANCE_METRICS_FETCH_INTERVAL', STATUS_PAGE_BACKGROUND_FETCH_INTERVAL);
 }
 
+// Public API GET /v1/operations: scheduler-built snapshot; readers serve up to max age if job stalls
+if (!defined('OPERATIONS_SNAPSHOT_BUILD_INTERVAL_SECONDS')) {
+    define('OPERATIONS_SNAPSHOT_BUILD_INTERVAL_SECONDS', 600); // 10 minutes
+}
+if (!defined('OPERATIONS_SNAPSHOT_MAX_AGE_SECONDS')) {
+    define('OPERATIONS_SNAPSHOT_MAX_AGE_SECONDS', 1800); // 30 minutes
+}
+
 // Runway geometry (FAA + OurAirports) - weekly check, fetch when missing or >30 days old
 if (!defined('RUNWAYS_FETCH_CHECK_INTERVAL')) {
     define('RUNWAYS_FETCH_CHECK_INTERVAL', 604800); // 7 days

--- a/lib/operations-snapshot.php
+++ b/lib/operations-snapshot.php
@@ -124,7 +124,7 @@ function operations_snapshot_read_log_tail(string $path, int $maxBytes = 2097152
     if ($fp === false) {
         return '';
     }
-    if ($start > 0 && !@fseek($fp, $start)) {
+    if ($start > 0 && @fseek($fp, $start) !== 0) {
         fclose($fp);
         return '';
     }

--- a/lib/operations-snapshot.php
+++ b/lib/operations-snapshot.php
@@ -1,0 +1,664 @@
+<?php
+/**
+ * Operations snapshot for Public API GET /v1/operations
+ *
+ * A scheduler-built JSON envelope (see scripts/build-operations-snapshot.php) aggregates
+ * pre-warmed status caches plus scrubbed log fingerprints. The API reads the envelope and
+ * applies freshness and optional detail gating.
+ */
+
+require_once __DIR__ . '/cache-paths.php';
+require_once __DIR__ . '/constants.php';
+require_once __DIR__ . '/logger.php';
+
+/** JSON schema version embedded in snapshot payloads. */
+if (!defined('OPERATIONS_SNAPSHOT_SCHEMA_VERSION')) {
+    define('OPERATIONS_SNAPSHOT_SCHEMA_VERSION', 1);
+}
+
+/**
+ * Redact sensitive substrings from a scalar string (URLs with query, obvious tokens).
+ *
+ * @param string $value Raw string
+ * @return string Redacted string
+ */
+function operations_snapshot_redact_scalar_string(string $value): string {
+    $out = preg_replace('#(https?://[^\s]+)\?[^\s]+#', '$1?[redacted]', $value) ?? $value;
+    $out = preg_replace('#(?i)(api[_-]?key|token|secret|password|bearer)\s*[:=]\s*\S+#', '$1=[redacted]', $out) ?? $out;
+    return $out;
+}
+
+/**
+ * Return true if a context key should have its value fully redacted.
+ *
+ * @param string $key Context array key
+ * @return bool True when value must be redacted
+ */
+function operations_snapshot_is_sensitive_context_key(string $key): bool {
+    $k = strtolower($key);
+    if (str_contains($k, 'password')) {
+        return true;
+    }
+    if (str_contains($k, 'token') || str_contains($k, 'secret')) {
+        return true;
+    }
+    if ($k === 'authorization' || str_contains($k, 'api_key') || str_contains($k, 'apikey')) {
+        return true;
+    }
+    if (str_contains($k, 'cookie') || str_contains($k, 'bearer')) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Recursively scrub context arrays for log fingerprint samples.
+ *
+ * @param mixed $ctx Context value
+ * @param int $depth Current recursion depth
+ * @return mixed Scrubbed structure
+ */
+function operations_snapshot_scrub_context(mixed $ctx, int $depth = 0): mixed {
+    if ($depth > 6) {
+        return '[truncated]';
+    }
+    if (is_string($ctx)) {
+        return operations_snapshot_redact_scalar_string($ctx);
+    }
+    if (is_int($ctx) || is_float($ctx) || is_bool($ctx) || $ctx === null) {
+        return $ctx;
+    }
+    if (!is_array($ctx)) {
+        return null;
+    }
+    $allow = [
+        'source' => true,
+        'log_type' => true,
+        'level' => true,
+        'component' => true,
+        'provider' => true,
+        'airport_id' => true,
+        'endpoint' => true,
+        'path' => true,
+        'exit_code' => true,
+        'http_code' => true,
+    ];
+    $out = [];
+    foreach ($ctx as $key => $val) {
+        if (!is_string($key)) {
+            continue;
+        }
+        if (operations_snapshot_is_sensitive_context_key($key)) {
+            $out[$key] = '[redacted]';
+            continue;
+        }
+        $lk = strtolower($key);
+        if (!isset($allow[$lk]) && !preg_match('/^(error|message|reason|stage|operation)$/i', $key)) {
+            continue;
+        }
+        $out[$key] = operations_snapshot_scrub_context($val, $depth + 1);
+    }
+    return $out;
+}
+
+/**
+ * Read the last $maxBytes of a file as a string (best-effort).
+ *
+ * @param string $path Absolute path
+ * @param int $maxBytes Maximum tail size
+ * @return string File tail or empty string
+ */
+function operations_snapshot_read_log_tail(string $path, int $maxBytes = 2097152): string {
+    if (!is_readable($path)) {
+        return '';
+    }
+    $size = @filesize($path);
+    if ($size === false || $size <= 0) {
+        return '';
+    }
+    $start = 0;
+    if ($size > $maxBytes) {
+        $start = $size - $maxBytes;
+    }
+    $fp = @fopen($path, 'rb');
+    if ($fp === false) {
+        return '';
+    }
+    if ($start > 0 && !@fseek($fp, $start)) {
+        fclose($fp);
+        return '';
+    }
+    $data = @stream_get_contents($fp);
+    fclose($fp);
+    if ($data === false) {
+        return '';
+    }
+    if ($start > 0) {
+        $nl = strpos($data, "\n");
+        if ($nl !== false) {
+            $data = substr($data, $nl + 1);
+        }
+    }
+    return $data;
+}
+
+/**
+ * Parse JSONL log tail and aggregate warning+ entries from the last hour.
+ *
+ * @param string $tailContent Tail content (UTF-8)
+ * @param int $sinceUnix Inclusive lower bound for entry timestamp
+ * @param int $maxFingerprints Cap on distinct fingerprints returned
+ * @return array<int, array{fingerprint:string,level:string,message:string,count:int,last_ts:string,sample_context:array}>
+ */
+function operations_snapshot_aggregate_log_fingerprints(
+    string $tailContent,
+    int $sinceUnix,
+    int $maxFingerprints = 30
+): array {
+    $levels = ['warning' => true, 'error' => true, 'critical' => true, 'alert' => true, 'emergency' => true];
+    $agg = [];
+
+    $lines = preg_split("/\r\n|\n|\r/", $tailContent) ?: [];
+    foreach ($lines as $line) {
+        $line = trim($line);
+        if ($line === '') {
+            continue;
+        }
+        $row = json_decode($line, true);
+        if (!is_array($row)) {
+            continue;
+        }
+        $level = isset($row['level']) ? strtolower((string) $row['level']) : '';
+        if (!isset($levels[$level])) {
+            continue;
+        }
+        $tsRaw = $row['ts'] ?? '';
+        $tsUnix = is_string($tsRaw) ? strtotime($tsRaw) : false;
+        if ($tsUnix === false || $tsUnix < $sinceUnix) {
+            continue;
+        }
+        $message = isset($row['message']) ? operations_snapshot_redact_scalar_string((string) $row['message']) : '';
+        $fingerprint = $level . '|' . $message;
+        if (!isset($agg[$fingerprint])) {
+            $ctx = isset($row['context']) && is_array($row['context'])
+                ? operations_snapshot_scrub_context($row['context'])
+                : [];
+            $agg[$fingerprint] = [
+                'fingerprint' => $fingerprint,
+                'level' => $level,
+                'message' => $message,
+                'count' => 0,
+                'last_ts' => gmdate('c', $tsUnix),
+                'sample_context' => is_array($ctx) ? $ctx : [],
+            ];
+        }
+        $agg[$fingerprint]['count']++;
+        $prevUnix = strtotime($agg[$fingerprint]['last_ts']);
+        if ($prevUnix === false || $tsUnix > $prevUnix) {
+            $agg[$fingerprint]['last_ts'] = gmdate('c', $tsUnix);
+        }
+    }
+
+    usort($agg, static function (array $a, array $b): int {
+        return ($b['count'] <=> $a['count']) ?: strcmp($a['fingerprint'], $b['fingerprint']);
+    });
+
+    return array_slice(array_values($agg), 0, $maxFingerprints);
+}
+
+/**
+ * Load JSON envelope written by status pre-warm workers (cached_at, ttl, key, data).
+ *
+ * @param string $path Absolute path
+ * @return mixed|null Decoded data payload or null
+ */
+function operations_snapshot_load_envelope_data(string $path): mixed {
+    if (!is_readable($path)) {
+        return null;
+    }
+    $raw = @file_get_contents($path);
+    if ($raw === false || $raw === '') {
+        return null;
+    }
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded) || !array_key_exists('data', $decoded)) {
+        return null;
+    }
+    return $decoded['data'];
+}
+
+/**
+ * Summarize airport health list into counts and worst rows.
+ *
+ * @param array<int, array<string, mixed>> $airports Airport health rows
+ * @param int $worstLimit Max worst airports to include in details
+ * @return array{counts: array<string,int>, worst: array<int, array<string, mixed>>}
+ */
+function operations_snapshot_summarize_airport_health(array $airports, int $worstLimit = 15): array {
+    $counts = ['operational' => 0, 'degraded' => 0, 'down' => 0, 'maintenance' => 0, 'other' => 0];
+    $worst = [];
+    foreach ($airports as $row) {
+        if (!is_array($row)) {
+            continue;
+        }
+        $st = isset($row['status']) ? (string) $row['status'] : 'other';
+        if (isset($counts[$st])) {
+            $counts[$st]++;
+        } else {
+            $counts['other']++;
+        }
+        if ($st === 'degraded' || $st === 'down' || $st === 'maintenance') {
+            $msg = '';
+            if (isset($row['components']) && is_array($row['components'])) {
+                foreach ($row['components'] as $comp) {
+                    if (!is_array($comp)) {
+                        continue;
+                    }
+                    $cst = $comp['status'] ?? '';
+                    if ($cst === 'degraded' || $cst === 'down' || $cst === 'failed') {
+                        $msg = isset($comp['message']) ? (string) $comp['message'] : '';
+                        break;
+                    }
+                }
+            }
+            $worst[] = [
+                'id' => $row['id'] ?? '',
+                'status' => $st,
+                'message' => operations_snapshot_redact_scalar_string($msg),
+            ];
+        }
+    }
+    usort($worst, static function (array $a, array $b): int {
+        $rank = ['down' => 0, 'maintenance' => 1, 'degraded' => 2];
+        $ra = $rank[$a['status']] ?? 9;
+        $rb = $rank[$b['status']] ?? 9;
+        return $ra <=> $rb;
+    });
+    $worst = array_slice($worst, 0, $worstLimit);
+
+    return ['counts' => $counts, 'worst' => $worst];
+}
+
+/**
+ * Merge circuit-open counters by source from recent weather health hourly buckets.
+ *
+ * @param array<string, mixed> $weatherFileDecoded Full weather_health.json decode
+ * @return array<string, int>
+ */
+function operations_snapshot_weather_circuit_by_source(array $weatherFileDecoded): array {
+    $oneHourAgo = gmdate('Y-m-d-H', time() - 3600);
+    $by = [];
+    $buckets = $weatherFileDecoded['hourly_buckets'] ?? [];
+    if (!is_array($buckets)) {
+        return $by;
+    }
+    foreach ($buckets as $hourKey => $bucket) {
+        if (!is_string($hourKey) || $hourKey < $oneHourAgo) {
+            continue;
+        }
+        if (!is_array($bucket)) {
+            continue;
+        }
+        foreach ($bucket as $k => $v) {
+            if (!is_string($k) || !str_starts_with($k, 'circuit_open_') || $k === 'circuit_open_events') {
+                continue;
+            }
+            $src = substr($k, strlen('circuit_open_'));
+            $n = is_int($v) ? $v : (int) $v;
+            if (!isset($by[$src])) {
+                $by[$src] = 0;
+            }
+            $by[$src] += $n;
+        }
+    }
+    ksort($by);
+    return $by;
+}
+
+/**
+ * Determine whether verbose detail should be exposed to API clients.
+ *
+ * @param array<string, mixed> $data Inner snapshot data (before freshness meta)
+ * @return bool True when details should be included
+ */
+function operations_snapshot_verbose_detail_warranted(array $data): bool {
+    $uptime = isset($data['uptime_layer']) && is_array($data['uptime_layer']) ? $data['uptime_layer'] : [];
+    $sys = $uptime['system'] ?? null;
+    if (is_array($sys) && (($sys['status'] ?? '') !== 'operational')) {
+        return true;
+    }
+    $api = $uptime['public_api'] ?? null;
+    if (is_array($api) && (($api['status'] ?? '') !== 'operational')) {
+        return true;
+    }
+    $dp = isset($data['data_plane']) && is_array($data['data_plane']) ? $data['data_plane'] : [];
+    $wx = $dp['weather'] ?? null;
+    if (is_array($wx) && (($wx['status'] ?? '') !== 'operational')) {
+        return true;
+    }
+    $var = $dp['variant'] ?? null;
+    if (is_array($var) && (($var['status'] ?? '') !== 'operational')) {
+        return true;
+    }
+    $summary = isset($dp['airport_summary']) && is_array($dp['airport_summary']) ? $dp['airport_summary'] : [];
+    $counts = isset($summary['counts']) && is_array($summary['counts']) ? $summary['counts'] : [];
+    $bad = (int) ($counts['degraded'] ?? 0) + (int) ($counts['down'] ?? 0);
+    if ($bad > 0) {
+        return true;
+    }
+    $details = isset($data['details']) && is_array($data['details']) ? $data['details'] : [];
+    $fps = $details['log_fingerprints'] ?? [];
+    if (is_array($fps) && $fps !== []) {
+        return true;
+    }
+    $m = is_array($wx) && isset($wx['metrics']) && is_array($wx['metrics']) ? $wx['metrics'] : [];
+    if ((int) ($m['circuit_open_events_last_hour'] ?? 0) > 0) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Strip verbose keys when not warranted.
+ *
+ * @param array<string, mixed> $data Inner snapshot
+ * @param bool $verbose When false, remove heavy detail blocks
+ * @return array<string, mixed> Filtered snapshot
+ */
+function operations_snapshot_apply_verbose_gate(array $data, bool $verbose): array {
+    if ($verbose) {
+        return $data;
+    }
+    if (isset($data['details']) && is_array($data['details'])) {
+        unset($data['details']['log_fingerprints'], $data['details']['airport_worst'], $data['details']['weather_circuit_by_source']);
+    }
+    return $data;
+}
+
+/**
+ * Build the inner snapshot payload (no envelope wrapper).
+ *
+ * @param string $cacheBaseDir Cache root (CACHE_BASE_DIR in production)
+ * @param array<string, mixed> $options Optional: int `now`, string `log_path`
+ * @return array<string, mixed> Snapshot data
+ */
+function operations_snapshot_build(string $cacheBaseDir, array $options = []): array {
+    $now = isset($options['now']) && is_int($options['now']) ? $options['now'] : time();
+    $logPath = isset($options['log_path']) && is_string($options['log_path'])
+        ? $options['log_path']
+        : (defined('AVIATIONWX_LOG_FILE') ? AVIATIONWX_LOG_FILE : '');
+
+    $system = operations_snapshot_load_envelope_data($cacheBaseDir . '/status_system_health.json');
+    $public = operations_snapshot_load_envelope_data($cacheBaseDir . '/public_api_health.json');
+    $airportsRaw = operations_snapshot_load_envelope_data($cacheBaseDir . '/status_airport_health.json');
+    $airports = is_array($airportsRaw) ? $airportsRaw : [];
+    $airSummary = operations_snapshot_summarize_airport_health($airports);
+
+    $weatherPath = $cacheBaseDir . '/weather_health.json';
+    $weatherHealth = [
+        'name' => 'Weather Data Fetching',
+        'status' => 'operational',
+        'message' => 'No data available',
+        'lastChanged' => 0,
+        'metrics' => [],
+    ];
+    $weatherFull = [];
+    if (is_readable($weatherPath)) {
+        $w = @file_get_contents($weatherPath);
+        if ($w !== false) {
+            $weatherFull = json_decode($w, true);
+            if (is_array($weatherFull) && isset($weatherFull['health']) && is_array($weatherFull['health'])) {
+                $weatherHealth = $weatherFull['health'];
+            }
+        }
+    }
+
+    $variantPath = $cacheBaseDir . '/variant_health.json';
+    $variantHealth = [
+        'name' => 'Webcam Variant Generation',
+        'status' => 'operational',
+        'message' => 'No data available',
+        'lastChanged' => 0,
+        'metrics' => [],
+    ];
+    if (is_readable($variantPath)) {
+        $v = @file_get_contents($variantPath);
+        if ($v !== false) {
+            $vd = json_decode($v, true);
+            if (is_array($vd) && isset($vd['health']) && is_array($vd['health'])) {
+                $variantHealth = $vd['health'];
+            }
+        }
+    }
+
+    $node = operations_snapshot_load_envelope_data($cacheBaseDir . '/status_node_performance.json');
+    $img = operations_snapshot_load_envelope_data($cacheBaseDir . '/status_image_processing.json');
+    $page = operations_snapshot_load_envelope_data($cacheBaseDir . '/status_page_render.json');
+
+    $memorySummary = ['snapshots_count' => 0, 'latest_memory_bytes' => null];
+    $memPath = $cacheBaseDir . '/memory_history.json';
+    if (is_readable($memPath)) {
+        $m = @file_get_contents($memPath);
+        if ($m !== false) {
+            $md = json_decode($m, true);
+            if (is_array($md) && isset($md['snapshots']) && is_array($md['snapshots'])) {
+                $memorySummary['snapshots_count'] = count($md['snapshots']);
+                $last = end($md['snapshots']);
+                if (is_array($last) && isset($last['memory'])) {
+                    $memorySummary['latest_memory_bytes'] = (int) $last['memory'];
+                }
+            }
+        }
+    }
+
+    $cloud = null;
+    $cfPath = $cacheBaseDir . '/cloudflare_analytics.json';
+    if (is_readable($cfPath)) {
+        $c = @file_get_contents($cfPath);
+        if ($c !== false) {
+            $cd = json_decode($c, true);
+            if (is_array($cd)) {
+                $cloud = [
+                    'unique_visitors_today' => $cd['unique_visitors_today'] ?? null,
+                    'requests_today' => $cd['requests_today'] ?? null,
+                    'bandwidth_today' => $cd['bandwidth_today'] ?? null,
+                    'cached_at' => $cd['cached_at'] ?? null,
+                ];
+            }
+        }
+    }
+
+    $aggLast = null;
+    if (function_exists('getMetricsAggregatorLastRunPath')) {
+        $p = getMetricsAggregatorLastRunPath();
+        if (is_readable($p)) {
+            $raw = @file_get_contents($p);
+            if ($raw !== false) {
+                $decoded = json_decode($raw, true);
+                if (is_array($decoded)) {
+                    $stats = $decoded['stats'] ?? [];
+                    $aggLast = [
+                        'finished_at' => $decoded['finished_at'] ?? null,
+                    ];
+                    if (is_array($stats)) {
+                        foreach ([
+                            'lock_contended',
+                            'hours_touched',
+                            'hourly_writes',
+                            'spills_merged',
+                            'spills_deleted',
+                            'orphans_pruned',
+                        ] as $k) {
+                            if (array_key_exists($k, $stats)) {
+                                $aggLast[$k] = $stats[$k];
+                            }
+                        }
+                        if (!empty($stats['errors']) && is_array($stats['errors'])) {
+                            $aggLast['errors'] = $stats['errors'];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    $since = $now - 3600;
+    $fingerprints = [];
+    if ($logPath !== '' && is_readable($logPath)) {
+        $tail = operations_snapshot_read_log_tail($logPath);
+        $fingerprints = operations_snapshot_aggregate_log_fingerprints($tail, $since);
+    }
+
+    $circuitBySource = is_array($weatherFull) ? operations_snapshot_weather_circuit_by_source($weatherFull) : [];
+
+    return [
+        'snapshot_meta' => [
+            'schema_version' => OPERATIONS_SNAPSHOT_SCHEMA_VERSION,
+            'generated_at' => gmdate('c', $now),
+            'generated_at_unix' => $now,
+        ],
+        'uptime_layer' => [
+            'system' => is_array($system) ? $system : null,
+            'public_api' => is_array($public) ? $public : null,
+        ],
+        'data_plane' => [
+            'airport_summary' => [
+                'total' => count($airports),
+                'counts' => $airSummary['counts'],
+            ],
+            'weather' => $weatherHealth,
+            'variant' => $variantHealth,
+        ],
+        'capacity_layer' => [
+            'node_performance' => is_array($node) ? $node : null,
+            'image_processing' => is_array($img) ? $img : null,
+            'page_render' => is_array($page) ? $page : null,
+            'memory_history_summary' => $memorySummary,
+        ],
+        'edge_layer' => [
+            'cloudflare' => $cloud,
+        ],
+        'pipeline_meta' => [
+            'metrics_aggregator_last_run' => $aggLast,
+        ],
+        'details' => [
+            'log_fingerprints' => $fingerprints,
+            'airport_worst' => $airSummary['worst'],
+            'weather_circuit_by_source' => $circuitBySource,
+        ],
+    ];
+}
+
+/**
+ * Write snapshot envelope to disk (atomic rename).
+ *
+ * @param string $path Target path (CACHE_OPERATIONS_SNAPSHOT_FILE)
+ * @param array<string, mixed> $data Inner snapshot payload
+ * @param int $ttlSeconds TTL hint stored in envelope (max staleness policy for readers)
+ * @return bool True on success
+ */
+function operations_snapshot_write_envelope(string $path, array $data, int $ttlSeconds): bool {
+    $dir = dirname($path);
+    if (!is_dir($dir)) {
+        @mkdir($dir, 0755, true);
+    }
+    $fileData = [
+        'cached_at' => time(),
+        'ttl' => $ttlSeconds,
+        'key' => 'operations_snapshot',
+        'data' => $data,
+    ];
+    $json = json_encode($fileData, JSON_PRETTY_PRINT);
+    if ($json === false) {
+        return false;
+    }
+    $tmp = $path . '.tmp.' . getmypid();
+    if (@file_put_contents($tmp, $json, LOCK_EX) === false) {
+        @unlink($tmp);
+        return false;
+    }
+    if (!@rename($tmp, $path)) {
+        @unlink($tmp);
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Read operations snapshot envelope from disk.
+ *
+ * @param string|null $path Absolute path; default CACHE_OPERATIONS_SNAPSHOT_FILE
+ * @return array<string, mixed>|null Full envelope or null
+ */
+function operations_snapshot_read_envelope(?string $path = null): ?array
+{
+    $path = $path ?? CACHE_OPERATIONS_SNAPSHOT_FILE;
+    if (!is_readable($path)) {
+        return null;
+    }
+    $raw = @file_get_contents($path);
+    if ($raw === false || $raw === '') {
+        return null;
+    }
+    $decoded = json_decode($raw, true);
+    return is_array($decoded) ? $decoded : null;
+}
+
+/**
+ * Prepare the operations object for GET /v1/operations (freshness + verbose gate).
+ *
+ * @param string|null $snapshotPath Optional envelope path (for tests)
+ * @return array<string, mixed> Payload keyed for sendPublicApiSuccess
+ */
+function operations_snapshot_get_api_payload(?string $snapshotPath = null): array
+{
+    $maxAge = defined('OPERATIONS_SNAPSHOT_MAX_AGE_SECONDS') ? OPERATIONS_SNAPSHOT_MAX_AGE_SECONDS : 1800;
+    $envelope = operations_snapshot_read_envelope($snapshotPath);
+    $now = time();
+
+    if ($envelope === null || !isset($envelope['data']) || !is_array($envelope['data'])) {
+        return [
+            'operations' => [
+                'snapshot_meta' => [
+                    'schema_version' => OPERATIONS_SNAPSHOT_SCHEMA_VERSION,
+                    'freshness' => 'missing',
+                    'generated_at' => null,
+                    'generated_at_unix' => null,
+                    'age_seconds' => null,
+                    'max_age_seconds' => $maxAge,
+                ],
+                'uptime_layer' => null,
+                'data_plane' => null,
+                'capacity_layer' => null,
+                'edge_layer' => null,
+                'pipeline_meta' => null,
+                'details' => null,
+            ],
+        ];
+    }
+
+    $cachedAt = isset($envelope['cached_at']) ? (int) $envelope['cached_at'] : 0;
+    $age = max(0, $now - $cachedAt);
+    $freshness = $age > $maxAge ? 'stale' : 'ok';
+
+    $inner = $envelope['data'];
+    if (!is_array($inner)) {
+        $inner = [];
+    }
+
+    $verbose = operations_snapshot_verbose_detail_warranted($inner);
+    $inner = operations_snapshot_apply_verbose_gate($inner, $verbose);
+
+    if (!isset($inner['snapshot_meta']) || !is_array($inner['snapshot_meta'])) {
+        $inner['snapshot_meta'] = [];
+    }
+    $inner['snapshot_meta']['freshness'] = $freshness;
+    $inner['snapshot_meta']['age_seconds'] = $age;
+    $inner['snapshot_meta']['max_age_seconds'] = $maxAge;
+    $inner['snapshot_meta']['verbose_detail'] = $verbose;
+    if (!array_key_exists('schema_version', $inner['snapshot_meta'])) {
+        $inner['snapshot_meta']['schema_version'] = OPERATIONS_SNAPSHOT_SCHEMA_VERSION;
+    }
+
+    return ['operations' => $inner];
+}

--- a/lib/public-api/response.php
+++ b/lib/public-api/response.php
@@ -57,6 +57,8 @@ function sendPublicApiSuccess(array $data, array $meta = [], int $httpCode = 200
         $response['frames'] = $data['frames'];
     } elseif (isset($data['status'])) {
         $response['status'] = $data['status'];
+    } elseif (isset($data['operations'])) {
+        $response['operations'] = $data['operations'];
     } elseif (isset($data['embed']) || isset($data['diff'])) {
         $response['data'] = $data;
     } else {

--- a/scripts/build-operations-snapshot.php
+++ b/scripts/build-operations-snapshot.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Build Public API operations snapshot (GET /v1/operations).
+ *
+ * Aggregates pre-warmed status JSON under CACHE_BASE_DIR, parses recent app.log tail,
+ * and writes cache/operations_snapshot.json. Invoked by scheduler every
+ * OPERATIONS_SNAPSHOT_BUILD_INTERVAL_SECONDS (non-blocking).
+ *
+ * Usage: php scripts/build-operations-snapshot.php
+ */
+
+require_once __DIR__ . '/../lib/config.php';
+require_once __DIR__ . '/../lib/constants.php';
+require_once __DIR__ . '/../lib/logger.php';
+require_once __DIR__ . '/../lib/cache-paths.php';
+require_once __DIR__ . '/../lib/operations-snapshot.php';
+
+$config = loadConfig();
+if ($config === null) {
+    fwrite(STDERR, "build-operations-snapshot: loadConfig failed\n");
+    exit(1);
+}
+
+$payload = operations_snapshot_build(CACHE_BASE_DIR, [
+    'now' => time(),
+    'log_path' => defined('AVIATIONWX_LOG_FILE') ? AVIATIONWX_LOG_FILE : '',
+]);
+
+if (!operations_snapshot_write_envelope(CACHE_OPERATIONS_SNAPSHOT_FILE, $payload, OPERATIONS_SNAPSHOT_MAX_AGE_SECONDS)) {
+    aviationwx_log('warning', 'build-operations-snapshot: failed to write envelope', [
+        'path' => CACHE_OPERATIONS_SNAPSHOT_FILE,
+    ], 'app');
+    exit(1);
+}
+
+exit(0);

--- a/scripts/production-health-check.php
+++ b/scripts/production-health-check.php
@@ -255,6 +255,20 @@ $checks = [
         }
         return ['ok' => true, 'detail' => 'HTTP 200'];
     },
+    'api_v1_operations' => static function () use ($api, $timeout) {
+        $r = productionHealthCheckRequest($api . '/v1/operations', productionHealthCheckFormatHeaders(['Accept' => 'application/json']), $timeout);
+        if ($r['code'] === 429) {
+            return ['ok' => true, 'detail' => 'HTTP 429 (rate limit)'];
+        }
+        if ($r['code'] !== 200) {
+            return ['ok' => false, 'detail' => 'HTTP ' . $r['code']];
+        }
+        $json = json_decode($r['body'], true);
+        if (!is_array($json) || empty($json['success']) || !isset($json['operations']['snapshot_meta'])) {
+            return ['ok' => false, 'detail' => 'invalid operations JSON'];
+        }
+        return ['ok' => true, 'detail' => 'HTTP 200'];
+    },
     'api_v1_airports' => static function () use ($api, $timeout) {
         $r = productionHealthCheckRequest($api . '/v1/airports', productionHealthCheckFormatHeaders(['Accept' => 'application/json']), $timeout);
         if ($r['code'] === 429) {

--- a/scripts/scheduler.php
+++ b/scripts/scheduler.php
@@ -57,6 +57,7 @@ $lastCountryResolutionSchedulerCheck = 0;
 $countryResolutionSchedulerStartupEval = false;
 $lastCloudflareAnalyticsFetch = 0;
 $lastStatusPageCachesFetch = 0;
+$lastOperationsSnapshotBuild = 0;
 $runwaysFetchOnStartupDone = false;
 $config = null;
 $healthStatus = 'healthy';
@@ -732,6 +733,16 @@ while ($running) {
             }
             reapZombies();
             $lastStatusPageCachesFetch = $now;
+        }
+
+        // 11. Public API operations snapshot (every OPERATIONS_SNAPSHOT_BUILD_INTERVAL_SECONDS, non-blocking)
+        if (($now - $lastOperationsSnapshotBuild) >= OPERATIONS_SNAPSHOT_BUILD_INTERVAL_SECONDS) {
+            $opsScript = __DIR__ . '/build-operations-snapshot.php';
+            if (file_exists($opsScript)) {
+                exec('php ' . escapeshellarg($opsScript) . ' > /dev/null 2>&1 &');
+                reapZombies();
+            }
+            $lastOperationsSnapshotBuild = $now;
         }
 
         // PASV / DDNS: root cron runs /usr/local/libexec/aviationwx/maybe-run-update-pasv-address.sh (vsftpd needs root).

--- a/tests/Integration/PublicApiIntegrationTest.php
+++ b/tests/Integration/PublicApiIntegrationTest.php
@@ -166,6 +166,23 @@ class PublicApiIntegrationTest extends TestCase
     }
     
     /**
+     * GET /v1/operations returns operations snapshot envelope
+     */
+    public function testOperationsEndpoint_ReturnsSnapshot(): void
+    {
+        $this->skipIfApiDisabled();
+        
+        $response = $this->apiRequest('/operations');
+        
+        $this->assertEquals(200, $response['code']);
+        $this->assertNotNull($response['json']);
+        $this->assertTrue($response['json']['success']);
+        $this->assertArrayHasKey('operations', $response['json']);
+        $this->assertIsArray($response['json']['operations']);
+        $this->assertArrayHasKey('snapshot_meta', $response['json']['operations']);
+    }
+    
+    /**
      * Invalid airport should return 404
      */
     public function testGetAirport_NotFound(): void

--- a/tests/Unit/OperationsSnapshotTest.php
+++ b/tests/Unit/OperationsSnapshotTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers operations_snapshot_redact_scalar_string
+ * @covers operations_snapshot_scrub_context
+ * @covers operations_snapshot_aggregate_log_fingerprints
+ * @covers operations_snapshot_summarize_airport_health
+ * @covers operations_snapshot_weather_circuit_by_source
+ * @covers operations_snapshot_verbose_detail_warranted
+ * @covers operations_snapshot_apply_verbose_gate
+ * @covers operations_snapshot_build
+ * @covers operations_snapshot_write_envelope
+ * @covers operations_snapshot_read_envelope
+ * @covers operations_snapshot_get_api_payload
+ */
+class OperationsSnapshotTest extends TestCase
+{
+    public function testRedactScalarString_stripsQueryFromUrl(): void
+    {
+        $in = 'failed https://example.com/api?token=secret&x=1 end';
+        $out = operations_snapshot_redact_scalar_string($in);
+        $this->assertStringNotContainsString('token=secret', $out);
+        $this->assertStringContainsString('[redacted]', $out);
+    }
+
+    public function testScrubContext_redactsSensitiveKeys(): void
+    {
+        $ctx = [
+            'source' => 'web',
+            'api_key' => 'should-redact',
+            'nested' => ['password' => 'x'],
+        ];
+        $out = operations_snapshot_scrub_context($ctx);
+        $this->assertSame('web', $out['source']);
+        $this->assertSame('[redacted]', $out['api_key']);
+        $this->assertArrayNotHasKey('nested', $out);
+    }
+
+    public function testAggregateLogFingerprints_groupsByMessage(): void
+    {
+        $now = strtotime('2026-05-14T12:00:00Z');
+        $t1 = gmdate('c', $now - 120);
+        $t2 = gmdate('c', $now - 60);
+        $lines = implode("\n", [
+            json_encode(['ts' => $t1, 'level' => 'warning', 'message' => 'same msg', 'context' => ['source' => 'cli']]),
+            json_encode(['ts' => $t2, 'level' => 'warning', 'message' => 'same msg', 'context' => ['source' => 'cli']]),
+            json_encode(['ts' => $t2, 'level' => 'info', 'message' => 'ignored', 'context' => []]),
+        ]);
+        $agg = operations_snapshot_aggregate_log_fingerprints($lines, $now - 3600, 10);
+        $this->assertCount(1, $agg);
+        $this->assertSame(2, $agg[0]['count']);
+        $this->assertSame('warning|same msg', $agg[0]['fingerprint']);
+    }
+
+    public function testSummarizeAirportHealth_countsAndWorst(): void
+    {
+        $airports = [
+            [
+                'id' => 'KAAA',
+                'status' => 'operational',
+                'components' => [
+                    ['name' => 'Weather', 'status' => 'operational', 'message' => 'OK'],
+                ],
+            ],
+            [
+                'id' => 'KBBB',
+                'status' => 'degraded',
+                'components' => [
+                    ['name' => 'Weather', 'status' => 'degraded', 'message' => 'Stale'],
+                ],
+            ],
+        ];
+        $sum = operations_snapshot_summarize_airport_health($airports, 5);
+        $this->assertSame(1, $sum['counts']['operational']);
+        $this->assertSame(1, $sum['counts']['degraded']);
+        $this->assertCount(1, $sum['worst']);
+        $this->assertSame('KBBB', $sum['worst'][0]['id']);
+        $this->assertStringContainsString('Stale', $sum['worst'][0]['message']);
+    }
+
+    public function testWeatherCircuitBySource_sumsRecentBuckets(): void
+    {
+        $h = gmdate('Y-m-d-H');
+        $prev = gmdate('Y-m-d-H', time() - 3600);
+        $data = [
+            'hourly_buckets' => [
+                $prev => ['circuit_open_tempest' => 2, 'circuit_open_events' => 2],
+                $h => ['circuit_open_tempest' => 3, 'circuit_open_ambient' => 1, 'circuit_open_events' => 4],
+            ],
+        ];
+        $by = operations_snapshot_weather_circuit_by_source($data);
+        $this->assertSame(5, $by['tempest']);
+        $this->assertSame(1, $by['ambient']);
+    }
+
+    public function testVerboseDetailWarranted_whenWeatherDegraded(): void
+    {
+        $data = [
+            'uptime_layer' => ['system' => ['status' => 'operational'], 'public_api' => ['status' => 'operational']],
+            'data_plane' => [
+                'airport_summary' => ['counts' => ['degraded' => 0, 'down' => 0]],
+                'weather' => ['status' => 'degraded', 'message' => 'x', 'metrics' => []],
+                'variant' => ['status' => 'operational'],
+            ],
+            'details' => ['log_fingerprints' => []],
+        ];
+        $this->assertTrue(operations_snapshot_verbose_detail_warranted($data));
+    }
+
+    public function testVerboseDetailWarranted_falseWhenAllOperational(): void
+    {
+        $data = [
+            'uptime_layer' => ['system' => ['status' => 'operational'], 'public_api' => ['status' => 'operational']],
+            'data_plane' => [
+                'airport_summary' => ['counts' => ['degraded' => 0, 'down' => 0]],
+                'weather' => ['status' => 'operational', 'metrics' => ['circuit_open_events_last_hour' => 0]],
+                'variant' => ['status' => 'operational'],
+            ],
+            'details' => ['log_fingerprints' => []],
+        ];
+        $this->assertFalse(operations_snapshot_verbose_detail_warranted($data));
+    }
+
+    public function testVerboseDetailWarranted_emptyDataDoesNotError(): void
+    {
+        $this->assertFalse(operations_snapshot_verbose_detail_warranted([]));
+    }
+
+    public function testApplyVerboseGate_removesDetailsWhenNotVerbose(): void
+    {
+        $data = [
+            'details' => [
+                'log_fingerprints' => [['fingerprint' => 'a']],
+                'airport_worst' => [['id' => 'KZZZ']],
+                'weather_circuit_by_source' => ['tempest' => 1],
+            ],
+        ];
+        $out = operations_snapshot_apply_verbose_gate($data, false);
+        $this->assertArrayNotHasKey('log_fingerprints', $out['details']);
+        $this->assertArrayNotHasKey('airport_worst', $out['details']);
+        $this->assertArrayNotHasKey('weather_circuit_by_source', $out['details']);
+    }
+
+    public function testBuildAndWriteEnvelope_roundTrip(): void
+    {
+        $tmp = sys_get_temp_dir() . '/awx_ops_test_' . bin2hex(random_bytes(4));
+        $this->assertTrue(@mkdir($tmp, 0755, true));
+
+        try {
+            $sys = json_encode([
+                'cached_at' => time(),
+                'ttl' => 600,
+                'key' => 'x',
+                'data' => ['status' => 'operational', 'components' => []],
+            ], JSON_THROW_ON_ERROR);
+            file_put_contents($tmp . '/status_system_health.json', $sys);
+            file_put_contents($tmp . '/public_api_health.json', json_encode([
+                'cached_at' => time(),
+                'ttl' => 600,
+                'key' => 'x',
+                'data' => ['status' => 'operational', 'endpoints' => []],
+            ], JSON_THROW_ON_ERROR));
+            file_put_contents($tmp . '/status_airport_health.json', json_encode([
+                'cached_at' => time(),
+                'ttl' => 600,
+                'key' => 'x',
+                'data' => [],
+            ], JSON_THROW_ON_ERROR));
+            file_put_contents($tmp . '/weather_health.json', json_encode([
+                'health' => [
+                    'name' => 'Weather Data Fetching',
+                    'status' => 'operational',
+                    'message' => 'OK',
+                    'lastChanged' => time(),
+                    'metrics' => ['circuit_open_events_last_hour' => 0],
+                ],
+                'hourly_buckets' => [],
+            ], JSON_THROW_ON_ERROR));
+            file_put_contents($tmp . '/variant_health.json', json_encode([
+                'health' => [
+                    'name' => 'Webcam Variant Generation',
+                    'status' => 'operational',
+                    'message' => 'OK',
+                    'lastChanged' => time(),
+                    'metrics' => [],
+                ],
+            ], JSON_THROW_ON_ERROR));
+
+            $built = operations_snapshot_build($tmp, ['now' => time(), 'log_path' => '']);
+            $this->assertSame(OPERATIONS_SNAPSHOT_SCHEMA_VERSION, $built['snapshot_meta']['schema_version']);
+            $this->assertArrayHasKey('uptime_layer', $built);
+
+            $snap = $tmp . '/operations_snapshot.json';
+            $this->assertTrue(operations_snapshot_write_envelope($snap, $built, OPERATIONS_SNAPSHOT_MAX_AGE_SECONDS));
+            $env = operations_snapshot_read_envelope($snap);
+            $this->assertIsArray($env);
+            $this->assertArrayHasKey('data', $env);
+        } finally {
+            foreach (glob($tmp . '/*') ?: [] as $f) {
+                @unlink($f);
+            }
+            @rmdir($tmp);
+        }
+    }
+
+    public function testGetApiPayload_staleWhenOlderThanMaxAge(): void
+    {
+        $snap = sys_get_temp_dir() . '/awx_ops_api_' . bin2hex(random_bytes(4)) . '.json';
+        $inner = [
+            'snapshot_meta' => [
+                'schema_version' => OPERATIONS_SNAPSHOT_SCHEMA_VERSION,
+                'generated_at' => gmdate('c', time() - 4000),
+                'generated_at_unix' => time() - 4000,
+            ],
+            'uptime_layer' => ['system' => ['status' => 'operational'], 'public_api' => null],
+            'data_plane' => [
+                'airport_summary' => ['total' => 0, 'counts' => ['operational' => 0, 'degraded' => 0, 'down' => 0, 'maintenance' => 0, 'other' => 0]],
+                'weather' => ['status' => 'operational', 'message' => 'x', 'metrics' => []],
+                'variant' => ['status' => 'operational'],
+            ],
+            'capacity_layer' => [],
+            'edge_layer' => [],
+            'pipeline_meta' => [],
+            'details' => ['log_fingerprints' => [], 'airport_worst' => [], 'weather_circuit_by_source' => []],
+        ];
+        $payload = [
+            'cached_at' => time() - 4000,
+            'ttl' => OPERATIONS_SNAPSHOT_MAX_AGE_SECONDS,
+            'key' => 'operations_snapshot',
+            'data' => $inner,
+        ];
+        file_put_contents($snap, json_encode($payload, JSON_THROW_ON_ERROR));
+
+        $api = operations_snapshot_get_api_payload($snap);
+        $this->assertSame('stale', $api['operations']['snapshot_meta']['freshness']);
+        @unlink($snap);
+    }
+
+    public function testGetApiPayload_missingReturnsFreshnessMissing(): void
+    {
+        $api = operations_snapshot_get_api_payload(sys_get_temp_dir() . '/nonexistent_ops_snapshot.json');
+        $this->assertSame('missing', $api['operations']['snapshot_meta']['freshness']);
+    }
+}

--- a/tests/Unit/OperationsSnapshotTest.php
+++ b/tests/Unit/OperationsSnapshotTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
  * @covers operations_snapshot_apply_verbose_gate
  * @covers operations_snapshot_build
  * @covers operations_snapshot_write_envelope
- * @covers operations_snapshot_read_envelope
+ * @covers operations_snapshot_read_log_tail
  * @covers operations_snapshot_get_api_payload
  */
 class OperationsSnapshotTest extends TestCase
@@ -25,6 +25,23 @@ class OperationsSnapshotTest extends TestCase
         $out = operations_snapshot_redact_scalar_string($in);
         $this->assertStringNotContainsString('token=secret', $out);
         $this->assertStringContainsString('[redacted]', $out);
+    }
+
+    /**
+     * Regression: fseek returns 0 on success; a negated check treated success as failure and returned ''.
+     */
+    public function testReadLogTail_returnsTailWhenFileExceedsMaxBytes(): void
+    {
+        $path = sys_get_temp_dir() . '/awx_log_tail_' . bin2hex(random_bytes(4)) . '.log';
+        $suffix = 'TAIL_MARKER_UNIQUE_XYZ';
+        $content = str_repeat('P', 150) . "\n" . $suffix;
+        $this->assertNotFalse(file_put_contents($path, $content));
+        try {
+            $tail = operations_snapshot_read_log_tail($path, 40);
+            $this->assertStringContainsString($suffix, $tail);
+        } finally {
+            @unlink($path);
+        }
     }
 
     public function testScrubContext_redactsSensitiveKeys(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,6 +62,7 @@ require_once __DIR__ . '/../lib/cache-paths.php';
 @mkdir(CACHE_METRICS_SPILL_DIR, 0755, true);
 require_once __DIR__ . '/../lib/rate-limit.php';
 require_once __DIR__ . '/../lib/logger.php';
+require_once __DIR__ . '/../lib/operations-snapshot.php';
 require_once __DIR__ . '/../api/weather.php'; // api/weather.php now has a conditional to prevent endpoint execution
 require_once __DIR__ . '/../lib/seo.php'; // SEO utilities for testing
 
@@ -113,6 +114,7 @@ function cleanTestCache(): void {
         CACHE_PEAK_GUSTS_FILE,
         CACHE_TEMP_EXTREMES_FILE,
         CACHE_AIRPORT_COUNTRY_RESOLUTION_FILE,
+        CACHE_OPERATIONS_SNAPSHOT_FILE,
     ];
     
     // Patterns to clean (weather in CACHE_WEATHER_DIR, outage in CACHE_BASE_DIR)


### PR DESCRIPTION
## Summary

Adds `GET /v1/operations` to the versioned Public API. Responses come from a scheduler-written envelope at `cache/operations_snapshot.json`, built about every 10 minutes, with clients treating snapshots as usable for up to 30 minutes when the job stalls (`snapshot_meta.freshness` and `age_seconds`).

## What ships

- **`lib/operations-snapshot.php`**: Build logic (read pre-warmed status JSON, tail `app.log` for warning-plus JSONL, scrub context, aggregate fingerprints), verbose gating, API payload assembly with safe handling for partial or malformed on-disk data.
- **`scripts/build-operations-snapshot.php`**: CLI worker invoked by the scheduler.
- **`scripts/scheduler.php`**: Non-blocking exec every `OPERATIONS_SNAPSHOT_BUILD_INTERVAL_SECONDS` (600s).
- **`api/v1/operations.php`** and **router** wiring; **`sendPublicApiSuccess`** maps the `operations` key.
- **Constants / `CACHE_OPERATIONS_SNAPSHOT_FILE`** for path and TTL knobs.
- **Docs**: `docs/API.md`, `api/docs/index.php`, `api/docs/openapi.json`.
- **`scripts/production-health-check.php`**: Optional check for the new endpoint.
- **Tests**: `tests/Unit/OperationsSnapshotTest.php`, integration case when Public API is enabled, bootstrap load and cache cleanup for the new file.

## Deploy notes

After deploy, the scheduler loop picks up the new script automatically. Until the first successful build, the API returns `freshness: missing` with null layers (still HTTP 200 when Public API is enabled).

## Testing

- `make test-ci` was run successfully on the branch before this PR was opened.
- Unit tests cover scrubbing, log aggregation, build or write envelope, API payload stale and missing paths, and verbose gating including empty partial data.