### PR TITLE
NOTAM TFR: match circle and legacy disks to published radius only

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -213,9 +213,9 @@ Optional **station power** telemetry on airport pages for `limited_availability`
   - **TFRs**: Text containing "TFR", "TEMPORARY FLIGHT RESTRICTION", or "RESTRICTED AIRSPACE"
 - **Geographic relevance** (TFRs only, when identifier and name rules do not already match):
   - Parses coordinate pairs from NOTAM text (`DDMMSSN/DDDMMSSW`)
-  - **Circle path** (parsed NM radius in text): first pair is center; haversine distance from airport must be ≤ parsed radius + `TFR_RELEVANCE_BUFFER_NM` (10 NM default)
+  - **Circle path** (parsed NM radius in text): first pair is center; haversine distance from airport must be ≤ parsed radius (no additional NM buffer beyond the published circle)
   - **Polygon path** (no parsed radius, ≥3 vertices, closed ring): point-in-polygon in a local NM plane; if outside the ring, distance to nearest edge must be ≤ `TFR_RELEVANCE_BUFFER_NM`; closed ring requires repeated first vertex or **POINT OF ORIGIN** phrase; degenerate area below `TFR_POLYGON_MIN_ABS_DOUBLE_AREA_NM2` is excluded
-  - **Legacy path** (no parsed radius, fewer than three vertices): first pair as center with `TFR_DEFAULT_RADIUS_NM` (30 NM) + buffer via haversine
+  - **Legacy path** (no parsed radius, fewer than three vertices): first pair as center with `TFR_DEFAULT_RADIUS_NM` (30 NM) via haversine, with no NM buffer beyond that default disk
   - Uses NOTAM `location` and `airport_name` for non-geographic matches when those fields align with the airport
 - **Status Classification**: active, upcoming_today, expired, upcoming_future
 
@@ -514,9 +514,9 @@ See [DATA_FLOW.md](DATA_FLOW.md#notam-data-fetching) for detailed NOTAM processi
 ### 8. TFR Geographic Relevance Filtering
 
 - **Why**: The NMS API can return TFRs for a wide FIR or ARTCC footprint relative to a single airport. Geographic rules in `lib/notam/filter.php` align banners with published circle or polygon text and with configured airport coordinates.
-- **Circle TFRs**: Parsed NM radius plus `TFR_RELEVANCE_BUFFER_NM` around the first stated coordinate pair (haversine NM).
+- **Circle TFRs**: Haversine distance from airport to the first stated coordinate pair must be ≤ the parsed NM radius (published circle only; no extra NM buffer).
 - **Polygon TFRs**: Closed-ring validation (duplicate first vertex or **POINT OF ORIGIN**), point-in-polygon in a local NM projection, boundary buffer `TFR_RELEVANCE_BUFFER_NM` for airports just outside the edge, and exclusion of degenerate rings via `TFR_POLYGON_MIN_ABS_DOUBLE_AREA_NM2`.
-- **Legacy point**: When fewer than three coordinate pairs exist and no radius is parsed, `TFR_DEFAULT_RADIUS_NM` plus the same buffer around the first pair.
+- **Legacy point**: When fewer than three coordinate pairs exist and no radius is parsed, `TFR_DEFAULT_RADIUS_NM` around the first pair with the same strict disk rule (no buffer beyond that default radius).
 - **Non-geographic matches**: NOTAM `location` / `airport_name` / text still gate relevance when they match airport identifiers or names before geometry runs.
 - **Safety posture**: Unparsed coordinates, unclosed polygon text, degenerate projected area, or missing airport lat/lon skip geographic relevance so the UI does not imply a footprint that cannot be verified from the NOTAM body.
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1486,10 +1486,10 @@ Parsed values must lie between `TFR_RADIUS_MIN_NM` and `TFR_RADIUS_MAX_NM` in `l
 For a circle TFR, **haversine** distance in nautical miles is computed between the airport and the circle center. The TFR is relevant when:
 
 ```
-distance NM ≤ (parsed radius NM + TFR_RELEVANCE_BUFFER_NM)
+distance NM ≤ parsed radius NM
 ```
 
-`TFR_RELEVANCE_BUFFER_NM` defaults to **10 NM** so airports immediately outside the published circle still receive a warning.
+Parsed circle geometry follows the published restriction only; `TFR_RELEVANCE_BUFFER_NM` applies to **polygon** edges (see below), not to expanding a stated circle radius.
 
 #### Polygon TFR geometry
 
@@ -1504,7 +1504,7 @@ Inside the polygon, relevance does **not** depend on distance to a single center
 
 #### Legacy point TFR (no radius, fewer than three vertices)
 
-When no radius is parsed and fewer than three vertices are available, the first coordinate is used as a center with **`TFR_DEFAULT_RADIUS_NM`** (30 NM) plus `TFR_RELEVANCE_BUFFER_NM` and haversine distance. This covers sparse coordinate text that is not a closed polygon.
+When no radius is parsed and fewer than three vertices are available, the first coordinate is used as a center with **`TFR_DEFAULT_RADIUS_NM`** (30 NM) and haversine distance with **no** NM buffer beyond that default disk. This covers sparse coordinate text that is not a closed polygon.
 
 #### Conservative filtering (safety-critical)
 

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -198,7 +198,7 @@ if (!defined('NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS')) {
 
 // TFR (Temporary Flight Restriction) filtering constants (nautical miles).
 // Default radius applies when the NOTAM body has no parseable NM radius.
-// Edge buffer applies only to polygon rings in lib/notam/filter.php, not to stated circle radii.
+// Edge buffer applies only to polygon rings in NOTAM TFR filtering, not to stated circle radii.
 
 // Default radius (NM) to assume when TFR radius cannot be parsed from text
 if (!defined('TFR_DEFAULT_RADIUS_NM')) {

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -196,17 +196,17 @@ if (!defined('NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS')) {
     define('NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS', 48 * 3600); // 48 hours
 }
 
-// TFR (Temporary Flight Restriction) filtering constants
-// Used for determining if a TFR is relevant to an airport based on distance
-// All distances in nautical miles (NM) - standard aviation unit
+// TFR (Temporary Flight Restriction) filtering constants (nautical miles).
+// Default radius applies when the NOTAM body has no parseable NM radius.
+// Edge buffer applies only to polygon rings in lib/notam/filter.php, not to stated circle radii.
 
 // Default radius (NM) to assume when TFR radius cannot be parsed from text
 if (!defined('TFR_DEFAULT_RADIUS_NM')) {
     define('TFR_DEFAULT_RADIUS_NM', 30);
 }
 
-// Buffer distance (NM) added to TFR radius when checking airport relevance
-// Ensures airports just outside TFR boundary are still warned
+// Buffer (NM) for polygon TFRs only: airports outside the ring but within this distance
+// of an edge still match. Parsed circle and legacy point-radius disks do not add this buffer.
 if (!defined('TFR_RELEVANCE_BUFFER_NM')) {
     define('TFR_RELEVANCE_BUFFER_NM', 10);
 }

--- a/lib/notam/filter.php
+++ b/lib/notam/filter.php
@@ -433,6 +433,9 @@ function polygonCentroidLatLonFromVertices(array $vertices): ?array {
  * {@see isTfrRelevantToAirport()}; this function returns null for that case.
  * Otherwise: first coordinate with {@see TFR_DEFAULT_RADIUS_NM} (legacy single-point behavior).
  *
+ * Disk path in {@see isTfrRelevantToAirport()}: distance to center <= returned radius (NM), with no
+ * added {@see TFR_RELEVANCE_BUFFER_NM} (that buffer is for polygon edges only).
+ *
  * @param string $text NOTAM body
  * @param array<int, array{lat: float, lon: float}>|null $vertices Pre-parsed vertices to avoid a second scan of $text; null parses from $text
  * @param float|null $parsedRadiusNm When set, skips re-parsing radius from $text (must match {@see parseTfrRadiusNm()} for the same body when applicable)
@@ -824,8 +827,9 @@ function isTfr(array $notam): bool {
  * 2. The NOTAM airport_name field matches the airport name (word boundary match)
  * 3. The TFR text explicitly mentions the airport's name or identifier
  * 4. The airport is inside a closed polygon TFR (explicit ring closure or POINT OF
- *    ORIGIN), or within {@see TFR_RELEVANCE_BUFFER_NM} of its boundary; otherwise circle
- *    or legacy point-radius distance rules apply
+ *    ORIGIN), or within {@see TFR_RELEVANCE_BUFFER_NM} of its boundary; otherwise parsed
+ *    circle radius or legacy default-radius disk uses haversine distance with no extra
+ *    buffer beyond the published NM radius
  * 
  * All distance calculations use nautical miles (standard aviation unit).
  * Conservative approach: excludes TFR when coordinates cannot be parsed.
@@ -866,7 +870,8 @@ function isTfrRelevantToAirport(array $tfr, array $airport): bool {
         }
     }
     
-    // Geographic relevance: polygon uses PiP + boundary buffer; circle/legacy use great-circle distance
+    // Geographic relevance: polygon uses PiP + boundary buffer; circle/legacy use great-circle
+    // distance to center with no buffer beyond the stated (or default) radius NM
     if (!isset($airport['lat']) || !isset($airport['lon'])) {
         // No airport coordinates - be conservative and exclude
         return false;
@@ -904,7 +909,7 @@ function isTfrRelevantToAirport(array $tfr, array $airport): bool {
         $geoRef['lon']
     );
 
-    return $distanceNm <= ($geoRef['radius_nm'] + TFR_RELEVANCE_BUFFER_NM);
+    return $distanceNm <= $geoRef['radius_nm'];
 }
 
 /**

--- a/lib/notam/filter.php
+++ b/lib/notam/filter.php
@@ -433,8 +433,9 @@ function polygonCentroidLatLonFromVertices(array $vertices): ?array {
  * {@see isTfrRelevantToAirport()}; this function returns null for that case.
  * Otherwise: first coordinate with {@see TFR_DEFAULT_RADIUS_NM} (legacy single-point behavior).
  *
- * Disk path in {@see isTfrRelevantToAirport()}: distance to center <= returned radius (NM), with no
- * added {@see TFR_RELEVANCE_BUFFER_NM} (that buffer is for polygon edges only).
+ * For disk geometry returned here, {@see isTfrRelevantToAirport()} requires haversine distance
+ * from the airport to the center to be <= the returned radius (NM), with no added
+ * {@see TFR_RELEVANCE_BUFFER_NM} (that buffer is for polygon edges only).
  *
  * @param string $text NOTAM body
  * @param array<int, array{lat: float, lon: float}>|null $vertices Pre-parsed vertices to avoid a second scan of $text; null parses from $text
@@ -829,7 +830,8 @@ function isTfr(array $notam): bool {
  * 4. The airport is inside a closed polygon TFR (explicit ring closure or POINT OF
  *    ORIGIN), or within {@see TFR_RELEVANCE_BUFFER_NM} of its boundary; otherwise parsed
  *    circle radius or legacy default-radius disk uses haversine distance with no extra
- *    buffer beyond the published NM radius
+ *    buffer beyond the applicable NM radius (parsed circle or {@see TFR_DEFAULT_RADIUS_NM}
+ *    for legacy when no radius is stated)
  * 
  * All distance calculations use nautical miles (standard aviation unit).
  * Conservative approach: excludes TFR when coordinates cannot be parsed.

--- a/tests/Unit/NotamFilterTest.php
+++ b/tests/Unit/NotamFilterTest.php
@@ -445,13 +445,15 @@ class NotamFilterTest extends TestCase {
             'lon' => -116.2228
         ];
         
-        // Ogden is ~180 NM from Boise, well outside the 5 NM TFR radius + 10 NM buffer
+        // Ogden is ~180 NM from Boise, well outside the published 5 NM TFR radius
         $this->assertFalse(isTfrRelevantToAirport($tfr, $airport));
     }
-    
-    public function testIsTfrRelevantToAirport_NearbyTfrIsRelevant() {
-        // TFR 8 NM from airport with 5 NM radius - airport is just outside TFR
-        // but within relevance buffer (5 NM radius + 10 NM buffer = 15 NM threshold)
+
+    /**
+     * Parsed circle: airport outside the published NM radius does not match (no outer buffer).
+     */
+    public function testIsTfrRelevantToAirport_CircleOutsidePublishedRadiusNotRelevant(): void {
+        // TFR 8 NM from airport with 5 NM radius - outside the published disk (no outer buffer)
         $tfr = [
             'text' => 'TEMPORARY FLIGHT RESTRICTIONS WITHIN 5NM RADIUS OF 450500N1220000W'
         ];
@@ -463,7 +465,25 @@ class NotamFilterTest extends TestCase {
             'lon' => -122.0
         ];
         
-        $this->assertTrue(isTfrRelevantToAirport($tfr, $airport));
+        $this->assertFalse(isTfrRelevantToAirport($tfr, $airport));
+    }
+
+    /**
+     * Regression: 5 NM aerobatic TFR near KHIO; KSPB is outside the published circle.
+     */
+    public function testIsTfrRelevantToAirport_HillsboroFiveNmCircleKspbExcluded(): void {
+        $tfr = [
+            'text' => 'OR..AIRSPACE HILLSBORO, OR..TEMPORARY FLIGHT RESTRICTIONS. '
+                . 'ACFT OPS ARE PROHIBITED WI AN AREA DEFINED AS 5NM RADIUS OF 453230N1225653W '
+                . '(UBG345011.4) SFC-15000FT MSL DUE TO HIGH SPEED AEROBATIC DEMONSTRATIONS.',
+        ];
+        $airport = [
+            'name' => 'Scappoose Industrial Airpark',
+            'icao' => 'KSPB',
+            'lat' => 45.7710278,
+            'lon' => -122.8618333,
+        ];
+        $this->assertFalse(isTfrRelevantToAirport($tfr, $airport));
     }
     
     public function testIsTfrRelevantToAirport_AirportInsideTfr() {
@@ -688,25 +708,76 @@ class NotamFilterTest extends TestCase {
             . '(BOI008032.4) TO 440330N1155500W (BOI004032.6) TO 440400N1155600W (BOI003032.8) TO 440530N1155430W (BOI004034.6) '
             . 'TO 440530N1155100W (BOI007035.6) TO POINT OF ORIGIN SFC-7500FT.';
     }
-    
-    public function testIsTfrRelevantToAirport_LargeTfrRadius() {
+
+    /**
+     * Parsed large circle: distance must not exceed the stated radius (no buffer past 30 NM here).
+     */
+    public function testIsTfrRelevantToAirport_LargeTfrRadius(): void {
         // Large TFR (30 NM radius) - tests that we use parsed radius, not default
         $tfr = [
             'text' => 'TEMPORARY FLIGHT RESTRICTIONS WITHIN 30NM RADIUS OF 450000N1220000W'
         ];
         $airport = [
             'name' => 'Test Airport',
-            // About 35 NM from TFR center - outside 30 NM but within 30+10=40 NM buffer
+            // About 35 NM from TFR center - outside published 30 NM disk (no buffer)
             // 0.583 degrees ≈ 35 NM at this latitude (1 degree = 60 NM)
             'lat' => 45.583,
             'lon' => -122.0
         ];
         
+        $this->assertFalse(isTfrRelevantToAirport($tfr, $airport));
+    }
+
+    /**
+     * Legacy disk (no parsed NM radius, only a coordinate): use default radius with no outer buffer.
+     */
+    public function testIsTfrRelevantToAirport_LegacySinglePointOutsideDefaultRadius(): void {
+        $tfr = [
+            'text' => 'TEMPORARY FLIGHT RESTRICTIONS WI 450000N1220000W SFC-5000FT',
+        ];
+        $airport = [
+            'name' => 'Test Airport',
+            // About 31 NM north of center (outside TFR_DEFAULT_RADIUS_NM)
+            'lat' => 45.5167,
+            'lon' => -122.0,
+        ];
+        $this->assertFalse(isTfrRelevantToAirport($tfr, $airport));
+    }
+
+    /**
+     * Legacy disk: airports inside the default-radius circle remain relevant.
+     */
+    public function testIsTfrRelevantToAirport_LegacySinglePointInsideDefaultRadius(): void {
+        $tfr = [
+            'text' => 'TEMPORARY FLIGHT RESTRICTIONS WI 450000N1220000W SFC-5000FT',
+        ];
+        $airport = [
+            'name' => 'Test Airport',
+            // About 25 NM north of center (inside 30 NM default)
+            'lat' => 45.4167,
+            'lon' => -122.0,
+        ];
+        $this->assertTrue(isTfrRelevantToAirport($tfr, $airport));
+    }
+
+    /**
+     * Parsed circle: airport inside the published NM radius matches.
+     */
+    public function testIsTfrRelevantToAirport_CircleInsidePublishedRadius(): void {
+        $tfr = [
+            'text' => 'TEMPORARY FLIGHT RESTRICTIONS WITHIN 5NM RADIUS OF 450500N1220000W',
+        ];
+        $airport = [
+            'name' => 'Test Airport',
+            // About 3 NM north of 45d05m N 122d00m W (inside 5 NM)
+            'lat' => 45.1333,
+            'lon' => -122.0,
+        ];
         $this->assertTrue(isTfrRelevantToAirport($tfr, $airport));
     }
     
     /**
-     * Test that constants are properly defined
+     * TFR constants for default legacy disk radius, polygon edge buffer, and parsed-radius bounds.
      */
     public function testTfrConstantsAreDefined() {
         $this->assertTrue(defined('TFR_DEFAULT_RADIUS_NM'), 'TFR_DEFAULT_RADIUS_NM should be defined');

--- a/tests/Unit/NotamFilterTest.php
+++ b/tests/Unit/NotamFilterTest.php
@@ -779,7 +779,7 @@ class NotamFilterTest extends TestCase {
     /**
      * TFR constants for default legacy disk radius, polygon edge buffer, and parsed-radius bounds.
      */
-    public function testTfrConstantsAreDefined() {
+    public function testTfrConstantsAreDefined(): void {
         $this->assertTrue(defined('TFR_DEFAULT_RADIUS_NM'), 'TFR_DEFAULT_RADIUS_NM should be defined');
         $this->assertTrue(defined('TFR_RELEVANCE_BUFFER_NM'), 'TFR_RELEVANCE_BUFFER_NM should be defined');
         $this->assertTrue(defined('TFR_RADIUS_MIN_NM'), 'TFR_RADIUS_MIN_NM should be defined');


### PR DESCRIPTION
## Summary
- Treat **parsed NM circle** and **legacy default-radius** TFR geometry as a strict disk: haversine distance to the center must be within the stated (or default) radius, with **no** added `TFR_RELEVANCE_BUFFER_NM` (that buffer remains **polygon edge** only).
- Fixes cases such as a **5 NM** aerobatic TFR near Hillsboro where nearby airports (for example KSPB) sat outside the published circle but inside the old `radius + 10 NM` band.
- Update `docs/ARCHITECTURE.md`, `docs/DATA_FLOW.md`, and TFR constant comments; extend `NotamFilterTest` (outside/inside circle, legacy disk, regression case).

## Test plan
- [x] `make test-ci`