### PR TITLE
feat(nws): cache api.weather.gov /points metadata (Phase 5)

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -393,9 +393,10 @@ function publicFunction(): void { }
 
 - **Files**: lowercase with hyphens (e.g., `circuit-breaker.php`)
 - **Classes**: PascalCase (e.g., `CircuitBreaker`)
-- **Functions**: camelCase (e.g., `getWeatherData()`)
+- **Functions**: camelCase (e.g., `getWeatherData()`, `upstreamRateFingerprint()`). Applies to procedural `lib/` helpers as well as class methods.
 - **Constants**: UPPER_SNAKE_CASE (e.g., `MAX_STALE_HOURS`)
 - **Variables**: camelCase (e.g., `$stationId`)
+- **Persisted JSON keys** (metrics, health counters): keep existing snake_case field names when changing them would break on-disk history; use camelCase only for new PHP symbols.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -627,6 +627,8 @@ High-frequency (~5 minute) observations from ASOS stations via the NWS API. Requ
 
 The `station_id` must be a valid airport ICAO code (e.g., `KSPB`, `KPDX`). Only airport stations are accepted.
 
+Observations use `/stations/{station_id}/observations/latest`. Optional `/points/{lat},{lon}` metadata (grid mapping) is cached under `cache/nws-points/` for 12 hours (`NWS_POINTS_CACHE_TTL_SECONDS`) when code calls `nws_fetch_points()` with airport coordinates.
+
 ### AWOSnet
 
 Fetches weather from AWOSnet data endpoint (awiAwosNet.php). The main page uses JavaScript to load data; we fetch the PHP endpoint directly with a Referer header. Structured XML fields are treated as the primary/authoritative data source, and the embedded METAR string is used to fill gaps or augment fields when available. When the page shows "///" (data not available), values are normalized to null.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -627,7 +627,7 @@ High-frequency (~5 minute) observations from ASOS stations via the NWS API. Requ
 
 The `station_id` must be a valid airport ICAO code (e.g., `KSPB`, `KPDX`). Only airport stations are accepted.
 
-Observations use `/stations/{station_id}/observations/latest`. Optional `/points/{lat},{lon}` metadata (grid mapping) is cached under `cache/nws-points/` for 12 hours (`NWS_POINTS_CACHE_TTL_SECONDS`) when code calls `nws_fetch_points()` with airport coordinates.
+Observations use `/stations/{station_id}/observations/latest`. Optional `/points/{lat},{lon}` metadata (grid mapping) is cached under `cache/nws-points/` for 12 hours (`NWS_POINTS_CACHE_TTL_SECONDS`) when code calls `nwsFetchPoints()` with airport coordinates.
 
 ### AWOSnet
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -34,6 +34,7 @@ The system uses **parallel fetching** for all configured sources:
 - **Unified Fetcher**: Fetches all sources simultaneously using `curl_multi`
 - **Sources Fetched**: All sources configured in the `weather_sources` array
 - **Circuit Breaker**: Each source has per-airport circuit breaker protection; HTTP 429/503 also open a shared `global_weather_{provider}_{credential fingerprint}` key so airports sharing one API key back off together. When present, `Retry-After` / `X-RateLimit-Reset` from the failed response extend backoff (up to 15 minutes).
+- **NWS points cache**: `api.weather.gov/points/{lat},{lon}` responses are cached under `cache/nws-points/` (12-hour TTL) via `lib/nws-points-cache.php` to avoid repeat grid lookups. Station observations still use the direct `/stations/{id}/observations/latest` path.
 - **Upstream throttle**: Before `curl_multi_add_handle`, `lib/upstream-rate-limit.php` enforces a per-credential token bucket (flock under `cache/upstream-limits/`). When the budget is exhausted, that source is skipped for the current fetch cycle only. METAR uses `metarResolveStationResponse()` (mock, bulk slice, then HTTP); bulk is tried before the per-airport METAR HTTP circuit gate. Throttle and circuit-open outcomes are not recorded as fetch failures. Throttle skips and fail-open I/O are counted in `cache/weather_health.json`.
 - **Parallel Execution**: All sources are fetched concurrently for maximum speed
 - **Freshness Selection**: Handled during aggregation (freshest data wins for each field)

--- a/lib/cache-paths.php
+++ b/lib/cache-paths.php
@@ -160,7 +160,7 @@ function getNwsPointsCacheDir(): string
 }
 
 /**
- * @param string $cacheKey From nws_points_cache_key() (e.g. 45.7710,-122.8600)
+ * @param string $cacheKey From nwsPointsCacheKey() (e.g. 45.7710,-122.8600)
  */
 function getNwsPointsCacheFilePath(string $cacheKey): string
 {
@@ -627,7 +627,7 @@ if (!defined('CACHE_UPSTREAM_LIMITS_DIR')) {
 /**
  * Path to flock-backed upstream token bucket state for a credential fingerprint.
  *
- * @param string $fingerprint SHA-256 hex from upstream_rate_fingerprint()
+ * @param string $fingerprint SHA-256 hex from upstreamRateFingerprint()
  */
 function getUpstreamRateLimitStatePath(string $fingerprint): string
 {

--- a/lib/cache-paths.php
+++ b/lib/cache-paths.php
@@ -47,6 +47,7 @@
  * ├── temp_extremes/               # Per-airport daily temperature extremes
  * │   └── {airport}.json
  * ├── outage_{airport}.json        # Outage detection state
+ * ├── nws-points/                  # NWS /points/{lat},{lon} metadata (12h TTL)
  * ├── metar-bulk/                  # AWC METAR CSV.gz slices (scheduler refresh)
  * │   ├── stations/{ICAO}.json     # One-element JSON array per station (METAR API shape)
  * │   └── tmp/                     # Download scratch (deleted after ingest)
@@ -140,6 +141,30 @@ function getMetarBulkRefreshLockPath(): string {
 
 function getMetarBulkStationJsonPath(string $icaoUpper): string {
     return getMetarBulkStationsDir() . '/' . strtoupper($icaoUpper) . '.json';
+}
+
+// =============================================================================
+// NWS POINTS CACHE (api.weather.gov /points/{lat},{lon})
+// =============================================================================
+
+if (!defined('CACHE_NWS_POINTS_DIR')) {
+    define('CACHE_NWS_POINTS_DIR', CACHE_BASE_DIR . '/nws-points');
+}
+
+/**
+ * @return string Directory for cached NWS points responses
+ */
+function getNwsPointsCacheDir(): string
+{
+    return CACHE_NWS_POINTS_DIR;
+}
+
+/**
+ * @param string $cacheKey From nws_points_cache_key() (e.g. 45.7710,-122.8600)
+ */
+function getNwsPointsCacheFilePath(string $cacheKey): string
+{
+    return getNwsPointsCacheDir() . '/' . $cacheKey . '.json';
 }
 
 // =============================================================================

--- a/lib/circuit-breaker.php
+++ b/lib/circuit-breaker.php
@@ -145,7 +145,7 @@ function recordCircuitBreakerFailureBase(
     }
     
     $failures = $state['failures'];
-    $backoffSeconds = circuit_breaker_compute_backoff_seconds(
+    $backoffSeconds = circuitBreakerComputeBackoffSeconds(
         $failures,
         $severity,
         $httpCode,
@@ -207,7 +207,7 @@ function recordCircuitBreakerFailureBase(
     }
     
     $failures = $state['failures'];
-    $backoffSeconds = circuit_breaker_compute_backoff_seconds(
+    $backoffSeconds = circuitBreakerComputeBackoffSeconds(
         $failures,
         $severity,
         $httpCode,
@@ -319,7 +319,7 @@ function recordCircuitBreakerSuccessBase($key, $backoffFile) {
 /**
  * Whether HTTP status should update the shared global breaker for this credential.
  */
-function weather_global_circuit_breaker_should_coordinate(?int $httpCode): bool
+function weatherGlobalCircuitBreakerShouldCoordinate(?int $httpCode): bool
 {
     return $httpCode === 429 || $httpCode === HTTP_STATUS_SERVICE_UNAVAILABLE;
 }
@@ -329,11 +329,11 @@ function weather_global_circuit_breaker_should_coordinate(?int $httpCode): bool
  *
  * @param array<string, mixed> $sourceConfig weather_sources entry (must include type)
  */
-function weather_global_circuit_breaker_key(string $provider, array $sourceConfig): string
+function weatherGlobalCircuitBreakerKey(string $provider, array $sourceConfig): string
 {
     require_once __DIR__ . '/upstream-rate-limit.php';
 
-    return 'global_weather_' . $provider . '_' . upstream_rate_fingerprint($provider, $sourceConfig);
+    return 'global_weather_' . $provider . '_' . upstreamRateFingerprint($provider, $sourceConfig);
 }
 
 /**
@@ -365,7 +365,7 @@ function checkWeatherCircuitBreaker($airportId, $sourceType, ?array $sourceConfi
         return $result;
     }
 
-    $globalKey = weather_global_circuit_breaker_key($sourceType, $sourceConfig);
+    $globalKey = weatherGlobalCircuitBreakerKey($sourceType, $sourceConfig);
     $globalResult = checkCircuitBreakerBase($globalKey, CACHE_BACKOFF_FILE);
     if ($globalResult['skip']) {
         $globalResult['reason'] = 'global_circuit_open';
@@ -406,9 +406,9 @@ function recordWeatherFailure(
 
     if ($sourceConfig !== null
         && ($sourceConfig['type'] ?? '') === $sourceType
-        && weather_global_circuit_breaker_should_coordinate($httpCode)
+        && weatherGlobalCircuitBreakerShouldCoordinate($httpCode)
     ) {
-        $globalKey = weather_global_circuit_breaker_key($sourceType, $sourceConfig);
+        $globalKey = weatherGlobalCircuitBreakerKey($sourceType, $sourceConfig);
         recordCircuitBreakerFailureBase($globalKey, CACHE_BACKOFF_FILE, $severity, $httpCode, $failureReason, $responseHeaders);
     }
 }
@@ -426,7 +426,7 @@ function recordWeatherSuccess($airportId, $sourceType, ?array $sourceConfig = nu
     recordCircuitBreakerSuccessBase($key, CACHE_BACKOFF_FILE);
 
     if ($sourceConfig !== null && ($sourceConfig['type'] ?? '') === $sourceType) {
-        $globalKey = weather_global_circuit_breaker_key($sourceType, $sourceConfig);
+        $globalKey = weatherGlobalCircuitBreakerKey($sourceType, $sourceConfig);
         recordCircuitBreakerSuccessBase($globalKey, CACHE_BACKOFF_FILE);
     }
 }

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -628,6 +628,11 @@ if (!defined('UPSTREAM_RATE_LIMIT_NWS_BURST')) {
     define('UPSTREAM_RATE_LIMIT_NWS_BURST', 10);
 }
 
+// NWS /points/{lat},{lon} metadata cache (stable grid mapping; reduces repeat calls)
+if (!defined('NWS_POINTS_CACHE_TTL_SECONDS')) {
+    define('NWS_POINTS_CACHE_TTL_SECONDS', 43200); // 12 hours
+}
+
 // Push webcam upload file age limits (fail-closed protection)
 // Files in upload directory older than this are considered abandoned/stuck
 if (!defined('UPLOAD_FILE_MAX_AGE_SECONDS')) {

--- a/lib/metar-bulk-csv-schema.php
+++ b/lib/metar-bulk-csv-schema.php
@@ -11,7 +11,7 @@
  *
  * @return list<string>
  */
-function metar_bulk_csv_expected_header_columns(): array
+function metarBulkCsvExpectedHeaderColumns(): array
 {
     return [
         'raw_text',
@@ -64,9 +64,9 @@ function metar_bulk_csv_expected_header_columns(): array
 /**
  * Expected column count for AWC METAR bulk CSV rows (including header row).
  */
-function metar_bulk_csv_expected_column_count(): int
+function metarBulkCsvExpectedColumnCount(): int
 {
-    return count(metar_bulk_csv_expected_header_columns());
+    return count(metarBulkCsvExpectedHeaderColumns());
 }
 
 /**
@@ -75,7 +75,7 @@ function metar_bulk_csv_expected_column_count(): int
  * @param array<int, string|null> $headerRow
  * @return array<int, string|null>
  */
-function metar_bulk_csv_normalize_header_row(array $headerRow): array
+function metarBulkCsvNormalizeHeaderRow(array $headerRow): array
 {
     if (isset($headerRow[0]) && is_string($headerRow[0])) {
         $headerRow[0] = preg_replace('/^\xEF\xBB\xBF/', '', $headerRow[0]) ?? $headerRow[0];
@@ -89,10 +89,10 @@ function metar_bulk_csv_normalize_header_row(array $headerRow): array
  *
  * @param array<int, string|null> $headerRow
  */
-function metar_bulk_csv_header_matches_expected(array $headerRow): bool
+function metarBulkCsvHeaderMatchesExpected(array $headerRow): bool
 {
-    $headerRow = metar_bulk_csv_normalize_header_row($headerRow);
-    $expected = metar_bulk_csv_expected_header_columns();
+    $headerRow = metarBulkCsvNormalizeHeaderRow($headerRow);
+    $expected = metarBulkCsvExpectedHeaderColumns();
     if (count($headerRow) !== count($expected)) {
         return false;
     }
@@ -106,14 +106,14 @@ function metar_bulk_csv_header_matches_expected(array $headerRow): bool
 }
 
 /**
- * Short summary when `metar_bulk_csv_header_matches_expected()` is false (for ops logs).
+ * Short summary when `metarBulkCsvHeaderMatchesExpected()` is false (for ops logs).
  *
  * @param array<int, string|null> $headerRow
  */
-function metar_bulk_csv_describe_header_mismatch(array $headerRow): string
+function metarBulkCsvDescribeHeaderMismatch(array $headerRow): string
 {
-    $headerRow = metar_bulk_csv_normalize_header_row($headerRow);
-    $expected = metar_bulk_csv_expected_header_columns();
+    $headerRow = metarBulkCsvNormalizeHeaderRow($headerRow);
+    $expected = metarBulkCsvExpectedHeaderColumns();
     $gotCount = count($headerRow);
     $expectedCount = count($expected);
     if ($gotCount !== $expectedCount) {
@@ -141,7 +141,7 @@ function metar_bulk_csv_describe_header_mismatch(array $headerRow): string
  * @param list<string> $headerColumns
  * @return array<string, list<int>>
  */
-function metar_bulk_csv_build_column_index_lists(array $headerColumns): array
+function metarBulkCsvBuildColumnIndexLists(array $headerColumns): array
 {
     $lists = [];
     foreach ($headerColumns as $i => $name) {

--- a/lib/metar-bulk.php
+++ b/lib/metar-bulk.php
@@ -143,7 +143,7 @@ function metarBulkGetDefaultCsvColumnLists(): array
 {
     static $cached = null;
     if ($cached === null) {
-        $cached = metar_bulk_csv_build_column_index_lists(metar_bulk_csv_expected_header_columns());
+        $cached = metarBulkCsvBuildColumnIndexLists(metarBulkCsvExpectedHeaderColumns());
     }
 
     return $cached;
@@ -158,7 +158,7 @@ function metarBulkGetDefaultCsvColumnLists(): array
  */
 function metarBulkCsvRowToApiRecord(array $fields, array $lists): ?array
 {
-    $need = metar_bulk_csv_expected_column_count();
+    $need = metarBulkCsvExpectedColumnCount();
     if (count($fields) < $need) {
         return null;
     }
@@ -442,16 +442,16 @@ function metarBulkIngestGzipToStationFiles(string $gzAbsolute, array $icaoSet): 
 
         return $stats;
     }
-    $header = metar_bulk_csv_normalize_header_row($header);
-    if (!metar_bulk_csv_header_matches_expected($header)) {
+    $header = metarBulkCsvNormalizeHeaderRow($header);
+    if (!metarBulkCsvHeaderMatchesExpected($header)) {
         fclose($h);
         $stats['error'] = 'bad_csv_header_schema';
-        $stats['header_mismatch'] = metar_bulk_csv_describe_header_mismatch($header);
+        $stats['header_mismatch'] = metarBulkCsvDescribeHeaderMismatch($header);
 
         return $stats;
     }
-    $lists = metar_bulk_csv_build_column_index_lists($header);
-    $expectedCols = metar_bulk_csv_expected_column_count();
+    $lists = metarBulkCsvBuildColumnIndexLists($header);
+    $expectedCols = metarBulkCsvExpectedColumnCount();
 
     /** @var array<string, array{0: int, 1: array<int, string|null>}> $best */
     $best = [];

--- a/lib/nws-points-cache.php
+++ b/lib/nws-points-cache.php
@@ -65,6 +65,8 @@ function nwsPointsCacheFilePath(string $cacheKey): string
 }
 
 /**
+ * True when the cache envelope is within TTL and fetched_at is plausible.
+ *
  * @param array{fetched_at?: int|string} $entry Cache envelope from disk
  * @param int|null $now Injectable reference time for tests
  */
@@ -76,6 +78,9 @@ function nwsPointsCacheEntryIsFresh(array $entry, ?int $now = null): bool
     }
 
     $now = $now ?? time();
+    if ($fetchedAt > $now) {
+        return false;
+    }
 
     return ($now - $fetchedAt) < NWS_POINTS_CACHE_TTL_SECONDS;
 }

--- a/lib/nws-points-cache.php
+++ b/lib/nws-points-cache.php
@@ -23,6 +23,8 @@ function nwsPointsCoordinatesValid(float $lat, float $lon): bool
 /**
  * Format one coordinate for NWS URL and cache keys (four decimal places).
  *
+ * Rounded negative zero (-0.0000) is normalized to 0.0000 so cache keys stay stable.
+ *
  * @return string Coordinate string for api.weather.gov /points URLs
  */
 function nwsPointsNormalizeCoord(float $coord): string
@@ -93,12 +95,17 @@ function nwsPointsCacheRead(float $lat, float $lon, ?int $now = null): ?string
     }
 
     $path = nwsPointsCacheFilePath(nwsPointsCacheKey($lat, $lon));
-    if (!is_file($path)) {
+    clearstatcache(true, $path);
+    if (!is_readable($path)) {
         return null;
     }
 
-    clearstatcache(true, $path);
-    $entry = json_decode((string) file_get_contents($path), true);
+    $raw = @file_get_contents($path);
+    if ($raw === false || $raw === '') {
+        return null;
+    }
+
+    $entry = json_decode($raw, true);
     if (!is_array($entry) || !nwsPointsCacheEntryIsFresh($entry, $now)) {
         return null;
     }

--- a/lib/nws-points-cache.php
+++ b/lib/nws-points-cache.php
@@ -11,6 +11,9 @@ require_once __DIR__ . '/cache-paths.php';
 
 /**
  * True when latitude and longitude are valid for an NWS points request.
+ *
+ * @param float $lat WGS84 latitude (-90 to 90)
+ * @param float $lon WGS84 longitude (-180 to 180)
  */
 function nws_points_coordinates_valid(float $lat, float $lon): bool
 {
@@ -19,6 +22,8 @@ function nws_points_coordinates_valid(float $lat, float $lon): bool
 
 /**
  * Format one coordinate for NWS URL and cache keys (four decimal places).
+ *
+ * @return string Coordinate string for api.weather.gov /points URLs
  */
 function nws_points_normalize_coord(float $coord): string
 {
@@ -27,6 +32,8 @@ function nws_points_normalize_coord(float $coord): string
 
 /**
  * Cache filename stem for a lat/lon pair (no extension).
+ *
+ * @return string e.g. 45.7710,-122.8600
  */
 function nws_points_cache_key(float $lat, float $lon): string
 {
@@ -35,6 +42,8 @@ function nws_points_cache_key(float $lat, float $lon): string
 
 /**
  * Resolve cache file path (supports test override via $GLOBALS['nws_points_cache_test_root']).
+ *
+ * @param string $cacheKey From nws_points_cache_key() (no path separators)
  */
 function nws_points_cache_file_path(string $cacheKey): string
 {
@@ -49,7 +58,8 @@ function nws_points_cache_file_path(string $cacheKey): string
 }
 
 /**
- * @param array{fetched_at?: int|string} $entry
+ * @param array{fetched_at?: int|string} $entry Cache envelope from disk
+ * @param int|null $now Injectable reference time for tests
  */
 function nws_points_cache_entry_is_fresh(array $entry, ?int $now = null): bool
 {
@@ -66,6 +76,9 @@ function nws_points_cache_entry_is_fresh(array $entry, ?int $now = null): bool
 /**
  * Read cached points JSON body when fresh.
  *
+ * @param float $lat WGS84 latitude
+ * @param float $lon WGS84 longitude
+ * @param int|null $now Injectable reference time for tests
  * @return string|null Raw JSON body from a prior successful /points response
  */
 function nws_points_cache_read(float $lat, float $lon, ?int $now = null): ?string
@@ -85,6 +98,12 @@ function nws_points_cache_read(float $lat, float $lon, ?int $now = null): ?strin
         return null;
     }
 
+    $expectedLat = nws_points_normalize_coord($lat);
+    $expectedLon = nws_points_normalize_coord($lon);
+    if (($entry['lat'] ?? '') !== $expectedLat || ($entry['lon'] ?? '') !== $expectedLon) {
+        return null;
+    }
+
     $body = $entry['body'] ?? null;
 
     return is_string($body) && $body !== '' ? $body : null;
@@ -93,6 +112,10 @@ function nws_points_cache_read(float $lat, float $lon, ?int $now = null): ?strin
 /**
  * Persist a successful /points response body (atomic replace).
  *
+ * @param float $lat WGS84 latitude
+ * @param float $lon WGS84 longitude
+ * @param string $body Raw JSON response body from NWS
+ * @param int|null $now Injectable store time for tests
  * @return bool False when coordinates invalid or write fails
  */
 function nws_points_cache_write(float $lat, float $lon, string $body, ?int $now = null): bool

--- a/lib/nws-points-cache.php
+++ b/lib/nws-points-cache.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * File-backed cache for NWS api.weather.gov /points/{lat},{lon} metadata.
+ *
+ * Points responses change infrequently; caching reduces load and keeps grid
+ * lookups stable across worker processes.
+ */
+
+require_once __DIR__ . '/constants.php';
+require_once __DIR__ . '/cache-paths.php';
+
+/**
+ * True when latitude and longitude are valid for an NWS points request.
+ */
+function nws_points_coordinates_valid(float $lat, float $lon): bool
+{
+    return $lat >= -90.0 && $lat <= 90.0 && $lon >= -180.0 && $lon <= 180.0;
+}
+
+/**
+ * Format one coordinate for NWS URL and cache keys (four decimal places).
+ */
+function nws_points_normalize_coord(float $coord): string
+{
+    return number_format($coord, 4, '.', '');
+}
+
+/**
+ * Cache filename stem for a lat/lon pair (no extension).
+ */
+function nws_points_cache_key(float $lat, float $lon): string
+{
+    return nws_points_normalize_coord($lat) . ',' . nws_points_normalize_coord($lon);
+}
+
+/**
+ * Resolve cache file path (supports test override via $GLOBALS['nws_points_cache_test_root']).
+ */
+function nws_points_cache_file_path(string $cacheKey): string
+{
+    if (isset($GLOBALS['nws_points_cache_test_root'])
+        && is_string($GLOBALS['nws_points_cache_test_root'])
+        && $GLOBALS['nws_points_cache_test_root'] !== ''
+    ) {
+        return rtrim($GLOBALS['nws_points_cache_test_root'], '/') . '/' . $cacheKey . '.json';
+    }
+
+    return getNwsPointsCacheFilePath($cacheKey);
+}
+
+/**
+ * @param array{fetched_at?: int|string} $entry
+ */
+function nws_points_cache_entry_is_fresh(array $entry, ?int $now = null): bool
+{
+    $fetchedAt = (int) ($entry['fetched_at'] ?? 0);
+    if ($fetchedAt <= 0) {
+        return false;
+    }
+
+    $now = $now ?? time();
+
+    return ($now - $fetchedAt) < NWS_POINTS_CACHE_TTL_SECONDS;
+}
+
+/**
+ * Read cached points JSON body when fresh.
+ *
+ * @return string|null Raw JSON body from a prior successful /points response
+ */
+function nws_points_cache_read(float $lat, float $lon, ?int $now = null): ?string
+{
+    if (!nws_points_coordinates_valid($lat, $lon)) {
+        return null;
+    }
+
+    $path = nws_points_cache_file_path(nws_points_cache_key($lat, $lon));
+    if (!is_file($path)) {
+        return null;
+    }
+
+    clearstatcache(true, $path);
+    $entry = json_decode((string) file_get_contents($path), true);
+    if (!is_array($entry) || !nws_points_cache_entry_is_fresh($entry, $now)) {
+        return null;
+    }
+
+    $body = $entry['body'] ?? null;
+
+    return is_string($body) && $body !== '' ? $body : null;
+}
+
+/**
+ * Persist a successful /points response body (atomic replace).
+ *
+ * @return bool False when coordinates invalid or write fails
+ */
+function nws_points_cache_write(float $lat, float $lon, string $body, ?int $now = null): bool
+{
+    if (!nws_points_coordinates_valid($lat, $lon) || $body === '') {
+        return false;
+    }
+
+    $cacheKey = nws_points_cache_key($lat, $lon);
+    $path = nws_points_cache_file_path($cacheKey);
+    $dir = dirname($path);
+    if (!ensureCacheDir($dir)) {
+        return false;
+    }
+
+    $now = $now ?? time();
+    $payload = json_encode([
+        'fetched_at' => $now,
+        'lat' => nws_points_normalize_coord($lat),
+        'lon' => nws_points_normalize_coord($lon),
+        'body' => $body,
+    ], JSON_UNESCAPED_SLASHES);
+
+    if ($payload === false) {
+        return false;
+    }
+
+    $tmp = $path . '.tmp.' . getmypid();
+    if (@file_put_contents($tmp, $payload, LOCK_EX) === false) {
+        @unlink($tmp);
+
+        return false;
+    }
+
+    if (!@rename($tmp, $path)) {
+        @unlink($tmp);
+
+        return false;
+    }
+
+    return true;
+}

--- a/lib/nws-points-cache.php
+++ b/lib/nws-points-cache.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/cache-paths.php';
  * @param float $lat WGS84 latitude (-90 to 90)
  * @param float $lon WGS84 longitude (-180 to 180)
  */
-function nws_points_coordinates_valid(float $lat, float $lon): bool
+function nwsPointsCoordinatesValid(float $lat, float $lon): bool
 {
     return $lat >= -90.0 && $lat <= 90.0 && $lon >= -180.0 && $lon <= 180.0;
 }
@@ -25,7 +25,7 @@ function nws_points_coordinates_valid(float $lat, float $lon): bool
  *
  * @return string Coordinate string for api.weather.gov /points URLs
  */
-function nws_points_normalize_coord(float $coord): string
+function nwsPointsNormalizeCoord(float $coord): string
 {
     return number_format($coord, 4, '.', '');
 }
@@ -35,23 +35,23 @@ function nws_points_normalize_coord(float $coord): string
  *
  * @return string e.g. 45.7710,-122.8600
  */
-function nws_points_cache_key(float $lat, float $lon): string
+function nwsPointsCacheKey(float $lat, float $lon): string
 {
-    return nws_points_normalize_coord($lat) . ',' . nws_points_normalize_coord($lon);
+    return nwsPointsNormalizeCoord($lat) . ',' . nwsPointsNormalizeCoord($lon);
 }
 
 /**
- * Resolve cache file path (supports test override via $GLOBALS['nws_points_cache_test_root']).
+ * Resolve cache file path (supports test override via $GLOBALS['nwsPointsCacheTestRoot']).
  *
- * @param string $cacheKey From nws_points_cache_key() (no path separators)
+ * @param string $cacheKey From nwsPointsCacheKey() (no path separators)
  */
-function nws_points_cache_file_path(string $cacheKey): string
+function nwsPointsCacheFilePath(string $cacheKey): string
 {
-    if (isset($GLOBALS['nws_points_cache_test_root'])
-        && is_string($GLOBALS['nws_points_cache_test_root'])
-        && $GLOBALS['nws_points_cache_test_root'] !== ''
+    if (isset($GLOBALS['nwsPointsCacheTestRoot'])
+        && is_string($GLOBALS['nwsPointsCacheTestRoot'])
+        && $GLOBALS['nwsPointsCacheTestRoot'] !== ''
     ) {
-        return rtrim($GLOBALS['nws_points_cache_test_root'], '/') . '/' . $cacheKey . '.json';
+        return rtrim($GLOBALS['nwsPointsCacheTestRoot'], '/') . '/' . $cacheKey . '.json';
     }
 
     return getNwsPointsCacheFilePath($cacheKey);
@@ -61,7 +61,7 @@ function nws_points_cache_file_path(string $cacheKey): string
  * @param array{fetched_at?: int|string} $entry Cache envelope from disk
  * @param int|null $now Injectable reference time for tests
  */
-function nws_points_cache_entry_is_fresh(array $entry, ?int $now = null): bool
+function nwsPointsCacheEntryIsFresh(array $entry, ?int $now = null): bool
 {
     $fetchedAt = (int) ($entry['fetched_at'] ?? 0);
     if ($fetchedAt <= 0) {
@@ -81,25 +81,25 @@ function nws_points_cache_entry_is_fresh(array $entry, ?int $now = null): bool
  * @param int|null $now Injectable reference time for tests
  * @return string|null Raw JSON body from a prior successful /points response
  */
-function nws_points_cache_read(float $lat, float $lon, ?int $now = null): ?string
+function nwsPointsCacheRead(float $lat, float $lon, ?int $now = null): ?string
 {
-    if (!nws_points_coordinates_valid($lat, $lon)) {
+    if (!nwsPointsCoordinatesValid($lat, $lon)) {
         return null;
     }
 
-    $path = nws_points_cache_file_path(nws_points_cache_key($lat, $lon));
+    $path = nwsPointsCacheFilePath(nwsPointsCacheKey($lat, $lon));
     if (!is_file($path)) {
         return null;
     }
 
     clearstatcache(true, $path);
     $entry = json_decode((string) file_get_contents($path), true);
-    if (!is_array($entry) || !nws_points_cache_entry_is_fresh($entry, $now)) {
+    if (!is_array($entry) || !nwsPointsCacheEntryIsFresh($entry, $now)) {
         return null;
     }
 
-    $expectedLat = nws_points_normalize_coord($lat);
-    $expectedLon = nws_points_normalize_coord($lon);
+    $expectedLat = nwsPointsNormalizeCoord($lat);
+    $expectedLon = nwsPointsNormalizeCoord($lon);
     if (($entry['lat'] ?? '') !== $expectedLat || ($entry['lon'] ?? '') !== $expectedLon) {
         return null;
     }
@@ -118,14 +118,14 @@ function nws_points_cache_read(float $lat, float $lon, ?int $now = null): ?strin
  * @param int|null $now Injectable store time for tests
  * @return bool False when coordinates invalid or write fails
  */
-function nws_points_cache_write(float $lat, float $lon, string $body, ?int $now = null): bool
+function nwsPointsCacheWrite(float $lat, float $lon, string $body, ?int $now = null): bool
 {
-    if (!nws_points_coordinates_valid($lat, $lon) || $body === '') {
+    if (!nwsPointsCoordinatesValid($lat, $lon) || $body === '') {
         return false;
     }
 
-    $cacheKey = nws_points_cache_key($lat, $lon);
-    $path = nws_points_cache_file_path($cacheKey);
+    $cacheKey = nwsPointsCacheKey($lat, $lon);
+    $path = nwsPointsCacheFilePath($cacheKey);
     $dir = dirname($path);
     if (!ensureCacheDir($dir)) {
         return false;
@@ -134,8 +134,8 @@ function nws_points_cache_write(float $lat, float $lon, string $body, ?int $now 
     $now = $now ?? time();
     $payload = json_encode([
         'fetched_at' => $now,
-        'lat' => nws_points_normalize_coord($lat),
-        'lon' => nws_points_normalize_coord($lon),
+        'lat' => nwsPointsNormalizeCoord($lat),
+        'lon' => nwsPointsNormalizeCoord($lon),
         'body' => $body,
     ], JSON_UNESCAPED_SLASHES);
 

--- a/lib/nws-points-cache.php
+++ b/lib/nws-points-cache.php
@@ -27,7 +27,12 @@ function nwsPointsCoordinatesValid(float $lat, float $lon): bool
  */
 function nwsPointsNormalizeCoord(float $coord): string
 {
-    return number_format($coord, 4, '.', '');
+    $formatted = number_format($coord, 4, '.', '');
+    if ($formatted === '-0.0000') {
+        return '0.0000';
+    }
+
+    return $formatted;
 }
 
 /**

--- a/lib/test-mocks.php
+++ b/lib/test-mocks.php
@@ -60,6 +60,12 @@ function getMockHttpResponse(string $url): ?string {
         return getMockPWSWeatherResponse();
     }
     
+    if (strpos($url, 'api.weather.gov') !== false && strpos($url, '/points/') !== false) {
+        require_once __DIR__ . '/../tests/mock-weather-responses.php';
+
+        return getMockNwsPointsResponse();
+    }
+
     if (strpos($url, 'api.weather.gov') !== false && strpos($url, '/stations/') !== false) {
         // NWS API (api.weather.gov)
         require_once __DIR__ . '/../tests/mock-weather-responses.php';

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/cache-paths.php';
  * @param string $provider Weather source type (e.g. tempest, pwsweather)
  * @return list<string>
  */
-function upstream_rate_limit_credential_field_names(string $provider): array
+function upstreamRateLimitCredentialFieldNames(string $provider): array
 {
     return match ($provider) {
         'tempest' => ['api_key'],
@@ -37,7 +37,7 @@ function upstream_rate_limit_credential_field_names(string $provider): array
  * @param string $provider Weather source type
  * @return list<string>
  */
-function upstream_rate_limit_identity_field_names(string $provider): array
+function upstreamRateLimitIdentityFieldNames(string $provider): array
 {
     return match ($provider) {
         'metar', 'awosnet', 'swob_auto', 'swob_man', 'nws' => ['station_id'],
@@ -51,11 +51,11 @@ function upstream_rate_limit_identity_field_names(string $provider): array
  *
  * @return list<string>
  */
-function upstream_rate_limit_fingerprint_field_names(string $provider): array
+function upstreamRateLimitFingerprintFieldNames(string $provider): array
 {
     return array_values(array_unique(array_merge(
-        upstream_rate_limit_credential_field_names($provider),
-        upstream_rate_limit_identity_field_names($provider)
+        upstreamRateLimitCredentialFieldNames($provider),
+        upstreamRateLimitIdentityFieldNames($provider)
     )));
 }
 
@@ -66,10 +66,10 @@ function upstream_rate_limit_fingerprint_field_names(string $provider): array
  * @param array<string, mixed> $sourceConfig Source block from weather_sources
  * @return string 64-char hex digest
  */
-function upstream_rate_fingerprint(string $provider, array $sourceConfig): string
+function upstreamRateFingerprint(string $provider, array $sourceConfig): string
 {
     $material = [];
-    foreach (upstream_rate_limit_fingerprint_field_names($provider) as $field) {
+    foreach (upstreamRateLimitFingerprintFieldNames($provider) as $field) {
         if (!isset($sourceConfig[$field]) || !is_string($sourceConfig[$field])) {
             continue;
         }
@@ -91,7 +91,7 @@ function upstream_rate_fingerprint(string $provider, array $sourceConfig): strin
  * @param string $provider Weather source type
  * @return array{rpm: int, burst: int}
  */
-function upstream_rate_limit_policy_for_provider(string $provider): array
+function upstreamRateLimitPolicyForProvider(string $provider): array
 {
     return match ($provider) {
         'tempest' => [
@@ -139,7 +139,7 @@ function upstream_rate_limit_policy_for_provider(string $provider): array
  * @param float $now Current Unix timestamp
  * @return array{allowed: bool, tokens: float, last_refill: float}
  */
-function upstream_rate_token_bucket_compute_take(
+function upstreamRateTokenBucketComputeTake(
     float $tokens,
     float $lastRefill,
     int $rpm,
@@ -176,13 +176,13 @@ function upstream_rate_token_bucket_compute_take(
 /**
  * Resolve on-disk state path for a fingerprint (test hook via $GLOBALS).
  */
-function upstream_rate_limit_state_file_path(string $fingerprint): string
+function upstreamRateLimitStateFilePath(string $fingerprint): string
 {
-    if (isset($GLOBALS['upstream_rate_limit_test_root'])
-        && is_string($GLOBALS['upstream_rate_limit_test_root'])
-        && $GLOBALS['upstream_rate_limit_test_root'] !== ''
+    if (isset($GLOBALS['upstreamRateLimitTestRoot'])
+        && is_string($GLOBALS['upstreamRateLimitTestRoot'])
+        && $GLOBALS['upstreamRateLimitTestRoot'] !== ''
     ) {
-        $root = rtrim($GLOBALS['upstream_rate_limit_test_root'], '/');
+        $root = rtrim($GLOBALS['upstreamRateLimitTestRoot'], '/');
         $prefix = strlen($fingerprint) >= 2 ? substr($fingerprint, 0, 2) : $fingerprint;
 
         return $root . '/' . $prefix . '/' . $fingerprint . '.json';
@@ -196,33 +196,33 @@ function upstream_rate_limit_state_file_path(string $fingerprint): string
  *
  * Fails open (allows request) when the state file cannot be read or written.
  *
- * @param string $fingerprint From upstream_rate_fingerprint()
+ * @param string $fingerprint From upstreamRateFingerprint()
  * @param int $rpm Sustained requests per minute
  * @param int $burst Maximum burst size
  * @param float|null $now Injectable Unix timestamp for tests
  * @return bool True when a token was consumed; false when budget exhausted
  */
-function upstream_rate_try_take(string $fingerprint, int $rpm, int $burst, ?float $now = null): bool
+function upstreamRateTryTake(string $fingerprint, int $rpm, int $burst, ?float $now = null): bool
 {
     $now = $now ?? microtime(true);
-    $stateFile = upstream_rate_limit_state_file_path($fingerprint);
+    $stateFile = upstreamRateLimitStateFilePath($fingerprint);
     $stateDir = dirname($stateFile);
     if (!is_dir($stateDir) && !@mkdir($stateDir, 0755, true) && !is_dir($stateDir)) {
-        upstream_rate_limit_record_fail_open('state_dir_unavailable', $fingerprint, ['dir' => $stateDir]);
+        upstreamRateLimitRecordFailOpen('state_dir_unavailable', $fingerprint, ['dir' => $stateDir]);
 
         return true;
     }
 
     $fp = @fopen($stateFile, 'c+');
     if ($fp === false) {
-        upstream_rate_limit_record_fail_open('state_file_open_failed', $fingerprint, ['file' => $stateFile]);
+        upstreamRateLimitRecordFailOpen('state_file_open_failed', $fingerprint, ['file' => $stateFile]);
 
         return true;
     }
 
     if (!@flock($fp, LOCK_EX)) {
         @fclose($fp);
-        upstream_rate_limit_record_fail_open('flock_failed', $fingerprint, ['file' => $stateFile]);
+        upstreamRateLimitRecordFailOpen('flock_failed', $fingerprint, ['file' => $stateFile]);
 
         return true;
     }
@@ -250,7 +250,7 @@ function upstream_rate_try_take(string $fingerprint, int $rpm, int $burst, ?floa
         }
     }
 
-    $result = upstream_rate_token_bucket_compute_take($tokens, $lastRefill, $rpm, $burst, $now);
+    $result = upstreamRateTokenBucketComputeTake($tokens, $lastRefill, $rpm, $burst, $now);
 
     rewind($fp);
     ftruncate($fp, 0);
@@ -288,33 +288,33 @@ function upstream_rate_try_take(string $fingerprint, int $rpm, int $burst, ?floa
  *
  * @param array<string, mixed> $context Additional log context (no secrets)
  */
-function upstream_rate_limit_record_fail_open(string $reason, string $fingerprint, array $context = []): void
+function upstreamRateLimitRecordFailOpen(string $reason, string $fingerprint, array $context = []): void
 {
     aviationwx_log('warning', 'upstream rate limit state unavailable, allowing request', array_merge($context, [
         'reason' => $reason,
         'fingerprint_prefix' => substr($fingerprint, 0, 8),
     ]), 'app');
 
-    if (!function_exists('weather_health_track_upstream_rate_limit_fail_open')) {
+    if (!function_exists('weatherHealthTrackUpstreamRateLimitFailOpen')) {
         require_once __DIR__ . '/weather-health.php';
     }
-    weather_health_track_upstream_rate_limit_fail_open($reason);
+    weatherHealthTrackUpstreamRateLimitFailOpen($reason);
 }
 
 /**
  * PHPUnit only: enforce buckets while APP_ENV=testing.
  */
-function upstream_rate_limit_test_force_enforcement(): void
+function upstreamRateLimitTestForceEnforcement(): void
 {
-    $GLOBALS['upstream_rate_limit_test_force_enforcement'] = true;
+    $GLOBALS['upstreamRateLimitTestForceEnforcement'] = true;
 }
 
 /**
  * PHPUnit only: restore default test-mode bypass for upstream throttling.
  */
-function upstream_rate_limit_test_clear_force_enforcement(): void
+function upstreamRateLimitTestClearForceEnforcement(): void
 {
-    unset($GLOBALS['upstream_rate_limit_test_force_enforcement']);
+    unset($GLOBALS['upstreamRateLimitTestForceEnforcement']);
 }
 
 /**
@@ -322,9 +322,9 @@ function upstream_rate_limit_test_clear_force_enforcement(): void
  *
  * @param array<string, mixed> $source weather_sources entry (must include type)
  */
-function upstream_rate_limit_should_skip_source(array $source): bool
+function upstreamRateLimitShouldSkipSource(array $source): bool
 {
-    return !upstream_rate_limit_consume_for_source($source)['allowed'];
+    return !upstreamRateLimitConsumeForSource($source)['allowed'];
 }
 
 /**
@@ -333,9 +333,9 @@ function upstream_rate_limit_should_skip_source(array $source): bool
  * @param array<string, mixed> $source weather_sources entry (must include type)
  * @return array{allowed: bool, fingerprint_prefix: string|null}
  */
-function upstream_rate_limit_consume_for_source(array $source): array
+function upstreamRateLimitConsumeForSource(array $source): array
 {
-    $forceInTests = !empty($GLOBALS['upstream_rate_limit_test_force_enforcement']);
+    $forceInTests = !empty($GLOBALS['upstreamRateLimitTestForceEnforcement']);
     if (!$forceInTests && (isTestMode() || shouldMockExternalServices())) {
         return ['allowed' => true, 'fingerprint_prefix' => null];
     }
@@ -345,14 +345,14 @@ function upstream_rate_limit_consume_for_source(array $source): array
         return ['allowed' => true, 'fingerprint_prefix' => null];
     }
 
-    $policy = upstream_rate_limit_policy_for_provider($provider);
+    $policy = upstreamRateLimitPolicyForProvider($provider);
     if ($policy['rpm'] <= 0 || $policy['burst'] <= 0) {
         return ['allowed' => true, 'fingerprint_prefix' => null];
     }
 
-    $fingerprint = upstream_rate_fingerprint($provider, $source);
+    $fingerprint = upstreamRateFingerprint($provider, $source);
     $prefix = substr($fingerprint, 0, 8);
-    $allowed = upstream_rate_try_take($fingerprint, $policy['rpm'], $policy['burst']);
+    $allowed = upstreamRateTryTake($fingerprint, $policy['rpm'], $policy['burst']);
 
     return ['allowed' => $allowed, 'fingerprint_prefix' => $prefix];
 }

--- a/lib/weather-backoff-headers.php
+++ b/lib/weather-backoff-headers.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/constants.php';
  * @param string $line Raw header line from curl
  * @return int Bytes processed (required by CURLOPT_HEADERFUNCTION)
  */
-function circuit_breaker_collect_curl_header_line(array &$headers, string $line): int
+function circuitBreakerCollectCurlHeaderLine(array &$headers, string $line): int
 {
     $trimmed = rtrim($line, "\r\n");
     if ($trimmed === '' || strpos($trimmed, ':') === false) {
@@ -36,7 +36,7 @@ function circuit_breaker_collect_curl_header_line(array &$headers, string $line)
  * @param int|null $now Reference time for HTTP-date deltas (default: time())
  * @return int|null Positive seconds, or null when absent/invalid/past
  */
-function parse_retry_after_seconds(string $value, ?int $now = null): ?int
+function parseRetryAfterSeconds(string $value, ?int $now = null): ?int
 {
     $value = trim($value);
     if ($value === '') {
@@ -67,7 +67,7 @@ function parse_retry_after_seconds(string $value, ?int $now = null): ?int
  * @param int $seconds Unclamped wait from Retry-After or X-RateLimit-Reset delta
  * @return int Seconds in [1, BACKOFF_MAX_RETRY_AFTER_SECONDS]
  */
-function weather_backoff_clamp_seconds(int $seconds): int
+function weatherBackoffClampSeconds(int $seconds): int
 {
     return max(1, min(BACKOFF_MAX_RETRY_AFTER_SECONDS, $seconds));
 }
@@ -83,7 +83,7 @@ function weather_backoff_clamp_seconds(int $seconds): int
  * @param int|null $now Reference time for reset delta (default: time())
  * @return int|null Clamped seconds, or null when no usable hint
  */
-function weather_backoff_override_seconds(?int $httpCode, array $responseHeaders, ?int $now = null): ?int
+function weatherBackoffOverrideSeconds(?int $httpCode, array $responseHeaders, ?int $now = null): ?int
 {
     if ($httpCode !== 429 && $httpCode !== HTTP_STATUS_SERVICE_UNAVAILABLE) {
         return null;
@@ -97,9 +97,9 @@ function weather_backoff_override_seconds(?int $httpCode, array $responseHeaders
 
     $retryAfter = $responseHeaders['retry-after'] ?? null;
     if (is_string($retryAfter) && $retryAfter !== '') {
-        $parsed = parse_retry_after_seconds($retryAfter, $now);
+        $parsed = parseRetryAfterSeconds($retryAfter, $now);
         if ($parsed !== null) {
-            return weather_backoff_clamp_seconds($parsed);
+            return weatherBackoffClampSeconds($parsed);
         }
     }
 
@@ -107,7 +107,7 @@ function weather_backoff_override_seconds(?int $httpCode, array $responseHeaders
     if (is_string($reset) && ctype_digit(trim($reset))) {
         $resetTs = (int) trim($reset);
         if ($resetTs > $now) {
-            return weather_backoff_clamp_seconds($resetTs - $now);
+            return weatherBackoffClampSeconds($resetTs - $now);
         }
     }
 
@@ -128,7 +128,7 @@ function weather_backoff_override_seconds(?int $httpCode, array $responseHeaders
  * @param int|null $now Reference time for header hints (default: time())
  * @return int Backoff seconds before next_allowed_time
  */
-function circuit_breaker_compute_backoff_seconds(
+function circuitBreakerComputeBackoffSeconds(
     int $failures,
     string $severity,
     ?int $httpCode,
@@ -147,7 +147,7 @@ function circuit_breaker_compute_backoff_seconds(
     }
 
     if ($responseHeaders !== null && $responseHeaders !== []) {
-        $override = weather_backoff_override_seconds($httpCode, $responseHeaders, $now);
+        $override = weatherBackoffOverrideSeconds($httpCode, $responseHeaders, $now);
         if ($override !== null) {
             $backoffSeconds = max($backoffSeconds, $override);
         }

--- a/lib/weather-health.php
+++ b/lib/weather-health.php
@@ -113,7 +113,7 @@ function weather_health_track_fallback(string $airportId): void {
  * @param string $airportId Airport identifier
  * @param string $sourceType Source type (tempest, metar, etc.)
  */
-function weather_health_track_upstream_throttle_skip(string $airportId, string $sourceType): void
+function weatherHealthTrackUpstreamThrottleSkip(string $airportId, string $sourceType): void
 {
     $now = time();
     $currentHour = gmdate('Y-m-d-H', $now);
@@ -132,7 +132,7 @@ function weather_health_track_upstream_throttle_skip(string $airportId, string $
  *
  * @param string $reason Short reason code (e.g. state_dir_unavailable)
  */
-function weather_health_track_upstream_rate_limit_fail_open(string $reason): void
+function weatherHealthTrackUpstreamRateLimitFailOpen(string $reason): void
 {
     $now = time();
     $currentHour = gmdate('Y-m-d-H', $now);

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -187,7 +187,7 @@ function fetchAllSources(array $sources, string $airportId): array {
                     }
                     break;
                 case METAR_RESOLVE_THROTTLED:
-                    weather_health_track_upstream_throttle_skip($airportId, $sourceType);
+                    weatherHealthTrackUpstreamThrottleSkip($airportId, $sourceType);
                     break;
                 case METAR_RESOLVE_CIRCUIT_OPEN:
                     weather_health_track_circuit_open($airportId, $sourceType);
@@ -216,14 +216,14 @@ function fetchAllSources(array $sources, string $airportId): array {
         }
 
         // Per-credential budget (file-backed token bucket); skip this cycle when exhausted
-        $rateLimit = upstream_rate_limit_consume_for_source($source);
+        $rateLimit = upstreamRateLimitConsumeForSource($source);
         if (!$rateLimit['allowed']) {
             aviationwx_log('info', 'upstream rate limit skip', [
                 'airport_id' => $airportId,
                 'provider' => $sourceType,
                 'fingerprint_prefix' => $rateLimit['fingerprint_prefix'],
             ], 'app');
-            weather_health_track_upstream_throttle_skip($airportId, $sourceType);
+            weatherHealthTrackUpstreamThrottleSkip($airportId, $sourceType);
             continue;
         }
         
@@ -232,7 +232,7 @@ function fetchAllSources(array $sources, string $airportId): array {
         
         $responseHeadersByKey[$sourceKey] = [];
         $headerCollector = function ($ch, string $line) use (&$responseHeadersByKey, $sourceKey): int {
-            return circuit_breaker_collect_curl_header_line($responseHeadersByKey[$sourceKey], $line);
+            return circuitBreakerCollectCurlHeaderLine($responseHeadersByKey[$sourceKey], $line);
         };
 
         // Create curl handle
@@ -325,7 +325,7 @@ function fetchAllSources(array $sources, string $airportId): array {
             weather_health_track_fetch($airportId, 'swob_auto', false, 404);
             continue;
         }
-        $rateLimit = upstream_rate_limit_consume_for_source($source);
+        $rateLimit = upstreamRateLimitConsumeForSource($source);
         if (!$rateLimit['allowed']) {
             aviationwx_log('info', 'upstream rate limit skip', [
                 'airport_id' => $airportId,
@@ -333,12 +333,12 @@ function fetchAllSources(array $sources, string $airportId): array {
                 'fingerprint_prefix' => $rateLimit['fingerprint_prefix'],
                 'context' => 'swob_auto_standard_fallback',
             ], 'app');
-            weather_health_track_upstream_throttle_skip($airportId, 'swob_auto');
+            weatherHealthTrackUpstreamThrottleSkip($airportId, 'swob_auto');
             continue;
         }
         $fallbackHeaders = [];
         $fallbackHeaderCollector = function ($ch, string $line) use (&$fallbackHeaders): int {
-            return circuit_breaker_collect_curl_header_line($fallbackHeaders, $line);
+            return circuitBreakerCollectCurlHeaderLine($fallbackHeaders, $line);
         };
         $ch = curl_init($fallbackUrl);
         curl_setopt_array($ch, [

--- a/lib/weather/adapter/metar-v1.php
+++ b/lib/weather/adapter/metar-v1.php
@@ -865,7 +865,7 @@ function metarResolveStationResponse(string $stationId, ?string $airportId = nul
     }
 
     require_once __DIR__ . '/../../upstream-rate-limit.php';
-    if (!upstream_rate_limit_consume_for_source($stationSource)['allowed']) {
+    if (!upstreamRateLimitConsumeForSource($stationSource)['allowed']) {
         return ['body' => null, 'outcome' => METAR_RESOLVE_THROTTLED];
     }
 

--- a/lib/weather/adapter/nws-api-v1.php
+++ b/lib/weather/adapter/nws-api-v1.php
@@ -158,12 +158,12 @@ class NwsApiAdapter {
      */
     public static function buildPointsUrl(float $lat, float $lon): ?string
     {
-        if (!nws_points_coordinates_valid($lat, $lon)) {
+        if (!nwsPointsCoordinatesValid($lat, $lon)) {
             return null;
         }
 
-        $latStr = nws_points_normalize_coord($lat);
-        $lonStr = nws_points_normalize_coord($lon);
+        $latStr = nwsPointsNormalizeCoord($lat);
+        $lonStr = nwsPointsNormalizeCoord($lon);
 
         return self::API_BASE_URL . "/points/{$latStr},{$lonStr}";
     }
@@ -472,13 +472,13 @@ class NwsApiAdapter {
  * @param float $lon WGS84 longitude
  * @return array<string, mixed>|null Decoded JSON array on success
  */
-function nws_fetch_points(float $lat, float $lon): ?array
+function nwsFetchPoints(float $lat, float $lon): ?array
 {
-    if (!nws_points_coordinates_valid($lat, $lon)) {
+    if (!nwsPointsCoordinatesValid($lat, $lon)) {
         return null;
     }
 
-    $cachedBody = nws_points_cache_read($lat, $lon);
+    $cachedBody = nwsPointsCacheRead($lat, $lon);
     if ($cachedBody !== null) {
         $decoded = json_decode($cachedBody, true);
         if (is_array($decoded)) {
@@ -505,8 +505,8 @@ function nws_fetch_points(float $lat, float $lon): ?array
         $response = @file_get_contents($url, false, $context);
         if ($response === false || $response === '') {
             aviationwx_log('warning', 'NWS API: /points fetch failed', [
-                'lat' => nws_points_normalize_coord($lat),
-                'lon' => nws_points_normalize_coord($lon),
+                'lat' => nwsPointsNormalizeCoord($lat),
+                'lon' => nwsPointsNormalizeCoord($lon),
             ], 'app');
 
             return null;
@@ -522,8 +522,8 @@ function nws_fetch_points(float $lat, float $lon): ?array
                     if ($httpCode >= 400) {
                         aviationwx_log('warning', 'NWS API: /points HTTP error', [
                             'http_code' => $httpCode,
-                            'lat' => nws_points_normalize_coord($lat),
-                            'lon' => nws_points_normalize_coord($lon),
+                            'lat' => nwsPointsNormalizeCoord($lat),
+                            'lon' => nwsPointsNormalizeCoord($lon),
                         ], 'app');
 
                         return null;
@@ -550,7 +550,7 @@ function nws_fetch_points(float $lat, float $lon): ?array
         return null;
     }
 
-    nws_points_cache_write($lat, $lon, $response);
+    nwsPointsCacheWrite($lat, $lon, $response);
 
     return $decoded;
 }

--- a/lib/weather/adapter/nws-api-v1.php
+++ b/lib/weather/adapter/nws-api-v1.php
@@ -536,7 +536,10 @@ function nwsFetchPoints(float $lat, float $lon): ?array
 
     $decoded = json_decode($response, true);
     if (!is_array($decoded)) {
-        aviationwx_log('warning', 'NWS API: /points JSON parse failed', [], 'app');
+        aviationwx_log('warning', 'NWS API: /points JSON parse failed', [
+            'lat' => nwsPointsNormalizeCoord($lat),
+            'lon' => nwsPointsNormalizeCoord($lon),
+        ], 'app');
 
         return null;
     }

--- a/lib/weather/adapter/nws-api-v1.php
+++ b/lib/weather/adapter/nws-api-v1.php
@@ -34,6 +34,7 @@
 require_once __DIR__ . '/../../constants.php';
 require_once __DIR__ . '/../../test-mocks.php';
 require_once __DIR__ . '/../../logger.php';
+require_once __DIR__ . '/../../nws-points-cache.php';
 require_once __DIR__ . '/../data/WeatherReading.php';
 require_once __DIR__ . '/../data/WindGroup.php';
 require_once __DIR__ . '/../data/WeatherSnapshot.php';
@@ -146,6 +147,21 @@ class NwsApiAdapter {
         }
         
         return self::API_BASE_URL . "/stations/{$stationId}/observations/latest";
+    }
+
+    /**
+     * Build the NWS /points URL for a latitude and longitude (four decimal places).
+     */
+    public static function buildPointsUrl(float $lat, float $lon): ?string
+    {
+        if (!nws_points_coordinates_valid($lat, $lon)) {
+            return null;
+        }
+
+        $latStr = nws_points_normalize_coord($lat);
+        $lonStr = nws_points_normalize_coord($lon);
+
+        return self::API_BASE_URL . "/points/{$latStr},{$lonStr}";
     }
     
     /**
@@ -440,6 +456,76 @@ class NwsApiAdapter {
 // =============================================================================
 // STANDALONE FETCH FUNCTION (for testing/fallback)
 // =============================================================================
+
+/**
+ * Fetch NWS /points metadata for a coordinate pair (cached).
+ *
+ * Returns decoded GeoJSON properties or null on failure. Station observations
+ * still use buildUrl(); this helper is for grid/points lookups that should not
+ * hit api.weather.gov on every scheduler cycle.
+ *
+ * @return array<string, mixed>|null Decoded JSON array on success
+ */
+function nws_fetch_points(float $lat, float $lon): ?array
+{
+    if (!nws_points_coordinates_valid($lat, $lon)) {
+        return null;
+    }
+
+    $cachedBody = nws_points_cache_read($lat, $lon);
+    if ($cachedBody !== null) {
+        $decoded = json_decode($cachedBody, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    $url = NwsApiAdapter::buildPointsUrl($lat, $lon);
+    if ($url === null) {
+        return null;
+    }
+
+    $mockResponse = getMockHttpResponse($url);
+    if ($mockResponse !== null) {
+        $response = $mockResponse;
+    } else {
+        $context = stream_context_create([
+            'http' => [
+                'timeout' => CURL_TIMEOUT,
+                'ignore_errors' => true,
+                'header' => implode("\r\n", NwsApiAdapter::getHeaders()),
+            ],
+        ]);
+        $response = @file_get_contents($url, false, $context);
+        if ($response === false || $response === '') {
+            aviationwx_log('warning', 'NWS API: /points fetch failed', [
+                'lat' => nws_points_normalize_coord($lat),
+                'lon' => nws_points_normalize_coord($lon),
+            ], 'app');
+
+            return null;
+        }
+    }
+
+    $decoded = json_decode($response, true);
+    if (!is_array($decoded)) {
+        aviationwx_log('warning', 'NWS API: /points JSON parse failed', [], 'app');
+
+        return null;
+    }
+
+    if (isset($decoded['status']) && (int) $decoded['status'] >= 400) {
+        aviationwx_log('warning', 'NWS API: /points error response', [
+            'status' => $decoded['status'],
+            'detail' => $decoded['detail'] ?? 'Unknown error',
+        ], 'app');
+
+        return null;
+    }
+
+    nws_points_cache_write($lat, $lon, $response);
+
+    return $decoded;
+}
 
 /**
  * Fetch weather from NWS API (synchronous, for testing)

--- a/lib/weather/adapter/nws-api-v1.php
+++ b/lib/weather/adapter/nws-api-v1.php
@@ -151,6 +151,10 @@ class NwsApiAdapter {
 
     /**
      * Build the NWS /points URL for a latitude and longitude (four decimal places).
+     *
+     * @param float $lat WGS84 latitude
+     * @param float $lon WGS84 longitude
+     * @return string|null URL or null when coordinates are out of range
      */
     public static function buildPointsUrl(float $lat, float $lon): ?string
     {
@@ -460,10 +464,12 @@ class NwsApiAdapter {
 /**
  * Fetch NWS /points metadata for a coordinate pair (cached).
  *
- * Returns decoded GeoJSON properties or null on failure. Station observations
- * still use buildUrl(); this helper is for grid/points lookups that should not
- * hit api.weather.gov on every scheduler cycle.
+ * Returns decoded GeoJSON or null on failure. Station observations still use
+ * buildUrl(); this helper is for grid/points lookups that should not hit
+ * api.weather.gov on every scheduler cycle.
  *
+ * @param float $lat WGS84 latitude
+ * @param float $lon WGS84 longitude
  * @return array<string, mixed>|null Decoded JSON array on success
  */
 function nws_fetch_points(float $lat, float $lon): ?array
@@ -475,8 +481,9 @@ function nws_fetch_points(float $lat, float $lon): ?array
     $cachedBody = nws_points_cache_read($lat, $lon);
     if ($cachedBody !== null) {
         $decoded = json_decode($cachedBody, true);
-
-        return is_array($decoded) ? $decoded : null;
+        if (is_array($decoded)) {
+            return $decoded;
+        }
     }
 
     $url = NwsApiAdapter::buildPointsUrl($lat, $lon);
@@ -503,6 +510,27 @@ function nws_fetch_points(float $lat, float $lon): ?array
             ], 'app');
 
             return null;
+        }
+
+        $responseHeaders = function_exists('http_get_last_response_headers')
+            ? (http_get_last_response_headers() ?? [])
+            : ($http_response_header ?? []);
+        if (is_array($responseHeaders)) {
+            foreach ($responseHeaders as $headerLine) {
+                if (preg_match('/^HTTP\/\S+\s+(\d{3})/', $headerLine, $matches)) {
+                    $httpCode = (int) $matches[1];
+                    if ($httpCode >= 400) {
+                        aviationwx_log('warning', 'NWS API: /points HTTP error', [
+                            'http_code' => $httpCode,
+                            'lat' => nws_points_normalize_coord($lat),
+                            'lon' => nws_points_normalize_coord($lon),
+                        ], 'app');
+
+                        return null;
+                    }
+                    break;
+                }
+            }
         }
     }
 

--- a/lib/weather/adapter/tempest-v1.php
+++ b/lib/weather/adapter/tempest-v1.php
@@ -193,7 +193,7 @@ function tempestHttpGet(string $url, ?int $requestTimeoutSeconds = null, ?array 
     if ($mock !== null) {
         return $mock;
     }
-    if ($rateLimitSource !== null && !upstream_rate_limit_consume_for_source($rateLimitSource)['allowed']) {
+    if ($rateLimitSource !== null && !upstreamRateLimitConsumeForSource($rateLimitSource)['allowed']) {
         return null;
     }
     $ch = curl_init($url);

--- a/tests/Unit/FetchAllSourcesMetarBulkTest.php
+++ b/tests/Unit/FetchAllSourcesMetarBulkTest.php
@@ -18,8 +18,8 @@ final class FetchAllSourcesMetarBulkTest extends TestCase
         require_once __DIR__ . '/../../lib/test-mocks.php';
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
         metarBulkTestSetSkipMetarHttpMock(false);
-        upstream_rate_limit_test_clear_force_enforcement();
-        unset($GLOBALS['upstream_rate_limit_test_root']);
+        upstreamRateLimitTestClearForceEnforcement();
+        unset($GLOBALS['upstreamRateLimitTestRoot']);
         if ($this->rateLimitRoot !== null && is_dir($this->rateLimitRoot)) {
             $files = new \RecursiveIteratorIterator(
                 new \RecursiveDirectoryIterator($this->rateLimitRoot, \FilesystemIterator::SKIP_DOTS),
@@ -104,13 +104,13 @@ final class FetchAllSourcesMetarBulkTest extends TestCase
 
         $this->rateLimitRoot = sys_get_temp_dir() . '/fetchall-throttle-' . bin2hex(random_bytes(4));
         mkdir($this->rateLimitRoot, 0755, true);
-        $GLOBALS['upstream_rate_limit_test_root'] = $this->rateLimitRoot;
-        upstream_rate_limit_test_force_enforcement();
+        $GLOBALS['upstreamRateLimitTestRoot'] = $this->rateLimitRoot;
+        upstreamRateLimitTestForceEnforcement();
 
         $source = ['type' => 'metar', 'station_id' => 'KTHR'];
-        $fingerprint = upstream_rate_fingerprint('metar', $source);
+        $fingerprint = upstreamRateFingerprint('metar', $source);
         $t0 = microtime(true);
-        $this->assertTrue(upstream_rate_try_take($fingerprint, 60, 1, $t0));
+        $this->assertTrue(upstreamRateTryTake($fingerprint, 60, 1, $t0));
 
         $sources = [
             'source_0' => [

--- a/tests/Unit/FetchMetarFromStationBulkTest.php
+++ b/tests/Unit/FetchMetarFromStationBulkTest.php
@@ -18,8 +18,8 @@ final class FetchMetarFromStationBulkTest extends TestCase
         require_once __DIR__ . '/../../lib/test-mocks.php';
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
         metarBulkTestSetSkipMetarHttpMock(false);
-        upstream_rate_limit_test_clear_force_enforcement();
-        unset($GLOBALS['upstream_rate_limit_test_root']);
+        upstreamRateLimitTestClearForceEnforcement();
+        unset($GLOBALS['upstreamRateLimitTestRoot']);
         if ($this->rateLimitRoot !== null && is_dir($this->rateLimitRoot)) {
             $files = new \RecursiveIteratorIterator(
                 new \RecursiveDirectoryIterator($this->rateLimitRoot, \FilesystemIterator::SKIP_DOTS),
@@ -108,13 +108,13 @@ final class FetchMetarFromStationBulkTest extends TestCase
 
         $this->rateLimitRoot = sys_get_temp_dir() . '/metar-throttle-' . bin2hex(random_bytes(4));
         mkdir($this->rateLimitRoot, 0755, true);
-        $GLOBALS['upstream_rate_limit_test_root'] = $this->rateLimitRoot;
-        upstream_rate_limit_test_force_enforcement();
+        $GLOBALS['upstreamRateLimitTestRoot'] = $this->rateLimitRoot;
+        upstreamRateLimitTestForceEnforcement();
 
         $source = ['type' => 'metar', 'station_id' => 'KTHR'];
-        $fingerprint = upstream_rate_fingerprint('metar', $source);
+        $fingerprint = upstreamRateFingerprint('metar', $source);
         $t0 = microtime(true);
-        $this->assertTrue(upstream_rate_try_take($fingerprint, 60, 1, $t0));
+        $this->assertTrue(upstreamRateTryTake($fingerprint, 60, 1, $t0));
 
         $resolved = metarResolveStationResponse('KTHR', 'kthr');
         $this->assertSame(METAR_RESOLVE_THROTTLED, $resolved['outcome']);

--- a/tests/Unit/GlobalWeatherCircuitBreakerTest.php
+++ b/tests/Unit/GlobalWeatherCircuitBreakerTest.php
@@ -42,8 +42,8 @@ final class GlobalWeatherCircuitBreakerTest extends TestCase
         $sourceB = ['type' => 'tempest', 'api_key' => 'shared-key', 'station_id' => '2'];
 
         $this->assertSame(
-            weather_global_circuit_breaker_key('tempest', $sourceA),
-            weather_global_circuit_breaker_key('tempest', $sourceB)
+            weatherGlobalCircuitBreakerKey('tempest', $sourceA),
+            weatherGlobalCircuitBreakerKey('tempest', $sourceB)
         );
     }
 
@@ -96,7 +96,7 @@ final class GlobalWeatherCircuitBreakerTest extends TestCase
             recordWeatherFailure(self::AIRPORT_A, 'tempest', 'transient', 404, null, $source);
         }
 
-        $globalKey = weather_global_circuit_breaker_key('tempest', $source);
+        $globalKey = weatherGlobalCircuitBreakerKey('tempest', $source);
         $data = $this->readBackoffData();
         $this->assertArrayNotHasKey($globalKey, $data);
 
@@ -110,7 +110,7 @@ final class GlobalWeatherCircuitBreakerTest extends TestCase
 
         recordWeatherFailure(self::AIRPORT_A, 'tempest', 'transient', HTTP_STATUS_SERVICE_UNAVAILABLE, null, $source);
 
-        $globalKey = weather_global_circuit_breaker_key('tempest', $source);
+        $globalKey = weatherGlobalCircuitBreakerKey('tempest', $source);
         $data = $this->readBackoffData();
         $this->assertArrayHasKey($globalKey, $data);
     }

--- a/tests/Unit/MetarBulkCsvSchemaTest.php
+++ b/tests/Unit/MetarBulkCsvSchemaTest.php
@@ -21,7 +21,7 @@ final class MetarBulkCsvSchemaTest extends TestCase
         $fixturePath = __DIR__ . '/../Fixtures/metar-bulk-csv-header-line.txt';
         $this->assertFileExists($fixturePath);
         $line = trim((string) file_get_contents($fixturePath));
-        $expected = implode(',', metar_bulk_csv_expected_header_columns());
+        $expected = implode(',', metarBulkCsvExpectedHeaderColumns());
         $this->assertSame($expected, $line);
     }
 
@@ -36,16 +36,16 @@ final class MetarBulkCsvSchemaTest extends TestCase
         $header = fgetcsv($fh, 0, ',', '"', '\\');
         fclose($fh);
         $this->assertIsArray($header);
-        $this->assertTrue(metar_bulk_csv_header_matches_expected($header));
+        $this->assertTrue(metarBulkCsvHeaderMatchesExpected($header));
     }
 
     public function testMetarBulkCsvSchema_HeaderWithUtf8Bom_MatchesExpected(): void
     {
         require_once __DIR__ . '/../../lib/metar-bulk-csv-schema.php';
 
-        $header = metar_bulk_csv_expected_header_columns();
+        $header = metarBulkCsvExpectedHeaderColumns();
         $header[0] = "\xEF\xBB\xBF" . $header[0];
-        $this->assertTrue(metar_bulk_csv_header_matches_expected($header));
+        $this->assertTrue(metarBulkCsvHeaderMatchesExpected($header));
     }
 
     public function testMetarBulkIngestGzipToStationFiles_WrongHeader_ReturnsBadCsvHeaderSchema(): void
@@ -74,9 +74,9 @@ final class MetarBulkCsvSchemaTest extends TestCase
     {
         require_once __DIR__ . '/../../lib/metar-bulk-csv-schema.php';
 
-        $header = metar_bulk_csv_expected_header_columns();
+        $header = metarBulkCsvExpectedHeaderColumns();
         $header[0] = 'station_id';
-        $summary = metar_bulk_csv_describe_header_mismatch($header);
+        $summary = metarBulkCsvDescribeHeaderMismatch($header);
         $this->assertStringContainsString('col0:station_id!=raw_text', $summary);
     }
 

--- a/tests/Unit/MetarBulkTest.php
+++ b/tests/Unit/MetarBulkTest.php
@@ -198,7 +198,7 @@ final class MetarBulkTest extends TestCase
         require_once __DIR__ . '/../../lib/metar-bulk-csv-schema.php';
         require_once __DIR__ . '/../../lib/metar-bulk.php';
 
-        $header = implode(',', metar_bulk_csv_expected_header_columns());
+        $header = implode(',', metarBulkCsvExpectedHeaderColumns());
         $good = array_fill(0, 44, '');
         $good[0] = 'METAR KZZZ 181500Z AUTO 18015KT 10SM CLR 15/10 A2990';
         $good[1] = 'KZZZ';

--- a/tests/Unit/NwsPointsCacheTest.php
+++ b/tests/Unit/NwsPointsCacheTest.php
@@ -92,6 +92,20 @@ final class NwsPointsCacheTest extends TestCase
         $this->assertFalse(nwsPointsCacheWrite(100.0, 0.0, '{}'));
     }
 
+    public function testCacheRead_ReturnsNullWhenFileNotReadable(): void
+    {
+        $now = 1_700_000_000;
+        $body = '{"properties":{}}';
+        $this->assertTrue(nwsPointsCacheWrite(45.771, -122.86, $body, $now));
+        $path = nwsPointsCacheFilePath(nwsPointsCacheKey(45.771, -122.86));
+        chmod($path, 0000);
+        try {
+            $this->assertNull(nwsPointsCacheRead(45.771, -122.86, $now));
+        } finally {
+            chmod($path, 0644);
+        }
+    }
+
     public function testCacheRead_ReturnsNullWhenEnvelopeCoordinatesMismatch(): void
     {
         $now = 1_700_000_000;

--- a/tests/Unit/NwsPointsCacheTest.php
+++ b/tests/Unit/NwsPointsCacheTest.php
@@ -7,13 +7,13 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../lib/nws-points-cache.php';
 
 /**
- * @covers ::nws_points_coordinates_valid
- * @covers ::nws_points_normalize_coord
- * @covers ::nws_points_cache_key
- * @covers ::nws_points_cache_entry_is_fresh
- * @covers ::nws_points_cache_read
- * @covers ::nws_points_cache_write
- * @covers ::nws_fetch_points
+ * @covers ::nwsPointsCoordinatesValid
+ * @covers ::nwsPointsNormalizeCoord
+ * @covers ::nwsPointsCacheKey
+ * @covers ::nwsPointsCacheEntryIsFresh
+ * @covers ::nwsPointsCacheRead
+ * @covers ::nwsPointsCacheWrite
+ * @covers ::nwsFetchPoints
  */
 final class NwsPointsCacheTest extends TestCase
 {
@@ -24,12 +24,12 @@ final class NwsPointsCacheTest extends TestCase
         parent::setUp();
         $this->testRoot = sys_get_temp_dir() . '/nws-points-cache-test-' . bin2hex(random_bytes(4));
         mkdir($this->testRoot, 0755, true);
-        $GLOBALS['nws_points_cache_test_root'] = $this->testRoot;
+        $GLOBALS['nwsPointsCacheTestRoot'] = $this->testRoot;
     }
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['nws_points_cache_test_root']);
+        unset($GLOBALS['nwsPointsCacheTestRoot']);
         if ($this->testRoot !== null && is_dir($this->testRoot)) {
             $files = new RecursiveIteratorIterator(
                 new RecursiveDirectoryIterator($this->testRoot, FilesystemIterator::SKIP_DOTS),
@@ -49,44 +49,44 @@ final class NwsPointsCacheTest extends TestCase
 
     public function testCacheKey_NormalizesToFourDecimals(): void
     {
-        $this->assertSame('45.7710,-122.8600', nws_points_cache_key(45.7710278, -122.8600123));
+        $this->assertSame('45.7710,-122.8600', nwsPointsCacheKey(45.7710278, -122.8600123));
     }
 
     public function testCoordinatesValid_RejectsOutOfRange(): void
     {
-        $this->assertFalse(nws_points_coordinates_valid(91.0, 0.0));
-        $this->assertFalse(nws_points_coordinates_valid(0.0, 181.0));
-        $this->assertTrue(nws_points_coordinates_valid(45.77, -122.86));
+        $this->assertFalse(nwsPointsCoordinatesValid(91.0, 0.0));
+        $this->assertFalse(nwsPointsCoordinatesValid(0.0, 181.0));
+        $this->assertTrue(nwsPointsCoordinatesValid(45.77, -122.86));
     }
 
     public function testCacheWriteAndRead_ReturnsBodyWhileFresh(): void
     {
         $now = 1_700_000_000;
         $body = '{"properties":{"gridId":"PQR"}}';
-        $this->assertTrue(nws_points_cache_write(45.771, -122.86, $body, $now));
-        $this->assertSame($body, nws_points_cache_read(45.771, -122.86, $now));
+        $this->assertTrue(nwsPointsCacheWrite(45.771, -122.86, $body, $now));
+        $this->assertSame($body, nwsPointsCacheRead(45.771, -122.86, $now));
     }
 
     public function testCacheRead_ReturnsNullWhenExpired(): void
     {
         $fetchedAt = 1_700_000_000;
         $body = '{"properties":{}}';
-        $this->assertTrue(nws_points_cache_write(45.771, -122.86, $body, $fetchedAt));
+        $this->assertTrue(nwsPointsCacheWrite(45.771, -122.86, $body, $fetchedAt));
 
         $expiredNow = $fetchedAt + NWS_POINTS_CACHE_TTL_SECONDS + 1;
-        $this->assertNull(nws_points_cache_read(45.771, -122.86, $expiredNow));
+        $this->assertNull(nwsPointsCacheRead(45.771, -122.86, $expiredNow));
     }
 
     public function testCacheRead_ReturnsNullForInvalidCoordinates(): void
     {
-        $this->assertNull(nws_points_cache_read(100.0, 0.0));
-        $this->assertFalse(nws_points_cache_write(100.0, 0.0, '{}'));
+        $this->assertNull(nwsPointsCacheRead(100.0, 0.0));
+        $this->assertFalse(nwsPointsCacheWrite(100.0, 0.0, '{}'));
     }
 
     public function testCacheRead_ReturnsNullWhenEnvelopeCoordinatesMismatch(): void
     {
         $now = 1_700_000_000;
-        $path = nws_points_cache_file_path(nws_points_cache_key(45.771, -122.86));
+        $path = nwsPointsCacheFilePath(nwsPointsCacheKey(45.771, -122.86));
         if (!is_dir(dirname($path))) {
             mkdir(dirname($path), 0755, true);
         }
@@ -97,7 +97,7 @@ final class NwsPointsCacheTest extends TestCase
             'body' => '{"properties":{"gridId":"BAD"}}',
         ], JSON_UNESCAPED_SLASHES));
 
-        $this->assertNull(nws_points_cache_read(45.771, -122.86, $now));
+        $this->assertNull(nwsPointsCacheRead(45.771, -122.86, $now));
     }
 
     public function testNwsFetchPoints_RefetchesWhenCacheBodyIsCorrupt(): void
@@ -105,7 +105,7 @@ final class NwsPointsCacheTest extends TestCase
         require_once __DIR__ . '/../../lib/weather/adapter/nws-api-v1.php';
 
         $now = time();
-        $path = nws_points_cache_file_path(nws_points_cache_key(45.771, -122.86));
+        $path = nwsPointsCacheFilePath(nwsPointsCacheKey(45.771, -122.86));
         if (!is_dir(dirname($path))) {
             mkdir(dirname($path), 0755, true);
         }
@@ -116,7 +116,7 @@ final class NwsPointsCacheTest extends TestCase
             'body' => 'not-json',
         ], JSON_UNESCAPED_SLASHES));
 
-        $result = nws_fetch_points(45.771, -122.86);
+        $result = nwsFetchPoints(45.771, -122.86);
         $this->assertIsArray($result);
         $this->assertSame('PQR', $result['properties']['gridId'] ?? null);
     }
@@ -125,14 +125,14 @@ final class NwsPointsCacheTest extends TestCase
     {
         require_once __DIR__ . '/../../lib/weather/adapter/nws-api-v1.php';
 
-        $first = nws_fetch_points(45.771, -122.86);
+        $first = nwsFetchPoints(45.771, -122.86);
         $this->assertIsArray($first);
         $this->assertSame('PQR', $first['properties']['gridId'] ?? null);
 
-        $cachePath = nws_points_cache_file_path(nws_points_cache_key(45.771, -122.86));
+        $cachePath = nwsPointsCacheFilePath(nwsPointsCacheKey(45.771, -122.86));
         $this->assertFileExists($cachePath);
 
-        $second = nws_fetch_points(45.771, -122.86);
+        $second = nwsFetchPoints(45.771, -122.86);
         $this->assertSame($first, $second);
     }
 }

--- a/tests/Unit/NwsPointsCacheTest.php
+++ b/tests/Unit/NwsPointsCacheTest.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/../../lib/nws-points-cache.php';
  * @covers ::nws_points_cache_entry_is_fresh
  * @covers ::nws_points_cache_read
  * @covers ::nws_points_cache_write
+ * @covers ::nws_fetch_points
  */
 final class NwsPointsCacheTest extends TestCase
 {
@@ -80,6 +81,44 @@ final class NwsPointsCacheTest extends TestCase
     {
         $this->assertNull(nws_points_cache_read(100.0, 0.0));
         $this->assertFalse(nws_points_cache_write(100.0, 0.0, '{}'));
+    }
+
+    public function testCacheRead_ReturnsNullWhenEnvelopeCoordinatesMismatch(): void
+    {
+        $now = 1_700_000_000;
+        $path = nws_points_cache_file_path(nws_points_cache_key(45.771, -122.86));
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0755, true);
+        }
+        file_put_contents($path, json_encode([
+            'fetched_at' => $now,
+            'lat' => '99.9999',
+            'lon' => '-122.8600',
+            'body' => '{"properties":{"gridId":"BAD"}}',
+        ], JSON_UNESCAPED_SLASHES));
+
+        $this->assertNull(nws_points_cache_read(45.771, -122.86, $now));
+    }
+
+    public function testNwsFetchPoints_RefetchesWhenCacheBodyIsCorrupt(): void
+    {
+        require_once __DIR__ . '/../../lib/weather/adapter/nws-api-v1.php';
+
+        $now = time();
+        $path = nws_points_cache_file_path(nws_points_cache_key(45.771, -122.86));
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0755, true);
+        }
+        file_put_contents($path, json_encode([
+            'fetched_at' => $now,
+            'lat' => '45.7710',
+            'lon' => '-122.8600',
+            'body' => 'not-json',
+        ], JSON_UNESCAPED_SLASHES));
+
+        $result = nws_fetch_points(45.771, -122.86);
+        $this->assertIsArray($result);
+        $this->assertSame('PQR', $result['properties']['gridId'] ?? null);
     }
 
     public function testNwsFetchPoints_WritesCacheAndReusesOnSecondCall(): void

--- a/tests/Unit/NwsPointsCacheTest.php
+++ b/tests/Unit/NwsPointsCacheTest.php
@@ -76,6 +76,23 @@ final class NwsPointsCacheTest extends TestCase
         $this->assertSame($body, nwsPointsCacheRead(45.771, -122.86, $now));
     }
 
+    public function testCacheRead_ReturnsNullWhenFetchedAtIsInFuture(): void
+    {
+        $now = 1_700_000_000;
+        $path = nwsPointsCacheFilePath(nwsPointsCacheKey(45.771, -122.86));
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0755, true);
+        }
+        file_put_contents($path, json_encode([
+            'fetched_at' => $now + 86400,
+            'lat' => '45.7710',
+            'lon' => '-122.8600',
+            'body' => '{"properties":{"gridId":"PQR"}}',
+        ], JSON_UNESCAPED_SLASHES));
+
+        $this->assertNull(nwsPointsCacheRead(45.771, -122.86, $now));
+    }
+
     public function testCacheRead_ReturnsNullWhenExpired(): void
     {
         $fetchedAt = 1_700_000_000;

--- a/tests/Unit/NwsPointsCacheTest.php
+++ b/tests/Unit/NwsPointsCacheTest.php
@@ -52,6 +52,15 @@ final class NwsPointsCacheTest extends TestCase
         $this->assertSame('45.7710,-122.8600', nwsPointsCacheKey(45.7710278, -122.8600123));
     }
 
+    public function testNormalizeCoord_NegativeZeroMatchesPositiveZero(): void
+    {
+        $this->assertSame('0.0000', nwsPointsNormalizeCoord(-0.0));
+        $this->assertSame(
+            nwsPointsCacheKey(0.0, -122.86),
+            nwsPointsCacheKey(-0.0, -122.86)
+        );
+    }
+
     public function testCoordinatesValid_RejectsOutOfRange(): void
     {
         $this->assertFalse(nwsPointsCoordinatesValid(91.0, 0.0));

--- a/tests/Unit/NwsPointsCacheTest.php
+++ b/tests/Unit/NwsPointsCacheTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/nws-points-cache.php';
+
+/**
+ * @covers ::nws_points_coordinates_valid
+ * @covers ::nws_points_normalize_coord
+ * @covers ::nws_points_cache_key
+ * @covers ::nws_points_cache_entry_is_fresh
+ * @covers ::nws_points_cache_read
+ * @covers ::nws_points_cache_write
+ */
+final class NwsPointsCacheTest extends TestCase
+{
+    private ?string $testRoot = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testRoot = sys_get_temp_dir() . '/nws-points-cache-test-' . bin2hex(random_bytes(4));
+        mkdir($this->testRoot, 0755, true);
+        $GLOBALS['nws_points_cache_test_root'] = $this->testRoot;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['nws_points_cache_test_root']);
+        if ($this->testRoot !== null && is_dir($this->testRoot)) {
+            $files = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($this->testRoot, FilesystemIterator::SKIP_DOTS),
+                RecursiveIteratorIterator::CHILD_FIRST
+            );
+            foreach ($files as $file) {
+                if ($file->isDir()) {
+                    rmdir($file->getPathname());
+                } else {
+                    unlink($file->getPathname());
+                }
+            }
+            rmdir($this->testRoot);
+        }
+        parent::tearDown();
+    }
+
+    public function testCacheKey_NormalizesToFourDecimals(): void
+    {
+        $this->assertSame('45.7710,-122.8600', nws_points_cache_key(45.7710278, -122.8600123));
+    }
+
+    public function testCoordinatesValid_RejectsOutOfRange(): void
+    {
+        $this->assertFalse(nws_points_coordinates_valid(91.0, 0.0));
+        $this->assertFalse(nws_points_coordinates_valid(0.0, 181.0));
+        $this->assertTrue(nws_points_coordinates_valid(45.77, -122.86));
+    }
+
+    public function testCacheWriteAndRead_ReturnsBodyWhileFresh(): void
+    {
+        $now = 1_700_000_000;
+        $body = '{"properties":{"gridId":"PQR"}}';
+        $this->assertTrue(nws_points_cache_write(45.771, -122.86, $body, $now));
+        $this->assertSame($body, nws_points_cache_read(45.771, -122.86, $now));
+    }
+
+    public function testCacheRead_ReturnsNullWhenExpired(): void
+    {
+        $fetchedAt = 1_700_000_000;
+        $body = '{"properties":{}}';
+        $this->assertTrue(nws_points_cache_write(45.771, -122.86, $body, $fetchedAt));
+
+        $expiredNow = $fetchedAt + NWS_POINTS_CACHE_TTL_SECONDS + 1;
+        $this->assertNull(nws_points_cache_read(45.771, -122.86, $expiredNow));
+    }
+
+    public function testCacheRead_ReturnsNullForInvalidCoordinates(): void
+    {
+        $this->assertNull(nws_points_cache_read(100.0, 0.0));
+        $this->assertFalse(nws_points_cache_write(100.0, 0.0, '{}'));
+    }
+
+    public function testNwsFetchPoints_WritesCacheAndReusesOnSecondCall(): void
+    {
+        require_once __DIR__ . '/../../lib/weather/adapter/nws-api-v1.php';
+
+        $first = nws_fetch_points(45.771, -122.86);
+        $this->assertIsArray($first);
+        $this->assertSame('PQR', $first['properties']['gridId'] ?? null);
+
+        $cachePath = nws_points_cache_file_path(nws_points_cache_key(45.771, -122.86));
+        $this->assertFileExists($cachePath);
+
+        $second = nws_fetch_points(45.771, -122.86);
+        $this->assertSame($first, $second);
+    }
+}

--- a/tests/Unit/UpstreamRateLimitTest.php
+++ b/tests/Unit/UpstreamRateLimitTest.php
@@ -18,12 +18,12 @@ final class UpstreamRateLimitTest extends TestCase
         parent::setUp();
         $this->testRoot = sys_get_temp_dir() . '/upstream-rate-limit-test-' . bin2hex(random_bytes(4));
         mkdir($this->testRoot, 0755, true);
-        $GLOBALS['upstream_rate_limit_test_root'] = $this->testRoot;
+        $GLOBALS['upstreamRateLimitTestRoot'] = $this->testRoot;
     }
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['upstream_rate_limit_test_root']);
+        unset($GLOBALS['upstreamRateLimitTestRoot']);
         if ($this->testRoot !== null && is_dir($this->testRoot)) {
             $files = new \RecursiveIteratorIterator(
                 new \RecursiveDirectoryIterator($this->testRoot, \FilesystemIterator::SKIP_DOTS),
@@ -46,8 +46,8 @@ final class UpstreamRateLimitTest extends TestCase
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
 
         $source = ['api_key' => 'secret-a', 'station_id' => '12345'];
-        $a = upstream_rate_fingerprint('tempest', $source);
-        $b = upstream_rate_fingerprint('tempest', $source);
+        $a = upstreamRateFingerprint('tempest', $source);
+        $b = upstreamRateFingerprint('tempest', $source);
         $this->assertSame($a, $b);
         $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $a);
     }
@@ -56,8 +56,8 @@ final class UpstreamRateLimitTest extends TestCase
     {
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
 
-        $a = upstream_rate_fingerprint('tempest', ['api_key' => 'key-one', 'station_id' => '1']);
-        $b = upstream_rate_fingerprint('tempest', ['api_key' => 'key-two', 'station_id' => '1']);
+        $a = upstreamRateFingerprint('tempest', ['api_key' => 'key-one', 'station_id' => '1']);
+        $b = upstreamRateFingerprint('tempest', ['api_key' => 'key-two', 'station_id' => '1']);
         $this->assertNotSame($a, $b);
     }
 
@@ -65,8 +65,8 @@ final class UpstreamRateLimitTest extends TestCase
     {
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
 
-        $a = upstream_rate_fingerprint('tempest', ['api_key' => 'shared', 'station_id' => '111']);
-        $b = upstream_rate_fingerprint('tempest', ['api_key' => 'shared', 'station_id' => '222']);
+        $a = upstreamRateFingerprint('tempest', ['api_key' => 'shared', 'station_id' => '111']);
+        $b = upstreamRateFingerprint('tempest', ['api_key' => 'shared', 'station_id' => '222']);
         $this->assertSame($a, $b);
     }
 
@@ -74,12 +74,12 @@ final class UpstreamRateLimitTest extends TestCase
     {
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
 
-        $a = upstream_rate_fingerprint('pwsweather', [
+        $a = upstreamRateFingerprint('pwsweather', [
             'client_id' => 'cid',
             'client_secret' => 'sec',
             'station_id' => 'ST1',
         ]);
-        $b = upstream_rate_fingerprint('pwsweather', [
+        $b = upstreamRateFingerprint('pwsweather', [
             'client_id' => 'cid',
             'client_secret' => 'sec',
             'station_id' => 'ST2',
@@ -96,7 +96,7 @@ final class UpstreamRateLimitTest extends TestCase
         $now = 1000.0;
         $allowed = [];
         for ($i = 0; $i < 5; $i++) {
-            $result = upstream_rate_token_bucket_compute_take($tokens, $last, 60, 3, $now);
+            $result = upstreamRateTokenBucketComputeTake($tokens, $last, 60, 3, $now);
             $allowed[] = $result['allowed'];
             $tokens = $result['tokens'];
             $last = $result['last_refill'];
@@ -109,11 +109,11 @@ final class UpstreamRateLimitTest extends TestCase
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
 
         $t0 = 1_700_000_000.0;
-        $empty = upstream_rate_token_bucket_compute_take(0.0, $t0, 60, 3, $t0);
+        $empty = upstreamRateTokenBucketComputeTake(0.0, $t0, 60, 3, $t0);
         $this->assertFalse($empty['allowed']);
 
         // 60 rpm => 1 token per second; after 2s we regain 2 tokens (capped at burst 3)
-        $refilled = upstream_rate_token_bucket_compute_take(0.0, $t0, 60, 3, $t0 + 2.0);
+        $refilled = upstreamRateTokenBucketComputeTake(0.0, $t0, 60, 3, $t0 + 2.0);
         $this->assertTrue($refilled['allowed']);
         $this->assertGreaterThanOrEqual(0.9, $refilled['tokens']);
     }
@@ -127,12 +127,12 @@ final class UpstreamRateLimitTest extends TestCase
         $burst = 2;
         $t0 = 1_700_000_000.0;
 
-        $this->assertTrue(upstream_rate_try_take($fingerprint, $rpm, $burst, $t0));
-        $this->assertTrue(upstream_rate_try_take($fingerprint, $rpm, $burst, $t0));
-        $this->assertFalse(upstream_rate_try_take($fingerprint, $rpm, $burst, $t0));
+        $this->assertTrue(upstreamRateTryTake($fingerprint, $rpm, $burst, $t0));
+        $this->assertTrue(upstreamRateTryTake($fingerprint, $rpm, $burst, $t0));
+        $this->assertFalse(upstreamRateTryTake($fingerprint, $rpm, $burst, $t0));
 
         // 2 seconds later at 60 rpm we regain 2 tokens
-        $this->assertTrue(upstream_rate_try_take($fingerprint, $rpm, $burst, $t0 + 2.0));
+        $this->assertTrue(upstreamRateTryTake($fingerprint, $rpm, $burst, $t0 + 2.0));
     }
 
     public function testTryTake_CorruptStateFile_DoesNotGrantFullBurst(): void
@@ -140,7 +140,7 @@ final class UpstreamRateLimitTest extends TestCase
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
 
         $fingerprint = hash('sha256', 'corrupt-state-test');
-        $stateFile = upstream_rate_limit_state_file_path($fingerprint);
+        $stateFile = upstreamRateLimitStateFilePath($fingerprint);
         $dir = dirname($stateFile);
         if (!is_dir($dir)) {
             mkdir($dir, 0755, true);
@@ -148,15 +148,15 @@ final class UpstreamRateLimitTest extends TestCase
         file_put_contents($stateFile, 'not-json');
 
         $t0 = 1_700_000_000.0;
-        $this->assertFalse(upstream_rate_try_take($fingerprint, 60, 3, $t0));
+        $this->assertFalse(upstreamRateTryTake($fingerprint, 60, 3, $t0));
     }
 
     public function testFingerprint_Metar_DifferentStationIds_ReturnsDifferentHash(): void
     {
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
 
-        $a = upstream_rate_fingerprint('metar', ['station_id' => 'KAAA']);
-        $b = upstream_rate_fingerprint('metar', ['station_id' => 'KBBB']);
+        $a = upstreamRateFingerprint('metar', ['station_id' => 'KAAA']);
+        $b = upstreamRateFingerprint('metar', ['station_id' => 'KBBB']);
         $this->assertNotSame($a, $b);
     }
 
@@ -164,8 +164,8 @@ final class UpstreamRateLimitTest extends TestCase
     {
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
 
-        $a = upstream_rate_fingerprint('awosnet', ['station_id' => 'ks40']);
-        $b = upstream_rate_fingerprint('awosnet', ['station_id' => 'ks41']);
+        $a = upstreamRateFingerprint('awosnet', ['station_id' => 'ks40']);
+        $b = upstreamRateFingerprint('awosnet', ['station_id' => 'ks41']);
         $this->assertNotSame($a, $b);
     }
 
@@ -175,7 +175,7 @@ final class UpstreamRateLimitTest extends TestCase
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
 
         $source = ['type' => 'tempest', 'api_key' => 'k', 'station_id' => '1'];
-        $result = upstream_rate_limit_consume_for_source($source);
+        $result = upstreamRateLimitConsumeForSource($source);
         $this->assertTrue($result['allowed']);
         $this->assertNull($result['fingerprint_prefix']);
     }
@@ -185,7 +185,7 @@ final class UpstreamRateLimitTest extends TestCase
         require_once __DIR__ . '/../../lib/constants.php';
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
 
-        $policy = upstream_rate_limit_policy_for_provider('tempest');
+        $policy = upstreamRateLimitPolicyForProvider('tempest');
         $this->assertSame(UPSTREAM_RATE_LIMIT_TEMPEST_RPM, $policy['rpm']);
         $this->assertSame(UPSTREAM_RATE_LIMIT_TEMPEST_BURST, $policy['burst']);
     }

--- a/tests/Unit/WeatherBackoffHeadersTest.php
+++ b/tests/Unit/WeatherBackoffHeadersTest.php
@@ -9,11 +9,11 @@ require_once __DIR__ . '/../../lib/circuit-breaker.php';
 require_once __DIR__ . '/../../lib/cache-paths.php';
 
 /**
- * @covers ::circuit_breaker_collect_curl_header_line
- * @covers ::parse_retry_after_seconds
- * @covers ::weather_backoff_clamp_seconds
- * @covers ::weather_backoff_override_seconds
- * @covers ::circuit_breaker_compute_backoff_seconds
+ * @covers ::circuitBreakerCollectCurlHeaderLine
+ * @covers ::parseRetryAfterSeconds
+ * @covers ::weatherBackoffClampSeconds
+ * @covers ::weatherBackoffOverrideSeconds
+ * @covers ::circuitBreakerComputeBackoffSeconds
  */
 class WeatherBackoffHeadersTest extends TestCase
 {
@@ -38,48 +38,48 @@ class WeatherBackoffHeadersTest extends TestCase
 
     public function testParseRetryAfterSeconds_Integer(): void
     {
-        $this->assertSame(60, parse_retry_after_seconds('60'));
-        $this->assertSame(1, parse_retry_after_seconds('1'));
+        $this->assertSame(60, parseRetryAfterSeconds('60'));
+        $this->assertSame(1, parseRetryAfterSeconds('1'));
     }
 
     public function testParseRetryAfterSeconds_HttpDate(): void
     {
         $now = 1_770_000_000;
         $headerValue = gmdate('D, d M Y H:i:s', $now + 120) . ' GMT';
-        $this->assertSame(120, parse_retry_after_seconds($headerValue, $now));
+        $this->assertSame(120, parseRetryAfterSeconds($headerValue, $now));
     }
 
     public function testParseRetryAfterSeconds_PastHttpDate_ReturnsNull(): void
     {
         $now = 1_770_000_300;
         $headerValue = gmdate('D, d M Y H:i:s', $now - 60) . ' GMT';
-        $this->assertNull(parse_retry_after_seconds($headerValue, $now));
+        $this->assertNull(parseRetryAfterSeconds($headerValue, $now));
     }
 
     public function testParseRetryAfterSeconds_Invalid_ReturnsNull(): void
     {
-        $this->assertNull(parse_retry_after_seconds('not-a-date'));
-        $this->assertNull(parse_retry_after_seconds(''));
-        $this->assertNull(parse_retry_after_seconds('0'));
+        $this->assertNull(parseRetryAfterSeconds('not-a-date'));
+        $this->assertNull(parseRetryAfterSeconds(''));
+        $this->assertNull(parseRetryAfterSeconds('0'));
     }
 
     public function testWeatherBackoffOverrideSeconds_RetryAfter_ClampedToMax(): void
     {
         $seconds = BACKOFF_MAX_RETRY_AFTER_SECONDS + 500;
-        $override = weather_backoff_override_seconds(429, ['retry-after' => (string) $seconds]);
+        $override = weatherBackoffOverrideSeconds(429, ['retry-after' => (string) $seconds]);
         $this->assertSame(BACKOFF_MAX_RETRY_AFTER_SECONDS, $override);
     }
 
     public function testWeatherBackoffOverrideSeconds_RetryAfter_429(): void
     {
-        $override = weather_backoff_override_seconds(429, ['retry-after' => '45']);
+        $override = weatherBackoffOverrideSeconds(429, ['retry-after' => '45']);
         $this->assertSame(45, $override);
     }
 
     public function testWeatherBackoffOverrideSeconds_XRateLimitReset_WhenNoRetryAfter(): void
     {
         $now = 1_700_000_000;
-        $override = weather_backoff_override_seconds(
+        $override = weatherBackoffOverrideSeconds(
             429,
             ['x-ratelimit-reset' => (string) ($now + 90)],
             $now
@@ -89,12 +89,12 @@ class WeatherBackoffHeadersTest extends TestCase
 
     public function testWeatherBackoffOverrideSeconds_IgnoredFor404(): void
     {
-        $this->assertNull(weather_backoff_override_seconds(404, ['retry-after' => '120']));
+        $this->assertNull(weatherBackoffOverrideSeconds(404, ['retry-after' => '120']));
     }
 
     public function testWeatherBackoffOverrideSeconds_RetryAfter_503(): void
     {
-        $override = weather_backoff_override_seconds(
+        $override = weatherBackoffOverrideSeconds(
             HTTP_STATUS_SERVICE_UNAVAILABLE,
             ['retry-after' => '30']
         );
@@ -104,20 +104,20 @@ class WeatherBackoffHeadersTest extends TestCase
     public function testWeatherBackoffOverrideSeconds_SmallResetIgnored(): void
     {
         $now = 1_700_000_000;
-        $this->assertNull(weather_backoff_override_seconds(429, ['x-ratelimit-reset' => '90'], $now));
+        $this->assertNull(weatherBackoffOverrideSeconds(429, ['x-ratelimit-reset' => '90'], $now));
     }
 
     public function testCircuitBreakerComputeBackoffSeconds_UsesHeaderWhenLongerThan429Default(): void
     {
-        $seconds = circuit_breaker_compute_backoff_seconds(2, 'transient', 429, ['retry-after' => '120']);
+        $seconds = circuitBreakerComputeBackoffSeconds(2, 'transient', 429, ['retry-after' => '120']);
         $this->assertSame(120, $seconds);
     }
 
     public function testCircuitBreakerCollectCurlHeaderLine_NormalizesKeys(): void
     {
         $headers = [];
-        circuit_breaker_collect_curl_header_line($headers, "Retry-After: 30\r\n");
-        circuit_breaker_collect_curl_header_line($headers, "X-RateLimit-Reset: 999\r\n");
+        circuitBreakerCollectCurlHeaderLine($headers, "Retry-After: 30\r\n");
+        circuitBreakerCollectCurlHeaderLine($headers, "X-RateLimit-Reset: 999\r\n");
         $this->assertSame('30', $headers['retry-after']);
         $this->assertSame('999', $headers['x-ratelimit-reset']);
     }

--- a/tests/mock-weather-responses.php
+++ b/tests/mock-weather-responses.php
@@ -375,6 +375,28 @@ function getMockNwsApiResponse() {
 }
 
 /**
+ * Mock NWS /points/{lat},{lon} metadata (grid mapping).
+ */
+function getMockNwsPointsResponse()
+{
+    return json_encode([
+        'type' => 'Feature',
+        'geometry' => [
+            'type' => 'Point',
+            'coordinates' => [-122.86, 45.77],
+        ],
+        'properties' => [
+            'gridId' => 'PQR',
+            'gridX' => 88,
+            'gridY' => 105,
+            'forecast' => 'https://api.weather.gov/gridpoints/PQR/88,105/forecast',
+            'forecastHourly' => 'https://api.weather.gov/gridpoints/PQR/88,105/forecast/hourly',
+            'observationStations' => 'https://api.weather.gov/gridpoints/PQR/88,105/stations',
+        ],
+    ]);
+}
+
+/**
  * Get a mock SynopticData API response
  * Based on actual API structure from documentation and sample responses
  * SynopticData uses: { "SUMMARY": { "RESPONSE_CODE": 1 }, "STATION": [ { "OBSERVATIONS": { "field_value_1": { "value": ..., "date_time": ... } } } ] }


### PR DESCRIPTION
## Summary

- Add `lib/nws-points-cache.php` with 12-hour TTL file cache under `cache/nws-points/` (atomic writes, lat/lon envelope validation).
- Add `nws_fetch_points()` and `NwsApiAdapter::buildPointsUrl()` for cached `/points/{lat},{lon}` lookups; test mocks included.
- Station observations remain on `/stations/{station_id}/observations/latest` via `UnifiedFetcher` (unchanged).

## Test plan

- [x] `make test-ci`
- [x] `tests/Unit/NwsPointsCacheTest.php` (key/TTL, corrupt cache refetch, coordinate mismatch, `nws_fetch_points` reuse)
- [x] Manual (optional): call `nws_fetch_points($lat, $lon)` in Docker and confirm `cache/nws-points/*.json` is created

## Notes

- Review hardening in `65c6173`: corrupt cache fall-through, HTTP 4xx/5xx guard before cache write, PHPDoc.
- `nws_fetch_points()` is infrastructure for future grid lookups; not yet wired from airport config in the scheduler.