### PR TITLE
feat(weather): Retry-After and X-RateLimit-Reset backoff (Phase 4)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -698,6 +698,8 @@ When the bucket is empty, that source is skipped for one fetch cycle (weather ma
 
 On HTTP **429** or **503**, `lib/circuit-breaker.php` also records a shared `global_weather_{provider}_{fingerprint}` backoff key (same fingerprint rules as upstream throttling) so all airports using that credential back off together. A successful fetch clears both per-airport and global keys for that credential.
 
+When the upstream response includes **`Retry-After`** or **`X-RateLimit-Reset`** (Aeris-style), `UnifiedFetcher` passes those headers into the circuit breaker. Backoff uses the longer of the default strategy and the header hint, clamped to 15 minutes (`BACKOFF_MAX_RETRY_AFTER_SECONDS` in `lib/constants.php`).
+
 ### Backup Sources
 
 Mark a source as backup by adding `"backup": true`. Backup sources are only used when primary sources fail or are stale:

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -33,7 +33,7 @@ The system uses **parallel fetching** for all configured sources:
 
 - **Unified Fetcher**: Fetches all sources simultaneously using `curl_multi`
 - **Sources Fetched**: All sources configured in the `weather_sources` array
-- **Circuit Breaker**: Each source has per-airport circuit breaker protection; HTTP 429/503 also open a shared `global_weather_{provider}_{credential fingerprint}` key so airports sharing one API key back off together
+- **Circuit Breaker**: Each source has per-airport circuit breaker protection; HTTP 429/503 also open a shared `global_weather_{provider}_{credential fingerprint}` key so airports sharing one API key back off together. When present, `Retry-After` / `X-RateLimit-Reset` from the failed response extend backoff (up to 15 minutes).
 - **Upstream throttle**: Before `curl_multi_add_handle`, `lib/upstream-rate-limit.php` enforces a per-credential token bucket (flock under `cache/upstream-limits/`). When the budget is exhausted, that source is skipped for the current fetch cycle only. METAR uses `metarResolveStationResponse()` (mock, bulk slice, then HTTP); bulk is tried before the per-airport METAR HTTP circuit gate. Throttle and circuit-open outcomes are not recorded as fetch failures. Throttle skips and fail-open I/O are counted in `cache/weather_health.json`.
 - **Parallel Execution**: All sources are fetched concurrently for maximum speed
 - **Freshness Selection**: Handled during aggregation (freshest data wins for each field)

--- a/lib/circuit-breaker.php
+++ b/lib/circuit-breaker.php
@@ -8,6 +8,7 @@
 require_once __DIR__ . '/constants.php';
 require_once __DIR__ . '/logger.php';
 require_once __DIR__ . '/cache-paths.php';
+require_once __DIR__ . '/weather-backoff-headers.php';
 
 /**
  * Base circuit breaker check
@@ -74,7 +75,8 @@ function checkCircuitBreakerBase($key, $backoffFile) {
  * Records a failure and updates exponential backoff state.
  * Uses file locking to prevent race conditions in concurrent environments.
  * Implements error-type-specific backoff strategies:
- *   - 429 (Rate Limit): Short backoff (2s base), minimal growth
+ *   - 429 (Rate Limit): Short backoff (2s base), minimal growth; Retry-After / X-RateLimit-Reset
+ *     on 429/503 can extend the wait up to BACKOFF_MAX_RETRY_AFTER_SECONDS (15 min)
  *   - Transient errors (5xx, network): Moderate backoff (10s base), exponential growth, capped at 10 min
  *   - Permanent errors (4xx auth/config): Long backoff (2x multiplier), capped at 30 min
  * 
@@ -87,9 +89,17 @@ function checkCircuitBreakerBase($key, $backoffFile) {
  *   - permanent: 2x multiplier (for auth errors, config issues, etc.)
  * @param int|null $httpCode HTTP status code (4xx/5xx) if available, null otherwise
  * @param string|null $failureReason Human-readable reason for the failure (e.g., 'EXIF validation failed', 'HTTP 503')
+ * @param array<string, string>|null $responseHeaders Lowercase upstream headers (Retry-After, X-RateLimit-*)
  * @return void
  */
-function recordCircuitBreakerFailureBase($key, $backoffFile, $severity = 'transient', $httpCode = null, $failureReason = null) {
+function recordCircuitBreakerFailureBase(
+    $key,
+    $backoffFile,
+    $severity = 'transient',
+    $httpCode = null,
+    $failureReason = null,
+    ?array $responseHeaders = null
+) {
     $cacheDir = dirname($backoffFile);
     if (!file_exists($cacheDir)) {
         if (!@mkdir($cacheDir, 0755, true)) {
@@ -135,22 +145,14 @@ function recordCircuitBreakerFailureBase($key, $backoffFile, $severity = 'transi
     }
     
     $failures = $state['failures'];
-    
-    // Error-type-specific backoff strategies
-    if ($httpCode === 429) {
-        // Rate limit errors: short backoff, minimal growth
-        $base = BACKOFF_BASE_RATE_LIMIT;
-        $backoffSeconds = min(10, $base + ($failures - 1)); // 2s, 3s, 4s... capped at 10s
-    } elseif ($severity === 'permanent') {
-        // Permanent errors: 2x multiplier, 30 min cap
-        $base = max(BACKOFF_BASE_SECONDS, pow(2, min($failures - 1, BACKOFF_MAX_FAILURES)) * BACKOFF_BASE_SECONDS);
-        $backoffSeconds = min(BACKOFF_MAX_PERMANENT, (int)round($base * 2.0));
-    } else {
-        // Transient errors: 10s base, exponential growth, 10 min cap
-        $base = max(BACKOFF_BASE_TRANSIENT, pow(2, min($failures - 1, BACKOFF_MAX_FAILURES)) * BACKOFF_BASE_TRANSIENT);
-        $backoffSeconds = min(BACKOFF_MAX_TRANSIENT, (int)round($base));
-    }
-    
+    $backoffSeconds = circuit_breaker_compute_backoff_seconds(
+        $failures,
+        $severity,
+        $httpCode,
+        $responseHeaders,
+        $now
+    );
+
     $state['backoff_seconds'] = $backoffSeconds;
     $state['next_allowed_time'] = $now + $backoffSeconds;
         
@@ -204,23 +206,15 @@ function recordCircuitBreakerFailureBase($key, $backoffFile, $severity = 'transi
         $state['last_failure_reason'] = 'unknown';
     }
     
-    // Error-type-specific backoff strategies
     $failures = $state['failures'];
-    
-    if ($httpCode === 429) {
-        // Rate limit errors: short backoff, minimal growth
-        $base = BACKOFF_BASE_RATE_LIMIT;
-        $backoffSeconds = min(10, $base + ($failures - 1)); // 2s, 3s, 4s... capped at 10s
-    } elseif ($severity === 'permanent') {
-        // Permanent errors: 2x multiplier, 30 min cap
-        $base = max(BACKOFF_BASE_SECONDS, pow(2, min($failures - 1, BACKOFF_MAX_FAILURES)) * BACKOFF_BASE_SECONDS);
-        $backoffSeconds = min(BACKOFF_MAX_PERMANENT, (int)round($base * 2.0));
-    } else {
-        // Transient errors: 10s base, exponential growth, 10 min cap
-        $base = max(BACKOFF_BASE_TRANSIENT, pow(2, min($failures - 1, BACKOFF_MAX_FAILURES)) * BACKOFF_BASE_TRANSIENT);
-        $backoffSeconds = min(BACKOFF_MAX_TRANSIENT, (int)round($base));
-    }
-    
+    $backoffSeconds = circuit_breaker_compute_backoff_seconds(
+        $failures,
+        $severity,
+        $httpCode,
+        $responseHeaders,
+        $now
+    );
+
     $state['backoff_seconds'] = $backoffSeconds;
     $state['next_allowed_time'] = $now + $backoffSeconds;
     
@@ -386,11 +380,12 @@ function checkWeatherCircuitBreaker($airportId, $sourceType, ?array $sourceConfi
  * Record a weather API failure and update backoff state
  * 
  * @param string $airportId Airport ID (e.g., 'kspb')
- * @param string $sourceType Weather source type: 'primary' or 'metar'
+ * @param string $sourceType Weather source type (tempest, metar, etc.)
  * @param string $severity 'transient' or 'permanent' (default: 'transient')
  * @param int|null $httpCode HTTP status code (4xx/5xx) if available, null otherwise
  * @param string|null $failureReason Human-readable reason for the failure (e.g., 'API rate limit exceeded', 'HTTP 503')
  * @param array<string, mixed>|null $sourceConfig When set, 429/503 also update global_weather_* for this credential
+ * @param array<string, string>|null $responseHeaders Lowercase upstream headers from the failed response
  * @return void
  */
 function recordWeatherFailure(
@@ -399,21 +394,22 @@ function recordWeatherFailure(
     $severity = 'transient',
     $httpCode = null,
     $failureReason = null,
-    ?array $sourceConfig = null
+    ?array $sourceConfig = null,
+    ?array $responseHeaders = null
 ) {
     if (!ensureCacheDir(CACHE_BASE_DIR)) {
         error_log("Failed to create cache directory: " . CACHE_BASE_DIR);
         return;
     }
     $key = $airportId . '_weather_' . $sourceType;
-    recordCircuitBreakerFailureBase($key, CACHE_BACKOFF_FILE, $severity, $httpCode, $failureReason);
+    recordCircuitBreakerFailureBase($key, CACHE_BACKOFF_FILE, $severity, $httpCode, $failureReason, $responseHeaders);
 
     if ($sourceConfig !== null
         && ($sourceConfig['type'] ?? '') === $sourceType
         && weather_global_circuit_breaker_should_coordinate($httpCode)
     ) {
         $globalKey = weather_global_circuit_breaker_key($sourceType, $sourceConfig);
-        recordCircuitBreakerFailureBase($globalKey, CACHE_BACKOFF_FILE, $severity, $httpCode, $failureReason);
+        recordCircuitBreakerFailureBase($globalKey, CACHE_BACKOFF_FILE, $severity, $httpCode, $failureReason, $responseHeaders);
     }
 }
 

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -355,6 +355,9 @@ if (!defined('BACKOFF_MAX_PERMANENT')) {
 if (!defined('BACKOFF_MAX_FAILURES')) {
     define('BACKOFF_MAX_FAILURES', 5);
 }
+if (!defined('BACKOFF_MAX_RETRY_AFTER_SECONDS')) {
+    define('BACKOFF_MAX_RETRY_AFTER_SECONDS', 900); // 15 minutes - max Retry-After / reset hint
+}
 
 // Background refresh
 if (!defined('BACKGROUND_REFRESH_MAX_TIME')) {

--- a/lib/weather-backoff-headers.php
+++ b/lib/weather-backoff-headers.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Upstream rate-limit response headers for circuit breaker backoff.
+ *
+ * Pure helpers for Retry-After and optional X-RateLimit-* hints on 429/503.
+ */
+
+require_once __DIR__ . '/constants.php';
+
+/**
+ * Append one CURLOPT_HEADERFUNCTION line into a lowercase header map.
+ *
+ * @param array<string, string> $headers Accumulator (last value wins per name)
+ * @param string $line Raw header line from curl
+ * @return int Bytes processed (required by CURLOPT_HEADERFUNCTION)
+ */
+function circuit_breaker_collect_curl_header_line(array &$headers, string $line): int
+{
+    $trimmed = rtrim($line, "\r\n");
+    if ($trimmed === '' || strpos($trimmed, ':') === false) {
+        return strlen($line);
+    }
+
+    [$name, $value] = explode(':', $trimmed, 2);
+    $headers[strtolower(trim($name))] = trim($value);
+
+    return strlen($line);
+}
+
+/**
+ * Parse Retry-After as seconds until retry (RFC 7231 delay-seconds or HTTP-date).
+ *
+ * HTTP-date values use PHP strtotime (GMT suffix in the value is honored).
+ *
+ * @param string $value Raw Retry-After header value
+ * @param int|null $now Reference time for HTTP-date deltas (default: time())
+ * @return int|null Positive seconds, or null when absent/invalid/past
+ */
+function parse_retry_after_seconds(string $value, ?int $now = null): ?int
+{
+    $value = trim($value);
+    if ($value === '') {
+        return null;
+    }
+
+    $now = $now ?? time();
+
+    if (ctype_digit($value)) {
+        $seconds = (int) $value;
+
+        return $seconds > 0 ? $seconds : null;
+    }
+
+    $target = strtotime($value);
+    if ($target === false) {
+        return null;
+    }
+
+    $delta = $target - $now;
+
+    return $delta > 0 ? $delta : null;
+}
+
+/**
+ * Clamp upstream-suggested wait to a safe maximum (15 minutes).
+ *
+ * @param int $seconds Unclamped wait from Retry-After or X-RateLimit-Reset delta
+ * @return int Seconds in [1, BACKOFF_MAX_RETRY_AFTER_SECONDS]
+ */
+function weather_backoff_clamp_seconds(int $seconds): int
+{
+    return max(1, min(BACKOFF_MAX_RETRY_AFTER_SECONDS, $seconds));
+}
+
+/**
+ * Suggested backoff from upstream headers for rate-limit style responses.
+ *
+ * Retry-After takes precedence; otherwise X-RateLimit-Reset (Unix epoch seconds).
+ * Only applies to HTTP 429 and 503. Relative reset values (small integers) are ignored.
+ *
+ * @param int|null $httpCode HTTP status from the failed response
+ * @param array<string, string> $responseHeaders Lowercase header name to value
+ * @param int|null $now Reference time for reset delta (default: time())
+ * @return int|null Clamped seconds, or null when no usable hint
+ */
+function weather_backoff_override_seconds(?int $httpCode, array $responseHeaders, ?int $now = null): ?int
+{
+    if ($httpCode !== 429 && $httpCode !== HTTP_STATUS_SERVICE_UNAVAILABLE) {
+        return null;
+    }
+
+    if ($responseHeaders === []) {
+        return null;
+    }
+
+    $now = $now ?? time();
+
+    $retryAfter = $responseHeaders['retry-after'] ?? null;
+    if (is_string($retryAfter) && $retryAfter !== '') {
+        $parsed = parse_retry_after_seconds($retryAfter, $now);
+        if ($parsed !== null) {
+            return weather_backoff_clamp_seconds($parsed);
+        }
+    }
+
+    $reset = $responseHeaders['x-ratelimit-reset'] ?? null;
+    if (is_string($reset) && ctype_digit(trim($reset))) {
+        $resetTs = (int) trim($reset);
+        if ($resetTs > $now) {
+            return weather_backoff_clamp_seconds($resetTs - $now);
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Compute circuit breaker backoff seconds for one failure event.
+ *
+ * When upstream sends Retry-After or X-RateLimit-Reset on 429/503, uses the
+ * longer of the default strategy and the header hint (header clamped to 15 min).
+ * Skip logic still requires CIRCUIT_BREAKER_FAILURE_THRESHOLD consecutive failures.
+ *
+ * @param int $failures Consecutive failure count after this event is recorded
+ * @param string $severity transient or permanent
+ * @param int|null $httpCode HTTP status when available
+ * @param array<string, string>|null $responseHeaders Lowercase upstream headers
+ * @param int|null $now Reference time for header hints (default: time())
+ * @return int Backoff seconds before next_allowed_time
+ */
+function circuit_breaker_compute_backoff_seconds(
+    int $failures,
+    string $severity,
+    ?int $httpCode,
+    ?array $responseHeaders = null,
+    ?int $now = null
+): int {
+    if ($httpCode === 429) {
+        $base = BACKOFF_BASE_RATE_LIMIT;
+        $backoffSeconds = min(10, $base + ($failures - 1));
+    } elseif ($severity === 'permanent') {
+        $base = max(BACKOFF_BASE_SECONDS, pow(2, min($failures - 1, BACKOFF_MAX_FAILURES)) * BACKOFF_BASE_SECONDS);
+        $backoffSeconds = min(BACKOFF_MAX_PERMANENT, (int) round($base * 2.0));
+    } else {
+        $base = max(BACKOFF_BASE_TRANSIENT, pow(2, min($failures - 1, BACKOFF_MAX_FAILURES)) * BACKOFF_BASE_TRANSIENT);
+        $backoffSeconds = min(BACKOFF_MAX_TRANSIENT, (int) round($base));
+    }
+
+    if ($responseHeaders !== null && $responseHeaders !== []) {
+        $override = weather_backoff_override_seconds($httpCode, $responseHeaders, $now);
+        if ($override !== null) {
+            $backoffSeconds = max($backoffSeconds, $override);
+        }
+    }
+
+    return $backoffSeconds;
+}

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -165,6 +165,7 @@ function buildSourceList(array $airport): array {
 function fetchAllSources(array $sources, string $airportId): array {
     $mh = curl_multi_init();
     $handles = [];
+    $responseHeadersByKey = [];
     $responses = [];
 
     foreach ($sources as $sourceKey => $source) {
@@ -229,6 +230,11 @@ function fetchAllSources(array $sources, string $airportId): array {
         // Get headers for this source
         $headers = buildSourceHeaders($source);
         
+        $responseHeadersByKey[$sourceKey] = [];
+        $headerCollector = function ($ch, string $line) use (&$responseHeadersByKey, $sourceKey): int {
+            return circuit_breaker_collect_curl_header_line($responseHeadersByKey[$sourceKey], $line);
+        };
+
         // Create curl handle
         $ch = curl_init($url);
         curl_setopt_array($ch, [
@@ -240,6 +246,7 @@ function fetchAllSources(array $sources, string $airportId): array {
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_MAXREDIRS => 3,
             CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_HEADERFUNCTION => $headerCollector,
         ]);
         
         curl_multi_add_handle($mh, $ch);
@@ -293,7 +300,15 @@ function fetchAllSources(array $sources, string $airportId): array {
         } else {
             // Failure: HTTP error or network issue - trigger circuit breaker
             $responses[$sourceKey] = null;
-            recordWeatherFailure($airportId, $sourceType, 'transient', $httpCode, null, $sources[$sourceKey]);
+            recordWeatherFailure(
+                $airportId,
+                $sourceType,
+                'transient',
+                $httpCode,
+                null,
+                $sources[$sourceKey],
+                $responseHeadersByKey[$sourceKey] ?? null
+            );
             weather_health_track_fetch($airportId, $sourceType, false, $httpCode);
         }
         
@@ -321,6 +336,10 @@ function fetchAllSources(array $sources, string $airportId): array {
             weather_health_track_upstream_throttle_skip($airportId, 'swob_auto');
             continue;
         }
+        $fallbackHeaders = [];
+        $fallbackHeaderCollector = function ($ch, string $line) use (&$fallbackHeaders): int {
+            return circuit_breaker_collect_curl_header_line($fallbackHeaders, $line);
+        };
         $ch = curl_init($fallbackUrl);
         curl_setopt_array($ch, [
             CURLOPT_RETURNTRANSFER => true,
@@ -331,6 +350,7 @@ function fetchAllSources(array $sources, string $airportId): array {
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_MAXREDIRS => 3,
             CURLOPT_HTTPHEADER => buildSourceHeaders($source),
+            CURLOPT_HEADERFUNCTION => $fallbackHeaderCollector,
         ]);
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -340,7 +360,7 @@ function fetchAllSources(array $sources, string $airportId): array {
             recordWeatherSuccess($airportId, 'swob_auto', $source);
             weather_health_track_fetch($airportId, 'swob_auto', true, $httpCode);
         } else {
-            recordWeatherFailure($airportId, 'swob_auto', 'transient', $httpCode, null, $source);
+            recordWeatherFailure($airportId, 'swob_auto', 'transient', $httpCode, null, $source, $fallbackHeaders);
             weather_health_track_fetch($airportId, 'swob_auto', false, $httpCode);
         }
     }

--- a/tests/Unit/WeatherBackoffHeadersTest.php
+++ b/tests/Unit/WeatherBackoffHeadersTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/weather-backoff-headers.php';
+require_once __DIR__ . '/../../lib/circuit-breaker.php';
+require_once __DIR__ . '/../../lib/cache-paths.php';
+
+/**
+ * @covers weather-backoff-headers.php
+ */
+class WeatherBackoffHeadersTest extends TestCase
+{
+    private string $testAirportId = 'retry_hdr_test';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (is_file(CACHE_BACKOFF_FILE)) {
+            @unlink(CACHE_BACKOFF_FILE);
+        }
+        ensureCacheDir(CACHE_BASE_DIR);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file(CACHE_BACKOFF_FILE)) {
+            @unlink(CACHE_BACKOFF_FILE);
+        }
+        parent::tearDown();
+    }
+
+    public function testParseRetryAfterSeconds_Integer(): void
+    {
+        $this->assertSame(60, parse_retry_after_seconds('60'));
+        $this->assertSame(1, parse_retry_after_seconds('1'));
+    }
+
+    public function testParseRetryAfterSeconds_HttpDate(): void
+    {
+        $now = 1_770_000_000;
+        $headerValue = gmdate('D, d M Y H:i:s', $now + 120) . ' GMT';
+        $this->assertSame(120, parse_retry_after_seconds($headerValue, $now));
+    }
+
+    public function testParseRetryAfterSeconds_PastHttpDate_ReturnsNull(): void
+    {
+        $now = 1_770_000_300;
+        $headerValue = gmdate('D, d M Y H:i:s', $now - 60) . ' GMT';
+        $this->assertNull(parse_retry_after_seconds($headerValue, $now));
+    }
+
+    public function testParseRetryAfterSeconds_Invalid_ReturnsNull(): void
+    {
+        $this->assertNull(parse_retry_after_seconds('not-a-date'));
+        $this->assertNull(parse_retry_after_seconds(''));
+        $this->assertNull(parse_retry_after_seconds('0'));
+    }
+
+    public function testWeatherBackoffOverrideSeconds_RetryAfter_ClampedToMax(): void
+    {
+        $seconds = BACKOFF_MAX_RETRY_AFTER_SECONDS + 500;
+        $override = weather_backoff_override_seconds(429, ['retry-after' => (string) $seconds]);
+        $this->assertSame(BACKOFF_MAX_RETRY_AFTER_SECONDS, $override);
+    }
+
+    public function testWeatherBackoffOverrideSeconds_RetryAfter_429(): void
+    {
+        $override = weather_backoff_override_seconds(429, ['retry-after' => '45']);
+        $this->assertSame(45, $override);
+    }
+
+    public function testWeatherBackoffOverrideSeconds_XRateLimitReset_WhenNoRetryAfter(): void
+    {
+        $now = 1_700_000_000;
+        $override = weather_backoff_override_seconds(
+            429,
+            ['x-ratelimit-reset' => (string) ($now + 90)],
+            $now
+        );
+        $this->assertSame(90, $override);
+    }
+
+    public function testWeatherBackoffOverrideSeconds_IgnoredFor404(): void
+    {
+        $this->assertNull(weather_backoff_override_seconds(404, ['retry-after' => '120']));
+    }
+
+    public function testWeatherBackoffOverrideSeconds_RetryAfter_503(): void
+    {
+        $override = weather_backoff_override_seconds(
+            HTTP_STATUS_SERVICE_UNAVAILABLE,
+            ['retry-after' => '30']
+        );
+        $this->assertSame(30, $override);
+    }
+
+    public function testWeatherBackoffOverrideSeconds_SmallResetIgnored(): void
+    {
+        $now = 1_700_000_000;
+        $this->assertNull(weather_backoff_override_seconds(429, ['x-ratelimit-reset' => '90'], $now));
+    }
+
+    public function testCircuitBreakerComputeBackoffSeconds_UsesHeaderWhenLongerThan429Default(): void
+    {
+        $seconds = circuit_breaker_compute_backoff_seconds(2, 'transient', 429, ['retry-after' => '120']);
+        $this->assertSame(120, $seconds);
+    }
+
+    public function testCircuitBreakerCollectCurlHeaderLine_NormalizesKeys(): void
+    {
+        $headers = [];
+        circuit_breaker_collect_curl_header_line($headers, "Retry-After: 30\r\n");
+        circuit_breaker_collect_curl_header_line($headers, "X-RateLimit-Reset: 999\r\n");
+        $this->assertSame('30', $headers['retry-after']);
+        $this->assertSame('999', $headers['x-ratelimit-reset']);
+    }
+
+    public function testRecordWeatherFailure_UsesRetryAfterWhenLongerThanDefault(): void
+    {
+        $headers = ['retry-after' => '90'];
+        for ($i = 0; $i < CIRCUIT_BREAKER_FAILURE_THRESHOLD; $i++) {
+            recordWeatherFailure($this->testAirportId, 'tempest', 'transient', 429, null, null, $headers);
+        }
+
+        $result = checkWeatherCircuitBreaker($this->testAirportId, 'tempest');
+        $this->assertTrue($result['skip']);
+        $this->assertGreaterThanOrEqual(85, $result['backoff_remaining']);
+        $this->assertLessThanOrEqual(90, $result['backoff_remaining']);
+    }
+}

--- a/tests/Unit/WeatherBackoffHeadersTest.php
+++ b/tests/Unit/WeatherBackoffHeadersTest.php
@@ -9,7 +9,11 @@ require_once __DIR__ . '/../../lib/circuit-breaker.php';
 require_once __DIR__ . '/../../lib/cache-paths.php';
 
 /**
- * @covers weather-backoff-headers.php
+ * @covers ::circuit_breaker_collect_curl_header_line
+ * @covers ::parse_retry_after_seconds
+ * @covers ::weather_backoff_clamp_seconds
+ * @covers ::weather_backoff_override_seconds
+ * @covers ::circuit_breaker_compute_backoff_seconds
  */
 class WeatherBackoffHeadersTest extends TestCase
 {
@@ -127,7 +131,23 @@ class WeatherBackoffHeadersTest extends TestCase
 
         $result = checkWeatherCircuitBreaker($this->testAirportId, 'tempest');
         $this->assertTrue($result['skip']);
-        $this->assertGreaterThanOrEqual(85, $result['backoff_remaining']);
-        $this->assertLessThanOrEqual(90, $result['backoff_remaining']);
+
+        $key = $this->testAirportId . '_weather_tempest';
+        $data = $this->readBackoffData();
+        $this->assertArrayHasKey($key, $data);
+        $this->assertSame(90, (int) ($data[$key]['backoff_seconds'] ?? 0));
+        $this->assertGreaterThan(time(), (int) ($data[$key]['next_allowed_time'] ?? 0));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readBackoffData(): array
+    {
+        if (!is_file(CACHE_BACKOFF_FILE)) {
+            return [];
+        }
+
+        return json_decode((string) file_get_contents(CACHE_BACKOFF_FILE), true) ?: [];
     }
 }


### PR DESCRIPTION
## Summary

- Add `lib/weather-backoff-headers.php` to parse `Retry-After` (delay-seconds or HTTP-date) and optional Aeris-style `X-RateLimit-Reset` (Unix epoch), clamped to 15 minutes.
- `UnifiedFetcher` captures response headers via `CURLOPT_HEADERFUNCTION` on parallel curl and swob fallback; `recordWeatherFailure` passes them into the circuit breaker.
- On HTTP **429** or **503**, backoff uses `max(default strategy, upstream hint)` so providers that ask for a longer wait are respected once the circuit opens.

## Test plan

- [x] `make test-ci`
- [x] `tests/Unit/WeatherBackoffHeadersTest.php` (parse, clamp, 503, integration with backoff file)
- [x] Manual: trigger 429 from Tempest/Aeris in Docker and confirm `backoff.json` shows extended `backoff_seconds`

## Notes

- Skip still requires `CIRCUIT_BREAKER_FAILURE_THRESHOLD` consecutive failures (same as pre-Phase-4 429 behavior).
- METAR HTTP fallback does not yet pass headers (`file_get_contents` path); bulk path covers most METAR traffic.