### PR TITLE
Harden scheduler daemon lock and cron watchdog

### DIFF
--- a/config/crontab
+++ b/config/crontab
@@ -15,9 +15,9 @@ CONFIG_PATH=/var/www/html/secrets/airports.json
 # Logs to /var/log/aviationwx/ (logrotate handles rotation: 7 days, 100MB max)
 * * * * * www-data cd /var/www/html && /usr/local/bin/php scripts/cron-heartbeat.php >> /var/log/aviationwx/cron-heartbeat.log 2>&1
 
-# Scheduler Health Check - Runs every minute
-# Validates scheduler daemon is running and healthy, restarts if needed.
-# The scheduler daemon handles all weather and webcam updates (replaces cron-based fetching).
+# Scheduler watchdog - Runs every minute (not the initial start; docker-entrypoint starts the daemon).
+# Confirms /tmp/scheduler.lock and live PID; starts a replacement only when recovery is needed
+# (missing process, unhealthy lock, etc.). Scheduler handles weather/webcam/NOTAM refresh cadence.
 # Logs to /var/log/aviationwx/ via aviationwx_log() function.
 * * * * * www-data cd /var/www/html && /usr/local/bin/php scripts/scheduler-health-check.php >> /var/log/aviationwx/scheduler-health-check.log 2>&1
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -289,10 +289,14 @@ else
     echo "⚠️  Warning: Cache directory does not exist and could not be created"
 fi
 
+# Scheduler: initial start authority is this entrypoint (one daemon after cache is ready).
+# Cron runs scripts/scheduler-health-check.php every minute as a watchdog only (confirm lock/PID,
+# start a replacement when missing or unhealthy). It must not duplicate a healthy daemon.
 # Scheduler runs as www-data so cache and worker subprocesses match Apache (see ProcessPool).
 # Must start after cache permissions (including webcams setgid) are applied.
+# Use POSIX sh (not bash -c): non-interactive sh exits right after backgrounding; avoids a lingering bash parent.
 echo "Starting scheduler daemon..."
-runuser -u www-data -- /bin/bash -c 'cd /var/www/html && nohup /usr/local/bin/php /var/www/html/scripts/scheduler.php > /dev/null 2>&1 &'
+runuser -u www-data -- /bin/sh -c 'cd /var/www/html && nohup /usr/local/bin/php /var/www/html/scripts/scheduler.php >/dev/null 2>&1 &'
 echo "✓ Scheduler started as www-data"
 
 # Initialize log directory with correct permissions

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,6 +29,7 @@ aviationwx.org/
 │   ├── logger.php            # Logging utilities
 │   ├── seo.php               # SEO utilities (structured data, meta tags)
 │   ├── constants.php         # Application constants
+│   ├── scheduler-daemon-lock.php # Exclusive flock helper for scheduler.php (no path unlink)
 │   ├── circuit-breaker.php   # Circuit breaker for API failures
 │   ├── airport-identifiers.php # Airport code validation
 │   ├── address-formatter.php # Address formatting utilities
@@ -60,8 +61,9 @@ aviationwx.org/
 │       │   └── WindGroup.php       # Grouped wind fields
 │       └── adapter/          # Weather API adapters
 ├── scripts/
-│   ├── scheduler.php         # Combined scheduler daemon (weather, webcam, NOTAM)
-│   ├── scheduler-health-check.php # Scheduler health check (runs via cron)
+│   ├── scheduler.php         # Combined scheduler daemon (weather, webcam, NOTAM); entrypoint starts at boot
+│   ├── scheduler-health-check.php # Cron watchdog: recover if daemon missing or unhealthy (not initial start)
+│   ├── diagnose-scheduler-duplicates.php # Read-only CLI: list scheduler PIDs and lock summary
 │   ├── unified-webcam-worker.php # Unified webcam worker (handles both pull and push cameras)
 │   ├── fetch-weather.php     # Weather fetcher (worker mode for scheduler)
 │   └── fetch-notam.php       # NOTAM fetcher (worker mode for scheduler)
@@ -146,7 +148,7 @@ Part of the **Internal API** (see [API.md](API.md)): JSON for the web dashboard;
 - **Background refresh**: Serves stale cache immediately, refreshes in background (similar to weather)
 
 **`scripts/scheduler.php`**: Combined scheduler daemon for data refresh
-- Runs continuously as background process (started on container boot)
+- Runs continuously as a background process: **Docker entrypoint** starts one instance after cache setup; **`scheduler-health-check.php`** (cron, every minute) confirms lock/PID/health and starts a replacement only when recovery is needed
 - Handles weather, webcam, and NOTAM updates with sub-minute granularity
 - Supports configurable refresh intervals (minimum 5 seconds, 1-second granularity)
 - Non-blocking main loop with ProcessPool integration

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -105,6 +105,8 @@ The **`production-health-check`** workflow runs **`scripts/production-health-che
 
 ### Scheduler Verification
 
+**Startup model:** the `web` container **entrypoint** starts one `scripts/scheduler.php` process after cache permissions are ready. **Cron** runs `scripts/scheduler-health-check.php` every minute as a **watchdog**: it checks the lock file and `/proc`, and starts a replacement only when recovery is needed (for example missing PID, lock health not healthy, or stale lock with no live daemon). It is not meant to compete with the entrypoint for a routine second start when one healthy daemon is already running.
+
 ```bash
 # Check scheduler is running
 docker compose -f docker/docker-compose.prod.yml exec web ps aux | grep scheduler
@@ -115,6 +117,14 @@ docker compose -f docker/docker-compose.prod.yml exec web cat /tmp/scheduler.loc
 # Force restart scheduler (auto-restarts within 60s)
 docker compose -f docker/docker-compose.prod.yml exec web pkill -f scheduler.php
 ```
+
+**Duplicate daemons:** if `app.log` reports multiple scheduler processes, gather facts before sending signals (killing the wrong PID can leave the lock path pointing at the wrong inode). Read-only summary:
+
+```bash
+docker compose -f docker/docker-compose.prod.yml exec -T web php scripts/diagnose-scheduler-duplicates.php
+```
+
+After a code fix, prefer a single clean `web` container restart so only the entrypoint-started daemon remains.
 
 ### Metrics System
 

--- a/lib/process-utils.php
+++ b/lib/process-utils.php
@@ -88,3 +88,66 @@ function canSignalProcess(int $pid): bool {
     return $result === true;
 }
 
+/**
+ * True if /proc cmdline looks like the combined scheduler daemon (not cron health check).
+ *
+ * Matches only the canonical path segment so unrelated CLIs (for example *-scheduler.php) are ignored.
+ *
+ * @param string $cmdline Contents of /proc/{pid}/cmdline (null byte separated argv)
+ * @return bool True when this process should count as a scheduler daemon
+ */
+function scheduler_daemon_matches_proc_cmdline(string $cmdline): bool {
+    if ($cmdline === '') {
+        return false;
+    }
+    if (stripos($cmdline, 'scheduler-health-check') !== false) {
+        return false;
+    }
+
+    return str_contains($cmdline, 'scripts/scheduler.php');
+}
+
+/**
+ * List PIDs of running scheduler daemons (scripts/scheduler.php), excluding this script.
+ *
+ * Used to avoid spawning a second scheduler when the lock file path is stale or out of sync
+ * with the inode the live daemon holds open.
+ *
+ * @return array<int, int> Unique PIDs sorted ascending
+ */
+function listSchedulerDaemonPids(): array {
+    $pids = [];
+    $procDirs = @glob('/proc/[0-9]*', GLOB_ONLYDIR);
+    if (!is_array($procDirs)) {
+        return [];
+    }
+
+    foreach ($procDirs as $dir) {
+        $pid = (int) basename($dir);
+        if ($pid <= 0) {
+            continue;
+        }
+
+        $cmdlineFile = $dir . '/cmdline';
+        if (!is_readable($cmdlineFile)) {
+            continue;
+        }
+
+        $cmdline = @file_get_contents($cmdlineFile);
+        if ($cmdline === false || $cmdline === '') {
+            continue;
+        }
+
+        if (!scheduler_daemon_matches_proc_cmdline($cmdline)) {
+            continue;
+        }
+
+        $pids[] = $pid;
+    }
+
+    $pids = array_values(array_unique($pids));
+    sort($pids, SORT_NUMERIC);
+
+    return $pids;
+}
+

--- a/lib/scheduler-daemon-lock.php
+++ b/lib/scheduler-daemon-lock.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Exclusive non-blocking flock for the scheduler daemon lock file.
+ *
+ * Used by scripts/scheduler.php only. Kept in a small library so flock behavior is unit-tested.
+ */
+
+/**
+ * Open the lock path and attempt LOCK_EX | LOCK_NB.
+ *
+ * Does not unlink the path. Unlinking while another process still holds an open file description
+ * can rebind the path to a new inode and allow a second daemon to flock successfully.
+ * A dead process releases flock automatically when its fds close.
+ *
+ * @param string $lockFile Absolute path to the lock file
+ * @return array{ok: true, fp: resource}|array{ok: false, reason: 'fopen'|'flock'}
+ */
+function scheduler_lock_acquire_exclusive_nb(string $lockFile): array {
+    $fp = @fopen($lockFile, 'c+');
+    if ($fp === false) {
+        return ['ok' => false, 'reason' => 'fopen'];
+    }
+
+    if (!@flock($fp, LOCK_EX | LOCK_NB)) {
+        fclose($fp);
+
+        return ['ok' => false, 'reason' => 'flock'];
+    }
+
+    return ['ok' => true, 'fp' => $fp];
+}

--- a/scripts/diagnose-scheduler-duplicates.php
+++ b/scripts/diagnose-scheduler-duplicates.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Read-only diagnostic for scheduler daemon and lock file state.
+ *
+ * Does not send signals or change files. Use when logs show multiple scheduler PIDs or lock drift.
+ *
+ * Usage (inside web container):
+ *   php scripts/diagnose-scheduler-duplicates.php
+ */
+
+require_once __DIR__ . '/../lib/process-utils.php';
+
+$lockFile = '/tmp/scheduler.lock';
+
+$pids = listSchedulerDaemonPids();
+echo 'Scheduler daemons (scripts/scheduler.php PIDs): ';
+echo $pids === [] ? '(none)' : implode(', ', $pids);
+echo "\n";
+
+if (!is_readable($lockFile)) {
+    echo "Lock file: not present or not readable ({$lockFile})\n";
+    exit(0);
+}
+
+$raw = @file_get_contents($lockFile);
+if ($raw === false || $raw === '') {
+    echo "Lock file: empty or unreadable ({$lockFile})\n";
+    exit(0);
+}
+
+$decoded = json_decode($raw, true);
+if (!is_array($decoded)) {
+    echo "Lock file: invalid JSON\n";
+    echo $raw . "\n";
+    exit(0);
+}
+
+echo "Lock file ({$lockFile}) JSON keys: " . implode(', ', array_keys($decoded)) . "\n";
+$lockPid = isset($decoded['pid']) ? (int) $decoded['pid'] : 0;
+if ($lockPid > 0) {
+    $running = isProcessRunning($lockPid, 'scheduler');
+    echo "Lock pid {$lockPid}: " . ($running ? 'running (cmdline matches scheduler)' : 'not running or cmdline mismatch') . "\n";
+} else {
+    echo "Lock pid: missing or invalid in JSON\n";
+}
+
+echo "\nNext steps: compare PIDs above with the lock pid. Prefer a clean web container restart after deploying scheduler lock fixes. Do not kill PIDs blindly.\n";

--- a/scripts/scheduler-health-check.php
+++ b/scripts/scheduler-health-check.php
@@ -1,14 +1,15 @@
 <?php
 /**
- * Scheduler Health Check
- * Validates scheduler is running and healthy
- * Restarts if unhealthy or missing
+ * Scheduler watchdog (cron): confirm health and recover only when needed
  *
- * Runs via cron every 60 seconds to ensure scheduler stays running.
+ * Startup model: docker-entrypoint.sh starts one scheduler daemon after cache setup (initial start).
+ * This script runs every minute as www-data. It reads /tmp/scheduler.lock and /proc, then:
+ * - Does nothing when the daemon is healthy and consistent with the lock file.
+ * - Recovers when appropriate: missing process, lock marked unhealthy, stale lock with no live
+ *   daemon to own the path, etc. It is not a second routine starter when a healthy daemon exists.
  *
- * Note: This script uses /proc filesystem to detect process existence.
- * The scheduler runs as www-data (see docker-entrypoint.sh), so this health check
- * can signal and restart it without crossing a privilege boundary.
+ * Uses /proc for PID checks (works across user boundaries). Kills only when the lock reports
+ * unhealthy, not for lock_stale alone against a live PID (see in-script comments).
  *
  * Usage:
  *   Via cron: * * * * * www-data cd /var/www/html && /usr/local/bin/php scripts/scheduler-health-check.php 2>&1
@@ -24,6 +25,14 @@ try {
     $lockFile = '/tmp/scheduler.lock';
     $schedulerScript = __DIR__ . '/scheduler.php';
     $maxLockAge = 120; // Consider stale if lock >2 minutes old
+
+    $daemonPidsSnapshot = listSchedulerDaemonPids();
+    if (count($daemonPidsSnapshot) > 1) {
+        aviationwx_log('error', 'scheduler health check: multiple scheduler daemons detected', [
+            'daemon_pids' => $daemonPidsSnapshot,
+            'hint' => 'Read-only inspect: php scripts/diagnose-scheduler-duplicates.php; then deploy plus web restart (see docs/OPERATIONS.md)'
+        ], 'app');
+    }
 
     // Check if scheduler is running
     $schedulerRunning = false;
@@ -69,13 +78,14 @@ try {
         $restartReason = 'not_running';
     }
 
-    // Restart if needed
+    // Recovery path: entrypoint already started the daemon at boot; this block only repairs outages.
     if ($needsRestart) {
         // Check if we can signal the process (have permission to kill it)
         $canKill = $schedulerPid && canSignalProcess($schedulerPid);
 
-        // Kill existing process if running but unhealthy (only if we have permission)
-        if ($schedulerPid && $schedulerRunning && $canKill) {
+        // Kill only when the lock reports unhealthy; lock_stale alone must not SIGTERM a live PID
+        // (first scheduler loop can exceed maxLockAge before the first updateLockFile write).
+        if ($schedulerPid && $schedulerRunning && $canKill && $restartReason === 'unhealthy') {
             aviationwx_log('info', 'scheduler health check: killing unhealthy scheduler', [
                 'pid' => $schedulerPid,
                 'reason' => $restartReason
@@ -99,8 +109,20 @@ try {
             exit(1);
         }
 
-        // Clean up lock file (only if process is actually dead or we killed it)
-        if (!isProcessRunning($schedulerPid ?? 0, 'scheduler')) {
+        $daemonPids = listSchedulerDaemonPids();
+
+        // Never unlink or spawn while any scheduler daemon is alive: the lock path can point at a
+        // different inode than the running process holds (unlink + second flock creates duplicates).
+        if ($daemonPids !== []) {
+            $lockMismatch = $schedulerPid === null || !in_array($schedulerPid, $daemonPids, true);
+            if (count($daemonPids) > 1 || $lockMismatch) {
+                aviationwx_log('warning', 'scheduler health check: restart suppressed - scheduler daemon already running', [
+                    'daemon_pids' => $daemonPids,
+                    'restart_reason' => $restartReason,
+                    'lock_pid' => $schedulerPid
+                ], 'app');
+            }
+        } elseif (!isProcessRunning($schedulerPid ?? 0, 'scheduler')) {
             @unlink($lockFile);
 
             // Start new scheduler (explicit cwd: cron provides it today, but stay correct if invoked elsewhere)

--- a/scripts/scheduler.php
+++ b/scripts/scheduler.php
@@ -34,6 +34,7 @@ require_once __DIR__ . '/../lib/webcam-schedule-queue.php';
 require_once __DIR__ . '/../lib/runways.php';
 require_once __DIR__ . '/../lib/airport-country-resolution-merge.php';
 require_once __DIR__ . '/../lib/weather/utils.php';
+require_once __DIR__ . '/../lib/scheduler-daemon-lock.php';
 // Note: variant-health flush uses variant_health_flush_via_http(); metrics use spill aggregator CLI
 
 // Lock file location
@@ -107,39 +108,31 @@ function scheduler_parse_metrics_aggregator_stdout(array $lines): ?int {
 
 /**
  * Acquire lock file with exclusive lock
- * 
- * Prevents duplicate scheduler instances from running.
- * Cleans up stale locks (uses FILE_LOCK_STALE_SECONDS constant).
- * 
+ *
+ * Prevents duplicate scheduler instances from running. Does not unlink stale paths: that
+ * overlapped with live fds and allowed a second daemon to flock a new inode (see scheduler_lock_acquire_exclusive_nb()).
+ *
  * @param string $lockFile Path to lock file
- * @return resource|false File handle on success, false on failure
+ * @return resource File handle on success (caller must hold until exit)
  */
-function acquireLock($lockFile) {
-    // Clean up stale locks (use constant for threshold)
-    if (file_exists($lockFile)) {
-        $lockAge = time() - filemtime($lockFile);
-        if ($lockAge > FILE_LOCK_STALE_SECONDS) {
-            @unlink($lockFile);
-        }
+function acquireLock(string $lockFile) {
+    $result = scheduler_lock_acquire_exclusive_nb($lockFile);
+    if (($result['ok'] ?? false) === true) {
+        return $result['fp'];
     }
-    
-    $fp = @fopen($lockFile, 'c+');
-    if (!$fp) {
+
+    $reason = $result['reason'] ?? 'unknown';
+    if ($reason === 'fopen') {
         aviationwx_log('error', 'scheduler: cannot create lock file', [
             'lock_file' => $lockFile
         ], 'app', true);
-        exit(1);
-    }
-    
-    if (!@flock($fp, LOCK_EX | LOCK_NB)) {
-        @fclose($fp);
+    } else {
         aviationwx_log('error', 'scheduler: another instance running', [
             'lock_file' => $lockFile
         ], 'app', true);
-        exit(1);
     }
-    
-    return $fp;
+
+    exit(1);
 }
 
 /**
@@ -202,16 +195,27 @@ aviationwx_log('info', 'scheduler: started', [
     'nice' => $schedulerNice
 ], 'app');
 
+// Refresh lock metadata immediately so cron health checks do not treat pre-restart mtime as stale
+// while the first loop (runways fetch, pools, etc.) can exceed the health check lock-age threshold.
+if ($lockFp) {
+    updateLockFile($lockFp, $pid, $startTime, 0, 'healthy', null, null, 0, null);
+}
+
 // Register shutdown function for cleanup
 register_shutdown_function(function() use ($lockFp, $lockFile, &$loopCount, $startTime) {
     if ($lockFp) {
+        $fpStat = @fstat($lockFp);
         @flock($lockFp, LOCK_UN);
         @fclose($lockFp);
+        $pathStat = @stat($lockFile);
+        if (is_array($fpStat) && is_array($pathStat)
+            && ($fpStat['dev'] ?? null) === ($pathStat['dev'] ?? null)
+            && ($fpStat['ino'] ?? null) === ($pathStat['ino'] ?? null)
+        ) {
+            @unlink($lockFile);
+        }
     }
-    if (file_exists($lockFile)) {
-        @unlink($lockFile);
-    }
-    
+
     aviationwx_log('info', 'scheduler: shutdown', [
         'pid' => getmypid(),
         'loop_count' => $loopCount,

--- a/tests/Unit/ProcessUtilsListSchedulerTest.php
+++ b/tests/Unit/ProcessUtilsListSchedulerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AviationWx\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Scheduler daemon detection and /proc enumeration (duplicate-scheduler hardening).
+ */
+final class ProcessUtilsListSchedulerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../../lib/process-utils.php';
+    }
+
+    public static function schedulerCmdlineCases(): array
+    {
+        $php = '/usr/local/bin/php';
+        $sched = '/var/www/html/scripts/scheduler.php';
+
+        return [
+            'real_scheduler_proc_style' => [
+                true,
+                $php . "\0" . $sched . "\0",
+            ],
+            'health_check_excluded' => [
+                false,
+                $php . "\0" . '/var/www/html/scripts/scheduler-health-check.php' . "\0",
+            ],
+            'fake_scheduler_suffix_excluded' => [
+                false,
+                $php . "\0" . '/var/www/html/scripts/fake-scheduler.php' . "\0",
+            ],
+            'unified_webcam_worker_excluded' => [
+                false,
+                $php . "\0" . '/var/www/html/scripts/unified-webcam-worker.php' . "\0",
+            ],
+            'empty_cmdline' => [
+                false,
+                '',
+            ],
+        ];
+    }
+
+    #[DataProvider('schedulerCmdlineCases')]
+    public function testSchedulerDaemonMatchesProcCmdline_ExpectedMatch(bool $expected, string $cmdline): void
+    {
+        $this->assertSame($expected, scheduler_daemon_matches_proc_cmdline($cmdline));
+    }
+
+    public function testListSchedulerDaemonPids_ReturnsSortedUniquePositiveInts(): void
+    {
+        $pids = listSchedulerDaemonPids();
+
+        $this->assertIsArray($pids);
+        $prev = -1;
+        foreach ($pids as $pid) {
+            $this->assertIsInt($pid);
+            $this->assertGreaterThan(0, $pid);
+            $this->assertGreaterThan($prev, $pid);
+            $prev = $pid;
+        }
+    }
+}

--- a/tests/Unit/SchedulerDaemonLockTest.php
+++ b/tests/Unit/SchedulerDaemonLockTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AviationWx\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression: scheduler daemon lock must not unlink paths; flock must exclude a second holder.
+ */
+final class SchedulerDaemonLockTest extends TestCase
+{
+    private string $lockPath;
+
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../../lib/scheduler-daemon-lock.php';
+        $this->lockPath = sys_get_temp_dir() . '/aviationwx_sched_lock_test_' . bin2hex(random_bytes(6)) . '.lock';
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->lockPath)) {
+            @unlink($this->lockPath);
+        }
+    }
+
+    public function testSchedulerLockAcquireExclusiveNb_SecondHolderGetsFlockReason(): void
+    {
+        $first = scheduler_lock_acquire_exclusive_nb($this->lockPath);
+        $this->assertTrue($first['ok']);
+        $this->assertIsResource($first['fp']);
+
+        $second = scheduler_lock_acquire_exclusive_nb($this->lockPath);
+        $this->assertFalse($second['ok']);
+        $this->assertSame('flock', $second['reason']);
+
+        fclose($first['fp']);
+
+        $third = scheduler_lock_acquire_exclusive_nb($this->lockPath);
+        $this->assertTrue($third['ok']);
+        $this->assertIsResource($third['fp']);
+        fclose($third['fp']);
+    }
+
+    public function testSchedulerLockAcquireExclusiveNb_FopenReasonWhenPathIsDirectory(): void
+    {
+        $dir = sys_get_temp_dir() . '/aviationwx_sched_lock_dir_' . bin2hex(random_bytes(4));
+        $this->assertNotFalse(mkdir($dir, 0700, true));
+
+        try {
+            $result = scheduler_lock_acquire_exclusive_nb($dir);
+            $this->assertFalse($result['ok']);
+            $this->assertSame('fopen', $result['reason']);
+        } finally {
+            @rmdir($dir);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Stops duplicate `scripts/scheduler.php` processes caused by lock path unlink racing with an open lock inode, and tightens cron recovery so it does not spawn a second healthy daemon.
- Adds a small flock-only lock helper with unit tests, immediate lock metadata after scheduler start, and inode-safe shutdown unlink.
- Adds `/proc`-based daemon listing with strict cmdline matching, error logging when multiple daemons are present, and a read-only operator diagnostic script.
- Documents the entrypoint (initial start) vs cron (watchdog recovery) model and switches the entrypoint scheduler launch to POSIX `sh`.

## Test plan

- [x] `make test-ci`
- [x] After deploy: `docker compose ... exec web ps aux | grep scheduler` shows a single `php .../scheduler.php`; `cat /tmp/scheduler.lock | jq .pid` matches that PID.
- [x] Optional: run `php scripts/diagnose-scheduler-duplicates.php` inside `web` when validating ops tooling.