### PR TITLE
feat(upstream): per-credential rate limiting (Phase 2)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -694,6 +694,8 @@ The scheduler also refreshes the shared AWC METAR bulk gzip when **more than one
 
 When the bucket is empty, that source is skipped for one fetch cycle (weather may be stale until the next refresh). If `cache/upstream-limits/` cannot be written, the limiter **fails open** (requests proceed) and logs `upstream rate limit state unavailable`. Monitor those warnings and `upstream_rate_limit_fail_open` counters in `cache/weather_health.json` (refreshed by the scheduler). PHPUnit and mock mode skip throttling.
 
+`metarResolveStationResponse()` in `lib/weather/adapter/metar-v1.php` reports outcomes as `METAR_RESOLVE_*` constants (`ok`, `throttled`, `circuit_open`, `http_failed`, `invalid_station`). Only `http_failed` and `invalid_station` count as fetch failures for the per-airport METAR circuit breaker; `throttled` is a self-throttle skip for one cycle.
+
 ### Backup Sources
 
 Mark a source as backup by adding `"backup": true`. Backup sources are only used when primary sources fail or are stale:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -686,7 +686,7 @@ METAR data from NOAA Aviation Weather provides aviation-specific observations in
 
 `nearby_stations` provides fallback stations if the primary METAR station is unavailable.
 
-The scheduler also refreshes the shared AWC METAR bulk gzip when **more than one airport is enabled** (`scripts/refresh-metar-bulk.php`, interval `METAR_BULK_REFRESH_INTERVAL_SECONDS` in `lib/constants.php`) and writes per-ICAO JSON slices under `cache/metar-bulk/stations/`. Weather workers read a fresh slice before calling the per-station HTTP API in that mode (`metarResolveStationResponseBody()` from `UnifiedFetcher` and legacy METAR helpers). Bulk ingest requires the gzip CSV header to match the canonical AWC column list in `lib/metar-bulk-csv-schema.php` (tests fail on drift). A **single enabled airport** uses per-station HTTP only (no national gzip download).
+The scheduler also refreshes the shared AWC METAR bulk gzip when **more than one airport is enabled** (`scripts/refresh-metar-bulk.php`, interval `METAR_BULK_REFRESH_INTERVAL_SECONDS` in `lib/constants.php`) and writes per-ICAO JSON slices under `cache/metar-bulk/stations/`. Weather workers read a fresh slice before calling the per-station HTTP API in that mode (`metarResolveStationResponse()` from `UnifiedFetcher` and `fetchMETARFromStation()`). Bulk ingest requires the gzip CSV header to match the canonical AWC column list in `lib/metar-bulk-csv-schema.php` (tests fail on drift). A **single enabled airport** uses per-station HTTP only (no national gzip download).
 
 ### Upstream rate limiting (weather fetch)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -686,7 +686,13 @@ METAR data from NOAA Aviation Weather provides aviation-specific observations in
 
 `nearby_stations` provides fallback stations if the primary METAR station is unavailable.
 
-The scheduler also refreshes the shared AWC METAR bulk gzip when **more than one airport is enabled** (`scripts/refresh-metar-bulk.php`, interval `METAR_BULK_REFRESH_INTERVAL_SECONDS` in `lib/constants.php`) and writes per-ICAO JSON slices under `cache/metar-bulk/stations/`. Weather workers read a fresh slice before calling the per-station HTTP API in that mode. Bulk ingest requires the gzip CSV header to match the canonical AWC column list in `lib/metar-bulk-csv-schema.php` (tests fail on drift). A **single enabled airport** uses per-station HTTP only (no national gzip download).
+The scheduler also refreshes the shared AWC METAR bulk gzip when **more than one airport is enabled** (`scripts/refresh-metar-bulk.php`, interval `METAR_BULK_REFRESH_INTERVAL_SECONDS` in `lib/constants.php`) and writes per-ICAO JSON slices under `cache/metar-bulk/stations/`. Weather workers read a fresh slice before calling the per-station HTTP API in that mode (`metarResolveStationResponseBody()` from `UnifiedFetcher` and legacy METAR helpers). Bulk ingest requires the gzip CSV header to match the canonical AWC column list in `lib/metar-bulk-csv-schema.php` (tests fail on drift). A **single enabled airport** uses per-station HTTP only (no national gzip download).
+
+### Upstream rate limiting (weather fetch)
+
+`lib/upstream-rate-limit.php` applies a file-backed token bucket per provider and credential fingerprint before outbound weather API calls (`cache/upstream-limits/`). Limits are defined in `lib/constants.php` (`UPSTREAM_RATE_LIMIT_*` per provider). Shared API keys (for example Tempest `api_key`) share one bucket across all airports using that key. Keyless sources use per-station identity in the fingerprint (`station_id` for AWOSnet, SWOB, NWS, METAR HTTP; `base_url` + `airport_id` for `aviationwx_api`).
+
+When the bucket is empty, that source is skipped for one fetch cycle (weather may be stale until the next refresh). If `cache/upstream-limits/` cannot be written, the limiter **fails open** (requests proceed) and logs `upstream rate limit state unavailable`. Monitor those warnings and `upstream_rate_limit_fail_open` counters in `cache/weather_health.json` (refreshed by the scheduler). PHPUnit and mock mode skip throttling.
 
 ### Backup Sources
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -34,6 +34,7 @@ The system uses **parallel fetching** for all configured sources:
 - **Unified Fetcher**: Fetches all sources simultaneously using `curl_multi`
 - **Sources Fetched**: All sources configured in the `weather_sources` array
 - **Circuit Breaker**: Each source has independent circuit breaker protection (skips sources in backoff)
+- **Upstream throttle**: Before `curl_multi_add_handle`, `lib/upstream-rate-limit.php` enforces a per-credential token bucket (flock under `cache/upstream-limits/`). When the budget is exhausted, that source is skipped for the current fetch cycle only. Circuit breaker (upstream health) is checked first so sick sources do not consume budget. METAR sources use `metarResolveStationResponseBody()` (bulk slice, then HTTP); bulk hits do not consume HTTP budget. Throttle skips and fail-open I/O are counted in `cache/weather_health.json`.
 - **Parallel Execution**: All sources are fetched concurrently for maximum speed
 - **Freshness Selection**: Handled during aggregation (freshest data wins for each field)
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -34,7 +34,7 @@ The system uses **parallel fetching** for all configured sources:
 - **Unified Fetcher**: Fetches all sources simultaneously using `curl_multi`
 - **Sources Fetched**: All sources configured in the `weather_sources` array
 - **Circuit Breaker**: Each source has independent circuit breaker protection (skips sources in backoff)
-- **Upstream throttle**: Before `curl_multi_add_handle`, `lib/upstream-rate-limit.php` enforces a per-credential token bucket (flock under `cache/upstream-limits/`). When the budget is exhausted, that source is skipped for the current fetch cycle only. Circuit breaker (upstream health) is checked first so sick sources do not consume budget. METAR sources use `metarResolveStationResponseBody()` (bulk slice, then HTTP); bulk hits do not consume HTTP budget. Throttle skips and fail-open I/O are counted in `cache/weather_health.json`.
+- **Upstream throttle**: Before `curl_multi_add_handle`, `lib/upstream-rate-limit.php` enforces a per-credential token bucket (flock under `cache/upstream-limits/`). When the budget is exhausted, that source is skipped for the current fetch cycle only. METAR uses `metarResolveStationResponse()` (mock, bulk slice, then HTTP); bulk is tried before the per-airport METAR HTTP circuit gate. Throttle and circuit-open outcomes are not recorded as fetch failures. Throttle skips and fail-open I/O are counted in `cache/weather_health.json`.
 - **Parallel Execution**: All sources are fetched concurrently for maximum speed
 - **Freshness Selection**: Handled during aggregation (freshest data wins for each field)
 

--- a/lib/cache-paths.php
+++ b/lib/cache-paths.php
@@ -37,6 +37,9 @@
  * ├── rate_limits/
  * │   └── {prefix}/                # First 2 chars of hash (git-style sharding)
  * │       └── {hash}.json          # Rate limit state files
+ * ├── upstream-limits/
+ * │   └── {prefix}/                # Per-credential upstream token buckets (flock)
+ * │       └── {fingerprint}.json
  * ├── backoff.json                 # Circuit breaker state
  * ├── operations_snapshot.json   # Public API GET /v1/operations (scheduler)
  * ├── peak_gusts/                  # Per-airport daily peak gust tracking
@@ -589,6 +592,26 @@ function getRateLimitPath(string $identifier): string {
 }
 
 // =============================================================================
+// UPSTREAM RATE LIMIT PATHS (per-credential token buckets)
+// =============================================================================
+
+if (!defined('CACHE_UPSTREAM_LIMITS_DIR')) {
+    define('CACHE_UPSTREAM_LIMITS_DIR', CACHE_BASE_DIR . '/upstream-limits');
+}
+
+/**
+ * Path to flock-backed upstream token bucket state for a credential fingerprint.
+ *
+ * @param string $fingerprint SHA-256 hex from upstream_rate_fingerprint()
+ */
+function getUpstreamRateLimitStatePath(string $fingerprint): string
+{
+    $prefix = strlen($fingerprint) >= 2 ? substr($fingerprint, 0, 2) : $fingerprint;
+
+    return CACHE_UPSTREAM_LIMITS_DIR . '/' . $prefix . '/' . $fingerprint . '.json';
+}
+
+// =============================================================================
 // METRICS CACHE PATHS
 // =============================================================================
 
@@ -935,6 +958,7 @@ function ensureAllCacheDirs(): array {
         CACHE_STATION_POWER_DIR,
         CACHE_PARTNERS_DIR,
         CACHE_RATE_LIMITS_DIR,
+        CACHE_UPSTREAM_LIMITS_DIR,
         CACHE_METRICS_DIR,
         CACHE_METRICS_HOURLY_DIR,
         CACHE_METRICS_DAILY_DIR,

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -574,6 +574,57 @@ if (!defined('METAR_BULK_DOWNLOAD_TIMEOUT_SECONDS')) {
     define('METAR_BULK_DOWNLOAD_TIMEOUT_SECONDS', 120);
 }
 
+// Upstream self-throttle (per-credential token bucket under cache/upstream-limits/)
+if (!defined('UPSTREAM_RATE_LIMIT_DEFAULT_RPM')) {
+    define('UPSTREAM_RATE_LIMIT_DEFAULT_RPM', 60);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_DEFAULT_BURST')) {
+    define('UPSTREAM_RATE_LIMIT_DEFAULT_BURST', 10);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_TEMPEST_RPM')) {
+    define('UPSTREAM_RATE_LIMIT_TEMPEST_RPM', 60);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_TEMPEST_BURST')) {
+    define('UPSTREAM_RATE_LIMIT_TEMPEST_BURST', 10);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_AMBIENT_RPM')) {
+    define('UPSTREAM_RATE_LIMIT_AMBIENT_RPM', 60);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_AMBIENT_BURST')) {
+    define('UPSTREAM_RATE_LIMIT_AMBIENT_BURST', 10);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_PWSWEATHER_RPM')) {
+    define('UPSTREAM_RATE_LIMIT_PWSWEATHER_RPM', 60);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_PWSWEATHER_BURST')) {
+    define('UPSTREAM_RATE_LIMIT_PWSWEATHER_BURST', 10);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_WEATHERLINK_RPM')) {
+    define('UPSTREAM_RATE_LIMIT_WEATHERLINK_RPM', 60);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_WEATHERLINK_BURST')) {
+    define('UPSTREAM_RATE_LIMIT_WEATHERLINK_BURST', 10);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_SYNOPTIC_RPM')) {
+    define('UPSTREAM_RATE_LIMIT_SYNOPTIC_RPM', 60);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_SYNOPTIC_BURST')) {
+    define('UPSTREAM_RATE_LIMIT_SYNOPTIC_BURST', 10);
+}
+// Shared anonymous bucket for per-station METAR HTTP (bulk path preferred when configured)
+if (!defined('UPSTREAM_RATE_LIMIT_METAR_HTTP_RPM')) {
+    define('UPSTREAM_RATE_LIMIT_METAR_HTTP_RPM', 90);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_METAR_HTTP_BURST')) {
+    define('UPSTREAM_RATE_LIMIT_METAR_HTTP_BURST', 15);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_NWS_RPM')) {
+    define('UPSTREAM_RATE_LIMIT_NWS_RPM', 60);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_NWS_BURST')) {
+    define('UPSTREAM_RATE_LIMIT_NWS_BURST', 10);
+}
+
 // Push webcam upload file age limits (fail-closed protection)
 // Files in upload directory older than this are considered abandoned/stuck
 if (!defined('UPLOAD_FILE_MAX_AGE_SECONDS')) {

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -611,7 +611,7 @@ if (!defined('UPSTREAM_RATE_LIMIT_SYNOPTIC_RPM')) {
 if (!defined('UPSTREAM_RATE_LIMIT_SYNOPTIC_BURST')) {
     define('UPSTREAM_RATE_LIMIT_SYNOPTIC_BURST', 10);
 }
-// Shared anonymous bucket for per-station METAR HTTP (bulk path preferred when configured)
+// Per-station bucket for METAR HTTP fallback (bulk preferred when configured)
 if (!defined('UPSTREAM_RATE_LIMIT_METAR_HTTP_RPM')) {
     define('UPSTREAM_RATE_LIMIT_METAR_HTTP_RPM', 90);
 }

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -258,9 +258,23 @@ function upstream_rate_try_take(string $fingerprint, int $rpm, int $burst, ?floa
         'tokens' => $result['tokens'],
         'last_refill' => $result['last_refill'],
     ], JSON_UNESCAPED_UNICODE);
-    if ($payload !== false) {
-        fwrite($fp, $payload);
-        fflush($fp);
+    if ($payload === false) {
+        aviationwx_log('warning', 'upstream rate limit state encode failed, allowing request', [
+            'fingerprint_prefix' => substr($fingerprint, 0, 8),
+        ], 'app');
+        flock($fp, LOCK_UN);
+        fclose($fp);
+
+        return $result['allowed'];
+    }
+
+    $written = @fwrite($fp, $payload);
+    @fflush($fp);
+    if ($written === false) {
+        aviationwx_log('warning', 'upstream rate limit state write failed, allowing request', [
+            'fingerprint_prefix' => substr($fingerprint, 0, 8),
+            'file' => $stateFile,
+        ], 'app');
     }
 
     flock($fp, LOCK_UN);
@@ -288,6 +302,22 @@ function upstream_rate_limit_record_fail_open(string $reason, string $fingerprin
 }
 
 /**
+ * PHPUnit only: enforce buckets while APP_ENV=testing.
+ */
+function upstream_rate_limit_test_force_enforcement(): void
+{
+    $GLOBALS['upstream_rate_limit_test_force_enforcement'] = true;
+}
+
+/**
+ * PHPUnit only: restore default test-mode bypass for upstream throttling.
+ */
+function upstream_rate_limit_test_clear_force_enforcement(): void
+{
+    unset($GLOBALS['upstream_rate_limit_test_force_enforcement']);
+}
+
+/**
  * Whether UnifiedFetcher should skip this source for the current cycle (budget exhausted).
  *
  * @param array<string, mixed> $source weather_sources entry (must include type)
@@ -303,22 +333,6 @@ function upstream_rate_limit_should_skip_source(array $source): bool
  * @param array<string, mixed> $source weather_sources entry (must include type)
  * @return array{allowed: bool, fingerprint_prefix: string|null}
  */
-/**
- * PHPUnit only: enforce buckets while APP_ENV=testing (see upstream_rate_limit_test_force_enforcement).
- */
-function upstream_rate_limit_test_force_enforcement(): void
-{
-    $GLOBALS['upstream_rate_limit_test_force_enforcement'] = true;
-}
-
-/**
- * PHPUnit only: restore default test-mode bypass for upstream throttling.
- */
-function upstream_rate_limit_test_clear_force_enforcement(): void
-{
-    unset($GLOBALS['upstream_rate_limit_test_force_enforcement']);
-}
-
 function upstream_rate_limit_consume_for_source(array $source): array
 {
     $forceInTests = !empty($GLOBALS['upstream_rate_limit_test_force_enforcement']);

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -1,0 +1,327 @@
+<?php
+/**
+ * Per-credential upstream rate limiting (file-backed token bucket).
+ *
+ * Coordinates outbound weather API calls across worker processes using flock.
+ * Fingerprint credentials with SHA-256; never log raw keys.
+ */
+
+require_once __DIR__ . '/constants.php';
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/logger.php';
+require_once __DIR__ . '/cache-paths.php';
+
+/**
+ * Secret/config keys used to fingerprint a shared credential (sorted when hashing).
+ *
+ * @param string $provider Weather source type (e.g. tempest, pwsweather)
+ * @return list<string>
+ */
+function upstream_rate_limit_credential_field_names(string $provider): array
+{
+    return match ($provider) {
+        'tempest' => ['api_key'],
+        'ambient' => ['api_key', 'application_key'],
+        'pwsweather' => ['client_id', 'client_secret'],
+        'weatherlink_v2' => ['api_key', 'api_secret'],
+        'weatherlink_v1' => ['api_token'],
+        'synopticdata' => ['api_token'],
+        'aviationwx_api' => ['api_key'],
+        default => [],
+    };
+}
+
+/**
+ * Non-secret identity fields for per-host buckets on keyless or multi-tenant sources.
+ *
+ * @param string $provider Weather source type
+ * @return list<string>
+ */
+function upstream_rate_limit_identity_field_names(string $provider): array
+{
+    return match ($provider) {
+        'metar', 'awosnet', 'swob_auto', 'swob_man', 'nws' => ['station_id'],
+        'aviationwx_api' => ['base_url', 'airport_id'],
+        default => [],
+    };
+}
+
+/**
+ * All config keys included in the fingerprint (credentials plus identity).
+ *
+ * @return list<string>
+ */
+function upstream_rate_limit_fingerprint_field_names(string $provider): array
+{
+    return array_values(array_unique(array_merge(
+        upstream_rate_limit_credential_field_names($provider),
+        upstream_rate_limit_identity_field_names($provider)
+    )));
+}
+
+/**
+ * Stable SHA-256 fingerprint for provider + credential material (no raw secrets in logs).
+ *
+ * @param string $provider Weather source type
+ * @param array<string, mixed> $sourceConfig Source block from weather_sources
+ * @return string 64-char hex digest
+ */
+function upstream_rate_fingerprint(string $provider, array $sourceConfig): string
+{
+    $material = [];
+    foreach (upstream_rate_limit_fingerprint_field_names($provider) as $field) {
+        if (!isset($sourceConfig[$field]) || !is_string($sourceConfig[$field])) {
+            continue;
+        }
+        $value = trim($sourceConfig[$field]);
+        if ($value === '') {
+            continue;
+        }
+        $material[$field] = $value;
+    }
+    ksort($material);
+
+    $canonical = $provider . "\n" . json_encode($material, JSON_UNESCAPED_UNICODE);
+    return hash('sha256', $canonical);
+}
+
+/**
+ * RPM and burst limits for a provider (self-throttle before upstream 429s).
+ *
+ * @param string $provider Weather source type
+ * @return array{rpm: int, burst: int}
+ */
+function upstream_rate_limit_policy_for_provider(string $provider): array
+{
+    return match ($provider) {
+        'tempest' => [
+            'rpm' => UPSTREAM_RATE_LIMIT_TEMPEST_RPM,
+            'burst' => UPSTREAM_RATE_LIMIT_TEMPEST_BURST,
+        ],
+        'ambient' => [
+            'rpm' => UPSTREAM_RATE_LIMIT_AMBIENT_RPM,
+            'burst' => UPSTREAM_RATE_LIMIT_AMBIENT_BURST,
+        ],
+        'pwsweather' => [
+            'rpm' => UPSTREAM_RATE_LIMIT_PWSWEATHER_RPM,
+            'burst' => UPSTREAM_RATE_LIMIT_PWSWEATHER_BURST,
+        ],
+        'weatherlink_v2', 'weatherlink_v1' => [
+            'rpm' => UPSTREAM_RATE_LIMIT_WEATHERLINK_RPM,
+            'burst' => UPSTREAM_RATE_LIMIT_WEATHERLINK_BURST,
+        ],
+        'synopticdata' => [
+            'rpm' => UPSTREAM_RATE_LIMIT_SYNOPTIC_RPM,
+            'burst' => UPSTREAM_RATE_LIMIT_SYNOPTIC_BURST,
+        ],
+        'metar' => [
+            'rpm' => UPSTREAM_RATE_LIMIT_METAR_HTTP_RPM,
+            'burst' => UPSTREAM_RATE_LIMIT_METAR_HTTP_BURST,
+        ],
+        'nws' => [
+            'rpm' => UPSTREAM_RATE_LIMIT_NWS_RPM,
+            'burst' => UPSTREAM_RATE_LIMIT_NWS_BURST,
+        ],
+        default => [
+            'rpm' => UPSTREAM_RATE_LIMIT_DEFAULT_RPM,
+            'burst' => UPSTREAM_RATE_LIMIT_DEFAULT_BURST,
+        ],
+    };
+}
+
+/**
+ * Pure token-bucket step (testable without filesystem).
+ *
+ * @param float $tokens Current token balance
+ * @param float $lastRefill Unix timestamp of last refill
+ * @param int $rpm Sustained requests per minute
+ * @param int $burst Maximum bucket size
+ * @param float $now Current Unix timestamp
+ * @return array{allowed: bool, tokens: float, last_refill: float}
+ */
+function upstream_rate_token_bucket_compute_take(
+    float $tokens,
+    float $lastRefill,
+    int $rpm,
+    int $burst,
+    float $now
+): array {
+    $rpm = max(1, $rpm);
+    $burst = max(1, $burst);
+    $refillRate = $rpm / 60.0;
+
+    if ($lastRefill <= 0.0) {
+        $lastRefill = $now;
+        $tokens = (float) $burst;
+    } elseif ($now > $lastRefill) {
+        $tokens = min((float) $burst, $tokens + ($now - $lastRefill) * $refillRate);
+        $lastRefill = $now;
+    }
+
+    if ($tokens >= 1.0) {
+        return [
+            'allowed' => true,
+            'tokens' => $tokens - 1.0,
+            'last_refill' => $lastRefill,
+        ];
+    }
+
+    return [
+        'allowed' => false,
+        'tokens' => $tokens,
+        'last_refill' => $lastRefill,
+    ];
+}
+
+/**
+ * Resolve on-disk state path for a fingerprint (test hook via $GLOBALS).
+ */
+function upstream_rate_limit_state_file_path(string $fingerprint): string
+{
+    if (isset($GLOBALS['upstream_rate_limit_test_root'])
+        && is_string($GLOBALS['upstream_rate_limit_test_root'])
+        && $GLOBALS['upstream_rate_limit_test_root'] !== ''
+    ) {
+        $root = rtrim($GLOBALS['upstream_rate_limit_test_root'], '/');
+        $prefix = strlen($fingerprint) >= 2 ? substr($fingerprint, 0, 2) : $fingerprint;
+
+        return $root . '/' . $prefix . '/' . $fingerprint . '.json';
+    }
+
+    return getUpstreamRateLimitStatePath($fingerprint);
+}
+
+/**
+ * Attempt to consume one outbound request token for this fingerprint.
+ *
+ * Fails open (allows request) when the state file cannot be read or written.
+ *
+ * @param string $fingerprint From upstream_rate_fingerprint()
+ * @param int $rpm Sustained requests per minute
+ * @param int $burst Maximum burst size
+ * @param float|null $now Injectable Unix timestamp for tests
+ * @return bool True when a token was consumed; false when budget exhausted
+ */
+function upstream_rate_try_take(string $fingerprint, int $rpm, int $burst, ?float $now = null): bool
+{
+    $now = $now ?? microtime(true);
+    $stateFile = upstream_rate_limit_state_file_path($fingerprint);
+    $stateDir = dirname($stateFile);
+    if (!is_dir($stateDir) && !@mkdir($stateDir, 0755, true) && !is_dir($stateDir)) {
+        upstream_rate_limit_record_fail_open('state_dir_unavailable', $fingerprint, ['dir' => $stateDir]);
+
+        return true;
+    }
+
+    $fp = @fopen($stateFile, 'c+');
+    if ($fp === false) {
+        upstream_rate_limit_record_fail_open('state_file_open_failed', $fingerprint, ['file' => $stateFile]);
+
+        return true;
+    }
+
+    if (!@flock($fp, LOCK_EX)) {
+        @fclose($fp);
+        upstream_rate_limit_record_fail_open('flock_failed', $fingerprint, ['file' => $stateFile]);
+
+        return true;
+    }
+
+    $tokens = (float) $burst;
+    $lastRefill = 0.0;
+    $fileSize = @filesize($stateFile);
+    if ($fileSize !== false && $fileSize > 0) {
+        rewind($fp);
+        $content = @stream_get_contents($fp);
+        if ($content !== false && $content !== '') {
+            $decoded = json_decode($content, true);
+            if (is_array($decoded)) {
+                $tokens = (float) ($decoded['tokens'] ?? $burst);
+                $lastRefill = (float) ($decoded['last_refill'] ?? 0.0);
+            } else {
+                // Corrupt state: do not reset to full burst (would bypass limits)
+                aviationwx_log('warning', 'upstream rate limit state corrupt, treating bucket as empty', [
+                    'file' => $stateFile,
+                    'fingerprint_prefix' => substr($fingerprint, 0, 8),
+                ], 'app');
+                $tokens = 0.0;
+                $lastRefill = $now;
+            }
+        }
+    }
+
+    $result = upstream_rate_token_bucket_compute_take($tokens, $lastRefill, $rpm, $burst, $now);
+
+    rewind($fp);
+    ftruncate($fp, 0);
+    $payload = json_encode([
+        'tokens' => $result['tokens'],
+        'last_refill' => $result['last_refill'],
+    ], JSON_UNESCAPED_UNICODE);
+    if ($payload !== false) {
+        fwrite($fp, $payload);
+        fflush($fp);
+    }
+
+    flock($fp, LOCK_UN);
+    fclose($fp);
+
+    return $result['allowed'];
+}
+
+/**
+ * Log fail-open and increment health counters (throttle disabled for that attempt).
+ *
+ * @param array<string, mixed> $context Additional log context (no secrets)
+ */
+function upstream_rate_limit_record_fail_open(string $reason, string $fingerprint, array $context = []): void
+{
+    aviationwx_log('warning', 'upstream rate limit state unavailable, allowing request', array_merge($context, [
+        'reason' => $reason,
+        'fingerprint_prefix' => substr($fingerprint, 0, 8),
+    ]), 'app');
+
+    if (!function_exists('weather_health_track_upstream_rate_limit_fail_open')) {
+        require_once __DIR__ . '/weather-health.php';
+    }
+    weather_health_track_upstream_rate_limit_fail_open($reason);
+}
+
+/**
+ * Whether UnifiedFetcher should skip this source for the current cycle (budget exhausted).
+ *
+ * @param array<string, mixed> $source weather_sources entry (must include type)
+ */
+function upstream_rate_limit_should_skip_source(array $source): bool
+{
+    return !upstream_rate_limit_consume_for_source($source)['allowed'];
+}
+
+/**
+ * Consume one upstream token for this source when throttling applies.
+ *
+ * @param array<string, mixed> $source weather_sources entry (must include type)
+ * @return array{allowed: bool, fingerprint_prefix: string|null}
+ */
+function upstream_rate_limit_consume_for_source(array $source): array
+{
+    if (isTestMode() || shouldMockExternalServices()) {
+        return ['allowed' => true, 'fingerprint_prefix' => null];
+    }
+
+    $provider = $source['type'] ?? '';
+    if (!is_string($provider) || $provider === '') {
+        return ['allowed' => true, 'fingerprint_prefix' => null];
+    }
+
+    $policy = upstream_rate_limit_policy_for_provider($provider);
+    if ($policy['rpm'] <= 0 || $policy['burst'] <= 0) {
+        return ['allowed' => true, 'fingerprint_prefix' => null];
+    }
+
+    $fingerprint = upstream_rate_fingerprint($provider, $source);
+    $prefix = substr($fingerprint, 0, 8);
+    $allowed = upstream_rate_try_take($fingerprint, $policy['rpm'], $policy['burst']);
+
+    return ['allowed' => $allowed, 'fingerprint_prefix' => $prefix];
+}

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -303,9 +303,26 @@ function upstream_rate_limit_should_skip_source(array $source): bool
  * @param array<string, mixed> $source weather_sources entry (must include type)
  * @return array{allowed: bool, fingerprint_prefix: string|null}
  */
+/**
+ * PHPUnit only: enforce buckets while APP_ENV=testing (see upstream_rate_limit_test_force_enforcement).
+ */
+function upstream_rate_limit_test_force_enforcement(): void
+{
+    $GLOBALS['upstream_rate_limit_test_force_enforcement'] = true;
+}
+
+/**
+ * PHPUnit only: restore default test-mode bypass for upstream throttling.
+ */
+function upstream_rate_limit_test_clear_force_enforcement(): void
+{
+    unset($GLOBALS['upstream_rate_limit_test_force_enforcement']);
+}
+
 function upstream_rate_limit_consume_for_source(array $source): array
 {
-    if (isTestMode() || shouldMockExternalServices()) {
+    $forceInTests = !empty($GLOBALS['upstream_rate_limit_test_force_enforcement']);
+    if (!$forceInTests && (isTestMode() || shouldMockExternalServices())) {
         return ['allowed' => true, 'fingerprint_prefix' => null];
     }
 

--- a/lib/weather-health.php
+++ b/lib/weather-health.php
@@ -107,6 +107,45 @@ function weather_health_track_fallback(string $airportId): void {
     weather_health_atomic_update($currentHour, $counters, $now);
 }
 
+/**
+ * Track an upstream self-throttle skip (budget exhausted for this cycle).
+ *
+ * @param string $airportId Airport identifier
+ * @param string $sourceType Source type (tempest, metar, etc.)
+ */
+function weather_health_track_upstream_throttle_skip(string $airportId, string $sourceType): void
+{
+    $now = time();
+    $currentHour = gmdate('Y-m-d-H', $now);
+
+    $counters = [
+        'upstream_throttle_skips' => 1,
+        "upstream_throttle_skip_{$sourceType}" => 1,
+        "upstream_throttle_skip_airport_{$airportId}" => 1,
+    ];
+
+    weather_health_atomic_update($currentHour, $counters, $now);
+}
+
+/**
+ * Track fail-open when upstream rate limit state cannot be read or written.
+ *
+ * @param string $reason Short reason code (e.g. state_dir_unavailable)
+ */
+function weather_health_track_upstream_rate_limit_fail_open(string $reason): void
+{
+    $now = time();
+    $currentHour = gmdate('Y-m-d-H', $now);
+
+    $safeReason = preg_replace('/[^a-z0-9_]/', '', strtolower($reason)) ?? 'unknown';
+    $counters = [
+        'upstream_rate_limit_fail_open' => 1,
+        "upstream_rate_limit_fail_open_{$safeReason}" => 1,
+    ];
+
+    weather_health_atomic_update($currentHour, $counters, $now);
+}
+
 // =============================================================================
 // FILE I/O FUNCTIONS
 // =============================================================================
@@ -305,7 +344,9 @@ function weather_health_compute_status(array $data): array {
         'total_successes' => 0,
         'total_failures' => 0,
         'circuit_open_events' => 0,
-        'fallback_activations' => 0
+        'fallback_activations' => 0,
+        'upstream_throttle_skips' => 0,
+        'upstream_rate_limit_fail_open' => 0,
     ];
     
     foreach ($data['hourly_buckets'] ?? [] as $hourKey => $bucket) {
@@ -334,6 +375,15 @@ function weather_health_compute_status(array $data): array {
     } elseif ($totals['circuit_open_events'] > 0) {
         $health['status'] = 'degraded';
         $health['message'] = sprintf('%d circuit breaker event(s) in last hour', $totals['circuit_open_events']);
+    } elseif ($totals['upstream_rate_limit_fail_open'] > 0) {
+        $health['status'] = 'degraded';
+        $health['message'] = sprintf(
+            '%d upstream rate limit fail-open event(s) in last hour (check cache/upstream-limits/)',
+            $totals['upstream_rate_limit_fail_open']
+        );
+    } elseif ($totals['upstream_throttle_skips'] > 0) {
+        $health['status'] = 'operational';
+        $health['message'] = sprintf('%d upstream throttle skip(s) in last hour', $totals['upstream_throttle_skips']);
     } elseif ($totals['fallback_activations'] > 0) {
         $health['status'] = 'operational';
         $health['message'] = sprintf('Operational with %d fallback(s)', $totals['fallback_activations']);
@@ -345,7 +395,9 @@ function weather_health_compute_status(array $data): array {
         'total_successes_last_hour' => $totals['total_successes'],
         'total_failures_last_hour' => $totals['total_failures'],
         'circuit_open_events_last_hour' => $totals['circuit_open_events'],
-        'fallback_activations_last_hour' => $totals['fallback_activations']
+        'fallback_activations_last_hour' => $totals['fallback_activations'],
+        'upstream_throttle_skips_last_hour' => $totals['upstream_throttle_skips'],
+        'upstream_rate_limit_fail_open_last_hour' => $totals['upstream_rate_limit_fail_open'],
     ];
     
     return $health;

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -168,34 +168,46 @@ function fetchAllSources(array $sources, string $airportId): array {
     $responses = [];
 
     foreach ($sources as $sourceKey => $source) {
-        // Check circuit breaker
         $sourceType = $source['type'];
-        $breakerResult = checkWeatherCircuitBreaker($airportId, $sourceType);
-        if (is_array($breakerResult) && ($breakerResult['skip'] ?? false)) {
-            // Track circuit breaker skip for health metrics
-            weather_health_track_circuit_open($airportId, $sourceType);
-            continue;
-        }
 
-        // METAR: bulk slice or per-station HTTP via metarResolveStationResponseBody (no curl_multi)
+        // METAR: mock/bulk/HTTP via metarResolveStationResponse (no curl_multi; bulk before HTTP circuit)
         if ($sourceType === 'metar') {
             $stationId = $source['station_id'] ?? '';
             if (!is_string($stationId) || trim($stationId) === '') {
                 continue;
             }
-            $body = metarResolveStationResponseBody(strtoupper(trim($stationId)));
-            if ($body !== null) {
-                $responses[$sourceKey] = $body;
-                recordWeatherSuccess($airportId, $sourceType);
-                weather_health_track_fetch($airportId, $sourceType, true, HTTP_STATUS_OK);
-            } else {
-                $responses[$sourceKey] = null;
-                recordWeatherFailure($airportId, $sourceType, 'transient', null);
-                weather_health_track_fetch($airportId, $sourceType, false, null);
+            $resolved = metarResolveStationResponse(strtoupper(trim($stationId)), $airportId);
+            switch ($resolved['outcome']) {
+                case METAR_RESOLVE_OK:
+                    if (is_string($resolved['body'])) {
+                        $responses[$sourceKey] = $resolved['body'];
+                        recordWeatherSuccess($airportId, $sourceType);
+                        weather_health_track_fetch($airportId, $sourceType, true, HTTP_STATUS_OK);
+                    }
+                    break;
+                case METAR_RESOLVE_THROTTLED:
+                    weather_health_track_upstream_throttle_skip($airportId, $sourceType);
+                    break;
+                case METAR_RESOLVE_CIRCUIT_OPEN:
+                    weather_health_track_circuit_open($airportId, $sourceType);
+                    break;
+                case METAR_RESOLVE_HTTP_FAILED:
+                case METAR_RESOLVE_INVALID_STATION:
+                    $responses[$sourceKey] = null;
+                    recordWeatherFailure($airportId, $sourceType, 'transient', null);
+                    weather_health_track_fetch($airportId, $sourceType, false, null);
+                    break;
             }
             continue;
         }
-        
+
+        // Check circuit breaker (non-METAR sources)
+        $breakerResult = checkWeatherCircuitBreaker($airportId, $sourceType);
+        if (is_array($breakerResult) && ($breakerResult['skip'] ?? false)) {
+            weather_health_track_circuit_open($airportId, $sourceType);
+            continue;
+        }
+
         // Build URL
         $url = buildSourceUrl($source);
         if ($url === null) {

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -40,6 +40,7 @@ require_once __DIR__ . '/calculator.php';
 require_once __DIR__ . '/validation.php';
 require_once __DIR__ . '/../constants.php';
 require_once __DIR__ . '/../circuit-breaker.php';
+require_once __DIR__ . '/../upstream-rate-limit.php';
 require_once __DIR__ . '/../logger.php';
 require_once __DIR__ . '/../weather-health.php';
 
@@ -164,7 +165,8 @@ function buildSourceList(array $airport): array {
 function fetchAllSources(array $sources, string $airportId): array {
     $mh = curl_multi_init();
     $handles = [];
-    
+    $responses = [];
+
     foreach ($sources as $sourceKey => $source) {
         // Check circuit breaker
         $sourceType = $source['type'];
@@ -174,10 +176,41 @@ function fetchAllSources(array $sources, string $airportId): array {
             weather_health_track_circuit_open($airportId, $sourceType);
             continue;
         }
+
+        // METAR: bulk slice or per-station HTTP via metarResolveStationResponseBody (no curl_multi)
+        if ($sourceType === 'metar') {
+            $stationId = $source['station_id'] ?? '';
+            if (!is_string($stationId) || trim($stationId) === '') {
+                continue;
+            }
+            $body = metarResolveStationResponseBody(strtoupper(trim($stationId)));
+            if ($body !== null) {
+                $responses[$sourceKey] = $body;
+                recordWeatherSuccess($airportId, $sourceType);
+                weather_health_track_fetch($airportId, $sourceType, true, HTTP_STATUS_OK);
+            } else {
+                $responses[$sourceKey] = null;
+                recordWeatherFailure($airportId, $sourceType, 'transient', null);
+                weather_health_track_fetch($airportId, $sourceType, false, null);
+            }
+            continue;
+        }
         
         // Build URL
         $url = buildSourceUrl($source);
         if ($url === null) {
+            continue;
+        }
+
+        // Per-credential budget (file-backed token bucket); skip this cycle when exhausted
+        $rateLimit = upstream_rate_limit_consume_for_source($source);
+        if (!$rateLimit['allowed']) {
+            aviationwx_log('info', 'upstream rate limit skip', [
+                'airport_id' => $airportId,
+                'provider' => $sourceType,
+                'fingerprint_prefix' => $rateLimit['fingerprint_prefix'],
+            ], 'app');
+            weather_health_track_upstream_throttle_skip($airportId, $sourceType);
             continue;
         }
         
@@ -218,8 +251,7 @@ function fetchAllSources(array $sources, string $airportId): array {
         }
     } while ($running > 0);
     
-    // Collect responses
-    $responses = [];
+    // Collect responses from curl_multi (METAR responses already in $responses)
     $swobAuto404Retries = [];
     foreach ($handles as $sourceKey => $ch) {
         $response = curl_multi_getcontent($ch);
@@ -264,6 +296,17 @@ function fetchAllSources(array $sources, string $airportId): array {
         if ($fallbackUrl === null) {
             recordWeatherFailure($airportId, 'swob_auto', 'transient', 404);
             weather_health_track_fetch($airportId, 'swob_auto', false, 404);
+            continue;
+        }
+        $rateLimit = upstream_rate_limit_consume_for_source($source);
+        if (!$rateLimit['allowed']) {
+            aviationwx_log('info', 'upstream rate limit skip', [
+                'airport_id' => $airportId,
+                'provider' => 'swob_auto',
+                'fingerprint_prefix' => $rateLimit['fingerprint_prefix'],
+                'context' => 'swob_auto_standard_fallback',
+            ], 'app');
+            weather_health_track_upstream_throttle_skip($airportId, 'swob_auto');
             continue;
         }
         $ch = curl_init($fallbackUrl);

--- a/lib/weather/adapter/metar-v1.php
+++ b/lib/weather/adapter/metar-v1.php
@@ -839,6 +839,12 @@ function metarResolveStationResponseBody(string $stationId): ?string
         return $bulkJson;
     }
 
+    require_once __DIR__ . '/../../upstream-rate-limit.php';
+    $stationSource = ['type' => 'metar', 'station_id' => $stationId];
+    if (!upstream_rate_limit_consume_for_source($stationSource)['allowed']) {
+        return null;
+    }
+
     $context = stream_context_create([
         'http' => [
             'timeout' => CURL_TIMEOUT,

--- a/lib/weather/adapter/metar-v1.php
+++ b/lib/weather/adapter/metar-v1.php
@@ -12,6 +12,9 @@
 require_once __DIR__ . '/../../constants.php';
 require_once __DIR__ . '/../../logger.php';
 require_once __DIR__ . '/../../test-mocks.php';
+require_once __DIR__ . '/../data/WeatherReading.php';
+require_once __DIR__ . '/../data/WindGroup.php';
+require_once __DIR__ . '/../data/WeatherSnapshot.php';
 
 /** METAR resolve produced a body (mock, bulk slice, or HTTP). */
 const METAR_RESOLVE_OK = 'ok';
@@ -23,9 +26,6 @@ const METAR_RESOLVE_CIRCUIT_OPEN = 'circuit_open';
 const METAR_RESOLVE_HTTP_FAILED = 'http_failed';
 /** Missing or empty station_id. */
 const METAR_RESOLVE_INVALID_STATION = 'invalid_station';
-require_once __DIR__ . '/../data/WeatherReading.php';
-require_once __DIR__ . '/../data/WindGroup.php';
-require_once __DIR__ . '/../data/WeatherSnapshot.php';
 
 use AviationWX\Weather\Data\WeatherReading;
 use AviationWX\Weather\Data\WindGroup;

--- a/lib/weather/adapter/metar-v1.php
+++ b/lib/weather/adapter/metar-v1.php
@@ -12,6 +12,17 @@
 require_once __DIR__ . '/../../constants.php';
 require_once __DIR__ . '/../../logger.php';
 require_once __DIR__ . '/../../test-mocks.php';
+
+/** METAR resolve produced a body (mock, bulk slice, or HTTP). */
+const METAR_RESOLVE_OK = 'ok';
+/** HTTP budget exhausted for this cycle; not an upstream failure. */
+const METAR_RESOLVE_THROTTLED = 'throttled';
+/** Per-airport METAR circuit open; HTTP skipped (bulk/mock already attempted). */
+const METAR_RESOLVE_CIRCUIT_OPEN = 'circuit_open';
+/** Per-station HTTP attempt failed after bulk miss. */
+const METAR_RESOLVE_HTTP_FAILED = 'http_failed';
+/** Missing or empty station_id. */
+const METAR_RESOLVE_INVALID_STATION = 'invalid_station';
 require_once __DIR__ . '/../data/WeatherReading.php';
 require_once __DIR__ . '/../data/WindGroup.php';
 require_once __DIR__ . '/../data/WeatherSnapshot.php';
@@ -814,35 +825,47 @@ function parseMETARResponse($response, $airport): ?array {
 /**
  * Resolve METAR JSON body for one station: test mock, fresh bulk slice, or per-station HTTP.
  *
- * Precedence is fixed: mock (test mode), bulk slice when fresh, then HTTP. Callers parse with
- * `parseMETARResponse()`.
+ * Precedence: mock, bulk slice when fresh, then HTTP (gated by circuit breaker and throttle).
+ * Throttle and circuit-open outcomes are not upstream failures; callers must not record them
+ * as weather fetch failures.
  *
- * @return string|null JSON array envelope body, or null when every source fails
+ * @param string $stationId ICAO station id (e.g. KSPB)
+ * @param string|null $airportId Airport slug for per-airport METAR circuit (null skips HTTP gate)
+ * @return array{body: ?string, outcome: string} One of METAR_RESOLVE_* constants
  */
-function metarResolveStationResponseBody(string $stationId): ?string
+function metarResolveStationResponse(string $stationId, ?string $airportId = null): array
 {
     $stationId = strtoupper(trim($stationId));
     if ($stationId === '') {
-        return null;
+        return ['body' => null, 'outcome' => METAR_RESOLVE_INVALID_STATION];
     }
+
     $url = 'https://aviationweather.gov/api/data/metar?ids=' . rawurlencode($stationId)
         . '&format=json&taf=false&hours=0';
 
     $mockResponse = getMockHttpResponse($url);
     if ($mockResponse !== null) {
-        return $mockResponse;
+        return ['body' => $mockResponse, 'outcome' => METAR_RESOLVE_OK];
     }
 
     require_once __DIR__ . '/../../metar-bulk.php';
     $bulkJson = metarBulkTryReadJsonResponseForStation($stationId);
     if ($bulkJson !== null) {
-        return $bulkJson;
+        return ['body' => $bulkJson, 'outcome' => METAR_RESOLVE_OK];
+    }
+
+    if ($airportId !== null && $airportId !== '') {
+        require_once __DIR__ . '/../../circuit-breaker.php';
+        $breakerResult = checkWeatherCircuitBreaker($airportId, 'metar');
+        if (is_array($breakerResult) && ($breakerResult['skip'] ?? false)) {
+            return ['body' => null, 'outcome' => METAR_RESOLVE_CIRCUIT_OPEN];
+        }
     }
 
     require_once __DIR__ . '/../../upstream-rate-limit.php';
     $stationSource = ['type' => 'metar', 'station_id' => $stationId];
     if (!upstream_rate_limit_consume_for_source($stationSource)['allowed']) {
-        return null;
+        return ['body' => null, 'outcome' => METAR_RESOLVE_THROTTLED];
     }
 
     $context = stream_context_create([
@@ -853,10 +876,10 @@ function metarResolveStationResponseBody(string $stationId): ?string
     ]);
     $response = @file_get_contents($url, false, $context);
     if ($response === false) {
-        return null;
+        return ['body' => null, 'outcome' => METAR_RESOLVE_HTTP_FAILED];
     }
 
-    return $response;
+    return ['body' => $response, 'outcome' => METAR_RESOLVE_OK];
 }
 
 /**
@@ -870,11 +893,12 @@ function fetchMETARFromStation($stationId, $airport): ?array {
     if (!is_string($stationId) || !is_array($airport)) {
         return null;
     }
-    $response = metarResolveStationResponseBody($stationId);
-    if ($response === null) {
+    $airportId = isset($airport['id']) && is_string($airport['id']) ? $airport['id'] : null;
+    $resolved = metarResolveStationResponse($stationId, $airportId);
+    if ($resolved['outcome'] !== METAR_RESOLVE_OK || !is_string($resolved['body'])) {
         return null;
     }
-    $parsed = parseMETARResponse($response, $airport);
+    $parsed = parseMETARResponse($resolved['body'], $airport);
     // If parsing succeeded, add metadata about which station was used
     if ($parsed !== null) {
         $parsed['_metar_station_used'] = $stationId;

--- a/lib/weather/adapter/tempest-v1.php
+++ b/lib/weather/adapter/tempest-v1.php
@@ -13,6 +13,7 @@
 require_once __DIR__ . '/../../constants.php';
 require_once __DIR__ . '/../../logger.php';
 require_once __DIR__ . '/../../test-mocks.php';
+require_once __DIR__ . '/../../upstream-rate-limit.php';
 require_once __DIR__ . '/../data/WeatherReading.php';
 require_once __DIR__ . '/../data/WindGroup.php';
 require_once __DIR__ . '/../data/WeatherSnapshot.php';
@@ -187,10 +188,13 @@ class TempestAdapter {
  * @param int|null $requestTimeoutSeconds CURLOPT_TIMEOUT; null uses CURL_TIMEOUT or 30s default
  * @return string|null Response body or null on failure
  */
-function tempestHttpGet(string $url, ?int $requestTimeoutSeconds = null): ?string {
+function tempestHttpGet(string $url, ?int $requestTimeoutSeconds = null, ?array $rateLimitSource = null): ?string {
     $mock = getMockHttpResponse($url);
     if ($mock !== null) {
         return $mock;
+    }
+    if ($rateLimitSource !== null && !upstream_rate_limit_consume_for_source($rateLimitSource)['allowed']) {
+        return null;
     }
     $ch = curl_init($url);
     if ($ch === false) {
@@ -382,7 +386,7 @@ function tempestApplyDeviceFallbackIfNeeded(string $stationObservationBody, arra
     if ($tStations === null) {
         return $stationObservationBody;
     }
-    $stationsBody = tempestHttpGet($metaUrl, $tStations);
+    $stationsBody = tempestHttpGet($metaUrl, $tStations, $source);
     if ($stationsBody === null) {
         return $stationObservationBody;
     }
@@ -395,7 +399,7 @@ function tempestApplyDeviceFallbackIfNeeded(string $stationObservationBody, arra
     if ($tDevice === null) {
         return $stationObservationBody;
     }
-    $deviceBody = tempestHttpGet($deviceUrl, $tDevice);
+    $deviceBody = tempestHttpGet($deviceUrl, $tDevice, $source);
     if ($deviceBody === null) {
         return $stationObservationBody;
     }

--- a/tests/Unit/FetchAllSourcesMetarBulkTest.php
+++ b/tests/Unit/FetchAllSourcesMetarBulkTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AviationWX\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * UnifiedFetcher METAR path uses bulk/mock resolution instead of curl_multi.
+ */
+final class FetchAllSourcesMetarBulkTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        require_once __DIR__ . '/../../lib/test-mocks.php';
+        metarBulkTestSetSkipMetarHttpMock(false);
+
+        parent::tearDown();
+    }
+
+    public function testFetchAllSources_MetarSource_UsesBulkSliceWithoutCurl(): void
+    {
+        require_once __DIR__ . '/../../lib/cache-paths.php';
+        require_once __DIR__ . '/../../lib/config.php';
+        require_once __DIR__ . '/../../lib/metar-bulk.php';
+        require_once __DIR__ . '/../../lib/test-mocks.php';
+        require_once __DIR__ . '/../../lib/weather/adapter/metar-v1.php';
+        require_once __DIR__ . '/../../lib/weather/UnifiedFetcher.php';
+
+        metarBulkTestSetSkipMetarHttpMock(true);
+        metarBulkEnsureDirectories();
+        $path = getMetarBulkStationJsonPath('KZZZ');
+        if (is_file($path)) {
+            @unlink($path);
+        }
+
+        $row = array_fill(0, 44, '');
+        $row[0] = 'METAR KZZZ 181500Z AUTO 09007KT 10SM CLR 42/40 A3000';
+        $row[1] = 'KZZZ';
+        $row[2] = '2026-05-18T15:00:00.000Z';
+        $row[5] = '42';
+        $json = metarBulkCsvRowToJsonEnvelope($row);
+        $this->assertNotNull($json);
+        file_put_contents($path, $json);
+        touch($path, time());
+
+        $sources = [
+            'source_0' => [
+                'type' => 'metar',
+                'station_id' => 'KZZZ',
+            ],
+        ];
+
+        $responses = fetchAllSources($sources, 'kzzz');
+        @unlink($path);
+
+        $this->assertArrayHasKey('source_0', $responses);
+        $this->assertIsString($responses['source_0']);
+        $this->assertStringContainsString('"temp":42', $responses['source_0']);
+    }
+}

--- a/tests/Unit/FetchAllSourcesMetarBulkTest.php
+++ b/tests/Unit/FetchAllSourcesMetarBulkTest.php
@@ -11,10 +11,29 @@ use PHPUnit\Framework\TestCase;
  */
 final class FetchAllSourcesMetarBulkTest extends TestCase
 {
+    private ?string $rateLimitRoot = null;
+
     protected function tearDown(): void
     {
         require_once __DIR__ . '/../../lib/test-mocks.php';
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
         metarBulkTestSetSkipMetarHttpMock(false);
+        upstream_rate_limit_test_clear_force_enforcement();
+        unset($GLOBALS['upstream_rate_limit_test_root']);
+        if ($this->rateLimitRoot !== null && is_dir($this->rateLimitRoot)) {
+            $files = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($this->rateLimitRoot, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
+            foreach ($files as $file) {
+                if ($file->isDir()) {
+                    rmdir($file->getPathname());
+                } else {
+                    unlink($file->getPathname());
+                }
+            }
+            rmdir($this->rateLimitRoot);
+        }
 
         parent::tearDown();
     }
@@ -58,5 +77,55 @@ final class FetchAllSourcesMetarBulkTest extends TestCase
         $this->assertArrayHasKey('source_0', $responses);
         $this->assertIsString($responses['source_0']);
         $this->assertStringContainsString('"temp":42', $responses['source_0']);
+    }
+
+    public function testFetchAllSources_MetarThrottled_DoesNotRecordCircuitFailure(): void
+    {
+        require_once __DIR__ . '/../../lib/cache-paths.php';
+        require_once __DIR__ . '/../../lib/config.php';
+        require_once __DIR__ . '/../../lib/metar-bulk.php';
+        require_once __DIR__ . '/../../lib/test-mocks.php';
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+        require_once __DIR__ . '/../../lib/constants.php';
+        require_once __DIR__ . '/../../lib/circuit-breaker.php';
+        require_once __DIR__ . '/../../lib/weather/adapter/metar-v1.php';
+        require_once __DIR__ . '/../../lib/weather/UnifiedFetcher.php';
+
+        metarBulkTestSetSkipMetarHttpMock(true);
+        metarBulkEnsureDirectories();
+        $path = getMetarBulkStationJsonPath('KTHR');
+        if (is_file($path)) {
+            @unlink($path);
+        }
+
+        if (is_file(CACHE_BACKOFF_FILE)) {
+            @unlink(CACHE_BACKOFF_FILE);
+        }
+
+        $this->rateLimitRoot = sys_get_temp_dir() . '/fetchall-throttle-' . bin2hex(random_bytes(4));
+        mkdir($this->rateLimitRoot, 0755, true);
+        $GLOBALS['upstream_rate_limit_test_root'] = $this->rateLimitRoot;
+        upstream_rate_limit_test_force_enforcement();
+
+        $source = ['type' => 'metar', 'station_id' => 'KTHR'];
+        $fingerprint = upstream_rate_fingerprint('metar', $source);
+        $t0 = microtime(true);
+        $this->assertTrue(upstream_rate_try_take($fingerprint, 60, 1, $t0));
+
+        $sources = [
+            'source_0' => [
+                'type' => 'metar',
+                'station_id' => 'KTHR',
+            ],
+        ];
+
+        $responses = fetchAllSources($sources, 'kthr');
+
+        $this->assertArrayNotHasKey('source_0', $responses);
+        if (is_file(CACHE_BACKOFF_FILE)) {
+            $data = json_decode((string) file_get_contents(CACHE_BACKOFF_FILE), true);
+            $this->assertIsArray($data);
+            $this->assertArrayNotHasKey('kthr_weather_metar', $data);
+        }
     }
 }

--- a/tests/Unit/FetchMetarFromStationBulkTest.php
+++ b/tests/Unit/FetchMetarFromStationBulkTest.php
@@ -7,19 +7,38 @@ namespace AviationWX\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 
 /**
- * METAR station response resolution: `metarResolveStationResponseBody()` and `fetchMETARFromStation()`.
+ * METAR station response resolution: `metarResolveStationResponse()` and `fetchMETARFromStation()`.
  */
 final class FetchMetarFromStationBulkTest extends TestCase
 {
+    private ?string $rateLimitRoot = null;
+
     protected function tearDown(): void
     {
         require_once __DIR__ . '/../../lib/test-mocks.php';
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
         metarBulkTestSetSkipMetarHttpMock(false);
+        upstream_rate_limit_test_clear_force_enforcement();
+        unset($GLOBALS['upstream_rate_limit_test_root']);
+        if ($this->rateLimitRoot !== null && is_dir($this->rateLimitRoot)) {
+            $files = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($this->rateLimitRoot, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
+            foreach ($files as $file) {
+                if ($file->isDir()) {
+                    rmdir($file->getPathname());
+                } else {
+                    unlink($file->getPathname());
+                }
+            }
+            rmdir($this->rateLimitRoot);
+        }
 
         parent::tearDown();
     }
 
-    public function testMetarResolveStationResponseBody_FreshBulkSlice_SkipHttpMock_ReturnsSliceJson(): void
+    public function testMetarResolveStationResponse_FreshBulkSlice_SkipHttpMock_ReturnsOkWithBody(): void
     {
         require_once __DIR__ . '/../../lib/cache-paths.php';
         require_once __DIR__ . '/../../lib/config.php';
@@ -44,14 +63,15 @@ final class FetchMetarFromStationBulkTest extends TestCase
         file_put_contents($path, $json);
         touch($path, time());
 
-        $body = metarResolveStationResponseBody('KZZZ');
+        $resolved = metarResolveStationResponse('KZZZ');
         @unlink($path);
 
-        $this->assertNotNull($body);
-        $this->assertStringContainsString('"temp":42', $body);
+        $this->assertSame(METAR_RESOLVE_OK, $resolved['outcome']);
+        $this->assertIsString($resolved['body']);
+        $this->assertStringContainsString('"temp":42', $resolved['body']);
     }
 
-    public function testMetarResolveStationResponseBody_NoBulkSlice_UsesHttpMock(): void
+    public function testMetarResolveStationResponse_NoBulkSlice_UsesHttpMock_ReturnsOk(): void
     {
         require_once __DIR__ . '/../../lib/cache-paths.php';
         require_once __DIR__ . '/../../lib/metar-bulk.php';
@@ -65,9 +85,40 @@ final class FetchMetarFromStationBulkTest extends TestCase
             @unlink($path);
         }
 
-        $body = metarResolveStationResponseBody('KSPB');
-        $this->assertNotNull($body);
-        $this->assertStringContainsString('KSPB', $body);
+        $resolved = metarResolveStationResponse('KSPB');
+        $this->assertSame(METAR_RESOLVE_OK, $resolved['outcome']);
+        $this->assertStringContainsString('KSPB', (string) $resolved['body']);
+    }
+
+    public function testMetarResolveStationResponse_ThrottleExhausted_ReturnsThrottledNotFailed(): void
+    {
+        require_once __DIR__ . '/../../lib/cache-paths.php';
+        require_once __DIR__ . '/../../lib/config.php';
+        require_once __DIR__ . '/../../lib/metar-bulk.php';
+        require_once __DIR__ . '/../../lib/test-mocks.php';
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+        require_once __DIR__ . '/../../lib/weather/adapter/metar-v1.php';
+
+        metarBulkTestSetSkipMetarHttpMock(true);
+        metarBulkEnsureDirectories();
+        $path = getMetarBulkStationJsonPath('KTHR');
+        if (is_file($path)) {
+            @unlink($path);
+        }
+
+        $this->rateLimitRoot = sys_get_temp_dir() . '/metar-throttle-' . bin2hex(random_bytes(4));
+        mkdir($this->rateLimitRoot, 0755, true);
+        $GLOBALS['upstream_rate_limit_test_root'] = $this->rateLimitRoot;
+        upstream_rate_limit_test_force_enforcement();
+
+        $source = ['type' => 'metar', 'station_id' => 'KTHR'];
+        $fingerprint = upstream_rate_fingerprint('metar', $source);
+        $t0 = microtime(true);
+        $this->assertTrue(upstream_rate_try_take($fingerprint, 60, 1, $t0));
+
+        $resolved = metarResolveStationResponse('KTHR', 'kthr');
+        $this->assertSame(METAR_RESOLVE_THROTTLED, $resolved['outcome']);
+        $this->assertNull($resolved['body']);
     }
 
     public function testFetchMETARFromStation_FreshBulkSlice_SkipHttpMock_UsesSliceTemperature(): void

--- a/tests/Unit/UpstreamRateLimitTest.php
+++ b/tests/Unit/UpstreamRateLimitTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AviationWX\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for lib/upstream-rate-limit.php (fingerprinting and token bucket).
+ */
+final class UpstreamRateLimitTest extends TestCase
+{
+    private ?string $testRoot = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testRoot = sys_get_temp_dir() . '/upstream-rate-limit-test-' . bin2hex(random_bytes(4));
+        mkdir($this->testRoot, 0755, true);
+        $GLOBALS['upstream_rate_limit_test_root'] = $this->testRoot;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['upstream_rate_limit_test_root']);
+        if ($this->testRoot !== null && is_dir($this->testRoot)) {
+            $files = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($this->testRoot, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
+            foreach ($files as $file) {
+                if ($file->isDir()) {
+                    rmdir($file->getPathname());
+                } else {
+                    unlink($file->getPathname());
+                }
+            }
+            rmdir($this->testRoot);
+        }
+        parent::tearDown();
+    }
+
+    public function testFingerprint_SameCredentials_ReturnsStableHash(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $source = ['api_key' => 'secret-a', 'station_id' => '12345'];
+        $a = upstream_rate_fingerprint('tempest', $source);
+        $b = upstream_rate_fingerprint('tempest', $source);
+        $this->assertSame($a, $b);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $a);
+    }
+
+    public function testFingerprint_DifferentApiKey_ReturnsDifferentHash(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $a = upstream_rate_fingerprint('tempest', ['api_key' => 'key-one', 'station_id' => '1']);
+        $b = upstream_rate_fingerprint('tempest', ['api_key' => 'key-two', 'station_id' => '1']);
+        $this->assertNotSame($a, $b);
+    }
+
+    public function testFingerprint_Tempest_IgnoresStationId(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $a = upstream_rate_fingerprint('tempest', ['api_key' => 'shared', 'station_id' => '111']);
+        $b = upstream_rate_fingerprint('tempest', ['api_key' => 'shared', 'station_id' => '222']);
+        $this->assertSame($a, $b);
+    }
+
+    public function testFingerprint_Pwsweather_UsesClientIdAndSecret(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $a = upstream_rate_fingerprint('pwsweather', [
+            'client_id' => 'cid',
+            'client_secret' => 'sec',
+            'station_id' => 'ST1',
+        ]);
+        $b = upstream_rate_fingerprint('pwsweather', [
+            'client_id' => 'cid',
+            'client_secret' => 'sec',
+            'station_id' => 'ST2',
+        ]);
+        $this->assertSame($a, $b);
+    }
+
+    public function testTokenBucketCompute_AllowsBurstThenDenies(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $tokens = 3.0;
+        $last = 1000.0;
+        $now = 1000.0;
+        $allowed = [];
+        for ($i = 0; $i < 5; $i++) {
+            $result = upstream_rate_token_bucket_compute_take($tokens, $last, 60, 3, $now);
+            $allowed[] = $result['allowed'];
+            $tokens = $result['tokens'];
+            $last = $result['last_refill'];
+        }
+        $this->assertSame([true, true, true, false, false], $allowed);
+    }
+
+    public function testTokenBucketCompute_RefillsOverTime(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $t0 = 1_700_000_000.0;
+        $empty = upstream_rate_token_bucket_compute_take(0.0, $t0, 60, 3, $t0);
+        $this->assertFalse($empty['allowed']);
+
+        // 60 rpm => 1 token per second; after 2s we regain 2 tokens (capped at burst 3)
+        $refilled = upstream_rate_token_bucket_compute_take(0.0, $t0, 60, 3, $t0 + 2.0);
+        $this->assertTrue($refilled['allowed']);
+        $this->assertGreaterThanOrEqual(0.9, $refilled['tokens']);
+    }
+
+    public function testTryTake_ExhaustsThenRecoversAfterElapsedTime(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $fingerprint = 'test-fingerprint-' . bin2hex(random_bytes(8));
+        $rpm = 60;
+        $burst = 2;
+        $t0 = 1_700_000_000.0;
+
+        $this->assertTrue(upstream_rate_try_take($fingerprint, $rpm, $burst, $t0));
+        $this->assertTrue(upstream_rate_try_take($fingerprint, $rpm, $burst, $t0));
+        $this->assertFalse(upstream_rate_try_take($fingerprint, $rpm, $burst, $t0));
+
+        // 2 seconds later at 60 rpm we regain 2 tokens
+        $this->assertTrue(upstream_rate_try_take($fingerprint, $rpm, $burst, $t0 + 2.0));
+    }
+
+    public function testTryTake_CorruptStateFile_DoesNotGrantFullBurst(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $fingerprint = hash('sha256', 'corrupt-state-test');
+        $stateFile = upstream_rate_limit_state_file_path($fingerprint);
+        $dir = dirname($stateFile);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        file_put_contents($stateFile, 'not-json');
+
+        $t0 = 1_700_000_000.0;
+        $this->assertFalse(upstream_rate_try_take($fingerprint, 60, 3, $t0));
+    }
+
+    public function testFingerprint_Metar_DifferentStationIds_ReturnsDifferentHash(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $a = upstream_rate_fingerprint('metar', ['station_id' => 'KAAA']);
+        $b = upstream_rate_fingerprint('metar', ['station_id' => 'KBBB']);
+        $this->assertNotSame($a, $b);
+    }
+
+    public function testFingerprint_Awosnet_DifferentStationIds_ReturnsDifferentHash(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $a = upstream_rate_fingerprint('awosnet', ['station_id' => 'ks40']);
+        $b = upstream_rate_fingerprint('awosnet', ['station_id' => 'ks41']);
+        $this->assertNotSame($a, $b);
+    }
+
+    public function testConsumeForSource_MockMode_ReturnsAllowed(): void
+    {
+        require_once __DIR__ . '/../../lib/config.php';
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $source = ['type' => 'tempest', 'api_key' => 'k', 'station_id' => '1'];
+        $result = upstream_rate_limit_consume_for_source($source);
+        $this->assertTrue($result['allowed']);
+        $this->assertNull($result['fingerprint_prefix']);
+    }
+
+    public function testPolicyForProvider_Tempest_ReturnsConfiguredLimits(): void
+    {
+        require_once __DIR__ . '/../../lib/constants.php';
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $policy = upstream_rate_limit_policy_for_provider('tempest');
+        $this->assertSame(UPSTREAM_RATE_LIMIT_TEMPEST_RPM, $policy['rpm']);
+        $this->assertSame(UPSTREAM_RATE_LIMIT_TEMPEST_BURST, $policy['burst']);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `lib/upstream-rate-limit.php`: file-backed token buckets (`flock` under `cache/upstream-limits/`) keyed by provider plus credential fingerprint (SHA-256, no secrets in logs).
- Wire `UnifiedFetcher` before `curl_multi_add_handle`; METAR sources use `metarResolveStationResponseBody()` (bulk slice, then HTTP) instead of curl. Tempest device fallback and `swob_auto` standard URL retry consume the same buckets.
- Per-station identity for keyless sources (`station_id` for AWOSnet/SWOB/NWS/METAR HTTP; `base_url` + `airport_id` for `aviationwx_api`). Shared API keys (e.g. Tempest `api_key`) share one bucket across airports.
- Health metrics: `upstream_throttle_skips` and `upstream_rate_limit_fail_open` in `cache/weather_health.json`. Fail-open when cache I/O fails (logged + counted).
- Constants in `lib/constants.php`; ops notes in `docs/CONFIGURATION.md` and `docs/DATA_FLOW.md`.

Closes Phase 2 of the upstream rate limiting plan (follows merged METAR bulk Phase 1, PR #101).

## Test plan

- [x] `make test-ci` green
- [x] After deploy: confirm `cache/upstream-limits/` populates under load
- [x] Confirm `upstream rate limit skip` logs appear only when expected; weather still degrades gracefully (stale cache / other sources)
- [x] Confirm METAR bulk slices used on dashboard path (no per-airport AWC HTTP when bulk fresh)