### PR TITLE
Airports map: TFR details in popup only (no hover tooltip)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -128,6 +128,26 @@ The API uses `s-maxage` to limit Cloudflare cache TTL separately from browser ca
 
 ---
 
+### NOTAM (airport dashboard)
+
+#### `GET /api/notam.php?airport={airport_id}`
+
+Returns filtered NOTAM rows (closures and relevant TFRs) as JSON for the per-airport dashboard. Responses include schedule fields when parsed from the NOTAM body (`effective_segments`, `schedule_source`, current or next restriction window times). See [`api/notam.php`](../api/notam.php) and [`lib/notam/filter.php`](../lib/notam/filter.php).
+
+---
+
+### TFR map layer (airports directory)
+
+#### `GET /api/notam-map.php`
+
+Returns a GeoJSON `FeatureCollection` of TFR geometries for the **airports directory map** (`pages/airports.php`). Features include properties such as `notam_id`, `status`, `status_line`, `vertical_limits`, `geometry_kind` (`polygon` or `circle`), `official_link`, and style hints. The payload is cached on disk with the same TTL as per-airport NOTAM JSON (`getNotamCacheTtlSeconds()`).
+
+**Access:** In production, callers must satisfy map-only browser rules (`lib/notam/map-api-access.php`); nginx also rejects `Sec-Fetch-Site: cross-site` for this path (`docker/nginx.conf`). Non-production and test mode allow open access for local development and CI.
+
+**UI:** The map shows TFR detail in a **Leaflet popup on tap or click only** (no hover tooltip), so mobile users do not see two stacked overlays for the same restriction.
+
+---
+
 ### Webcam Images
 
 #### `GET /webcam.php?id={airport_id}&cam={camera_index}[&fmt={format}][&size={height}][&v={hash}][&mtime=1]`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,7 +185,7 @@ Part of the **Internal API** (see [API.md](API.md)): JSON for the web dashboard;
 - Formats times in airport local timezone
 - Includes official FAA NOTAM links
 
-**`api/notam-map.php`**: Internal GeoJSON for the **airports directory map** only (aggregated TFR layer). **Not** a general integration surface: production enforces browser-oriented access (`lib/notam/map-api-access.php`); nginx returns 403 when `Sec-Fetch-Site` is `cross-site` (`docker/nginx.conf`). Non-production and test mode stay open for local and CI.
+**`api/notam-map.php`**: Internal GeoJSON for the **airports directory map** only (aggregated TFR layer). **Not** a general integration surface: production enforces browser-oriented access (`lib/notam/map-api-access.php`); nginx returns 403 when `Sec-Fetch-Site` is `cross-site` (`docker/nginx.conf`). Non-production and test mode stay open for local and CI. The map uses a **tap or click popup** for restriction copy (no hover tooltip) so touch UIs avoid duplicate overlays.
 
 **`lib/notam/`**: NOTAM processing library
 - **`auth.php`**: NMS API OAuth authentication (bearer token with auto-refresh)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1134,6 +1134,12 @@ Only include preferences you want to change from defaults. Users who have previo
 
 ---
 
+## TFR NOTAM overlay (airport map)
+
+The airport network map loads aggregated TFR GeoJSON from the Internal API route **`GET /api/notam-map.php`** (built from per-airport NOTAM caches). Restrictions are drawn as polygons or true-radius circles. **Detail copy (NOTAM id, schedule line, vertical summary, FAA link) opens in a Leaflet popup on tap or click only** so touch devices do not get a second hover tooltip over the same feature.
+
+---
+
 ## Weather Overlays (Airport Map)
 
 The airport network map at https://airports.aviationwx.org/ can display weather overlays from two sources:

--- a/pages/airports.php
+++ b/pages/airports.php
@@ -209,18 +209,6 @@ $breadcrumbs = generateBreadcrumbSchema([
             max-height: 1200px;
         }
 
-        .leaflet-tooltip.notam-map-hover-tip {
-            background: rgba(255, 255, 255, 0.96);
-            color: #1a1a1a;
-            border: 1px solid rgba(0, 0, 0, 0.35);
-            border-radius: 6px;
-            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-            font-size: 12px;
-            line-height: 1.35;
-            max-width: 260px;
-            padding: 6px 10px;
-        }
-
         .tfr-map-popup-cta {
             display: inline-block;
             margin-top: 0.35rem;
@@ -1614,32 +1602,8 @@ $breadcrumbs = generateBreadcrumbSchema([
             return '<strong>TFR - ' + notamTfrMapEscapeTipText(p.notam_id) + '</strong>';
         }
 
-        function bindNotamMapHoverTooltip(feature, layer) {
-            var p = feature.properties || {};
-            var parts = [];
-            var titleHtml = notamTfrMapLayerTitleHtml(p);
-            if (titleHtml) {
-                parts.push(titleHtml);
-            }
-            var cap = notamTfrMapStatusLineForFeature(p);
-            if (cap) {
-                parts.push(cap);
-            }
-            if (p.vertical_limits) {
-                parts.push(notamTfrMapEscapeTipText(p.vertical_limits));
-            }
-            parts.push('<span style="opacity:0.85;font-size:11px;">Tap or click for briefing link</span>');
-            layer.bindTooltip(parts.join('<br>'), {
-                sticky: true,
-                direction: 'auto',
-                className: 'notam-map-hover-tip',
-                interactive: false
-            });
-        }
-
         function onEachTfrFeature(feature, layer) {
             var p = feature.properties || {};
-            bindNotamMapHoverTooltip(feature, layer);
             var lines = [];
             var titleLine = notamTfrMapLayerTitleHtml(p);
             if (titleLine) {

--- a/tests/Unit/AirportsDirectoryTfrLayerUiTest.php
+++ b/tests/Unit/AirportsDirectoryTfrLayerUiTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Regression tests for TFR map layer UI wiring in pages/airports.php.
+ *
+ * Ensures the directory map uses a single tap or click popup for TFR copy (no hover tooltip),
+ * which avoids duplicate overlays on mobile.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class AirportsDirectoryTfrLayerUiTest extends TestCase {
+    private string $airportsPhp;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $path = dirname(__DIR__, 2) . '/pages/airports.php';
+        $this->assertFileExists($path);
+        $raw = file_get_contents($path);
+        $this->assertIsString($raw);
+        $this->airportsPhp = $raw;
+    }
+
+    public function testTfrLayerUsesBindPopupOnly(): void {
+        $this->assertStringContainsString(
+            'layer.bindPopup(\'<div class="tfr-map-popup">\' + lines.join(\'\') + \'</div>\');',
+            $this->airportsPhp
+        );
+        $this->assertStringContainsString('function onEachTfrFeature(feature, layer)', $this->airportsPhp);
+    }
+
+    public function testTfrLayerDoesNotUseHoverTooltip(): void {
+        $this->assertStringNotContainsString('bindTooltip', $this->airportsPhp);
+        $this->assertStringNotContainsString('notam-map-hover-tip', $this->airportsPhp);
+        $this->assertStringNotContainsString('bindNotamMapHoverTooltip', $this->airportsPhp);
+    }
+
+    public function testTfrLayerLoadsInternalMapApi(): void {
+        $this->assertStringContainsString('/api/notam-map.php', $this->airportsPhp);
+        $this->assertStringContainsString('loadTfrMapLayer', $this->airportsPhp);
+    }
+}


### PR DESCRIPTION
## Summary
- Remove the Leaflet **hover tooltip** on the TFR GeoJSON layer so mobile (and desktop) do not get two overlays for the same restriction; **tap or click popup** keeps the same content (TFR id, schedule line, vertical summary, FAA link).
- Document **`GET /api/notam.php`** and **`GET /api/notam-map.php`** in `docs/API.md`, extend `docs/ARCHITECTURE.md` and `docs/CONFIGURATION.md` for operator-facing context.
- Add **`AirportsDirectoryTfrLayerUiTest`** to regress the popup-only wiring.

## Code review notes
- **UX:** `onEachTfrFeature` only calls `bindPopup`; no `bindNotamMapHoverTooltip` or `.notam-map-hover-tip` CSS.
- **Tests:** The new unit test asserts **`bindTooltip` does not appear anywhere in `pages/airports.php`**. Today the airports directory page uses no Leaflet tooltips at all; if marker tooltips are added later, narrow this assertion to the TFR block or adjust the test.
- **Docs:** Internal API links from `docs/API.md` use repo-relative paths to `api/*.php` and `lib/notam/filter.php`.

## Test plan
- [x] `make test-ci`
- [x] Manual: open `/airports`, tap a TFR ring; confirm one popup and no hover card on long-press or mouse hover