### PR TITLE
NOTAM schedule, TFR directory map layer, and map-only notam-map API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,13 +224,14 @@ check-builtin-aviation-links: ## HEAD-probe built-in aviation HTTPS URLs (networ
 production-health-check: ## HTTPS probes against production (networked; same as daily workflow)
 	@php scripts/production-health-check.php
 
-test-unit: ## Run unit tests only (fast, no Docker needed)
+# Optional: PHPUNIT_ARGS='--filter NotamScheduleTest' (do not use `make test-unit -- --filter ...`; Make treats --filter as a target)
+test-unit: ## Run unit tests only (fast; optional PHPUNIT_ARGS for PHPUnit)
 	@echo "Running unit tests..."
-	@APP_ENV=testing vendor/bin/phpunit --testsuite Unit --testdox
+	@APP_ENV=testing vendor/bin/phpunit --testsuite Unit --testdox $(PHPUNIT_ARGS)
 
-test-integration: ## Run integration tests only
+test-integration: ## Run integration tests (optional PHPUNIT_ARGS for PHPUnit)
 	@echo "Running integration tests..."
-	@APP_ENV=testing vendor/bin/phpunit --testsuite Integration --testdox
+	@APP_ENV=testing vendor/bin/phpunit --testsuite Integration --testdox $(PHPUNIT_ARGS)
 
 # Live HTTPS to RainViewer, aviationweather.gov, OWM (if API key in the chosen config). Not part of test-ci.
 # Honors CONFIG_PATH from the environment or `make CONFIG_PATH=/path/to/airports.json`; defaults to config/airports.json.example.

--- a/api/notam-map.php
+++ b/api/notam-map.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Internal NOTAM TFR map layer API (airports directory map only).
+ *
+ * Serves a GeoJSON FeatureCollection built from per-airport NOTAM caches.
+ * Cache TTL matches {@see getNotamCacheTtlSeconds()} (same as per-airport NOTAM JSON).
+ * In production, access is limited to browser use from the airport map UI; see
+ * {@see notamMapLayerApiRequestIsAllowed()}.
+ */
+
+require_once __DIR__ . '/../lib/config.php';
+require_once __DIR__ . '/../lib/logger.php';
+require_once __DIR__ . '/../lib/constants.php';
+require_once __DIR__ . '/../lib/notam/map-api-access.php';
+require_once __DIR__ . '/../lib/notam/map-layer.php';
+
+ob_start();
+header('Content-Type: application/json; charset=UTF-8');
+
+if (!notamMapLayerApiRequestIsAllowed()) {
+    http_response_code(403);
+    aviationwx_log('warning', 'notam map layer api: request denied', [
+        'sec_fetch_site' => $_SERVER['HTTP_SEC_FETCH_SITE'] ?? '',
+        'referer' => isset($_SERVER['HTTP_REFERER']) ? substr((string)$_SERVER['HTTP_REFERER'], 0, 200) : '',
+    ], 'app');
+    echo json_encode([
+        'type' => 'FeatureCollection',
+        'features' => [],
+        'generated_at' => time(),
+        'cache_ttl_seconds' => getNotamCacheTtlSeconds(),
+        'error' => 'Forbidden',
+    ], JSON_UNESCAPED_SLASHES);
+    ob_end_flush();
+    exit;
+}
+
+try {
+    $payload = notamTfrMapLayerServeOrRebuild();
+    echo json_encode($payload, JSON_UNESCAPED_SLASHES);
+} catch (Throwable $e) {
+    ob_clean();
+    http_response_code(500);
+    aviationwx_log('error', 'notam map layer api: failure', [
+        'error' => $e->getMessage(),
+    ], 'app');
+    echo json_encode([
+        'type' => 'FeatureCollection',
+        'features' => [],
+        'generated_at' => time(),
+        'cache_ttl_seconds' => getNotamCacheTtlSeconds(),
+        'error' => 'Map layer unavailable',
+    ], JSON_UNESCAPED_SLASHES);
+}
+
+ob_end_flush();

--- a/api/notam.php
+++ b/api/notam.php
@@ -5,6 +5,7 @@
  * Serves NOTAM data to frontend with stale-while-revalidate caching.
  * Safety-critical: Re-validates NOTAM expiration at serve time and
  * implements failclosed when cache exceeds staleness threshold.
+ * JSON NOTAM entries may include schedule_source, effective_segments, and current/next restriction window times.
  */
 
 require_once __DIR__ . '/../lib/config.php';
@@ -13,6 +14,7 @@ require_once __DIR__ . '/../lib/constants.php';
 require_once __DIR__ . '/../lib/weather/utils.php';
 require_once __DIR__ . '/../lib/notam/fetcher.php';
 require_once __DIR__ . '/../lib/notam/filter.php';
+require_once __DIR__ . '/../lib/notam/schedule.php';
 
 // Start output buffering
 ob_start();
@@ -114,11 +116,13 @@ $formattedNotams = [];
 $timezone = getAirportTimezone($airportId, $airport);
 
 foreach ($notams as $notam) {
+    notamEnsureEffectiveSegments($notam);
     // Re-validate status at serve time using airport timezone (safety-critical)
     $currentStatus = revalidateNotamStatus($notam, $timezone);
     
-    // Filter out expired and future NOTAMs - only show active and upcoming_today
-    if ($currentStatus !== 'active' && $currentStatus !== 'upcoming_today') {
+    // Drop expired and unknown; retain active, scheduled gaps, and upcoming windows
+    $allowedStatuses = ['active', 'inactive_scheduled', 'upcoming_today', 'upcoming_future'];
+    if (!in_array($currentStatus, $allowedStatuses, true)) {
         continue;
     }
     
@@ -149,6 +153,62 @@ foreach ($notams as $notam) {
         }
     }
     
+    $effectiveSegmentsOut = [];
+    foreach ($notam['effective_segments'] ?? [] as $seg) {
+        $su = $seg['start_time_utc'] ?? '';
+        $eu = $seg['end_time_utc'] ?? '';
+        $sl = '';
+        $el = '';
+        if ($su !== '') {
+            try {
+                $dt = new DateTime($su, new DateTimeZone('UTC'));
+                $dt->setTimezone(new DateTimeZone($timezone));
+                $sl = $dt->format('Y-m-d H:i:s T');
+            } catch (Exception $e) {
+                $sl = $su;
+            }
+        }
+        if ($eu !== '') {
+            try {
+                $dt = new DateTime($eu, new DateTimeZone('UTC'));
+                $dt->setTimezone(new DateTimeZone($timezone));
+                $el = $dt->format('Y-m-d H:i:s T');
+            } catch (Exception $e) {
+                $el = $eu;
+            }
+        }
+        $effectiveSegmentsOut[] = [
+            'start_time_utc' => $su,
+            'end_time_utc' => $eu,
+            'start_time_local' => $sl,
+            'end_time_local' => $el,
+        ];
+    }
+    
+    $nowUnix = time();
+    $currentWindowEndUtc = notamCurrentRestrictionEndUtc($notam, $nowUnix);
+    $nextWindowStartUtc = notamNextRestrictionStartUtc($notam, $nowUnix);
+    $currentWindowEndLocal = '';
+    $nextWindowStartLocal = '';
+    if ($currentWindowEndUtc !== null && $currentWindowEndUtc !== '') {
+        try {
+            $dt = new DateTime($currentWindowEndUtc, new DateTimeZone('UTC'));
+            $dt->setTimezone(new DateTimeZone($timezone));
+            $currentWindowEndLocal = $dt->format('Y-m-d H:i:s T');
+        } catch (Exception $e) {
+            $currentWindowEndLocal = $currentWindowEndUtc;
+        }
+    }
+    if ($nextWindowStartUtc !== null && $nextWindowStartUtc !== '') {
+        try {
+            $dt = new DateTime($nextWindowStartUtc, new DateTimeZone('UTC'));
+            $dt->setTimezone(new DateTimeZone($timezone));
+            $nextWindowStartLocal = $dt->format('Y-m-d H:i:s T');
+        } catch (Exception $e) {
+            $nextWindowStartLocal = $nextWindowStartUtc;
+        }
+    }
+    
     // Build official NOTAM link
     $officialLink = '';
     $notamId = $notam['id'] ?? '';
@@ -165,7 +225,13 @@ foreach ($notams as $notam) {
         'start_time_local' => $startTimeLocal,
         'end_time_local' => $endTimeLocal,
         'message' => $notam['text'] ?? '',
-        'official_link' => $officialLink
+        'official_link' => $officialLink,
+        'schedule_source' => $notam['schedule_source'] ?? 'none',
+        'effective_segments' => $effectiveSegmentsOut,
+        'current_restriction_end_time_utc' => $currentWindowEndUtc,
+        'current_restriction_end_time_local' => $currentWindowEndLocal,
+        'next_restriction_start_time_utc' => $nextWindowStartUtc,
+        'next_restriction_start_time_local' => $nextWindowStartLocal,
     ];
 }
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -371,6 +371,18 @@ server {
         add_header X-Nginx-Cache $upstream_cache_status;
         add_header Cache-Control "public, max-age=3600, stale-while-revalidate=86400";
     }
+
+    # Internal NOTAM TFR map layer: block cross-site fetch at edge (PHP enforces full policy).
+    location = /api/notam-map.php {
+        if ($http_sec_fetch_site = "cross-site") {
+            return 403;
+        }
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
     
     # API Documentation
     location /api/docs/ {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,6 +185,8 @@ Part of the **Internal API** (see [API.md](API.md)): JSON for the web dashboard;
 - Formats times in airport local timezone
 - Includes official FAA NOTAM links
 
+**`api/notam-map.php`**: Internal GeoJSON for the **airports directory map** only (aggregated TFR layer). **Not** a general integration surface: production enforces browser-oriented access (`lib/notam/map-api-access.php`); nginx returns 403 when `Sec-Fetch-Site` is `cross-site` (`docker/nginx.conf`). Non-production and test mode stay open for local and CI.
+
 **`lib/notam/`**: NOTAM processing library
 - **`auth.php`**: NMS API OAuth authentication (bearer token with auto-refresh)
 - **`fetcher.php`**: Dual query strategy (location + geospatial)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -155,6 +155,7 @@ If using Cloudflare:
 5. Choose proxy status:
    - **DNS only (gray cloud)**: Direct connection - better for dynamic content
    - **Proxied (orange cloud)**: Cloudflare CDN - adds caching and DDoS protection
+6. **Optional:** For extra edge blocking on the internal TFR map layer, add a **Cloudflare WAF** custom rule: URI Path equals `/api/notam-map.php` and `Sec-Fetch-Site` equals `cross-site` (return 403). Origin PHP already enforces map-only access (`lib/notam/map-api-access.php`); production **nginx** matches the same `Sec-Fetch-Site` check (see `docker/nginx.conf`).
 
 ## SSL Certificates
 

--- a/lib/cache-paths.php
+++ b/lib/cache-paths.php
@@ -479,6 +479,15 @@ function getNotamCachePath(string $airportId): string {
 }
 
 /**
+ * Aggregated TFR GeoJSON for the airports directory map (internal use).
+ *
+ * @return string Full path to JSON cache file
+ */
+function getNotamTfrMapLayerCachePath(): string {
+    return CACHE_NOTAM_DIR . '/tfr-map-layer.json';
+}
+
+/**
  * Get path to NOTAM token cache file
  * 
  * @return string Full path to token cache file

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -191,6 +191,10 @@ if (!defined('NOTAM_GEO_RADIUS_DEFAULT')) {
 if (!defined('NOTAM_RATE_LIMIT_SECONDS')) {
     define('NOTAM_RATE_LIMIT_SECONDS', 1); // 1 request per second
 }
+// Banner: include upcoming_future NOTAMs whose first restriction window starts within this horizon
+if (!defined('NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS')) {
+    define('NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS', 48 * 3600); // 48 hours
+}
 
 // TFR (Temporary Flight Restriction) filtering constants
 // Used for determining if a TFR is relevant to an airport based on distance

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -11,6 +11,22 @@ require_once __DIR__ . '/../constants.php';
 require_once __DIR__ . '/auth.php';
 require_once __DIR__ . '/parser.php';
 require_once __DIR__ . '/filter.php';
+require_once __DIR__ . '/schedule.php';
+
+/**
+ * Decode NMS JSON; strips illegal ASCII control characters some payloads embed in strings.
+ *
+ * @param string $response Raw HTTP body
+ * @return array|null Decoded array or null on failure
+ */
+function notamDecodeNmsJsonResponse(string $response): ?array {
+    $clean = preg_replace('/[\x00-\x08\x0b\x0c\x0e-\x1f]/', '', $response);
+    $data = json_decode($clean, true);
+    if (!is_array($data)) {
+        return null;
+    }
+    return $data;
+}
 
 /**
  * Rate limit wait - ensures we don't exceed 1 request per second
@@ -74,8 +90,8 @@ function queryNotamsByLocation(string $location, float &$lastRequestTime): array
         return [];
     }
     
-    $data = json_decode($response, true);
-    if (!isset($data['data']['aixm']) || !is_array($data['data']['aixm'])) {
+    $data = notamDecodeNmsJsonResponse($response);
+    if ($data === null || !isset($data['data']['aixm']) || !is_array($data['data']['aixm'])) {
         return [];
     }
     
@@ -134,8 +150,8 @@ function queryNotamsByCoordinates(float $latitude, float $longitude, int $radius
         return [];
     }
     
-    $data = json_decode($response, true);
-    if (!isset($data['data']['aixm']) || !is_array($data['data']['aixm'])) {
+    $data = notamDecodeNmsJsonResponse($response);
+    if ($data === null || !isset($data['data']['aixm']) || !is_array($data['data']['aixm'])) {
         return [];
     }
     
@@ -145,22 +161,28 @@ function queryNotamsByCoordinates(float $latitude, float $longitude, int $radius
 /**
  * Deduplicate NOTAMs by ID
  * 
- * @param array $notams Array of parsed NOTAM data
- * @return array Deduplicated array
+ * Merges duplicate payloads (location + geo queries) so the richest NOTAM text survives
+ * for TFR parsing and EFFECTIVE window extraction.
+ * 
+ * @param array<int, array<string, mixed>> $notams Parsed NOTAM rows (same id may appear from location and geo queries)
+ * @return array<int, array<string, mixed>> Deduplicated rows merged by {@see mergeParsedNotamDuplicates()}
  */
 function deduplicateNotams(array $notams): array {
-    $seen = [];
-    $deduplicated = [];
+    $byId = [];
     
     foreach ($notams as $notam) {
         $id = $notam['id'] ?? '';
-        if (!empty($id) && !isset($seen[$id])) {
-            $seen[$id] = true;
-            $deduplicated[] = $notam;
+        if ($id === '') {
+            continue;
         }
+        if (!isset($byId[$id])) {
+            $byId[$id] = $notam;
+            continue;
+        }
+        $byId[$id] = mergeParsedNotamDuplicates($byId[$id], $notam);
     }
     
-    return $deduplicated;
+    return array_values($byId);
 }
 
 /**
@@ -170,9 +192,9 @@ function deduplicateNotams(array $notams): array {
  * 1. Location-based query (if ICAO/IATA available)
  * 2. Geospatial query (for TFRs and fallback for FAA identifiers)
  * 
- * @param string $airportId Airport ID
- * @param array $airport Airport configuration
- * @return array Filtered NOTAMs with status
+ * @param string $airportId Airport ID (e.g., 'khio')
+ * @param array<string, mixed> $airport Airport configuration
+ * @return array<int, array<string, mixed>> Filtered NOTAMs with notam_type and status
  */
 function fetchNotamsForAirport(string $airportId, array $airport): array {
     $lastRequestTime = 0.0;

--- a/lib/notam/filter.php
+++ b/lib/notam/filter.php
@@ -510,6 +510,107 @@ function parseTfrRadiusNm(string $text): ?float {
 }
 
 /**
+ * Extract a short vertical limit summary from TFR NOTAM body text (visual cue only).
+ *
+ * Matches common FAA phrasing. Output uses pilot-style wording (SFC, FL, ft, AGL, MSL).
+ * Not for navigation; official limits remain on the government NOTAM.
+ *
+ * @param string $text Full NOTAM text
+ * @return string|null Null when no supported altitude pattern is found
+ */
+function parseTfrVerticalLimitsSummary(string $text): ?string {
+    if ($text === '') {
+        return null;
+    }
+    $u = strtoupper($text);
+
+    $feetOk = static function (int $ft): bool {
+        return $ft >= 50 && $ft <= 80000;
+    };
+    $flOk = static function (int $fl): bool {
+        return $fl >= 10 && $fl <= 600;
+    };
+
+    // Prose: FROM THE SURFACE TO ... FEET (MEAN SEA LEVEL / MSL / AGL)
+    if (preg_match(
+        '/\bFROM\s+THE\s+SURFACE\s+TO\s+(?:AND\s+INCLUDING\s+)?(\d+)\s+FEET\s+'
+        . '(?:MEAN\s+SEA\s+LEVEL|MSL)\b/',
+        $u,
+        $m
+    )) {
+        $ft = (int)$m[1];
+        if ($feetOk($ft)) {
+            return 'SFC - ' . $ft . ' ft MSL';
+        }
+    }
+    if (preg_match(
+        '/\bFROM\s+THE\s+SURFACE\s+TO\s+(?:AND\s+INCLUDING\s+)?(\d+)\s+FEET\s+'
+        . '(?:ABOVE\s+GROUND\s+LEVEL|AGL)\b/',
+        $u,
+        $m
+    )) {
+        $ft = (int)$m[1];
+        if ($feetOk($ft)) {
+            return 'SFC - ' . $ft . ' ft AGL';
+        }
+    }
+    if (preg_match(
+        '/\bFROM\s+THE\s+SURFACE\s+TO\s+(?:AND\s+INCLUDING\s+)?(\d+)\s+FEET\b/',
+        $u,
+        $m
+    )) {
+        $ft = (int)$m[1];
+        if ($feetOk($ft)) {
+            return 'SFC - ' . $ft . ' ft';
+        }
+    }
+
+    // SFC TO FL180 / FROM THE SURFACE TO FL 180
+    if (preg_match(
+        '/\b(?:FROM\s+THE\s+SURFACE|SFC)\s+TO\s+(?:AND\s+INCLUDING\s+)?FL\s*(\d{2,3})\b/',
+        $u,
+        $m
+    )) {
+        $fl = (int)$m[1];
+        if ($flOk($fl)) {
+            return 'SFC - FL' . $fl;
+        }
+    }
+
+    if (preg_match('/\bSFC\s*-\s*FL\s*(\d{2,3})\b/', $u, $m)) {
+        $fl = (int)$m[1];
+        if ($flOk($fl)) {
+            return 'SFC - FL' . $fl;
+        }
+    }
+
+    if (preg_match('/\bFL\s*(\d{2,3})\s+(?:-|TO)\s+FL\s*(\d{2,3})\b/', $u, $m)) {
+        $a = (int)$m[1];
+        $b = (int)$m[2];
+        if ($flOk($a) && $flOk($b)) {
+            return 'FL' . $a . ' - FL' . $b;
+        }
+    }
+
+    // SFC-5000FT / SFC - 5000 FEET (FAA area line; feet assumed unless AGL/MSL present nearby)
+    if (preg_match('/\bSFC\s*-\s*(\d+)\s*(?:FT|FEET)\b/', $u, $m)) {
+        $ft = (int)$m[1];
+        if ($feetOk($ft)) {
+            return 'SFC - ' . $ft . ' ft';
+        }
+    }
+
+    if (preg_match('/\bSFC\s+TO\s+(\d+)\s+FEET\s+(AGL|MSL)\b/', $u, $m)) {
+        $ft = (int)$m[1];
+        if ($feetOk($ft)) {
+            return 'SFC - ' . $ft . ' ft ' . $m[2];
+        }
+    }
+
+    return null;
+}
+
+/**
  * Calculate haversine distance between two points in nautical miles
  * 
  * Uses the standard haversine formula with Earth radius constant from units.php

--- a/lib/notam/filter.php
+++ b/lib/notam/filter.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/../constants.php';
 require_once __DIR__ . '/../units.php';
 require_once __DIR__ . '/../airport-identifiers.php';
 require_once __DIR__ . '/../weather/utils.php';
+require_once __DIR__ . '/schedule.php';
 
 /** Epsilon for comparing decoded TFR vertices (degrees) */
 const TFR_VERTEX_EQUAL_EPSILON_DEG = 1.0e-6;
@@ -806,6 +807,128 @@ function isTfrRelevantToAirport(array $tfr, array $airport): bool {
 }
 
 /**
+ * Classify NOTAM display status using effective time windows when available.
+ *
+ * Uses {@see notamEnsureEffectiveSegments()} so older cache rows still classify correctly.
+ * When {@see parseFaaEffectiveUtcSegmentsFromText()} finds slices, "active" means inside a slice,
+ * not merely inside the wider GML envelope used by NMS for some TFRs.
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM row (mutated: segments ensured via {@see notamEnsureEffectiveSegments()})
+ * @param string $timezone IANA timezone for "today" boundaries
+ * @param int $nowUnix Current Unix timestamp (injectable for tests)
+ * @return string active|inactive_scheduled|upcoming_today|upcoming_future|expired|unknown
+ */
+function classifyNotamDisplayStatusAt(array &$notam, string $timezone, int $nowUnix): string {
+    notamEnsureEffectiveSegments($notam);
+    $segments = $notam['effective_segments'] ?? [];
+    if ($segments !== []) {
+        return classifyNotamStatusFromSegmentsAt($notam, $timezone, $nowUnix, $segments);
+    }
+    return classifyNotamEnvelopeOnlyStatusAt($notam, $timezone, $nowUnix);
+}
+
+/**
+ * Segment-based classification (FAA EFFECTIVE windows or envelope-as-single-segment).
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM (used only if segment timestamps are invalid)
+ * @param string $timezone IANA timezone
+ * @param int $nowUnix Current time
+ * @param array<int, array{start_time_utc: string, end_time_utc: string}> $segments Effective windows
+ * @return string Status code
+ */
+function classifyNotamStatusFromSegmentsAt(
+    array $notam,
+    string $timezone,
+    int $nowUnix,
+    array $segments
+): string {
+    $firstStart = PHP_INT_MAX;
+    $lastEnd = 0;
+    foreach ($segments as $seg) {
+        $s = strtotime($seg['start_time_utc'] ?? '');
+        $e = strtotime($seg['end_time_utc'] ?? '');
+        if ($s === false || $e === false || $s <= 0 || $e <= 0) {
+            continue;
+        }
+        $firstStart = min($firstStart, $s);
+        $lastEnd = max($lastEnd, $e);
+    }
+    if ($firstStart === PHP_INT_MAX || $lastEnd <= 0) {
+        return classifyNotamEnvelopeOnlyStatusAt($notam, $timezone, $nowUnix);
+    }
+    if ($nowUnix > $lastEnd) {
+        return 'expired';
+    }
+    foreach ($segments as $seg) {
+        $s = strtotime($seg['start_time_utc'] ?? '');
+        $e = strtotime($seg['end_time_utc'] ?? '');
+        if ($s === false || $e === false || $s <= 0 || $e <= 0) {
+            continue;
+        }
+        if ($nowUnix >= $s && $nowUnix <= $e) {
+            return 'active';
+        }
+    }
+    if ($nowUnix < $firstStart) {
+        return notamUpcomingBucketForStartAt($firstStart, $timezone, $nowUnix);
+    }
+    return 'inactive_scheduled';
+}
+
+/**
+ * Envelope-only classification (legacy NOTAMs, PERM, or prose without EFFECTIVE pairs).
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM (start_time_utc, end_time_utc)
+ * @param string $timezone IANA timezone
+ * @param int $nowUnix Current time
+ * @return string Status code
+ */
+function classifyNotamEnvelopeOnlyStatusAt(array $notam, string $timezone, int $nowUnix): string {
+    $startTimeRaw = !empty($notam['start_time_utc']) ? strtotime($notam['start_time_utc']) : false;
+    if ($startTimeRaw === false || $startTimeRaw === 0) {
+        return 'unknown';
+    }
+    $startTime = $startTimeRaw;
+    $endTimeRaw = !empty($notam['end_time_utc']) ? strtotime($notam['end_time_utc']) : false;
+    $endTime = ($endTimeRaw !== false && $endTimeRaw > 0) ? $endTimeRaw : null;
+    if ($endTime !== null && $nowUnix > $endTime) {
+        return 'expired';
+    }
+    if ($nowUnix >= $startTime) {
+        if ($endTime === null) {
+            return 'active';
+        }
+        return $nowUnix <= $endTime ? 'active' : 'expired';
+    }
+    return notamUpcomingBucketForStartAt($startTime, $timezone, $nowUnix);
+}
+
+/**
+ * Map a future start timestamp to upcoming_today vs upcoming_future using local midnight.
+ *
+ * @param int $startUnix Segment or envelope start (UTC)
+ * @param string $timezone IANA timezone
+ * @param int $nowUnix Current time
+ * @return string upcoming_today|upcoming_future
+ */
+function notamUpcomingBucketForStartAt(int $startUnix, string $timezone, int $nowUnix): string {
+    try {
+        $tz = new DateTimeZone($timezone);
+        $nowDt = new DateTimeImmutable('@' . $nowUnix);
+        $nowDt = $nowDt->setTimezone($tz);
+        $todayStart = (clone $nowDt)->setTime(0, 0, 0)->getTimestamp();
+        $todayEnd = (clone $nowDt)->setTime(23, 59, 59)->getTimestamp();
+    } catch (Exception $e) {
+        $todayStart = strtotime('today', $nowUnix);
+        $todayEnd = strtotime('tomorrow', $nowUnix) - 1;
+    }
+    if ($startUnix >= $todayStart && $startUnix <= $todayEnd) {
+        return 'upcoming_today';
+    }
+    return 'upcoming_future';
+}
+
+/**
  * Re-validate NOTAM status at serve time
  * 
  * NOTAMs may expire between cache time and serve time. This function
@@ -813,121 +936,51 @@ function isTfrRelevantToAirport(array $tfr, array $airport): bool {
  * are not displayed to pilots. Uses airport local timezone for "today"
  * calculation to maintain consistency with determineNotamStatus().
  * 
- * @param array $notam NOTAM data with 'start_time_utc', 'end_time_utc', and 'status'
+ * @param array<string, mixed> $notam Cached NOTAM row: start_time_utc, optional effective_segments, optional status
  * @param string $timezone Airport timezone (e.g., 'America/Denver'), defaults to UTC
- * @return string Updated status: 'active', 'upcoming_today', 'upcoming_future', 'expired', or original
+ * @return string When start_time_utc is valid: 'active', 'inactive_scheduled', 'upcoming_today', 'upcoming_future', or 'expired'. When start is missing or invalid: cached status or 'unknown'
  */
 function revalidateNotamStatus(array $notam, string $timezone = 'UTC'): string {
     $now = time();
-    
-    // Parse times - strtotime returns false on failure
     $startTimeRaw = !empty($notam['start_time_utc']) ? strtotime($notam['start_time_utc']) : false;
-    $endTimeRaw = !empty($notam['end_time_utc']) ? strtotime($notam['end_time_utc']) : false;
-    
     $startTime = ($startTimeRaw !== false && $startTimeRaw > 0) ? $startTimeRaw : null;
-    $endTime = ($endTimeRaw !== false && $endTimeRaw > 0) ? $endTimeRaw : null;
-    
-    // Check if expired (end time has passed)
-    if ($endTime !== null && $now > $endTime) {
-        return 'expired';
+    if ($startTime === null) {
+        return $notam['status'] ?? 'unknown';
     }
-    
-    // Check if active (started and not expired)
-    if ($startTime !== null && $now >= $startTime) {
-        return 'active';
-    }
-    
-    // Check if upcoming today (starts before end of today in airport's local timezone)
-    if ($startTime !== null) {
-        try {
-            $tz = new DateTimeZone($timezone);
-            $nowLocal = new DateTime('now', $tz);
-            $todayEndLocal = new DateTime('tomorrow', $tz);
-            $todayEndLocal->modify('-1 second');
-            $todayEndTimestamp = $todayEndLocal->getTimestamp();
-            
-            if ($startTime <= $todayEndTimestamp) {
-                return 'upcoming_today';
-            }
-        } catch (Exception $e) {
-            // Invalid timezone - fall back to server time
-            $todayEnd = strtotime('tomorrow') - 1;
-            if ($startTime <= $todayEnd) {
-                return 'upcoming_today';
-            }
-        }
-        return 'upcoming_future';
-    }
-    
-    // Preserve original status if we can't determine
-    return $notam['status'] ?? 'unknown';
+    return classifyNotamDisplayStatusAt($notam, $timezone, $now);
 }
 
 /**
- * Determine NOTAM status (active, upcoming_today, expired, upcoming_future)
- * 
+ * Determine NOTAM status (active, inactive_scheduled, upcoming_today, upcoming_future, expired, unknown)
+ *
  * Uses airport's local timezone to determine "today" for proper classification
  * of upcoming NOTAMs. Without airport context, falls back to UTC.
  * 
- * @param array $notam Parsed NOTAM data with 'start_time_utc' and 'end_time_utc'
- * @param array|null $airport Airport config for timezone (optional, defaults to UTC)
- * @return string One of: 'active', 'upcoming_today', 'upcoming_future', 'expired', 'unknown'
+ * @param array<string, mixed> $notam Parsed NOTAM: start_time_utc, end_time_utc, text; optional effective_segments after enrichment
+ * @param array<string, mixed>|null $airport Airport config for timezone (optional, defaults to UTC)
+ * @return string One of: 'active', 'inactive_scheduled', 'upcoming_today', 'upcoming_future', 'expired', 'unknown'
  */
 function determineNotamStatus(array $notam, ?array $airport = null): string {
-    $now = time();
-    
-    // Parse start time - strtotime returns false on failure
+    $timezone = $airport !== null ? getAirportTimezone($airport) : 'UTC';
     $startTimeRaw = !empty($notam['start_time_utc']) ? strtotime($notam['start_time_utc']) : false;
     if ($startTimeRaw === false || $startTimeRaw === 0) {
         return 'unknown';
     }
-    $startTime = $startTimeRaw;
-    
-    // Parse end time (null for permanent NOTAMs)
-    $endTimeRaw = !empty($notam['end_time_utc']) ? strtotime($notam['end_time_utc']) : false;
-    $endTime = ($endTimeRaw !== false && $endTimeRaw > 0) ? $endTimeRaw : null;
-    
-    // Expired
-    if ($endTime !== null && $now > $endTime) {
-        return 'expired';
-    }
-    
-    // Active
-    if ($now >= $startTime) {
-        return 'active';
-    }
-    
-    // Determine "today" boundaries using airport timezone
-    $timezone = $airport !== null ? getAirportTimezone($airport) : 'UTC';
-    try {
-        $tz = new DateTimeZone($timezone);
-        $nowDt = new DateTime('now', $tz);
-        $todayStart = (clone $nowDt)->setTime(0, 0, 0)->getTimestamp();
-        $todayEnd = (clone $nowDt)->setTime(23, 59, 59)->getTimestamp();
-    } catch (Exception $e) {
-        // Fallback to server time if timezone is invalid
-        $todayStart = strtotime('today');
-        $todayEnd = strtotime('tomorrow') - 1;
-    }
-    
-    // Upcoming today (starts later today in airport's local time)
-    if ($startTime >= $todayStart && $startTime <= $todayEnd) {
-        return 'upcoming_today';
-    }
-    
-    return 'upcoming_future';
+    return classifyNotamDisplayStatusAt($notam, $timezone, time());
 }
 
 /**
  * Filter NOTAMs for relevant closures and TFRs
- * 
+ *
  * Returns only NOTAMs that are:
  * - Relevant to this airport (location match or geographic proximity)
- * - Currently active or starting later today (in airport's local timezone)
- * 
- * @param array $notams Array of parsed NOTAM data
- * @param array $airport Airport configuration with timezone, coordinates, and identifiers
- * @return array Filtered NOTAMs with 'notam_type' and 'status' fields added
+ * - Banner-worthy status: active, inactive_scheduled (gap between EFFECTIVE windows),
+ *   upcoming_today, or upcoming_future within {@see NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS}
+ *   of the first restriction window
+ *
+ * @param array<int, array<string, mixed>> $notams Parsed NOTAM rows from {@see parseNotamXmlArray()}
+ * @param array<string, mixed> $airport Airport configuration with timezone, coordinates, and identifiers
+ * @return array<int, array<string, mixed>> Filtered NOTAMs with 'notam_type' and 'status' fields added
  */
 function filterRelevantNotams(array $notams, array $airport): array {
     $relevant = [];
@@ -938,7 +991,7 @@ function filterRelevantNotams(array $notams, array $airport): array {
         
         if ($isClosureNotam) {
             $status = determineNotamStatus($notam, $airport);
-            if ($status === 'active' || $status === 'upcoming_today') {
+            if (notamIsBannerRelevantStatus($status, $notam)) {
                 $notam['notam_type'] = 'aerodrome_closure';
                 $notam['status'] = $status;
                 $relevant[] = $notam;
@@ -946,7 +999,7 @@ function filterRelevantNotams(array $notams, array $airport): array {
         } elseif ($isTfrNotam) {
             if (isTfrRelevantToAirport($notam, $airport)) {
                 $status = determineNotamStatus($notam, $airport);
-                if ($status === 'active' || $status === 'upcoming_today') {
+                if (notamIsBannerRelevantStatus($status, $notam)) {
                     $notam['notam_type'] = 'tfr';
                     $notam['status'] = $status;
                     $relevant[] = $notam;
@@ -956,4 +1009,29 @@ function filterRelevantNotams(array $notams, array $airport): array {
     }
     
     return $relevant;
+}
+
+/**
+ * Whether a NOTAM status should be cached for the airport banner pipeline.
+ *
+ * Includes near-future {@see NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS} upcoming_future rows
+ * so pilots see advance warning before the first restriction window.
+ *
+ * @param string $status Status from {@see determineNotamStatus()}
+ * @param array<string, mixed> $notam Parsed NOTAM; upcoming_future horizon uses {@see notamFirstRestrictionStartUnix()}
+ * @return bool True when the NOTAM should be retained in cache for this airport
+ */
+function notamIsBannerRelevantStatus(string $status, array $notam): bool {
+    $now = time();
+    if (in_array($status, ['active', 'upcoming_today', 'inactive_scheduled'], true)) {
+        return true;
+    }
+    if ($status !== 'upcoming_future') {
+        return false;
+    }
+    $firstStart = notamFirstRestrictionStartUnix($notam);
+    if ($firstStart === null || $firstStart <= $now) {
+        return false;
+    }
+    return ($firstStart - $now) <= NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS;
 }

--- a/lib/notam/map-api-access.php
+++ b/lib/notam/map-api-access.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Access control for GET /api/notam-map.php (airports directory map only).
+ *
+ * Intended for browser use from the airport network map UI. Production rejects
+ * cross-site fetches, direct tab opens without trusted Referer, and unmarked
+ * scripted clients (no Sec-Fetch-Site). Non-production and test mode stay open
+ * for local Docker, PHPUnit, and curl debugging.
+ */
+
+require_once __DIR__ . '/../config.php';
+
+/**
+ * Hostnames that may serve GET /api/notam-map.php in production (airports map origin only).
+ *
+ * @param string $httpHost Raw HTTP Host header (may include port)
+ * @param string $baseDomain Lowercase base domain from {@see getBaseDomain()}
+ * @return bool True when Host is the airports directory site or local dev
+ */
+function notamMapLayerApiRequestHostIsAllowedForMapLayerJson(string $httpHost, string $baseDomain): bool {
+    $h = strtolower(preg_replace('/:\d+$/', '', $httpHost));
+    $base = strtolower($baseDomain);
+    if ($h === 'airports.' . $base) {
+        return true;
+    }
+    if ($h === $base || $h === 'www.' . $base) {
+        return true;
+    }
+    if ($h === 'localhost' || $h === '127.0.0.1' || $h === '[::1]') {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * True when Referer identifies the airport map page on an allowed host.
+ *
+ * @param string $refererRaw Raw HTTP Referer header
+ * @param string $baseDomain Lowercase base domain from {@see getBaseDomain()}
+ * @return bool True when Referer is a map page URL we trust
+ */
+function notamMapLayerApiRefererIsTrustedMapPage(string $refererRaw, string $baseDomain): bool {
+    if ($refererRaw === '') {
+        return false;
+    }
+    $parsed = parse_url($refererRaw);
+    if ($parsed === false || !isset($parsed['scheme'], $parsed['host'])) {
+        return false;
+    }
+    $scheme = strtolower((string)$parsed['scheme']);
+    if ($scheme !== 'http' && $scheme !== 'https') {
+        return false;
+    }
+    $host = strtolower(preg_replace('/:\d+$/', '', (string)$parsed['host']));
+    $path = isset($parsed['path']) && $parsed['path'] !== '' ? (string)$parsed['path'] : '/';
+    $base = strtolower($baseDomain);
+
+    if ($host === 'airports.' . $base) {
+        return true;
+    }
+    if (($host === $base || $host === 'www.' . $base) && str_starts_with($path, '/airports')) {
+        return true;
+    }
+    if (($host === 'localhost' || $host === '127.0.0.1' || $host === '[::1]') && str_starts_with($path, '/airports')) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Whether the current HTTP request may load the internal NOTAM map layer JSON.
+ *
+ * @return bool True when the request should receive GeoJSON; false for 403
+ */
+function notamMapLayerApiRequestIsAllowed(): bool {
+    if (isTestMode()) {
+        return true;
+    }
+    if (!isProduction()) {
+        return true;
+    }
+
+    $baseDomain = strtolower(getBaseDomain());
+    $requestHost = (string)($_SERVER['HTTP_HOST'] ?? '');
+    if (!notamMapLayerApiRequestHostIsAllowedForMapLayerJson($requestHost, $baseDomain)) {
+        return false;
+    }
+
+    $fetchSite = strtolower(trim((string)($_SERVER['HTTP_SEC_FETCH_SITE'] ?? '')));
+    if ($fetchSite === 'same-origin' || $fetchSite === 'same-site') {
+        return true;
+    }
+
+    $referer = (string)($_SERVER['HTTP_REFERER'] ?? '');
+
+    return notamMapLayerApiRefererIsTrustedMapPage($referer, $baseDomain);
+}

--- a/lib/notam/map-layer.php
+++ b/lib/notam/map-layer.php
@@ -1,0 +1,405 @@
+<?php
+/**
+ * Aggregated TFR GeoJSON for the airports directory map (internal API only).
+ *
+ * Rebuilds from per-airport NOTAM cache files using the same TTL as
+ * {@see getNotamCacheTtlSeconds()} so map geometry tracks NOTAM fetch cadence.
+ */
+
+require_once __DIR__ . '/../logger.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../constants.php';
+require_once __DIR__ . '/../cache-paths.php';
+require_once __DIR__ . '/../units.php';
+require_once __DIR__ . '/../weather/utils.php';
+require_once __DIR__ . '/filter.php';
+require_once __DIR__ . '/schedule.php';
+
+/** Segments on approximate circle rings (visual only, not for navigation). */
+const NOTAM_TFR_MAP_CIRCLE_SEGMENTS = 64;
+
+/**
+ * Build one closed GeoJSON outer ring [lon, lat] from decoded TFR vertices.
+ *
+ * @param array<int, array{lat: float, lon: float}> $vertices Ring vertices without repeated closing point
+ * @param bool $ringClosed True when the NOTAM defines a closed polygon
+ * @return array<int, array{0: float, 1: float}>|null Null when not drawable
+ */
+function notamTfrMapLayerGeoJsonRingFromVertices(array $vertices, bool $ringClosed): ?array {
+    if (!$ringClosed || count($vertices) < 3) {
+        return null;
+    }
+    $plane = tfrPolygonProjectVerticesToLocalPlaneNm($vertices);
+    if ($plane === null) {
+        return null;
+    }
+    $signed = tfrPolygonSignedDoubleAreaNm2($plane['xs'], $plane['ys']);
+    if (abs($signed) < TFR_POLYGON_MIN_ABS_DOUBLE_AREA_NM2) {
+        return null;
+    }
+    $ring = [];
+    foreach ($vertices as $v) {
+        $ring[] = [(float)$v['lon'], (float)$v['lat']];
+    }
+    $first = $ring[0];
+    $last = $ring[count($ring) - 1];
+    if (abs($first[0] - $last[0]) > 1e-9 || abs($first[1] - $last[1]) > 1e-9) {
+        $ring[] = [$first[0], $first[1]];
+    }
+    return $ring;
+}
+
+/**
+ * Approximate a NM circle as a closed GeoJSON ring (visual only).
+ *
+ * @param float $centerLat Center latitude (degrees)
+ * @param float $centerLon Center longitude (degrees)
+ * @param float $radiusNm Radius (NM)
+ * @return array<int, array{0: float, 1: float}>
+ */
+function notamTfrMapLayerGeoJsonRingFromCircle(float $centerLat, float $centerLon, float $radiusNm): array {
+    $n = NOTAM_TFR_MAP_CIRCLE_SEGMENTS;
+    $latScale = $radiusNm / 60.0;
+    $cosLat = cos(deg2rad($centerLat));
+    $lonScale = $latScale / max($cosLat, 0.02);
+    $ring = [];
+    for ($i = 0; $i < $n; $i++) {
+        $theta = (2 * M_PI * $i) / $n;
+        $ring[] = [
+            $centerLon + $lonScale * sin($theta),
+            $centerLat + $latScale * cos($theta),
+        ];
+    }
+    $ring[] = $ring[0];
+    return $ring;
+}
+
+/**
+ * Map segment-aware status to a simple EFB-style stroke bucket for the directory map.
+ *
+ * @param string $status From {@see classifyNotamDisplayStatusAt()}
+ * @return string 'active' or 'upcoming'
+ */
+function notamTfrMapLayerStyleBucket(string $status): string {
+    return $status === 'active' ? 'active' : 'upcoming';
+}
+
+/**
+ * Format one UTC instant for map tooltip copy (airport local clock, matches dashboard NOTAM phrasing).
+ *
+ * @param int $unixUtc Unix timestamp (UTC)
+ * @param string $timezone IANA timezone (e.g. America/Los_Angeles)
+ * @return string e.g. "6:00 PM PDT, May 15, 2026"
+ */
+function notamTfrMapLayerFormatLocalDateTimeForTooltip(int $unixUtc, string $timezone): string {
+    try {
+        $tz = new DateTimeZone($timezone);
+    } catch (Exception $e) {
+        $tz = new DateTimeZone('UTC');
+    }
+    $dt = (new DateTimeImmutable('@' . $unixUtc))->setTimezone($tz);
+
+    return $dt->format('g:i A T') . ', ' . $dt->format('M j, Y');
+}
+
+/**
+ * Resolve EFFECTIVE segments (or a single envelope window) for tooltip wording.
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM row (mutated by {@see notamEnsureEffectiveSegments()})
+ * @return array<int, array{start_time_utc: string, end_time_utc: string}>
+ */
+function notamTfrMapLayerResolveSegmentsForTooltip(array &$notam): array {
+    notamEnsureEffectiveSegments($notam);
+    $segs = $notam['effective_segments'] ?? null;
+    if (is_array($segs) && $segs !== []) {
+        return $segs;
+    }
+    $start = trim((string)($notam['start_time_utc'] ?? ''));
+    $endRaw = $notam['end_time_utc'] ?? null;
+    $end = is_string($endRaw) ? trim($endRaw) : '';
+    if ($start === '' || $end === '' || strtoupper($end) === 'PERM') {
+        return [];
+    }
+    $sTs = strtotime($start);
+    $eTs = strtotime($end);
+    if ($sTs === false || $eTs === false || $sTs <= 0 || $eTs <= 0 || $eTs < $sTs) {
+        return [];
+    }
+    $sIso = notamTimestampToIsoUtc($sTs);
+    $eIso = notamTimestampToIsoUtc($eTs);
+    if ($sIso === null || $eIso === null) {
+        return [];
+    }
+
+    return [['start_time_utc' => $sIso, 'end_time_utc' => $eIso]];
+}
+
+/**
+ * Human-readable schedule line for directory map tooltip and popup (not for navigation).
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM row
+ * @param string $status From {@see classifyNotamDisplayStatusAt()}
+ * @param string $timezone Airport IANA timezone
+ * @param int $nowUnix Current Unix time (UTC-based instants)
+ * @return string|null Null when schedule does not support the requested phrasing
+ */
+function notamTfrMapLayerTooltipStatusLine(array &$notam, string $status, string $timezone, int $nowUnix): ?string {
+    $segments = notamTfrMapLayerResolveSegmentsForTooltip($notam);
+    if ($segments === []) {
+        if ($status !== 'active') {
+            return null;
+        }
+        $endRaw = $notam['end_time_utc'] ?? '';
+        $endStr = is_string($endRaw) ? trim($endRaw) : '';
+        if ($endStr === '' || strtoupper($endStr) === 'PERM') {
+            return null;
+        }
+        $eTs = strtotime($endStr);
+        if ($eTs === false || $eTs <= 0 || $nowUnix > $eTs) {
+            return null;
+        }
+
+        return 'Active now until ' . notamTfrMapLayerFormatLocalDateTimeForTooltip($eTs, $timezone);
+    }
+
+    if ($status === 'active') {
+        foreach ($segments as $seg) {
+            $s = strtotime($seg['start_time_utc'] ?? '');
+            $e = strtotime($seg['end_time_utc'] ?? '');
+            if ($s === false || $e === false || $s <= 0 || $e <= 0) {
+                continue;
+            }
+            if ($nowUnix >= $s && $nowUnix <= $e) {
+                return 'Active now until ' . notamTfrMapLayerFormatLocalDateTimeForTooltip($e, $timezone);
+            }
+        }
+
+        return null;
+    }
+
+    if ($status === 'inactive_scheduled' || $status === 'upcoming_today' || $status === 'upcoming_future') {
+        foreach ($segments as $seg) {
+            $s = strtotime($seg['start_time_utc'] ?? '');
+            $e = strtotime($seg['end_time_utc'] ?? '');
+            if ($s === false || $e === false || $s <= 0 || $e <= 0) {
+                continue;
+            }
+            if ($nowUnix < $s) {
+                return 'Upcoming from ' . notamTfrMapLayerFormatLocalDateTimeForTooltip($s, $timezone)
+                    . ' to ' . notamTfrMapLayerFormatLocalDateTimeForTooltip($e, $timezone);
+            }
+        }
+
+        return null;
+    }
+
+    return null;
+}
+
+/**
+ * Build GeoJSON FeatureCollection payload from listed airport NOTAM caches.
+ *
+ * @param array<string, mixed> $config Full config from {@see loadConfig()}
+ * @return array{type: string, features: array<int, array<string, mixed>>, generated_at: int, cache_ttl_seconds: int}
+ */
+function notamTfrMapLayerBuildPayload(array $config): array {
+    $ttl = getNotamCacheTtlSeconds();
+    $features = [];
+    $seenIds = [];
+
+    $listed = getListedAirports($config);
+    foreach ($listed as $airportId => $airport) {
+        if (!is_array($airport) || !isAirportEnabled($airport)) {
+            continue;
+        }
+        if (!isset($airport['lat'], $airport['lon'])) {
+            continue;
+        }
+        $cachePath = getNotamCachePath((string)$airportId);
+        if (!is_readable($cachePath)) {
+            continue;
+        }
+        $raw = @file_get_contents($cachePath);
+        if ($raw === false || $raw === '') {
+            continue;
+        }
+        $cache = json_decode($raw, true);
+        if (!is_array($cache) || !isset($cache['notams']) || !is_array($cache['notams'])) {
+            continue;
+        }
+        $timezone = getAirportTimezone($airport);
+        $now = time();
+
+        foreach ($cache['notams'] as $notam) {
+            if (!is_array($notam)) {
+                continue;
+            }
+            if (!isTfr($notam)) {
+                continue;
+            }
+            $id = trim((string)($notam['id'] ?? ''));
+            if ($id === '') {
+                continue;
+            }
+            if (isset($seenIds[$id])) {
+                continue;
+            }
+
+            notamEnsureEffectiveSegments($notam);
+            $status = classifyNotamDisplayStatusAt($notam, $timezone, $now);
+            if ($status === 'expired' || $status === 'unknown') {
+                continue;
+            }
+
+            $text = (string)($notam['text'] ?? '');
+            $meta = parseTfrPolygonVerticesMeta($text);
+            $vertices = $meta['vertices'];
+            $ringClosed = $meta['ring_closed'];
+            $parsedRadius = parseTfrRadiusNm($text);
+            $polygonRing = null;
+            if ($ringClosed && count($vertices) >= 3) {
+                $polygonRing = notamTfrMapLayerGeoJsonRingFromVertices($vertices, true);
+            }
+
+            $geo = null;
+            if ($polygonRing === null) {
+                $geo = parseTfrGeographicRelevanceReference($text, $vertices, $parsedRadius);
+                if ($geo === null || $geo['radius_nm'] <= 0) {
+                    continue;
+                }
+            }
+
+            $seenIds[$id] = true;
+            $bucket = notamTfrMapLayerStyleBucket($status);
+            $official = 'https://notams.aim.faa.gov/notamSearch/search?notamNumber=' . rawurlencode($id);
+
+            $baseProps = [
+                'notam_id' => $id,
+                'airport_id' => (string)$airportId,
+                'status' => $status,
+                'map_layer_style' => $bucket,
+                'official_link' => $official,
+            ];
+            $statusLine = notamTfrMapLayerTooltipStatusLine($notam, $status, $timezone, $now);
+            if ($statusLine !== null && $statusLine !== '') {
+                $baseProps['status_line'] = $statusLine;
+            }
+            $verticalLimits = parseTfrVerticalLimitsSummary($text);
+            if ($verticalLimits !== null && $verticalLimits !== '') {
+                $baseProps['vertical_limits'] = $verticalLimits;
+            }
+
+            if ($polygonRing !== null) {
+                $baseProps['geometry_kind'] = 'polygon';
+                $features[] = [
+                    'type' => 'Feature',
+                    'id' => 'tfr-' . preg_replace('/[^A-Za-z0-9_-]+/', '-', $id),
+                    'geometry' => [
+                        'type' => 'Polygon',
+                        'coordinates' => [$polygonRing],
+                    ],
+                    'properties' => $baseProps,
+                ];
+                continue;
+            }
+
+            // Circle TFRs: Point + radius so the client can use L.circle (true circle in map projection).
+            $baseProps['geometry_kind'] = 'circle';
+            $baseProps['radius_nm'] = (float)$geo['radius_nm'];
+            $baseProps['radius_m'] = (float)$geo['radius_nm'] * METERS_PER_NAUTICAL_MILE;
+            $features[] = [
+                'type' => 'Feature',
+                'id' => 'tfr-' . preg_replace('/[^A-Za-z0-9_-]+/', '-', $id),
+                'geometry' => [
+                    'type' => 'Point',
+                    'coordinates' => [(float)$geo['lon'], (float)$geo['lat']],
+                ],
+                'properties' => $baseProps,
+            ];
+        }
+    }
+
+    return [
+        'type' => 'FeatureCollection',
+        'features' => $features,
+        'generated_at' => time(),
+        'cache_ttl_seconds' => $ttl,
+    ];
+}
+
+/**
+ * Write aggregated map layer JSON to disk (atomic replace when possible).
+ *
+ * @param array<string, mixed> $payload GeoJSON payload plus metadata
+ * @return bool True when the file was written
+ */
+function notamTfrMapLayerWriteCache(array $payload): bool {
+    $path = getNotamTfrMapLayerCachePath();
+    $dir = dirname($path);
+    if (!is_dir($dir)) {
+        if (!@mkdir($dir, 0755, true) && !is_dir($dir)) {
+            return false;
+        }
+    }
+    $json = json_encode($payload, JSON_UNESCAPED_SLASHES);
+    if ($json === false) {
+        return false;
+    }
+    $tmp = $path . '.tmp.' . bin2hex(random_bytes(4));
+    if (@file_put_contents($tmp, $json, LOCK_EX) === false) {
+        return false;
+    }
+    if (!@rename($tmp, $path)) {
+        $ok = @file_put_contents($path, $json, LOCK_EX) !== false;
+        @unlink($tmp);
+        return $ok;
+    }
+    return true;
+}
+
+/**
+ * Return cached GeoJSON if fresh; otherwise rebuild from NOTAM caches and write.
+ *
+ * @return array<string, mixed> GeoJSON FeatureCollection plus generated_at and cache_ttl_seconds
+ */
+function notamTfrMapLayerServeOrRebuild(): array {
+    $path = getNotamTfrMapLayerCachePath();
+    $ttl = getNotamCacheTtlSeconds();
+    if (is_readable($path)) {
+        $age = time() - (int)@filemtime($path);
+        if ($age >= 0 && $age < $ttl) {
+            $decoded = json_decode((string)@file_get_contents($path), true);
+            if (is_array($decoded) && ($decoded['type'] ?? '') === 'FeatureCollection'
+                && isset($decoded['features']) && is_array($decoded['features'])) {
+                return $decoded;
+            }
+        }
+    }
+
+    $config = loadConfig();
+    if ($config === null || !isset($config['airports'])) {
+        $empty = [
+            'type' => 'FeatureCollection',
+            'features' => [],
+            'generated_at' => time(),
+            'cache_ttl_seconds' => $ttl,
+        ];
+        notamTfrMapLayerWriteCache($empty);
+        return $empty;
+    }
+
+    $payload = notamTfrMapLayerBuildPayload($config);
+    if (!notamTfrMapLayerWriteCache($payload)) {
+        aviationwx_log('warning', 'notam map layer: failed to write cache', [
+            'path' => $path,
+            'feature_count' => count($payload['features'] ?? []),
+        ], 'app');
+    } else {
+        aviationwx_log('info', 'notam map layer: cache rebuilt', [
+            'feature_count' => count($payload['features'] ?? []),
+            'ttl_seconds' => $ttl,
+        ], 'app');
+    }
+
+    return $payload;
+}

--- a/lib/notam/parser.php
+++ b/lib/notam/parser.php
@@ -6,6 +6,7 @@
  */
 
 require_once __DIR__ . '/../logger.php';
+require_once __DIR__ . '/schedule.php';
 
 /**
  * Parse AIXM 5.1.1 XML NOTAM string
@@ -19,9 +20,10 @@ require_once __DIR__ . '/../logger.php';
  * - Start/end times (UTC)
  * - Airport name
  * - Classification
- * 
+ * - effective_segments and schedule_source from {@see enrichParsedNotamWithSchedule()} (FAA EFFECTIVE windows)
+ *
  * @param string $xmlString AIXM XML string
- * @return array|null Parsed NOTAM data or null on failure
+ * @return array<string, mixed>|null Parsed NOTAM data or null on failure
  */
 function parseNotamXml(string $xmlString): ?array {
     if (empty($xmlString)) {
@@ -87,7 +89,7 @@ function parseNotamXml(string $xmlString): ?array {
     // Extract classification
     $classification = (string)($xml->xpath('//fnse:classification')[0] ?? '');
     
-    return [
+    $result = [
         'id' => $notamId,
         'type' => $type,
         'location' => $finalLocation,
@@ -98,13 +100,15 @@ function parseNotamXml(string $xmlString): ?array {
         'airport_name' => $airportName,
         'classification' => $classification,
     ];
+    enrichParsedNotamWithSchedule($result);
+    return $result;
 }
 
 /**
  * Parse multiple AIXM XML NOTAM strings
  * 
- * @param array $xmlStrings Array of AIXM XML strings
- * @return array Array of parsed NOTAM data (null entries filtered out)
+ * @param array<int, string> $xmlStrings Array of AIXM XML strings
+ * @return array<int, array<string, mixed>> Parsed NOTAM rows (null entries filtered out)
  */
 function parseNotamXmlArray(array $xmlStrings): array {
     $parsed = [];

--- a/lib/notam/schedule.php
+++ b/lib/notam/schedule.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * NOTAM schedule helpers (FAA-style EFFECTIVE windows vs GML envelope times).
+ *
+ * NMS often exposes one gml:beginPosition / gml:endPosition pair for the whole NOTAM
+ * while the NOTAM body lists disjunct EFFECTIVE ... UTC UNTIL ... slices (see TFRs).
+ */
+
+require_once __DIR__ . '/../logger.php';
+
+/**
+ * Convert a FAA 10-digit UTC group (YYMMDDHHMM) to a Unix timestamp (UTC).
+ *
+ * @param string $digits Exactly 10 digits (YY MM DD HH MM in UTC)
+ * @return int|null Unix timestamp or null if invalid
+ */
+function faaTenDigitUtcGroupToTimestamp(string $digits): ?int {
+    if (strlen($digits) !== 10 || !ctype_digit($digits)) {
+        return null;
+    }
+    $yy = (int)substr($digits, 0, 2);
+    $year = 2000 + $yy;
+    $month = (int)substr($digits, 2, 2);
+    $day = (int)substr($digits, 4, 2);
+    $hour = (int)substr($digits, 6, 2);
+    $minute = (int)substr($digits, 8, 2);
+    if ($month < 1 || $month > 12 || $day < 1 || $day > 31 || $hour > 23 || $minute > 59) {
+        return null;
+    }
+    $ts = gmmktime($hour, $minute, 0, $month, $day, $year);
+    if ($ts === false) {
+        return null;
+    }
+    return $ts;
+}
+
+/**
+ * Format a Unix timestamp as ISO 8601 UTC with Z suffix.
+ *
+ * @param int $timestamp Unix timestamp (UTC)
+ * @return string|null ISO string or null on failure
+ */
+function notamTimestampToIsoUtc(int $timestamp): ?string {
+    $formatted = gmdate('Y-m-d\TH:i:s\Z', $timestamp);
+    return $formatted !== false ? $formatted : null;
+}
+
+/**
+ * Parse FAA-style EFFECTIVE pairs from NOTAM prose (10-digit UTC groups).
+ *
+ * Matches patterns such as: "2605151800 UTC UNTIL 2605152200 UTC" (real Hillsboro TFR text).
+ *
+ * @param string $text NOTAM body (case-insensitive match)
+ * @return array<int, array{start_time_utc: string, end_time_utc: string}> Sorted, merged overlaps
+ */
+function parseFaaEffectiveUtcSegmentsFromText(string $text): array {
+    if ($text === '') {
+        return [];
+    }
+    if (!preg_match_all('/(\d{10})\s*UTC\s*UNTIL\s*(\d{10})\s*UTC/i', $text, $matches, PREG_SET_ORDER)) {
+        return [];
+    }
+    $raw = [];
+    foreach ($matches as $row) {
+        $startTs = faaTenDigitUtcGroupToTimestamp($row[1]);
+        $endTs = faaTenDigitUtcGroupToTimestamp($row[2]);
+        if ($startTs === null || $endTs === null || $endTs < $startTs) {
+            continue;
+        }
+        $startIso = notamTimestampToIsoUtc($startTs);
+        $endIso = notamTimestampToIsoUtc($endTs);
+        if ($startIso === null || $endIso === null) {
+            continue;
+        }
+        $raw[] = ['start_time_utc' => $startIso, 'end_time_utc' => $endIso];
+    }
+    return notamNormalizeEffectiveSegments($raw);
+}
+
+/**
+ * Sort and merge overlapping or touching effective segments.
+ *
+ * @param array<int, array{start_time_utc: string, end_time_utc: string}> $segments Segments
+ * @return array<int, array{start_time_utc: string, end_time_utc: string}> Normalized segments
+ */
+function notamNormalizeEffectiveSegments(array $segments): array {
+    if ($segments === []) {
+        return [];
+    }
+    $parsed = [];
+    foreach ($segments as $seg) {
+        $s = strtotime($seg['start_time_utc'] ?? '');
+        $e = strtotime($seg['end_time_utc'] ?? '');
+        if ($s === false || $e === false || $s <= 0 || $e <= 0 || $e < $s) {
+            continue;
+        }
+        $parsed[] = ['s' => $s, 'e' => $e];
+    }
+    if ($parsed === []) {
+        return [];
+    }
+    usort($parsed, static function (array $a, array $b): int {
+        return $a['s'] <=> $b['s'];
+    });
+    $merged = [];
+    $cur = $parsed[0];
+    for ($i = 1, $n = count($parsed); $i < $n; $i++) {
+        $nxt = $parsed[$i];
+        if ($nxt['s'] <= $cur['e'] + 1) {
+            $cur['e'] = max($cur['e'], $nxt['e']);
+        } else {
+            $merged[] = $cur;
+            $cur = $nxt;
+        }
+    }
+    $merged[] = $cur;
+    $out = [];
+    foreach ($merged as $m) {
+        $sIso = notamTimestampToIsoUtc($m['s']);
+        $eIso = notamTimestampToIsoUtc($m['e']);
+        if ($sIso !== null && $eIso !== null) {
+            $out[] = ['start_time_utc' => $sIso, 'end_time_utc' => $eIso];
+        }
+    }
+    return $out;
+}
+
+/**
+ * Add effective_segments and schedule_source from NOTAM text and GML envelope fields.
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM row from {@see parseNotamXml()}; mutates effective_segments and schedule_source
+ * @return array<string, mixed> Same array reference for chaining
+ */
+function enrichParsedNotamWithSchedule(array &$notam): array {
+    $text = (string)($notam['text'] ?? '');
+    $segments = parseFaaEffectiveUtcSegmentsFromText($text);
+    if ($segments !== []) {
+        $notam['effective_segments'] = $segments;
+        $notam['schedule_source'] = 'text_effective';
+        return $notam;
+    }
+    $start = trim((string)($notam['start_time_utc'] ?? ''));
+    $endRaw = $notam['end_time_utc'] ?? null;
+    $end = is_string($endRaw) ? trim($endRaw) : '';
+    if ($start !== '' && $end !== '' && strtoupper($end) !== 'PERM') {
+        $sTs = strtotime($start);
+        $eTs = strtotime($end);
+        if ($sTs !== false && $eTs !== false && $sTs > 0 && $eTs > 0 && $eTs >= $sTs) {
+            $sIso = notamTimestampToIsoUtc($sTs);
+            $eIso = notamTimestampToIsoUtc($eTs);
+            if ($sIso !== null && $eIso !== null) {
+                $notam['effective_segments'] = [['start_time_utc' => $sIso, 'end_time_utc' => $eIso]];
+                $notam['schedule_source'] = 'envelope';
+                return $notam;
+            }
+        }
+    }
+    $notam['effective_segments'] = [];
+    $notam['schedule_source'] = 'none';
+    return $notam;
+}
+
+/**
+ * Ensure effective_segments exist (for older cache files predating schedule enrichment).
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM row (mutated in place)
+ * @return void
+ */
+function notamEnsureEffectiveSegments(array &$notam): void {
+    if (isset($notam['effective_segments']) && is_array($notam['effective_segments'])) {
+        return;
+    }
+    enrichParsedNotamWithSchedule($notam);
+}
+
+/**
+ * Merge two parsed NOTAM rows with the same id (richer text wins; envelope widened).
+ *
+ * @param array<string, mixed> $primary Primary row (typically longer text); keys id, text, start_time_utc, end_time_utc
+ * @param array<string, mixed> $secondary Secondary row with same shape
+ * @return array<string, mixed> Merged NOTAM
+ */
+function mergeParsedNotamDuplicates(array $primary, array $secondary): array {
+    $out = $primary;
+    $t1 = (string)($primary['text'] ?? '');
+    $t2 = (string)($secondary['text'] ?? '');
+    if (strlen($t2) > strlen($t1)) {
+        $out['text'] = $t2;
+    }
+    $pickEarlier = static function (string $a, string $b): string {
+        $ta = strtotime($a);
+        $tb = strtotime($b);
+        if ($ta === false || $ta <= 0) {
+            return $b;
+        }
+        if ($tb === false || $tb <= 0) {
+            return $a;
+        }
+        return $ta <= $tb ? $a : $b;
+    };
+    $pickLater = static function (string $a, string $b): string {
+        $ta = strtotime($a);
+        $tb = strtotime($b);
+        if ($ta === false || $ta <= 0) {
+            return $b;
+        }
+        if ($tb === false || $tb <= 0) {
+            return $a;
+        }
+        return $ta >= $tb ? $a : $b;
+    };
+    $s1 = trim((string)($primary['start_time_utc'] ?? ''));
+    $s2 = trim((string)($secondary['start_time_utc'] ?? ''));
+    if ($s1 !== '' && $s2 !== '') {
+        $out['start_time_utc'] = $pickEarlier($s1, $s2);
+    } elseif ($s2 !== '') {
+        $out['start_time_utc'] = $s2;
+    }
+    $e1 = isset($primary['end_time_utc']) && is_string($primary['end_time_utc'])
+        ? trim($primary['end_time_utc']) : '';
+    $e2 = isset($secondary['end_time_utc']) && is_string($secondary['end_time_utc'])
+        ? trim($secondary['end_time_utc']) : '';
+    if ($e1 !== '' && strtoupper($e1) !== 'PERM' && $e2 !== '' && strtoupper($e2) !== 'PERM') {
+        $out['end_time_utc'] = $pickLater($e1, $e2);
+    } elseif ($e2 !== '' && strtoupper($e2) !== 'PERM') {
+        $out['end_time_utc'] = $e2;
+    } elseif ($e1 !== '' && strtoupper($e1) !== 'PERM') {
+        $out['end_time_utc'] = $e1;
+    }
+    unset($out['effective_segments'], $out['schedule_source']);
+    enrichParsedNotamWithSchedule($out);
+    return $out;
+}
+
+/**
+ * Earliest restriction start as Unix time (UTC), from segments or envelope start.
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM (mutated by {@see notamEnsureEffectiveSegments()})
+ * @return int|null Unix timestamp or null
+ */
+function notamFirstRestrictionStartUnix(array &$notam): ?int {
+    notamEnsureEffectiveSegments($notam);
+    $segments = $notam['effective_segments'] ?? [];
+    $min = PHP_INT_MAX;
+    foreach ($segments as $seg) {
+        $t = strtotime($seg['start_time_utc'] ?? '');
+        if ($t !== false && $t > 0) {
+            $min = min($min, $t);
+        }
+    }
+    if ($min !== PHP_INT_MAX) {
+        return $min;
+    }
+    $s = strtotime(trim((string)($notam['start_time_utc'] ?? '')));
+    if ($s === false || $s <= 0) {
+        return null;
+    }
+    return $s;
+}
+
+/**
+ * End time (UTC ISO) of the restriction window containing $nowUnix, if any.
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM
+ * @param int $nowUnix Current time
+ * @return string|null ISO8601 Z or null
+ */
+function notamCurrentRestrictionEndUtc(array &$notam, int $nowUnix): ?string {
+    notamEnsureEffectiveSegments($notam);
+    foreach ($notam['effective_segments'] ?? [] as $seg) {
+        $s = strtotime($seg['start_time_utc'] ?? '');
+        $e = strtotime($seg['end_time_utc'] ?? '');
+        if ($s === false || $e === false || $s <= 0 || $e <= 0) {
+            continue;
+        }
+        if ($nowUnix >= $s && $nowUnix <= $e) {
+            return $seg['end_time_utc'];
+        }
+    }
+    return null;
+}
+
+/**
+ * Start time (UTC ISO) of the next restriction window strictly after $nowUnix.
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM
+ * @param int $nowUnix Current time
+ * @return string|null ISO8601 Z or null
+ */
+function notamNextRestrictionStartUtc(array &$notam, int $nowUnix): ?string {
+    notamEnsureEffectiveSegments($notam);
+    $bestTs = PHP_INT_MAX;
+    $bestIso = null;
+    foreach ($notam['effective_segments'] ?? [] as $seg) {
+        $s = strtotime($seg['start_time_utc'] ?? '');
+        if ($s === false || $s <= 0 || $s <= $nowUnix) {
+            continue;
+        }
+        if ($s < $bestTs) {
+            $bestTs = $s;
+            $bestIso = $seg['start_time_utc'];
+        }
+    }
+    return $bestIso;
+}

--- a/pages/airport.php
+++ b/pages/airport.php
@@ -7412,6 +7412,39 @@ function formatNotamTime(timeUtc, timeLocal) {
 }
 
 /**
+ * Format NOTAM end (or similar) as local time plus calendar date for the airport timezone.
+ * Prefers UTC ISO for correct instant when both API fields are present.
+ *
+ * @param {string} timeUtc ISO 8601 UTC
+ * @param {string} timeLocal Local time string from API (fallback)
+ * @return {string} e.g. "10:00 PM PDT, May 16, 2026"
+ */
+function formatNotamDateTimeForAirport(timeUtc, timeLocal) {
+    const timezone = (AIRPORT_DATA && AIRPORT_DATA.timezone) || DEFAULT_TIMEZONE;
+    const timeFormat = getTimeFormat();
+    if (!timeUtc && !timeLocal) {
+        return '';
+    }
+    const dt = timeUtc ? new Date(timeUtc) : new Date(timeLocal);
+    if (isNaN(dt.getTime())) {
+        return '';
+    }
+    const timePart = dt.toLocaleString('en-US', {
+        timeZone: timezone,
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: timeFormat === '12hr'
+    }) + ' ' + getTimezoneAbbreviation(dt, timezone);
+    const datePart = dt.toLocaleString('en-US', {
+        timeZone: timezone,
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+    });
+    return timePart + ', ' + datePart;
+}
+
+/**
  * Fetch NOTAM data and update banner
  */
 async function fetchAndUpdateNotamBanner() {
@@ -7476,12 +7509,7 @@ function updateNotamBanner(notams) {
 
 /**
  * Format NOTAM time range for display
- * 
- * @param {Object} notam NOTAM object
- * @param {boolean} isActive Whether the NOTAM is currently active
- * @return {string} Formatted time string
- */
-/**
+ *
  * @param {Object} notam NOTAM object from API
  * @param {string} mode 'active' | 'scheduled' | 'upcoming'
  * @return {string} Short human-readable time summary
@@ -7491,40 +7519,41 @@ function formatNotamTimeRange(notam, mode) {
         const curEndUtc = notam.current_restriction_end_time_utc;
         const curEndLoc = notam.current_restriction_end_time_local;
         if (curEndUtc || curEndLoc) {
-            return `restriction until ${formatNotamTime(curEndUtc, curEndLoc)}`;
+            const when = formatNotamDateTimeForAirport(curEndUtc, curEndLoc);
+            return when ? `Active until ${when}` : 'Active until further notice';
         }
-        const endTime = notam.end_time_utc
-            ? formatNotamTime(notam.end_time_utc, notam.end_time_local)
-            : null;
-        return endTime ? `until ${endTime}` : 'until further notice';
+        const whenEnv = notam.end_time_utc
+            ? formatNotamDateTimeForAirport(notam.end_time_utc, notam.end_time_local)
+            : '';
+        return whenEnv ? `Active until ${whenEnv}` : 'Active until further notice';
     }
     if (mode === 'scheduled') {
         const nxtUtc = notam.next_restriction_start_time_utc;
         const nxtLoc = notam.next_restriction_start_time_local;
         if (nxtUtc || nxtLoc) {
-            return `not active now - next window ${formatNotamTime(nxtUtc, nxtLoc)}`;
+            const when = formatNotamDateTimeForAirport(nxtUtc, nxtLoc);
+            return when ? `not active now - next window ${when}` : 'not active now - see NOTAM for schedule';
         }
         return 'not active now - see NOTAM for schedule';
     }
-    const startTime = formatNotamTime(notam.start_time_utc, notam.start_time_local);
-    const endTime = notam.end_time_utc
-        ? formatNotamTime(notam.end_time_utc, notam.end_time_local)
-        : null;
-    if (endTime) {
-        return `effective ${startTime} to ${endTime}`;
+    const startWhen = formatNotamDateTimeForAirport(notam.start_time_utc, notam.start_time_local);
+    const endWhen = notam.end_time_utc
+        ? formatNotamDateTimeForAirport(notam.end_time_utc, notam.end_time_local)
+        : '';
+    if (endWhen) {
+        return startWhen
+            ? `effective ${startWhen} to ${endWhen}`
+            : `effective through ${endWhen}`;
     }
-    return `effective ${startTime} until further notice`;
+    return startWhen
+        ? `effective ${startWhen} until further notice`
+        : 'effective see NOTAM for schedule';
 }
 
 /**
- * Create a single NOTAM line element
- * 
- * @param {Object} notam NOTAM object
- * @param {boolean} isActive Whether the NOTAM is currently active
- * @return {string} HTML string for the NOTAM line
- */
-/**
- * @param {Object} notam NOTAM object
+ * Create a single NOTAM line element.
+ *
+ * @param {Object} notam NOTAM object from API
  * @param {string} mode 'active' | 'scheduled' | 'upcoming'
  * @return {string} HTML fragment
  */

--- a/pages/airport.php
+++ b/pages/airport.php
@@ -7457,23 +7457,20 @@ function updateNotamBanner(notams) {
     const container = document.getElementById('notam-banner-container');
     if (!container) return;
     
-    // Filter for active and upcoming today
     const activeNotams = notams.filter(n => n.status === 'active');
-    const upcomingNotams = notams.filter(n => n.status === 'upcoming_today');
+    const scheduledNotams = notams.filter(n => n.status === 'inactive_scheduled');
+    const upcomingNotams = notams.filter(n => n.status === 'upcoming_today' || n.status === 'upcoming_future');
     
-    // Clear container
     container.innerHTML = '';
     
-    // Show active NOTAMs first (red banner)
     if (activeNotams.length > 0) {
-        const banner = createNotamBanner('active', activeNotams);
-        container.appendChild(banner);
+        container.appendChild(createNotamBanner('active', activeNotams));
     }
-    
-    // Show upcoming NOTAMs (orange banner)
+    if (scheduledNotams.length > 0) {
+        container.appendChild(createNotamBanner('scheduled', scheduledNotams));
+    }
     if (upcomingNotams.length > 0) {
-        const banner = createNotamBanner('upcoming', upcomingNotams);
-        container.appendChild(banner);
+        container.appendChild(createNotamBanner('upcoming', upcomingNotams));
     }
 }
 
@@ -7484,23 +7481,39 @@ function updateNotamBanner(notams) {
  * @param {boolean} isActive Whether the NOTAM is currently active
  * @return {string} Formatted time string
  */
-function formatNotamTimeRange(notam, isActive) {
+/**
+ * @param {Object} notam NOTAM object from API
+ * @param {string} mode 'active' | 'scheduled' | 'upcoming'
+ * @return {string} Short human-readable time summary
+ */
+function formatNotamTimeRange(notam, mode) {
+    if (mode === 'active') {
+        const curEndUtc = notam.current_restriction_end_time_utc;
+        const curEndLoc = notam.current_restriction_end_time_local;
+        if (curEndUtc || curEndLoc) {
+            return `restriction until ${formatNotamTime(curEndUtc, curEndLoc)}`;
+        }
+        const endTime = notam.end_time_utc
+            ? formatNotamTime(notam.end_time_utc, notam.end_time_local)
+            : null;
+        return endTime ? `until ${endTime}` : 'until further notice';
+    }
+    if (mode === 'scheduled') {
+        const nxtUtc = notam.next_restriction_start_time_utc;
+        const nxtLoc = notam.next_restriction_start_time_local;
+        if (nxtUtc || nxtLoc) {
+            return `not active now - next window ${formatNotamTime(nxtUtc, nxtLoc)}`;
+        }
+        return 'not active now - see NOTAM for schedule';
+    }
     const startTime = formatNotamTime(notam.start_time_utc, notam.start_time_local);
-    const endTime = notam.end_time_utc 
+    const endTime = notam.end_time_utc
         ? formatNotamTime(notam.end_time_utc, notam.end_time_local)
         : null;
-    
-    if (isActive) {
-        // Active: show "until X" or "until further notice"
-        return endTime ? `until ${endTime}` : 'until further notice';
-    } else {
-        // Upcoming: show "effective X to Y" or "effective X until further notice"
-        if (endTime) {
-            return `effective ${startTime} to ${endTime}`;
-        } else {
-            return `effective ${startTime} until further notice`;
-        }
+    if (endTime) {
+        return `effective ${startTime} to ${endTime}`;
     }
+    return `effective ${startTime} until further notice`;
 }
 
 /**
@@ -7510,11 +7523,23 @@ function formatNotamTimeRange(notam, isActive) {
  * @param {boolean} isActive Whether the NOTAM is currently active
  * @return {string} HTML string for the NOTAM line
  */
-function createNotamLine(notam, isActive) {
-    const icon = isActive ? '🚨' : '⚠️';
-    const statusText = isActive ? 'ACTIVE NOTAM' : 'UPCOMING NOTAM';
+/**
+ * @param {Object} notam NOTAM object
+ * @param {string} mode 'active' | 'scheduled' | 'upcoming'
+ * @return {string} HTML fragment
+ */
+function createNotamLine(notam, mode) {
+    let icon = '⚠️';
+    let statusText = 'UPCOMING NOTAM';
+    if (mode === 'active') {
+        icon = '🚨';
+        statusText = 'ACTIVE NOTAM';
+    } else if (mode === 'scheduled') {
+        icon = '⏸️';
+        statusText = 'SCHEDULED BREAK';
+    }
     const notamId = notam.id ? `[${escapeHtml(notam.id)}]` : '';
-    const timeRange = formatNotamTimeRange(notam, isActive);
+    const timeRange = formatNotamTimeRange(notam, mode);
     
     return `
         <div class="notam-line">
@@ -7530,7 +7555,7 @@ function createNotamLine(notam, isActive) {
 /**
  * Create NOTAM banner element
  * 
- * @param {string} type 'active' or 'upcoming'
+ * @param {string} type 'active', 'scheduled', or 'upcoming'
  * @param {Array} notams Array of NOTAM objects
  * @return {HTMLElement} Banner element
  */
@@ -7538,10 +7563,10 @@ function createNotamBanner(type, notams) {
     const banner = document.createElement('div');
     banner.className = `notam-banner-${type}`;
     
-    const isActive = type === 'active';
+    const mode = type === 'scheduled' ? 'scheduled' : (type === 'active' ? 'active' : 'upcoming');
     
     // Create a line for each NOTAM - no expand/collapse, just show all
-    const notamLines = notams.map(notam => createNotamLine(notam, isActive)).join('');
+    const notamLines = notams.map(notam => createNotamLine(notam, mode)).join('');
     
     banner.innerHTML = notamLines;
     

--- a/pages/airports.php
+++ b/pages/airports.php
@@ -6,6 +6,7 @@
 
 // Note: config.php is already loaded by index.php
 require_once __DIR__ . '/../lib/seo.php';
+require_once __DIR__ . '/../lib/config.php';
 require_once __DIR__ . '/../lib/cache-paths.php';
 require_once __DIR__ . '/../lib/weather/utils.php';
 require_once __DIR__ . '/../lib/pwa-help-screenshots.php';
@@ -111,6 +112,9 @@ foreach ($airports as $airportId => $airport) {
 }
 $airportsJson = json_encode($airportsForMap);
 
+// NOTAM TFR map layer refresh (matches per-airport NOTAM cache TTL)
+$notamMapLayerRefreshMs = max(60_000, (int)getNotamCacheTtlSeconds() * 1000);
+
 // Optional screenshots for Add to Home Screen help: public/images/pwa-add-to-home-screen-{android,ios}.{avif,webp,jpg}
 $pwaHelpImageDir = __DIR__ . '/../public/images';
 $pwaHelpScreenshotAndroid = getPwaHelpScreenshotSet($pwaHelpImageDir, 'pwa-add-to-home-screen-android');
@@ -203,6 +207,25 @@ $breadcrumbs = generateBreadcrumbSchema([
             height: calc(85vh - 60px);
             min-height: 500px;
             max-height: 1200px;
+        }
+
+        .leaflet-tooltip.notam-map-hover-tip {
+            background: rgba(255, 255, 255, 0.96);
+            color: #1a1a1a;
+            border: 1px solid rgba(0, 0, 0, 0.35);
+            border-radius: 6px;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+            font-size: 12px;
+            line-height: 1.35;
+            max-width: 260px;
+            padding: 6px 10px;
+        }
+
+        .tfr-map-popup-cta {
+            display: inline-block;
+            margin-top: 0.35rem;
+            font-weight: 600;
+            color: #0066cc;
         }
         
         .map-container {
@@ -1498,6 +1521,7 @@ $breadcrumbs = generateBreadcrumbSchema([
         // Configuration from PHP
         var openWeatherMapApiKey = <?= json_encode($openWeatherMapApiKey) ?>;
         var hasCloudLayer = <?= json_encode($hasCloudLayer) ?>;
+        var notamMapLayerRefreshMs = <?= (int)$notamMapLayerRefreshMs ?>;
         
         // Airport data from PHP
         var airports = <?= $airportsJson ?>;
@@ -1528,6 +1552,176 @@ $breadcrumbs = generateBreadcrumbSchema([
             maxZoom: 19,
             attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         }).addTo(map);
+
+        // TFR polygons (internal NOTAM map layer): bold stroke, very light fill (EFB-style cueing)
+        map.createPane('tfrMapPane');
+        map.getPane('tfrMapPane').style.zIndex = 450;
+        var tfrMapLayer = null;
+        var tfrMapRefreshTimer = null;
+
+        function styleTfrMapFeature(feature) {
+            var props = feature && feature.properties ? feature.properties : {};
+            var active = props.map_layer_style === 'active';
+            return {
+                color: active ? '#c62828' : '#c49000',
+                weight: 3,
+                opacity: 1,
+                fillColor: active ? '#c62828' : '#c49000',
+                fillOpacity: 0.18,
+                lineJoin: 'round',
+                lineCap: 'round'
+            };
+        }
+
+        function notamTfrMapStatusLineForFeature(p) {
+            p = p || {};
+            if (p.status_line) {
+                return String(p.status_line).replace(/</g, '&lt;');
+            }
+            return notamTfrMapStatusCaption(p.status);
+        }
+
+        function notamTfrMapStatusCaption(status) {
+            if (!status) {
+                return '';
+            }
+            switch (String(status)) {
+                case 'active':
+                    return 'Active now';
+                case 'inactive_scheduled':
+                    return 'Between active windows';
+                case 'upcoming_today':
+                    return 'Starting later today';
+                case 'upcoming_future':
+                    return 'Upcoming';
+                default:
+                    return String(status).replace(/_/g, ' ');
+            }
+        }
+
+        function notamTfrMapEscapeTipText(s) {
+            return String(s).replace(/</g, '&lt;');
+        }
+
+        /**
+         * Map-only title: GeoJSON layer includes TFR NOTAMs only.
+         */
+        function notamTfrMapLayerTitleHtml(p) {
+            p = p || {};
+            if (!p.notam_id) {
+                return '';
+            }
+            return '<strong>TFR - ' + notamTfrMapEscapeTipText(p.notam_id) + '</strong>';
+        }
+
+        function bindNotamMapHoverTooltip(feature, layer) {
+            var p = feature.properties || {};
+            var parts = [];
+            var titleHtml = notamTfrMapLayerTitleHtml(p);
+            if (titleHtml) {
+                parts.push(titleHtml);
+            }
+            var cap = notamTfrMapStatusLineForFeature(p);
+            if (cap) {
+                parts.push(cap);
+            }
+            if (p.vertical_limits) {
+                parts.push(notamTfrMapEscapeTipText(p.vertical_limits));
+            }
+            parts.push('<span style="opacity:0.85;font-size:11px;">Tap or click for briefing link</span>');
+            layer.bindTooltip(parts.join('<br>'), {
+                sticky: true,
+                direction: 'auto',
+                className: 'notam-map-hover-tip',
+                interactive: false
+            });
+        }
+
+        function onEachTfrFeature(feature, layer) {
+            var p = feature.properties || {};
+            bindNotamMapHoverTooltip(feature, layer);
+            var lines = [];
+            var titleLine = notamTfrMapLayerTitleHtml(p);
+            if (titleLine) {
+                lines.push('<div>' + titleLine + '</div>');
+            }
+            if (p.status) {
+                lines.push('<div>' + notamTfrMapStatusLineForFeature(p) + '</div>');
+            }
+            if (p.vertical_limits) {
+                lines.push('<div>' + notamTfrMapEscapeTipText(p.vertical_limits) + '</div>');
+            }
+            if (p.official_link) {
+                lines.push(
+                    '<div><a class="tfr-map-popup-cta" href="' + String(p.official_link).replace(/"/g, '&quot;') + '" target="_blank" rel="noopener">Details on FAA Notam Search</a></div>'
+                );
+            }
+            if (lines.length) {
+                layer.bindPopup('<div class="tfr-map-popup">' + lines.join('') + '</div>');
+            }
+        }
+
+        function pointToLayerNotamMap(feature, latlng) {
+            var p = feature.properties || {};
+            var gk = p.geometry_kind;
+            var radiusM = typeof p.radius_m === 'number' ? p.radius_m : null;
+            if (gk === 'circle' && radiusM !== null && radiusM > 0) {
+                var s = styleTfrMapFeature(feature);
+                return L.circle(latlng, {
+                    radius: radiusM,
+                    pane: 'tfrMapPane',
+                    color: s.color,
+                    weight: s.weight,
+                    opacity: s.opacity,
+                    fillColor: s.fillColor,
+                    fillOpacity: s.fillOpacity
+                });
+            }
+            return L.circleMarker(latlng, {
+                radius: 0,
+                opacity: 0,
+                fillOpacity: 0,
+                interactive: false,
+                pane: 'tfrMapPane'
+            });
+        }
+
+        function applyTfrMapGeoJson(data) {
+            if (!data || data.type !== 'FeatureCollection' || !Array.isArray(data.features)) {
+                return;
+            }
+            if (tfrMapLayer) {
+                map.removeLayer(tfrMapLayer);
+                tfrMapLayer = null;
+            }
+            tfrMapLayer = L.geoJSON(data, {
+                pane: 'tfrMapPane',
+                interactive: true,
+                pointToLayer: pointToLayerNotamMap,
+                style: styleTfrMapFeature,
+                onEachFeature: onEachTfrFeature
+            });
+            tfrMapLayer.addTo(map);
+        }
+
+        function loadTfrMapLayer() {
+            fetch('/api/notam-map.php')
+                .then(function(response) {
+                    if (!response.ok) {
+                        throw new Error('NOTAM map layer HTTP ' + response.status);
+                    }
+                    return response.json();
+                })
+                .then(applyTfrMapGeoJson)
+                .catch(function(err) {
+                    console.warn('TFR map layer:', err);
+                });
+        }
+
+        loadTfrMapLayer();
+        if (notamMapLayerRefreshMs > 0) {
+            tfrMapRefreshTimer = setInterval(loadTfrMapLayer, notamMapLayerRefreshMs);
+        }
         
         // Weather Radar Layer (RainViewer API)
         var radarLayer = null;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -298,6 +298,19 @@ body {
     border-left: 4px solid #ffaa00;
 }
 
+/* Between EFFECTIVE windows (still inside NOTAM envelope) - distinct from active/upcoming */
+.notam-banner-scheduled {
+    background-color: #5c6bc0;
+    color: white;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    box-sizing: border-box;
+    position: relative;
+    z-index: 1000;
+    border-left: 4px solid #3949ab;
+}
+
 /* Individual NOTAM line within banner */
 .notam-line {
     padding: 10px 20px;
@@ -2985,6 +2998,11 @@ body.night-mode .notam-banner-upcoming {
     background-color: #553300 !important;
 }
 
+body.night-mode .notam-banner-scheduled {
+    background-color: #1a237e !important;
+    border-color: #283593 !important;
+}
+
 /* Loading state */
 body.night-mode .loading {
     color: var(--night-text-dim) !important;
@@ -3471,6 +3489,11 @@ body.dark-mode .data-outage-banner-limited-availability {
 
 body.dark-mode .notam-banner-upcoming {
     background-color: #3a4000 !important;
+}
+
+body.dark-mode .notam-banner-scheduled {
+    background-color: #1a237e !important;
+    border-color: #283593 !important;
 }
 
 /* Loading state */

--- a/tests/Integration/AirportsDirectoryTest.php
+++ b/tests/Integration/AirportsDirectoryTest.php
@@ -82,6 +82,7 @@ class AirportsDirectoryTest extends TestCase
         
         $this->assertStringContainsString('id="map"', $output, 'Should have map container');
         $this->assertStringContainsString('leaflet', strtolower($output), 'Should load Leaflet.js');
+        $this->assertStringContainsString('/api/notam-map.php', $output, 'Should load internal TFR map layer API');
     }
     
     /**

--- a/tests/Unit/ConstantsTest.php
+++ b/tests/Unit/ConstantsTest.php
@@ -46,6 +46,7 @@ class ConstantsTest extends TestCase
             'DEFAULT_NOTAM_STALE_ERROR_SECONDS',
             'DEFAULT_NOTAM_STALE_FAILCLOSED_SECONDS',
             'STALE_WHILE_REVALIDATE_SECONDS',
+            'NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS',
         ];
         
         foreach ($requiredConstants as $const) {

--- a/tests/Unit/NginxEmbedVhostConfigTest.php
+++ b/tests/Unit/NginxEmbedVhostConfigTest.php
@@ -41,4 +41,18 @@ class NginxEmbedVhostConfigTest extends TestCase
             $errors !== [] ? implode('; ', $errors) : ''
         );
     }
+
+    /**
+     * Production nginx should block cross-site fetches to the internal map layer before PHP.
+     */
+    public function testMainSiteServerBlockIncludesNotamMapCrossSite403(): void
+    {
+        $path = self::nginxConfPath();
+        $content = file_get_contents($path);
+        $this->assertIsString($content);
+        $this->assertStringContainsString('location = /api/notam-map.php', $content);
+        $this->assertStringContainsString('$http_sec_fetch_site', $content);
+        $this->assertStringContainsString('cross-site', $content);
+        $this->assertStringContainsString('return 403', $content);
+    }
 }

--- a/tests/Unit/NotamApiTest.php
+++ b/tests/Unit/NotamApiTest.php
@@ -8,6 +8,7 @@
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../lib/notam/filter.php';
+require_once __DIR__ . '/../../lib/notam/schedule.php';
 require_once __DIR__ . '/../../lib/constants.php';
 
 class NotamApiTest extends TestCase {
@@ -154,6 +155,30 @@ class NotamApiTest extends TestCase {
         
         $status = revalidateNotamStatus($notam, 'America/Denver');
         $this->assertEquals('upcoming_future', $status);
+    }
+
+    /**
+     * Between EFFECTIVE windows the envelope can still read "active"; segments must win.
+     */
+    public function testRevalidateNotamStatus_InactiveScheduledGap() {
+        $anchor = time();
+        $segA = [
+            'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $anchor - 7200),
+            'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $anchor - 3600),
+        ];
+        $segB = [
+            'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $anchor + 3600),
+            'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $anchor + 7200),
+        ];
+        $notam = [
+            'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $anchor - 86400),
+            'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $anchor + 86400),
+            'effective_segments' => [$segA, $segB],
+            'status' => 'active',
+        ];
+
+        $status = revalidateNotamStatus($notam, 'UTC');
+        $this->assertEquals('inactive_scheduled', $status);
     }
     
     /**

--- a/tests/Unit/NotamFilterTest.php
+++ b/tests/Unit/NotamFilterTest.php
@@ -294,6 +294,45 @@ class NotamFilterTest extends TestCase {
         $this->assertNotNull($radiusNm);
         $this->assertEquals(2.5, $radiusNm);
     }
+
+    public function testParseTfrVerticalLimitsSummary_SfcDashFeet(): void {
+        $text = 'TEMPORARY FLIGHT RESTRICTIONS WI AN AREA DEFINED AS 450000N1220000W TO POINT OF ORIGIN SFC-5000FT';
+        $this->assertSame('SFC - 5000 ft', parseTfrVerticalLimitsSummary($text));
+    }
+
+    public function testParseTfrVerticalLimitsSummary_SfcDashFeetWithPeriod(): void {
+        $text = 'TO POINT OF ORIGIN SFC-7500FT.';
+        $this->assertSame('SFC - 7500 ft', parseTfrVerticalLimitsSummary($text));
+    }
+
+    public function testParseTfrVerticalLimitsSummary_FromSurfaceMsl(): void {
+        $text = 'PURSUANT TO 14 CFR SECTION 91.137 WI AN AREA DEFINED AS ... FROM THE SURFACE TO 3000 FEET MEAN SEA LEVEL';
+        $this->assertSame('SFC - 3000 ft MSL', parseTfrVerticalLimitsSummary($text));
+    }
+
+    public function testParseTfrVerticalLimitsSummary_FromSurfaceAgl(): void {
+        $text = 'FROM THE SURFACE TO 2500 FEET AGL';
+        $this->assertSame('SFC - 2500 ft AGL', parseTfrVerticalLimitsSummary($text));
+    }
+
+    public function testParseTfrVerticalLimitsSummary_SfcToFl(): void {
+        $text = 'SFC TO FL180';
+        $this->assertSame('SFC - FL180', parseTfrVerticalLimitsSummary($text));
+    }
+
+    public function testParseTfrVerticalLimitsSummary_FlRange(): void {
+        $text = 'RESTRICTION WI FL100 TO FL200';
+        $this->assertSame('FL100 - FL200', parseTfrVerticalLimitsSummary($text));
+    }
+
+    public function testParseTfrVerticalLimitsSummary_SfcToFeetWithQualifier(): void {
+        $text = 'AREA ... SFC TO 4000 FEET MSL';
+        $this->assertSame('SFC - 4000 ft MSL', parseTfrVerticalLimitsSummary($text));
+    }
+
+    public function testParseTfrVerticalLimitsSummary_NoMatch(): void {
+        $this->assertNull(parseTfrVerticalLimitsSummary('TEMPORARY FLIGHT RESTRICTIONS WITHIN 5NM'));
+    }
     
     /**
      * Test haversine distance calculation in nautical miles

--- a/tests/Unit/NotamMapApiAccessTest.php
+++ b/tests/Unit/NotamMapApiAccessTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Unit tests for internal NOTAM map layer API access control.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/notam/map-api-access.php';
+
+class NotamMapApiAccessTest extends TestCase {
+    public function testReferer_AirportsSubdomain(): void {
+        $this->assertTrue(
+            notamMapLayerApiRefererIsTrustedMapPage('https://airports.example.org/map', 'example.org')
+        );
+    }
+
+    public function testReferer_ApexPathAirports(): void {
+        $this->assertTrue(
+            notamMapLayerApiRefererIsTrustedMapPage('https://example.org/airports', 'example.org')
+        );
+    }
+
+    public function testReferer_LocalhostPathAirports(): void {
+        $this->assertTrue(
+            notamMapLayerApiRefererIsTrustedMapPage('http://localhost:8080/airports', 'example.org')
+        );
+    }
+
+    public function testReferer_RejectWrongPathOnApex(): void {
+        $this->assertFalse(
+            notamMapLayerApiRefererIsTrustedMapPage('https://example.org/', 'example.org')
+        );
+    }
+
+    public function testReferer_RejectExternalHost(): void {
+        $this->assertFalse(
+            notamMapLayerApiRefererIsTrustedMapPage('https://evil.example/airports', 'example.org')
+        );
+    }
+
+    public function testReferer_RejectEmpty(): void {
+        $this->assertFalse(notamMapLayerApiRefererIsTrustedMapPage('', 'example.org'));
+    }
+
+    public function testHost_AllowsAirportsSubdomain(): void {
+        $this->assertTrue(notamMapLayerApiRequestHostIsAllowedForMapLayerJson('airports.example.org', 'example.org'));
+    }
+
+    public function testHost_AllowsApexAndWww(): void {
+        $this->assertTrue(notamMapLayerApiRequestHostIsAllowedForMapLayerJson('example.org', 'example.org'));
+        $this->assertTrue(notamMapLayerApiRequestHostIsAllowedForMapLayerJson('www.example.org', 'example.org'));
+    }
+
+    public function testHost_AllowsLocalhost(): void {
+        $this->assertTrue(notamMapLayerApiRequestHostIsAllowedForMapLayerJson('localhost:8080', 'example.org'));
+    }
+
+    public function testHost_RejectsAirportDashboardSubdomain(): void {
+        $this->assertFalse(notamMapLayerApiRequestHostIsAllowedForMapLayerJson('kspb.example.org', 'example.org'));
+    }
+
+    public function testHost_RejectsEmbedSubdomain(): void {
+        $this->assertFalse(notamMapLayerApiRequestHostIsAllowedForMapLayerJson('embed.example.org', 'example.org'));
+    }
+}

--- a/tests/Unit/NotamMapLayerTest.php
+++ b/tests/Unit/NotamMapLayerTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * NOTAM TFR map layer (GeoJSON aggregation) unit tests.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/notam/map-layer.php';
+
+class NotamMapLayerTest extends TestCase {
+    public function testGeoJsonRingFromVertices_ClosedSquare(): void {
+        $vertices = [
+            ['lat' => 45.0, 'lon' => -122.0],
+            ['lat' => 45.0, 'lon' => -123.0],
+            ['lat' => 46.0, 'lon' => -123.0],
+            ['lat' => 46.0, 'lon' => -122.0],
+        ];
+        $ring = notamTfrMapLayerGeoJsonRingFromVertices($vertices, true);
+        $this->assertNotNull($ring);
+        $this->assertGreaterThanOrEqual(4, count($ring));
+        $first = $ring[0];
+        $last = $ring[count($ring) - 1];
+        $this->assertEqualsWithDelta($first[0], $last[0], 1e-9);
+        $this->assertEqualsWithDelta($first[1], $last[1], 1e-9);
+    }
+
+    public function testGeoJsonRingFromCircle_Closed(): void {
+        $ring = notamTfrMapLayerGeoJsonRingFromCircle(45.0, -122.0, 5.0);
+        $this->assertCount(NOTAM_TFR_MAP_CIRCLE_SEGMENTS + 1, $ring);
+        $this->assertEqualsWithDelta($ring[0][0], $ring[count($ring) - 1][0], 1e-9);
+        $this->assertEqualsWithDelta($ring[0][1], $ring[count($ring) - 1][1], 1e-9);
+    }
+
+    public function testMapLayerStyleBucket(): void {
+        $this->assertSame('active', notamTfrMapLayerStyleBucket('active'));
+        $this->assertSame('upcoming', notamTfrMapLayerStyleBucket('inactive_scheduled'));
+        $this->assertSame('upcoming', notamTfrMapLayerStyleBucket('upcoming_today'));
+    }
+
+    public function testTooltipStatusLine_ActiveUntilSegmentEnd(): void {
+        $notam = [
+            'id' => 'T1',
+            'text' => '',
+            'effective_segments' => [
+                ['start_time_utc' => '2026-05-15T18:00:00Z', 'end_time_utc' => '2026-05-15T22:00:00Z'],
+            ],
+        ];
+        $now = strtotime('2026-05-15T20:00:00Z');
+        $line = notamTfrMapLayerTooltipStatusLine($notam, 'active', 'UTC', $now);
+        $this->assertNotNull($line);
+        $this->assertStringStartsWith('Active now until', $line);
+        $this->assertStringContainsString('10:00 PM', $line);
+        $this->assertStringContainsString('May 15, 2026', $line);
+    }
+
+    public function testTooltipStatusLine_UpcomingFirstWindow(): void {
+        $notam = [
+            'id' => 'T1',
+            'text' => '',
+            'effective_segments' => [
+                ['start_time_utc' => '2026-05-15T18:00:00Z', 'end_time_utc' => '2026-05-15T22:00:00Z'],
+            ],
+        ];
+        $now = strtotime('2026-05-15T10:00:00Z');
+        $line = notamTfrMapLayerTooltipStatusLine($notam, 'upcoming_future', 'UTC', $now);
+        $this->assertNotNull($line);
+        $this->assertStringStartsWith('Upcoming from', $line);
+        $this->assertStringContainsString(' to ', $line);
+    }
+
+    public function testTooltipStatusLine_InactiveScheduledNextWindow(): void {
+        $notam = [
+            'id' => 'T1',
+            'text' => '',
+            'effective_segments' => [
+                ['start_time_utc' => '2026-05-15T18:00:00Z', 'end_time_utc' => '2026-05-15T20:00:00Z'],
+                ['start_time_utc' => '2026-05-15T22:00:00Z', 'end_time_utc' => '2026-05-16T02:00:00Z'],
+            ],
+        ];
+        $now = strtotime('2026-05-15T21:00:00Z');
+        $line = notamTfrMapLayerTooltipStatusLine($notam, 'inactive_scheduled', 'UTC', $now);
+        $this->assertNotNull($line);
+        $this->assertStringStartsWith('Upcoming from', $line);
+        $this->assertStringContainsString('10:00 PM', $line);
+    }
+
+    public function testTooltipStatusLine_EnvelopeOnlyActive(): void {
+        $notam = [
+            'id' => 'T2',
+            'text' => '',
+            'start_time_utc' => '2026-05-15T12:00:00Z',
+            'end_time_utc' => '2026-05-15T23:59:59Z',
+        ];
+        $now = strtotime('2026-05-15T15:00:00Z');
+        $line = notamTfrMapLayerTooltipStatusLine($notam, 'active', 'UTC', $now);
+        $this->assertNotNull($line);
+        $this->assertStringStartsWith('Active now until', $line);
+    }
+}

--- a/tests/Unit/NotamScheduleTest.php
+++ b/tests/Unit/NotamScheduleTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * NOTAM schedule parsing and segment-based status (FAA EFFECTIVE ... UTC UNTIL ... text).
+ *
+ * Examples mirror FAA prose (10-digit UTC groups); times are built relative to a fixed anchor
+ * so tests stay deterministic.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/notam/schedule.php';
+require_once __DIR__ . '/../../lib/notam/filter.php';
+require_once __DIR__ . '/../../lib/constants.php';
+
+class NotamScheduleTest extends TestCase {
+    /**
+     * FAA-style YYMMDDHHMM from a UTC Unix instant.
+     *
+     * @param int $unix UTC Unix timestamp
+     * @return string Ten-digit group
+     */
+    private function faaTenDigitFromUnix(int $unix): string {
+        return gmdate('ymdHi', $unix);
+    }
+
+    /**
+     * @param int $startUnix UTC start
+     * @param int $endUnix UTC end
+     * @return array{start_time_utc: string, end_time_utc: string}
+     */
+    private function segmentFromUnix(int $startUnix, int $endUnix): array {
+        $s = notamTimestampToIsoUtc($startUnix);
+        $e = notamTimestampToIsoUtc($endUnix);
+        $this->assertNotNull($s);
+        $this->assertNotNull($e);
+        return ['start_time_utc' => $s, 'end_time_utc' => $e];
+    }
+
+    public function testFaaTenDigitUtcGroupToTimestamp_RejectsNonDigit(): void {
+        $this->assertNull(faaTenDigitUtcGroupToTimestamp('260515180a'));
+        $this->assertNull(faaTenDigitUtcGroupToTimestamp('123456789'));
+    }
+
+    public function testParseFaaEffectiveUtcSegmentsFromText_RealisticTfrProse(): void {
+        // Anchor: 2026-05-15 12:00 UTC (matches user session date); two disjunct windows like Hillsboro TFR lists.
+        $anchor = gmmktime(12, 0, 0, 5, 15, 2026);
+        $w1a = $anchor - 7200;
+        $w1b = $anchor - 3600;
+        $w2a = $anchor + 3600;
+        $w2b = $anchor + 7200;
+        $g1a = $this->faaTenDigitFromUnix($w1a);
+        $g1b = $this->faaTenDigitFromUnix($w1b);
+        $g2a = $this->faaTenDigitFromUnix($w2a);
+        $g2b = $this->faaTenDigitFromUnix($w2b);
+        $text = 'TEMPORARY FLIGHT RESTRICTIONS. KHIO AREA. '
+            . "EFFECTIVE {$g1a} UTC UNTIL {$g1b} UTC AND {$g2a} UTC UNTIL {$g2b} UTC "
+            . 'SEE FDC 6/9458 FOR FULL TEXT.';
+        $segs = parseFaaEffectiveUtcSegmentsFromText($text);
+        $this->assertCount(2, $segs);
+        $this->assertEquals($this->segmentFromUnix($w1a, $w1b), $segs[0]);
+        $this->assertEquals($this->segmentFromUnix($w2a, $w2b), $segs[1]);
+    }
+
+    public function testNotamNormalizeEffectiveSegments_MergesOverlapping(): void {
+        $anchor = gmmktime(0, 0, 0, 6, 1, 2026);
+        $a = $this->segmentFromUnix($anchor, $anchor + 3600);
+        $b = $this->segmentFromUnix($anchor + 1800, $anchor + 5400);
+        $out = notamNormalizeEffectiveSegments([$a, $b]);
+        $this->assertCount(1, $out);
+        $this->assertEquals($this->segmentFromUnix($anchor, $anchor + 5400), $out[0]);
+    }
+
+    public function testEnrichParsedNotamWithSchedule_TextWinsOverEnvelope(): void {
+        $anchor = gmmktime(10, 0, 0, 7, 4, 2026);
+        $ga = $this->faaTenDigitFromUnix($anchor);
+        $gb = $this->faaTenDigitFromUnix($anchor + 3600);
+        $notam = [
+            'text' => "EFFECTIVE {$ga} UTC UNTIL {$gb} UTC",
+            'start_time_utc' => notamTimestampToIsoUtc($anchor - 86400),
+            'end_time_utc' => notamTimestampToIsoUtc($anchor + 86400 * 2),
+        ];
+        enrichParsedNotamWithSchedule($notam);
+        $this->assertSame('text_effective', $notam['schedule_source']);
+        $this->assertCount(1, $notam['effective_segments']);
+    }
+
+    public function testEnrichParsedNotamWithSchedule_EnvelopeWhenNoTextPairs(): void {
+        $s = gmmktime(8, 0, 0, 8, 1, 2026);
+        $e = gmmktime(20, 0, 0, 8, 1, 2026);
+        $notam = [
+            'text' => 'RWY 09/27 CLSD',
+            'start_time_utc' => notamTimestampToIsoUtc($s),
+            'end_time_utc' => notamTimestampToIsoUtc($e),
+        ];
+        enrichParsedNotamWithSchedule($notam);
+        $this->assertSame('envelope', $notam['schedule_source']);
+        $this->assertCount(1, $notam['effective_segments']);
+    }
+
+    public function testClassifyNotamDisplayStatusAt_InGapBetweenWindows(): void {
+        $anchor = gmmktime(12, 0, 0, 9, 10, 2026);
+        $segA = $this->segmentFromUnix($anchor - 7200, $anchor - 3600);
+        $segB = $this->segmentFromUnix($anchor + 3600, $anchor + 7200);
+        $notam = [
+            'start_time_utc' => notamTimestampToIsoUtc($anchor - 86400),
+            'end_time_utc' => notamTimestampToIsoUtc($anchor + 86400),
+            'text' => '',
+            'effective_segments' => [$segA, $segB],
+        ];
+        $this->assertSame(
+            'inactive_scheduled',
+            classifyNotamDisplayStatusAt($notam, 'UTC', $anchor)
+        );
+    }
+
+    public function testClassifyNotamDisplayStatusAt_ActiveInsideSecondWindow(): void {
+        $anchor = gmmktime(12, 0, 0, 10, 1, 2026);
+        $segA = $this->segmentFromUnix($anchor - 7200, $anchor - 3600);
+        $segB = $this->segmentFromUnix($anchor + 3600, $anchor + 7200);
+        $now = $anchor + 5400;
+        $notam = [
+            'start_time_utc' => notamTimestampToIsoUtc($anchor - 86400),
+            'end_time_utc' => notamTimestampToIsoUtc($anchor + 86400 * 2),
+            'text' => '',
+            'effective_segments' => [$segA, $segB],
+        ];
+        $this->assertSame('active', classifyNotamDisplayStatusAt($notam, 'UTC', $now));
+        $this->assertEquals(
+            $segB['end_time_utc'],
+            notamCurrentRestrictionEndUtc($notam, $now)
+        );
+        $this->assertNull(notamNextRestrictionStartUtc($notam, $now));
+    }
+
+    public function testNotamNextRestrictionStartUtc_InGap(): void {
+        $anchor = gmmktime(12, 0, 0, 11, 1, 2026);
+        $segA = $this->segmentFromUnix($anchor - 7200, $anchor - 3600);
+        $segB = $this->segmentFromUnix($anchor + 3600, $anchor + 7200);
+        $notam = [
+            'start_time_utc' => notamTimestampToIsoUtc($anchor - 86400),
+            'end_time_utc' => notamTimestampToIsoUtc($anchor + 86400),
+            'effective_segments' => [$segA, $segB],
+        ];
+        $this->assertEquals(
+            $segB['start_time_utc'],
+            notamNextRestrictionStartUtc($notam, $anchor)
+        );
+    }
+
+    public function testNotamIsBannerRelevantStatus_UpcomingFutureWithinHorizon(): void {
+        $start = time() + (int)(NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS / 2);
+        $end = $start + 3600;
+        $notam = [
+            'start_time_utc' => notamTimestampToIsoUtc($start),
+            'end_time_utc' => notamTimestampToIsoUtc($end),
+            'text' => '',
+        ];
+        enrichParsedNotamWithSchedule($notam);
+        $this->assertTrue(notamIsBannerRelevantStatus('upcoming_future', $notam));
+    }
+
+    public function testNotamIsBannerRelevantStatus_UpcomingFutureBeyondHorizon(): void {
+        $start = time() + NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS + 3600;
+        $end = $start + 3600;
+        $notam = [
+            'start_time_utc' => notamTimestampToIsoUtc($start),
+            'end_time_utc' => notamTimestampToIsoUtc($end),
+            'text' => '',
+        ];
+        enrichParsedNotamWithSchedule($notam);
+        $this->assertFalse(notamIsBannerRelevantStatus('upcoming_future', $notam));
+    }
+
+    public function testMergeParsedNotamDuplicates_PrefersLongerTextAndWidensEnvelope(): void {
+        $s = gmmktime(0, 0, 0, 12, 1, 2026);
+        $e = gmmktime(23, 59, 0, 12, 1, 2026);
+        $isoS = notamTimestampToIsoUtc($s);
+        $isoE = notamTimestampToIsoUtc($e);
+        $this->assertNotNull($isoS);
+        $this->assertNotNull($isoE);
+        $thin = [
+            'id' => 'FDC 0/0000',
+            'text' => 'TFR',
+            'start_time_utc' => $isoS,
+            'end_time_utc' => $isoE,
+        ];
+        $ga = $this->faaTenDigitFromUnix($s + 3600);
+        $gb = $this->faaTenDigitFromUnix($s + 7200);
+        $rich = [
+            'id' => 'FDC 0/0000',
+            'text' => "TEMPORARY FLIGHT RESTRICTIONS. FULL POLYGON TEXT. EFFECTIVE {$ga} UTC UNTIL {$gb} UTC",
+            'start_time_utc' => $isoS,
+            'end_time_utc' => $isoE,
+        ];
+        $merged = mergeParsedNotamDuplicates($thin, $rich);
+        $this->assertStringContainsString('EFFECTIVE', $merged['text']);
+        $this->assertSame('text_effective', $merged['schedule_source']);
+    }
+}


### PR DESCRIPTION
## Summary
- Parse and display NOTAMs using FAA-style EFFECTIVE windows (schedule on parse, dedupe, internal API, airport banner, and horizon for upcoming TFRs).
- Add an aggregated TFR GeoJSON internal endpoint and Leaflet layer on the airports directory map (active versus upcoming styling, true circles, tooltips with schedule and vertical summary, FAA link).
- Restrict `GET /api/notam-map.php` to the map UI in production (PHP Host plus Sec-Fetch-Site or Referer; nginx blocks `Sec-Fetch-Site: cross-site`; docs note optional Cloudflare WAF parity).
- Makefile: `PHPUNIT_ARGS` passthrough for filtered PHPUnit runs.

## Test plan
- [x] `make test-ci` (full suite) on this branch
- [x] Local Docker: open `/airports`, confirm TFR layer loads and tooltips or popups show TFR id, schedule line, and vertical text when parsed
- [x] Optional: `curl -I http://localhost:8080/api/notam-map.php` in local dev expects 200 (non-production allows tooling)