### PR TITLE
feat(weather): global circuit breaker on 429/503 (Phase 3)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -696,6 +696,8 @@ When the bucket is empty, that source is skipped for one fetch cycle (weather ma
 
 `metarResolveStationResponse()` in `lib/weather/adapter/metar-v1.php` reports outcomes as `METAR_RESOLVE_*` constants (`ok`, `throttled`, `circuit_open`, `http_failed`, `invalid_station`). Only `http_failed` and `invalid_station` count as fetch failures for the per-airport METAR circuit breaker; `throttled` is a self-throttle skip for one cycle.
 
+On HTTP **429** or **503**, `lib/circuit-breaker.php` also records a shared `global_weather_{provider}_{fingerprint}` backoff key (same fingerprint rules as upstream throttling) so all airports using that credential back off together. A successful fetch clears both per-airport and global keys for that credential.
+
 ### Backup Sources
 
 Mark a source as backup by adding `"backup": true`. Backup sources are only used when primary sources fail or are stale:

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -33,7 +33,7 @@ The system uses **parallel fetching** for all configured sources:
 
 - **Unified Fetcher**: Fetches all sources simultaneously using `curl_multi`
 - **Sources Fetched**: All sources configured in the `weather_sources` array
-- **Circuit Breaker**: Each source has independent circuit breaker protection (skips sources in backoff)
+- **Circuit Breaker**: Each source has per-airport circuit breaker protection; HTTP 429/503 also open a shared `global_weather_{provider}_{credential fingerprint}` key so airports sharing one API key back off together
 - **Upstream throttle**: Before `curl_multi_add_handle`, `lib/upstream-rate-limit.php` enforces a per-credential token bucket (flock under `cache/upstream-limits/`). When the budget is exhausted, that source is skipped for the current fetch cycle only. METAR uses `metarResolveStationResponse()` (mock, bulk slice, then HTTP); bulk is tried before the per-airport METAR HTTP circuit gate. Throttle and circuit-open outcomes are not recorded as fetch failures. Throttle skips and fail-open I/O are counted in `cache/weather_health.json`.
 - **Parallel Execution**: All sources are fetched concurrently for maximum speed
 - **Freshness Selection**: Handled during aggregation (freshest data wins for each field)

--- a/lib/circuit-breaker.php
+++ b/lib/circuit-breaker.php
@@ -323,25 +323,61 @@ function recordCircuitBreakerSuccessBase($key, $backoffFile) {
 }
 
 /**
+ * Whether HTTP status should update the shared global breaker for this credential.
+ */
+function weather_global_circuit_breaker_should_coordinate(?int $httpCode): bool
+{
+    return $httpCode === 429 || $httpCode === HTTP_STATUS_SERVICE_UNAVAILABLE;
+}
+
+/**
+ * Backoff key shared by all airports using the same provider credential fingerprint.
+ *
+ * @param array<string, mixed> $sourceConfig weather_sources entry (must include type)
+ */
+function weather_global_circuit_breaker_key(string $provider, array $sourceConfig): string
+{
+    require_once __DIR__ . '/upstream-rate-limit.php';
+
+    return 'global_weather_' . $provider . '_' . upstream_rate_fingerprint($provider, $sourceConfig);
+}
+
+/**
  * Check if weather API should be skipped due to backoff
- * 
+ *
  * @param string $airportId Airport ID (e.g., 'kspb')
- * @param string $sourceType Weather source type: 'primary' or 'metar'
+ * @param string $sourceType Weather source type (tempest, metar, etc.)
+ * @param array<string, mixed>|null $sourceConfig When set, also checks global_weather_* for this credential
  * @return array {
- *   'skip' => bool,              // True if should skip (circuit open)
- *   'reason' => string,          // Reason for skip ('circuit_open' or '')
- *   'backoff_remaining' => int,  // Seconds remaining in backoff period
- *   'failures' => int,           // Number of consecutive failures
- *   'last_failure_reason' => string|null  // Reason for last failure (if available)
+ *   'skip' => bool,
+ *   'reason' => string,
+ *   'backoff_remaining' => int,
+ *   'failures' => int,
+ *   'last_failure_reason' => string|null
  * }
  */
-function checkWeatherCircuitBreaker($airportId, $sourceType) {
+function checkWeatherCircuitBreaker($airportId, $sourceType, ?array $sourceConfig = null) {
     if (!ensureCacheDir(CACHE_BASE_DIR)) {
         error_log("Failed to create cache directory: " . CACHE_BASE_DIR);
         return ['skip' => false, 'reason' => '', 'backoff_remaining' => 0, 'failures' => 0, 'last_failure_reason' => null];
     }
     $key = $airportId . '_weather_' . $sourceType;
-    return checkCircuitBreakerBase($key, CACHE_BACKOFF_FILE);
+    $result = checkCircuitBreakerBase($key, CACHE_BACKOFF_FILE);
+    if ($result['skip']) {
+        return $result;
+    }
+
+    if ($sourceConfig === null || ($sourceConfig['type'] ?? '') !== $sourceType) {
+        return $result;
+    }
+
+    $globalKey = weather_global_circuit_breaker_key($sourceType, $sourceConfig);
+    $globalResult = checkCircuitBreakerBase($globalKey, CACHE_BACKOFF_FILE);
+    if ($globalResult['skip']) {
+        $globalResult['reason'] = 'global_circuit_open';
+    }
+
+    return $globalResult;
 }
 
 /**
@@ -352,27 +388,49 @@ function checkWeatherCircuitBreaker($airportId, $sourceType) {
  * @param string $severity 'transient' or 'permanent' (default: 'transient')
  * @param int|null $httpCode HTTP status code (4xx/5xx) if available, null otherwise
  * @param string|null $failureReason Human-readable reason for the failure (e.g., 'API rate limit exceeded', 'HTTP 503')
+ * @param array<string, mixed>|null $sourceConfig When set, 429/503 also update global_weather_* for this credential
  * @return void
  */
-function recordWeatherFailure($airportId, $sourceType, $severity = 'transient', $httpCode = null, $failureReason = null) {
+function recordWeatherFailure(
+    $airportId,
+    $sourceType,
+    $severity = 'transient',
+    $httpCode = null,
+    $failureReason = null,
+    ?array $sourceConfig = null
+) {
     if (!ensureCacheDir(CACHE_BASE_DIR)) {
         error_log("Failed to create cache directory: " . CACHE_BASE_DIR);
         return;
     }
     $key = $airportId . '_weather_' . $sourceType;
     recordCircuitBreakerFailureBase($key, CACHE_BACKOFF_FILE, $severity, $httpCode, $failureReason);
+
+    if ($sourceConfig !== null
+        && ($sourceConfig['type'] ?? '') === $sourceType
+        && weather_global_circuit_breaker_should_coordinate($httpCode)
+    ) {
+        $globalKey = weather_global_circuit_breaker_key($sourceType, $sourceConfig);
+        recordCircuitBreakerFailureBase($globalKey, CACHE_BACKOFF_FILE, $severity, $httpCode, $failureReason);
+    }
 }
 
 /**
  * Record a weather API success and reset backoff state
  * 
  * @param string $airportId Airport ID (e.g., 'kspb')
- * @param string $sourceType Weather source type: 'primary' or 'metar'
+ * @param string $sourceType Weather source type (tempest, metar, etc.)
+ * @param array<string, mixed>|null $sourceConfig When set, also clears global_weather_* for this credential
  * @return void
  */
-function recordWeatherSuccess($airportId, $sourceType) {
+function recordWeatherSuccess($airportId, $sourceType, ?array $sourceConfig = null) {
     $key = $airportId . '_weather_' . $sourceType;
     recordCircuitBreakerSuccessBase($key, CACHE_BACKOFF_FILE);
+
+    if ($sourceConfig !== null && ($sourceConfig['type'] ?? '') === $sourceType) {
+        $globalKey = weather_global_circuit_breaker_key($sourceType, $sourceConfig);
+        recordCircuitBreakerSuccessBase($globalKey, CACHE_BACKOFF_FILE);
+    }
 }
 
 /**

--- a/lib/circuit-breaker.php
+++ b/lib/circuit-breaker.php
@@ -375,9 +375,11 @@ function checkWeatherCircuitBreaker($airportId, $sourceType, ?array $sourceConfi
     $globalResult = checkCircuitBreakerBase($globalKey, CACHE_BACKOFF_FILE);
     if ($globalResult['skip']) {
         $globalResult['reason'] = 'global_circuit_open';
+
+        return $globalResult;
     }
 
-    return $globalResult;
+    return $result;
 }
 
 /**

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -181,7 +181,7 @@ function fetchAllSources(array $sources, string $airportId): array {
                 case METAR_RESOLVE_OK:
                     if (is_string($resolved['body'])) {
                         $responses[$sourceKey] = $resolved['body'];
-                        recordWeatherSuccess($airportId, $sourceType);
+                        recordWeatherSuccess($airportId, $sourceType, $source);
                         weather_health_track_fetch($airportId, $sourceType, true, HTTP_STATUS_OK);
                     }
                     break;
@@ -194,7 +194,7 @@ function fetchAllSources(array $sources, string $airportId): array {
                 case METAR_RESOLVE_HTTP_FAILED:
                 case METAR_RESOLVE_INVALID_STATION:
                     $responses[$sourceKey] = null;
-                    recordWeatherFailure($airportId, $sourceType, 'transient', null);
+                    recordWeatherFailure($airportId, $sourceType, 'transient', null, null, $source);
                     weather_health_track_fetch($airportId, $sourceType, false, null);
                     break;
             }
@@ -202,7 +202,7 @@ function fetchAllSources(array $sources, string $airportId): array {
         }
 
         // Check circuit breaker (non-METAR sources)
-        $breakerResult = checkWeatherCircuitBreaker($airportId, $sourceType);
+        $breakerResult = checkWeatherCircuitBreaker($airportId, $sourceType, $source);
         if (is_array($breakerResult) && ($breakerResult['skip'] ?? false)) {
             weather_health_track_circuit_open($airportId, $sourceType);
             continue;
@@ -288,12 +288,12 @@ function fetchAllSources(array $sources, string $airportId): array {
                 $response = tempestApplyDeviceFallbackIfNeeded($response, $sources[$sourceKey], $airportId);
             }
             $responses[$sourceKey] = $response; // Pass through even if empty - aggregator will handle it
-            recordWeatherSuccess($airportId, $sourceType);
+            recordWeatherSuccess($airportId, $sourceType, $sources[$sourceKey]);
             weather_health_track_fetch($airportId, $sourceType, true, $httpCode);
         } else {
             // Failure: HTTP error or network issue - trigger circuit breaker
             $responses[$sourceKey] = null;
-            recordWeatherFailure($airportId, $sourceType, 'transient', $httpCode);
+            recordWeatherFailure($airportId, $sourceType, 'transient', $httpCode, null, $sources[$sourceKey]);
             weather_health_track_fetch($airportId, $sourceType, false, $httpCode);
         }
         
@@ -306,7 +306,7 @@ function fetchAllSources(array $sources, string $airportId): array {
     foreach ($swobAuto404Retries as $sourceKey => $source) {
         $fallbackUrl = SwobAutoAdapter::buildStandardUrl($source);
         if ($fallbackUrl === null) {
-            recordWeatherFailure($airportId, 'swob_auto', 'transient', 404);
+            recordWeatherFailure($airportId, 'swob_auto', 'transient', 404, null, $source);
             weather_health_track_fetch($airportId, 'swob_auto', false, 404);
             continue;
         }
@@ -337,10 +337,10 @@ function fetchAllSources(array $sources, string $airportId): array {
         curl_close($ch);
         if ($httpCode >= 200 && $httpCode < 300) {
             $responses[$sourceKey] = $response;
-            recordWeatherSuccess($airportId, 'swob_auto');
+            recordWeatherSuccess($airportId, 'swob_auto', $source);
             weather_health_track_fetch($airportId, 'swob_auto', true, $httpCode);
         } else {
-            recordWeatherFailure($airportId, 'swob_auto', 'transient', $httpCode);
+            recordWeatherFailure($airportId, 'swob_auto', 'transient', $httpCode, null, $source);
             weather_health_track_fetch($airportId, 'swob_auto', false, $httpCode);
         }
     }

--- a/lib/weather/adapter/metar-v1.php
+++ b/lib/weather/adapter/metar-v1.php
@@ -840,6 +840,8 @@ function metarResolveStationResponse(string $stationId, ?string $airportId = nul
         return ['body' => null, 'outcome' => METAR_RESOLVE_INVALID_STATION];
     }
 
+    $stationSource = ['type' => 'metar', 'station_id' => $stationId];
+
     $url = 'https://aviationweather.gov/api/data/metar?ids=' . rawurlencode($stationId)
         . '&format=json&taf=false&hours=0';
 
@@ -856,14 +858,13 @@ function metarResolveStationResponse(string $stationId, ?string $airportId = nul
 
     if ($airportId !== null && $airportId !== '') {
         require_once __DIR__ . '/../../circuit-breaker.php';
-        $breakerResult = checkWeatherCircuitBreaker($airportId, 'metar');
+        $breakerResult = checkWeatherCircuitBreaker($airportId, 'metar', $stationSource);
         if (is_array($breakerResult) && ($breakerResult['skip'] ?? false)) {
             return ['body' => null, 'outcome' => METAR_RESOLVE_CIRCUIT_OPEN];
         }
     }
 
     require_once __DIR__ . '/../../upstream-rate-limit.php';
-    $stationSource = ['type' => 'metar', 'station_id' => $stationId];
     if (!upstream_rate_limit_consume_for_source($stationSource)['allowed']) {
         return ['body' => null, 'outcome' => METAR_RESOLVE_THROTTLED];
     }

--- a/tests/Unit/GlobalWeatherCircuitBreakerTest.php
+++ b/tests/Unit/GlobalWeatherCircuitBreakerTest.php
@@ -60,6 +60,17 @@ final class GlobalWeatherCircuitBreakerTest extends TestCase
         $this->assertSame('global_circuit_open', $result['reason']);
     }
 
+    public function testCheckWeatherCircuitBreaker_GlobalNotOpen_ReturnsPerAirportStats(): void
+    {
+        $source = ['type' => 'tempest', 'api_key' => 'stats-key', 'station_id' => '1'];
+
+        recordWeatherFailure(self::AIRPORT_B, 'tempest', 'transient', HTTP_STATUS_SERVICE_UNAVAILABLE, null, $source);
+
+        $result = checkWeatherCircuitBreaker(self::AIRPORT_B, 'tempest', $source);
+        $this->assertFalse($result['skip']);
+        $this->assertSame(1, $result['failures']);
+    }
+
     public function testRecordWeatherSuccess_GlobalKey_ClearsSharedBackoff(): void
     {
         $source = ['type' => 'tempest', 'api_key' => 'clear-global-key', 'station_id' => '1'];

--- a/tests/Unit/GlobalWeatherCircuitBreakerTest.php
+++ b/tests/Unit/GlobalWeatherCircuitBreakerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AviationWX\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Global weather circuit breaker keys shared across airports for one credential.
+ */
+final class GlobalWeatherCircuitBreakerTest extends TestCase
+{
+    private string $backoffFile;
+
+    private const AIRPORT_A = 'global_breaker_test_a';
+
+    private const AIRPORT_B = 'global_breaker_test_b';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/../../lib/cache-paths.php';
+        require_once __DIR__ . '/../../lib/constants.php';
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+        require_once __DIR__ . '/../../lib/circuit-breaker.php';
+
+        $this->backoffFile = CACHE_BACKOFF_FILE;
+        ensureCacheDir(dirname($this->backoffFile));
+        $this->cleanupKeys();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanupKeys();
+        parent::tearDown();
+    }
+
+    public function testGlobalKey_SameTempestApiKey_ReturnsSameKey(): void
+    {
+        $sourceA = ['type' => 'tempest', 'api_key' => 'shared-key', 'station_id' => '1'];
+        $sourceB = ['type' => 'tempest', 'api_key' => 'shared-key', 'station_id' => '2'];
+
+        $this->assertSame(
+            weather_global_circuit_breaker_key('tempest', $sourceA),
+            weather_global_circuit_breaker_key('tempest', $sourceB)
+        );
+    }
+
+    public function testCheckWeatherCircuitBreaker_GlobalOpenDifferentAirport_Skips(): void
+    {
+        $source = ['type' => 'tempest', 'api_key' => 'global-test-key', 'station_id' => '99'];
+
+        for ($i = 0; $i < CIRCUIT_BREAKER_FAILURE_THRESHOLD; $i++) {
+            recordWeatherFailure(self::AIRPORT_A, 'tempest', 'transient', 429, null, $source);
+        }
+
+        $result = checkWeatherCircuitBreaker(self::AIRPORT_B, 'tempest', $source);
+        $this->assertTrue($result['skip']);
+        $this->assertSame('global_circuit_open', $result['reason']);
+    }
+
+    public function testRecordWeatherSuccess_GlobalKey_ClearsSharedBackoff(): void
+    {
+        $source = ['type' => 'tempest', 'api_key' => 'clear-global-key', 'station_id' => '1'];
+
+        for ($i = 0; $i < CIRCUIT_BREAKER_FAILURE_THRESHOLD; $i++) {
+            recordWeatherFailure(self::AIRPORT_A, 'tempest', 'transient', 429, null, $source);
+        }
+
+        $blocked = checkWeatherCircuitBreaker(self::AIRPORT_B, 'tempest', $source);
+        $this->assertTrue($blocked['skip']);
+
+        recordWeatherSuccess(self::AIRPORT_A, 'tempest', $source);
+
+        $allowed = checkWeatherCircuitBreaker(self::AIRPORT_B, 'tempest', $source);
+        $this->assertFalse($allowed['skip']);
+    }
+
+    public function testRecordWeatherFailure_NonCoordinatingHttpCode_DoesNotOpenGlobalOnly(): void
+    {
+        $source = ['type' => 'tempest', 'api_key' => '404-only-key', 'station_id' => '1'];
+
+        for ($i = 0; $i < CIRCUIT_BREAKER_FAILURE_THRESHOLD; $i++) {
+            recordWeatherFailure(self::AIRPORT_A, 'tempest', 'transient', 404, null, $source);
+        }
+
+        $globalKey = weather_global_circuit_breaker_key('tempest', $source);
+        $data = $this->readBackoffData();
+        $this->assertArrayNotHasKey($globalKey, $data);
+
+        $perAirport = checkWeatherCircuitBreaker(self::AIRPORT_B, 'tempest', $source);
+        $this->assertFalse($perAirport['skip']);
+    }
+
+    public function testRecordWeatherFailure_Http503_RecordsGlobalKey(): void
+    {
+        $source = ['type' => 'tempest', 'api_key' => '503-key', 'station_id' => '1'];
+
+        recordWeatherFailure(self::AIRPORT_A, 'tempest', 'transient', HTTP_STATUS_SERVICE_UNAVAILABLE, null, $source);
+
+        $globalKey = weather_global_circuit_breaker_key('tempest', $source);
+        $data = $this->readBackoffData();
+        $this->assertArrayHasKey($globalKey, $data);
+    }
+
+    private function readBackoffData(): array
+    {
+        if (!is_file($this->backoffFile)) {
+            return [];
+        }
+
+        return json_decode((string) file_get_contents($this->backoffFile), true) ?: [];
+    }
+
+    private function cleanupKeys(): void
+    {
+        if (!is_file($this->backoffFile)) {
+            return;
+        }
+
+        $data = $this->readBackoffData();
+        $prefixes = [
+            self::AIRPORT_A . '_weather_',
+            self::AIRPORT_B . '_weather_',
+            'global_weather_tempest_',
+        ];
+        $changed = false;
+        foreach (array_keys($data) as $key) {
+            foreach ($prefixes as $prefix) {
+                if (str_starts_with($key, $prefix)) {
+                    unset($data[$key]);
+                    $changed = true;
+                    break;
+                }
+            }
+        }
+        if ($changed) {
+            file_put_contents($this->backoffFile, json_encode($data, JSON_PRETTY_PRINT), LOCK_EX);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- On HTTP **429** or **503**, record a shared `global_weather_{provider}_{fingerprint}` backoff key (credential fingerprint from Phase 2) so all airports using the same API identity back off together.
- Extend `checkWeatherCircuitBreaker`, `recordWeatherFailure`, and `recordWeatherSuccess` with optional `sourceConfig`; global open returns reason `global_circuit_open`.
- Wire `UnifiedFetcher` and METAR HTTP path to pass `weather_sources` entries for global checks and clears.
- Document behavior in `docs/CONFIGURATION.md` and `docs/DATA_FLOW.md`.

Follows merged Phase 2 (per-credential upstream throttle, PR #102). Phase 4 (Retry-After) is out of scope.

## Test plan

- [x] `make test-ci` green
- [x] `GlobalWeatherCircuitBreakerTest`: shared Tempest key, cross-airport skip, success clears global, 404 does not open global, 503 opens global
- [x] After deploy: trigger 429 on one airport with shared key; confirm other airports skip that source until backoff expires or one airport succeeds