### PR TITLE
Add FTPS/SFTP upload health probes and service watchdog

### DIFF
--- a/config/airports.json.example
+++ b/config/airports.json.example
@@ -23,7 +23,7 @@
     },
     "dynamic_dns_refresh_seconds": 0,
 
-    "_comment_upload_health_probe": "Production only. Probe every interval_sec (default 30); service-watchdog runs every 50s. Dedicated probe user must not match any push camera username. probe_connect_host optional (e.g. 127.0.0.1) when public upload hostname fails hairpin NAT from the container.",
+    "_comment_upload_health_probe": "Production only. Probe every interval_sec (default 30); service-watchdog runs every 50s. Dedicated probe user must not match any push camera username. Production Docker (host networking): set probe_connect_host to 127.0.0.1.",
     "upload_health_probe": {
       "enabled": false,
       "interval_sec": 30,

--- a/config/airports.json.example
+++ b/config/airports.json.example
@@ -22,6 +22,15 @@
       "ftps_alt": null
     },
     "dynamic_dns_refresh_seconds": 0,
+
+    "_comment_upload_health_probe": "Production only. Probe every interval_sec (default 30); service-watchdog runs every 50s. Dedicated probe user must not match any push camera username. probe_connect_host optional (e.g. 127.0.0.1) when public upload hostname fails hairpin NAT from the container.",
+    "upload_health_probe": {
+      "enabled": false,
+      "interval_sec": 30,
+      "probe_connect_host": "",
+      "ftps": { "username": "", "password": "" },
+      "sftp": { "username": "", "password": "" }
+    },
     
     "_comment_version": "Client version management. dead_man_switch_days=0 disables. force_cleanup triggers immediate cleanup for all clients.",
     "dead_man_switch_days": 7,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,15 +97,21 @@ RUN chmod 0644 /etc/cron.d/aviationwx-cron \
 RUN mkdir -p /usr/local/libexec/aviationwx \
     && chown root:root /usr/local/libexec/aviationwx \
     && chmod 755 /usr/local/libexec/aviationwx
-COPY scripts/maybe-run-update-pasv-address.sh scripts/update-pasv-address.sh scripts/set-cache-permissions.sh scripts/repair-sftp-chroot-permissions.sh /usr/local/libexec/aviationwx/
+COPY scripts/maybe-run-update-pasv-address.sh scripts/update-pasv-address.sh scripts/set-cache-permissions.sh scripts/repair-sftp-chroot-permissions.sh scripts/upload-daemon-common.sh scripts/upload-probe.sh scripts/upload-probe-runner.sh /usr/local/libexec/aviationwx/
 RUN chmod 755 /usr/local/libexec/aviationwx/maybe-run-update-pasv-address.sh \
     /usr/local/libexec/aviationwx/update-pasv-address.sh \
     /usr/local/libexec/aviationwx/set-cache-permissions.sh \
     /usr/local/libexec/aviationwx/repair-sftp-chroot-permissions.sh \
+    /usr/local/libexec/aviationwx/upload-daemon-common.sh \
+    /usr/local/libexec/aviationwx/upload-probe.sh \
+    /usr/local/libexec/aviationwx/upload-probe-runner.sh \
     && chown root:root /usr/local/libexec/aviationwx/maybe-run-update-pasv-address.sh \
     /usr/local/libexec/aviationwx/update-pasv-address.sh \
     /usr/local/libexec/aviationwx/set-cache-permissions.sh \
-    /usr/local/libexec/aviationwx/repair-sftp-chroot-permissions.sh
+    /usr/local/libexec/aviationwx/repair-sftp-chroot-permissions.sh \
+    /usr/local/libexec/aviationwx/upload-daemon-common.sh \
+    /usr/local/libexec/aviationwx/upload-probe.sh \
+    /usr/local/libexec/aviationwx/upload-probe-runner.sh
 
 # Copy application files LAST (changes most frequently)
 # This ensures code changes don't invalidate earlier layers

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -333,6 +333,7 @@ if [ -d "${LOG_DIR}" ]; then
           "${LOG_DIR}/apache-error.log" \
           "${LOG_DIR}/sshd.log" \
           "${LOG_DIR}/service-watchdog.log" \
+          "${LOG_DIR}/upload-probe.log" \
           "${LOG_DIR}/app.log" \
           "${LOG_DIR}/user.log" 2>/dev/null || true
     
@@ -342,8 +343,8 @@ if [ -d "${LOG_DIR}" ]; then
     chown www-data:www-data "${LOG_DIR}"/*.log 2>/dev/null || true
     chmod 644 "${LOG_DIR}"/*.log 2>/dev/null || true
     # System logs owned by root (nightly set-cache-permissions log lives under /var/lib/aviationwx; see config/crontab)
-    chown root:root "${LOG_DIR}/sshd.log" "${LOG_DIR}/service-watchdog.log" 2>/dev/null || true
-    chmod 644 "${LOG_DIR}/sshd.log" "${LOG_DIR}/service-watchdog.log" 2>/dev/null || true
+    chown root:root "${LOG_DIR}/sshd.log" "${LOG_DIR}/service-watchdog.log" "${LOG_DIR}/upload-probe.log" 2>/dev/null || true
+    chmod 644 "${LOG_DIR}/sshd.log" "${LOG_DIR}/service-watchdog.log" "${LOG_DIR}/upload-probe.log" 2>/dev/null || true
     # Ensure heartbeat log is writable by both www-data and root
     chmod 666 "${LOG_DIR}/cron-heartbeat.log" 2>/dev/null || true
     
@@ -767,13 +768,17 @@ fi
 
 echo "All services started successfully"
 
-# Start service watchdog in background
+# Start upload probe runner (30s) and service watchdog (50s loop) in background
+echo "Starting upload health probe runner..."
+/usr/local/libexec/aviationwx/upload-probe-runner.sh &
+PROBE_RUNNER_PID=$!
+
 echo "Starting service watchdog..."
 /usr/local/bin/service-watchdog.sh &
 WATCHDOG_PID=$!
 
-# Trap signals to clean up watchdog on exit
-trap "kill $WATCHDOG_PID 2>/dev/null || true" EXIT
+# Trap signals to clean up background monitors on exit
+trap "kill $PROBE_RUNNER_PID $WATCHDOG_PID 2>/dev/null || true" EXIT
 
 # Write fail2ban jail and sshd-sftp filter for the configured FTP/SFTP ports
 echo "Configuring fail2ban ports..."

--- a/docker/logrotate-aviationwx
+++ b/docker/logrotate-aviationwx
@@ -68,6 +68,17 @@
     create 0644 root root
 }
 
+# Upload health probe log
+/var/log/aviationwx/upload-probe.log {
+    daily
+    rotate 1
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0644 root root
+}
+
 # PHP application logs
 /var/log/aviationwx/app.log
 /var/log/aviationwx/user.log

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -282,7 +282,7 @@ Production-only functional checks for FTPS and SFTP upload paths. When enabled, 
 |-------|------|-------------|
 | `enabled` | boolean | Must be `true` to activate (not `1` or `"true"`) |
 | `interval_sec` | integer | Probe period in seconds (15-300, default 30) |
-| `probe_connect_host` | string | Optional connect host when `upload_hostname` fails hairpin NAT from the container (for example `127.0.0.1`) |
+| `probe_connect_host` | string | Connect host for on-box probes. Empty uses `upload_hostname`. Production Docker (`network_mode: host`) should use `127.0.0.1` so probes hit local vsftpd/sshd without hairpin NAT through the public IP |
 | `ftps` | object | `username` and `password` for FTPS probe (passive TLS upload) |
 | `sftp` | object | `username` and `password` for SFTP probe (upload under `files/`) |
 
@@ -293,6 +293,9 @@ Credential shape matches push cameras: `username` is alphanumeric, max 14 charac
 - Use a **dedicated** probe account synced via `sync-push-config.php`. Usernames must **not** match any push camera `push_config.username` (config validation enforces this).
 - Do not use a live camera account: probe files are `aviationwx-probe-*.txt` and must not enter the webcam pipeline.
 - Apache container health does not reflect upload health; use heartbeat and logs under [Operations](OPERATIONS.md#upload-health-probe-and-service-watchdog).
+- Heartbeat `ftps.duration_sec` / `sftp.duration_sec` report probe wall time in seconds (not milliseconds).
+
+**Production Docker:** The web container uses host networking. Set `probe_connect_host` to `127.0.0.1` so functional probes connect to local listeners on `network_ports.ftp_control` and `network_ports.sftp`. Cameras still use `upload_hostname` as usual.
 
 **Recommended: Hostname (default)**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -291,7 +291,7 @@ Credential shape matches push cameras: `username` is alphanumeric, max 14 charac
 **Requirements:**
 
 - Use a **dedicated** probe account synced via `sync-push-config.php`. Usernames must **not** match any push camera `push_config.username` (config validation enforces this).
-- Do not use a live camera account: probe files are `aviationwx-probe-*.txt` and must not enter the webcam pipeline.
+- Do not use a live camera account: probe uploads use a fixed remote name (`aviationwx-probe-healthcheck.txt`) and must not enter the webcam pipeline.
 - Apache container health does not reflect upload health; use heartbeat and logs under [Operations](OPERATIONS.md#upload-health-probe-and-service-watchdog).
 - Heartbeat `ftps.duration_sec` / `sftp.duration_sec` report probe wall time in seconds (not milliseconds).
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -29,6 +29,7 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 | `public_ip` | - | Optional: explicit IPv4 for FTP passive mode (use only if DNS unavailable at startup) |
 | `public_ipv6` | - | Optional: reserved for future IPv6 support |
 | `upload_hostname` | `upload.{base_domain}` | Hostname for FTP/SFTP uploads (recommended) |
+| `upload_health_probe` | disabled | Production: functional FTPS/SFTP probes and automatic daemon recovery; see [Upload health probe](#upload-health-probe) |
 | `network_ports` | - | Optional (self-hosted prod): TCP ports for the app stack, UFW, and in-container services; see [Network configuration](#network-configuration). |
 | `dynamic_dns_refresh_seconds` | `0` | Re-resolve DNS for DDNS (0=disabled, min 60). When set, root cron runs `/usr/local/libexec/aviationwx/maybe-run-update-pasv-address.sh` every minute (same sources in `scripts/` in the repo); it gates on this interval and invokes `update-pasv-address.sh` from the same directory as that wrapper. |
 | `webcam_refresh_default` | `60` | Default webcam refresh (seconds) |
@@ -272,6 +273,26 @@ Configure the server's public network identity for FTP/SFTP services and URL gen
 2. **`upload_hostname`** - If `public_ip` not set, resolve via DNS (recommended; survives IP changes)
 3. **`upload.{base_domain}`** - Default fallback if `upload_hostname` not set
 4. **`upload.aviationwx.org`** - Final fallback
+
+### Upload health probe
+
+Production-only functional checks for FTPS and SFTP upload paths. When enabled, `upload-probe-runner.sh` uploads a small test file every `interval_sec` (default 30). `service-watchdog.sh` evaluates the heartbeat every 50 seconds and may restart **vsftpd** or the container **sshd** after consecutive failures (at most once per 30 minutes per daemon).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | boolean | Must be `true` to activate (not `1` or `"true"`) |
+| `interval_sec` | integer | Probe period in seconds (15-300, default 30) |
+| `probe_connect_host` | string | Optional connect host when `upload_hostname` fails hairpin NAT from the container (for example `127.0.0.1`) |
+| `ftps` | object | `username` and `password` for FTPS probe (passive TLS upload) |
+| `sftp` | object | `username` and `password` for SFTP probe (upload under `files/`) |
+
+Credential shape matches push cameras: `username` is alphanumeric, max 14 characters; `password` is exactly 14 alphanumeric characters. Config validation (`validate-airports-json.php` / `validateRuntimeConfigSchema`) enforces these rules.
+
+**Requirements:**
+
+- Use a **dedicated** probe account synced via `sync-push-config.php`. Usernames must **not** match any push camera `push_config.username` (config validation enforces this).
+- Do not use a live camera account: probe files are `aviationwx-probe-*.txt` and must not enter the webcam pipeline.
+- Apache container health does not reflect upload health; use heartbeat and logs under [Operations](OPERATIONS.md#upload-health-probe-and-service-watchdog).
 
 **Recommended: Hostname (default)**
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -465,7 +465,7 @@ Production can run functional FTPS/SFTP upload probes and restart wedged daemons
 | `/var/log/aviationwx/service-watchdog.log` | Watchdog and restart actions |
 | `app.log` | Structured `upload health` events (failures, restarts, throttling) |
 
-**Recovery policy:** Two consecutive failed or stale probe evaluations per protocol, then at most one daemon restart per 30 minutes (shared throttle). Process death uses the same throttle. Missing `jq` or a corrupt heartbeat is treated as unhealthy (fail closed).
+**Recovery policy:** Two consecutive failed or stale probe evaluations per protocol, then at most one restart per 30 minutes per daemon (vsftpd and container sshd throttled separately). Process death uses the same per-daemon throttle. Missing `jq` or a corrupt heartbeat is treated as unhealthy (fail closed).
 
 **Probe connect host:** Production Docker uses `network_mode: host`. Set `config.upload_health_probe.probe_connect_host` to `127.0.0.1` so on-box probes reach vsftpd and sshd locally. Leave empty only if probes succeed via `upload_hostname` without hairpin NAT. External cameras still use `upload_hostname`.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -445,6 +445,40 @@ docker exec -u root aviationwx-web php /var/www/html/scripts/sync-push-config.ph
 
 **Prevention:** Deploy applies `www-data` ownership only to cache data directories, not `sftp/{user}/`. Nightly `set-cache-permissions.sh` and every `sync-push-config.php` run call the repair script; both exit non-zero if repair fails (check `set-cache-permissions.log` or deploy sync output). Do not run `chown -R www-data` on `/tmp/aviationwx-cache` on the host without re-running repair afterward.
 
+### Upload health probe and service watchdog
+
+Production can run functional FTPS/SFTP upload probes and restart wedged daemons automatically.
+
+| Component | Interval | Role |
+|-----------|----------|------|
+| `upload-probe-runner.sh` | `config.upload_health_probe.interval_sec` (default 30s) | Passive upload test, writes heartbeat |
+| `service-watchdog.sh` | 50s loop | Reads heartbeat, restarts vsftpd or container sshd when unhealthy |
+
+**Enable:** Set `config.upload_health_probe.enabled` to `true` in production `airports.json` with a **dedicated** probe user (must not match any `push_config.username`). See [Configuration](CONFIGURATION.md#upload-health-probe).
+
+**State and logs:**
+
+| Path | Purpose |
+|------|---------|
+| `/var/lib/aviationwx/upload-probe.json` | Last probe heartbeat (mode 600) |
+| `/var/log/aviationwx/upload-probe.log` | Probe runner output |
+| `/var/log/aviationwx/service-watchdog.log` | Watchdog and restart actions |
+| `app.log` | Structured `upload health` events (failures, restarts, throttling) |
+
+**Recovery policy:** Two consecutive failed or stale probe evaluations per protocol, then at most one daemon restart per 30 minutes (shared throttle). Process death uses the same throttle. Missing `jq` or a corrupt heartbeat is treated as unhealthy (fail closed).
+
+**Hairpin NAT:** If probes fail while cameras upload, set `config.upload_health_probe.probe_connect_host` (for example `127.0.0.1`) so the probe connects without looping through the public IP.
+
+```bash
+# Heartbeat and recent probe log
+docker exec aviationwx-web cat /var/lib/aviationwx/upload-probe.json | jq .
+docker exec aviationwx-web tail -50 /var/log/aviationwx/upload-probe.log
+
+# Watchdog / restarts
+docker exec aviationwx-web tail -50 /var/log/aviationwx/service-watchdog.log
+sudo grep -i 'upload health\|upload probe' /var/aviationwx/logs/app.log | tail -20
+```
+
 ---
 
 ## Related Documentation

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -467,7 +467,7 @@ Production can run functional FTPS/SFTP upload probes and restart wedged daemons
 
 **Recovery policy:** Two consecutive failed or stale probe evaluations per protocol, then at most one daemon restart per 30 minutes (shared throttle). Process death uses the same throttle. Missing `jq` or a corrupt heartbeat is treated as unhealthy (fail closed).
 
-**Hairpin NAT:** If probes fail while cameras upload, set `config.upload_health_probe.probe_connect_host` (for example `127.0.0.1`) so the probe connects without looping through the public IP.
+**Probe connect host:** Production Docker uses `network_mode: host`. Set `config.upload_health_probe.probe_connect_host` to `127.0.0.1` so on-box probes reach vsftpd and sshd locally. Leave empty only if probes succeed via `upload_hostname` without hairpin NAT. External cameras still use `upload_hostname`.
 
 ```bash
 # Heartbeat and recent probe log

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -469,6 +469,8 @@ Production can run functional FTPS/SFTP upload probes and restart wedged daemons
 
 **Probe connect host:** Production Docker uses `network_mode: host`. Set `config.upload_health_probe.probe_connect_host` to `127.0.0.1` so on-box probes reach vsftpd and sshd locally. Leave empty only if probes succeed via `upload_hostname` without hairpin NAT. External cameras still use `upload_hostname`.
 
+**Probe files:** Each run overwrites `aviationwx-probe-healthcheck.txt` on the probe account (no per-run timestamp filenames).
+
 ```bash
 # Heartbeat and recent probe log
 docker exec aviationwx-web cat /var/lib/aviationwx/upload-probe.json | jq .

--- a/lib/config.php
+++ b/lib/config.php
@@ -597,6 +597,288 @@ function isDynamicDnsEnabled(): bool {
 }
 
 /**
+ * Stale threshold for upload probe heartbeat (watchdog): 2x interval plus grace.
+ */
+function getUploadHealthProbeStaleSeconds(?int $intervalSec = null): int
+{
+    $interval = $intervalSec ?? UPLOAD_HEALTH_PROBE_INTERVAL_DEFAULT_SEC;
+    $interval = max(
+        UPLOAD_HEALTH_PROBE_INTERVAL_MIN_SEC,
+        min(UPLOAD_HEALTH_PROBE_INTERVAL_MAX_SEC, $interval)
+    );
+
+    return ($interval * 2) + UPLOAD_HEALTH_PROBE_STALE_GRACE_SEC;
+}
+
+/**
+ * Host used for FTPS/SFTP probe connections (may differ from upload_hostname for NAT/hairpin).
+ */
+function getUploadHealthProbeConnectHost(): string
+{
+    $raw = getGlobalConfig('upload_health_probe');
+    if (is_array($raw) && isset($raw['probe_connect_host'])) {
+        $host = $raw['probe_connect_host'];
+        if (is_string($host) && $host !== '') {
+            return $host;
+        }
+    }
+
+    return getUploadHostname();
+}
+
+/**
+ * Collect usernames from all push webcam push_config entries (lowercase keys).
+ *
+ * @return array<string, true>
+ */
+function getPushWebcamUsernameIndex(?array $config = null): array
+{
+    $config = $config ?? loadConfig();
+    $index = [];
+    foreach ($config['airports'] ?? [] as $airport) {
+        if (!isset($airport['webcams']) || !is_array($airport['webcams'])) {
+            continue;
+        }
+        foreach ($airport['webcams'] as $cam) {
+            if (!is_array($cam)) {
+                continue;
+            }
+            $isPush = (isset($cam['type']) && $cam['type'] === 'push')
+                || isset($cam['push_config']);
+            if (!$isPush || !isset($cam['push_config']['username'])) {
+                continue;
+            }
+            $user = $cam['push_config']['username'];
+            if (is_string($user) && $user !== '') {
+                $index[strtolower($user)] = true;
+            }
+        }
+    }
+
+    return $index;
+}
+
+/**
+ * Upload health probe settings for FTPS/SFTP functional checks (production watchdog).
+ *
+ * When disabled or not production, probe writes a skipped heartbeat and watchdog does not
+ * restart daemons based on probe results. Credentials live in config.upload_health_probe only.
+ *
+ * @return array{
+ *   enabled: bool,
+ *   interval_sec: int,
+ *   stale_sec: int,
+ *   connect_host: string,
+ *   upload_hostname: string,
+ *   ftp_port: int,
+ *   sftp_port: int,
+ *   ftps: ?array{username: string, password: string},
+ *   sftp: ?array{username: string, password: string}
+ * }
+ */
+function getUploadHealthProbeSettings(): array {
+    $networkPorts = getGlobalConfig('network_ports');
+    $ftpPort = 2121;
+    $sftpPort = 2222;
+    if (is_array($networkPorts)) {
+        if (isset($networkPorts['ftp_control']) && is_int($networkPorts['ftp_control'])) {
+            $ftpPort = $networkPorts['ftp_control'];
+        }
+        if (isset($networkPorts['sftp']) && is_int($networkPorts['sftp'])) {
+            $sftpPort = $networkPorts['sftp'];
+        }
+    }
+
+    $interval = UPLOAD_HEALTH_PROBE_INTERVAL_DEFAULT_SEC;
+    $defaults = [
+        'enabled' => false,
+        'interval_sec' => $interval,
+        'stale_sec' => getUploadHealthProbeStaleSeconds($interval),
+        'connect_host' => getUploadHostname(),
+        'upload_hostname' => getUploadHostname(),
+        'ftp_port' => $ftpPort,
+        'sftp_port' => $sftpPort,
+        'ftps' => null,
+        'sftp' => null,
+    ];
+
+    if (!isProduction()) {
+        return $defaults;
+    }
+
+    $raw = getGlobalConfig('upload_health_probe');
+    if (!is_array($raw) || ($raw['enabled'] ?? false) !== true) {
+        return $defaults;
+    }
+
+    $interval = isset($raw['interval_sec']) && is_int($raw['interval_sec'])
+        ? max(UPLOAD_HEALTH_PROBE_INTERVAL_MIN_SEC, min(UPLOAD_HEALTH_PROBE_INTERVAL_MAX_SEC, $raw['interval_sec']))
+        : UPLOAD_HEALTH_PROBE_INTERVAL_DEFAULT_SEC;
+
+    $ftps = null;
+    if (isset($raw['ftps']) && is_array($raw['ftps'])) {
+        $user = $raw['ftps']['username'] ?? null;
+        $pass = $raw['ftps']['password'] ?? null;
+        if (is_string($user) && $user !== '' && is_string($pass) && $pass !== '') {
+            $ftps = ['username' => $user, 'password' => $pass];
+        }
+    }
+
+    $sftp = null;
+    if (isset($raw['sftp']) && is_array($raw['sftp'])) {
+        $user = $raw['sftp']['username'] ?? null;
+        $pass = $raw['sftp']['password'] ?? null;
+        if (is_string($user) && $user !== '' && is_string($pass) && $pass !== '') {
+            $sftp = ['username' => $user, 'password' => $pass];
+        }
+    }
+
+    if ($ftps === null && $sftp === null) {
+        return $defaults;
+    }
+
+    return [
+        'enabled' => true,
+        'interval_sec' => $interval,
+        'stale_sec' => getUploadHealthProbeStaleSeconds($interval),
+        'connect_host' => getUploadHealthProbeConnectHost(),
+        'upload_hostname' => getUploadHostname(),
+        'ftp_port' => $ftpPort,
+        'sftp_port' => $sftpPort,
+        'ftps' => $ftps,
+        'sftp' => $sftp,
+    ];
+}
+
+/**
+ * Validate config.upload_health_probe structure (global section).
+ *
+ * @return array<int, string>
+ */
+function validateUploadHealthProbeConfig(array $config): array
+{
+    require_once __DIR__ . '/push-webcam-validator.php';
+
+    $errors = [];
+    $cfg = $config['config'] ?? null;
+    if (!is_array($cfg) || !isset($cfg['upload_health_probe'])) {
+        return $errors;
+    }
+
+    $probe = $cfg['upload_health_probe'];
+    if (!is_array($probe)) {
+        $errors[] = 'config.upload_health_probe must be an object';
+
+        return $errors;
+    }
+
+    $allowedProbeKeys = ['enabled', 'interval_sec', 'probe_connect_host', 'ftps', 'sftp'];
+    foreach ($probe as $key => $value) {
+        if (!in_array($key, $allowedProbeKeys, true)) {
+            $errors[] = "config.upload_health_probe has unknown field '{$key}'. Allowed fields: "
+                . implode(', ', $allowedProbeKeys);
+        }
+    }
+
+    if (isset($probe['enabled']) && !is_bool($probe['enabled'])) {
+        $errors[] = 'config.upload_health_probe.enabled must be a boolean';
+    }
+
+    if (isset($probe['interval_sec'])) {
+        if (!is_int($probe['interval_sec'])) {
+            $errors[] = 'config.upload_health_probe.interval_sec must be an integer';
+        } elseif ($probe['interval_sec'] < UPLOAD_HEALTH_PROBE_INTERVAL_MIN_SEC
+            || $probe['interval_sec'] > UPLOAD_HEALTH_PROBE_INTERVAL_MAX_SEC) {
+            $errors[] = 'config.upload_health_probe.interval_sec must be between '
+                . UPLOAD_HEALTH_PROBE_INTERVAL_MIN_SEC . ' and ' . UPLOAD_HEALTH_PROBE_INTERVAL_MAX_SEC;
+        }
+    }
+
+    if (isset($probe['probe_connect_host'])) {
+        if (!is_string($probe['probe_connect_host'])) {
+            $errors[] = 'config.upload_health_probe.probe_connect_host must be a string';
+        } elseif ($probe['probe_connect_host'] !== ''
+            && !preg_match('/^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$/', $probe['probe_connect_host'])
+            && !filter_var($probe['probe_connect_host'], FILTER_VALIDATE_IP)) {
+            $errors[] = 'config.upload_health_probe.probe_connect_host must be a valid hostname or IP (or empty to use upload_hostname)';
+        }
+    }
+
+    $enabled = ($probe['enabled'] ?? false) === true;
+    $hasFtps = false;
+    $hasSftp = false;
+
+    foreach (['ftps', 'sftp'] as $protocol) {
+        if (!isset($probe[$protocol])) {
+            continue;
+        }
+        if (!is_array($probe[$protocol])) {
+            $errors[] = "config.upload_health_probe.{$protocol} must be an object";
+            continue;
+        }
+
+        $block = $probe[$protocol];
+        $allowedCredentialKeys = ['username', 'password'];
+        foreach ($block as $key => $value) {
+            if (!in_array($key, $allowedCredentialKeys, true)) {
+                $errors[] = "config.upload_health_probe.{$protocol} has unknown field '{$key}'. Allowed fields: "
+                    . implode(', ', $allowedCredentialKeys);
+            }
+        }
+
+        $contextLabel = "config.upload_health_probe.{$protocol}";
+        $username = isset($block['username']) && is_string($block['username']) ? $block['username'] : '';
+        $password = isset($block['password']) && is_string($block['password']) ? $block['password'] : '';
+
+        $hasUsername = $username !== '';
+        $hasPassword = $password !== '';
+
+        if ($hasUsername xor $hasPassword) {
+            $errors[] = "{$contextLabel}: username and password must both be set";
+        }
+
+        if ($hasUsername) {
+            $errors = array_merge($errors, validatePushUploadUsername($username, $contextLabel));
+        } elseif ($enabled) {
+            $errors[] = "{$contextLabel}: username is required when upload_health_probe.enabled is true";
+        }
+
+        if ($hasPassword) {
+            $errors = array_merge($errors, validatePushUploadPassword($password, $contextLabel));
+        } elseif ($enabled && $hasUsername) {
+            $errors[] = "{$contextLabel}: password is required when upload_health_probe.enabled is true";
+        }
+
+        if ($hasUsername && $hasPassword) {
+            if ($protocol === 'ftps') {
+                $hasFtps = true;
+            } else {
+                $hasSftp = true;
+            }
+        }
+    }
+
+    if ($enabled && !$hasFtps && !$hasSftp) {
+        $errors[] = 'config.upload_health_probe: when enabled is true, set valid ftps and/or sftp credentials';
+    }
+
+    if ($hasFtps || $hasSftp) {
+        $pushUsernames = getPushWebcamUsernameIndex($config);
+        foreach (['ftps', 'sftp'] as $protocol) {
+            if (!isset($probe[$protocol]['username']) || !is_string($probe[$protocol]['username'])) {
+                continue;
+            }
+            $user = $probe[$protocol]['username'];
+            if ($user !== '' && isset($pushUsernames[strtolower($user)])) {
+                $errors[] = "config.upload_health_probe.{$protocol}.username must not match a push camera username ('{$user}')";
+            }
+        }
+    }
+
+    return $errors;
+}
+
+/**
  * Max mtime age in seconds before non-allowlisted push FTP/SFTP inbox files are deleted.
  *
  * Uses `config.cleanup_push_upload_debris_max_age_seconds` when it is an integer
@@ -1988,6 +2270,12 @@ function validateRuntimeConfigSchema(array $config): array {
         if (!$usernameValidation['valid']) {
             $errors = array_merge($errors, $usernameValidation['errors']);
         }
+
+    }
+
+    $probeErrors = validateUploadHealthProbeConfig($config);
+    if ($probeErrors !== []) {
+        $errors = array_merge($errors, $probeErrors);
     }
 
     return [
@@ -3825,6 +4113,11 @@ function validateAirportsJsonStructure(array $config): array {
             if (isset($cfg['public_api'])) {
                 $apiErrors = validatePublicApiConfig($cfg['public_api']);
                 $errors = array_merge($errors, $apiErrors);
+            }
+
+            $probeErrors = validateUploadHealthProbeConfig($config);
+            if ($probeErrors !== []) {
+                $errors = array_merge($errors, $probeErrors);
             }
         }
     }

--- a/lib/config.php
+++ b/lib/config.php
@@ -827,8 +827,22 @@ function validateUploadHealthProbeConfig(array $config): array
         }
 
         $contextLabel = "config.upload_health_probe.{$protocol}";
-        $username = isset($block['username']) && is_string($block['username']) ? $block['username'] : '';
-        $password = isset($block['password']) && is_string($block['password']) ? $block['password'] : '';
+        $username = '';
+        $password = '';
+        if (isset($block['username'])) {
+            if (!is_string($block['username'])) {
+                $errors[] = "{$contextLabel}: username must be a string";
+            } else {
+                $username = $block['username'];
+            }
+        }
+        if (isset($block['password'])) {
+            if (!is_string($block['password'])) {
+                $errors[] = "{$contextLabel}: password must be a string";
+            } else {
+                $password = $block['password'];
+            }
+        }
 
         $hasUsername = $username !== '';
         $hasPassword = $password !== '';

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -1088,3 +1088,37 @@ function push_upload_master_image_extensions(): array
     return ['jpg', 'jpeg', 'png', 'webp'];
 }
 
+// Upload health probe (production FTPS/SFTP watchdog)
+if (!defined('UPLOAD_HEALTH_PROBE_INTERVAL_MIN_SEC')) {
+    define('UPLOAD_HEALTH_PROBE_INTERVAL_MIN_SEC', 15);
+}
+if (!defined('UPLOAD_HEALTH_PROBE_INTERVAL_MAX_SEC')) {
+    define('UPLOAD_HEALTH_PROBE_INTERVAL_MAX_SEC', 300);
+}
+if (!defined('UPLOAD_HEALTH_PROBE_INTERVAL_DEFAULT_SEC')) {
+    define('UPLOAD_HEALTH_PROBE_INTERVAL_DEFAULT_SEC', 30);
+}
+if (!defined('UPLOAD_HEALTH_PROBE_STALE_GRACE_SEC')) {
+    define('UPLOAD_HEALTH_PROBE_STALE_GRACE_SEC', 15);
+}
+if (!defined('UPLOAD_HEALTH_PROBE_FAIL_STREAK_THRESHOLD')) {
+    define('UPLOAD_HEALTH_PROBE_FAIL_STREAK_THRESHOLD', 2);
+}
+if (!defined('UPLOAD_HEALTH_PROBE_RESTART_MIN_INTERVAL_SEC')) {
+    define('UPLOAD_HEALTH_PROBE_RESTART_MIN_INTERVAL_SEC', 1800);
+}
+if (!defined('UPLOAD_HEALTH_PROBE_WATCHDOG_LOOP_SEC')) {
+    define('UPLOAD_HEALTH_PROBE_WATCHDOG_LOOP_SEC', 50);
+}
+if (!defined('UPLOAD_HEALTH_PROBE_FILE_PREFIX')) {
+    define('UPLOAD_HEALTH_PROBE_FILE_PREFIX', 'aviationwx-probe-');
+}
+
+// Push FTP/SFTP credentials (push_config and upload_health_probe)
+if (!defined('PUSH_UPLOAD_USERNAME_MAX_LENGTH')) {
+    define('PUSH_UPLOAD_USERNAME_MAX_LENGTH', 14);
+}
+if (!defined('PUSH_UPLOAD_PASSWORD_LENGTH')) {
+    define('PUSH_UPLOAD_PASSWORD_LENGTH', 14);
+}
+

--- a/lib/push-webcam-validator.php
+++ b/lib/push-webcam-validator.php
@@ -90,19 +90,23 @@ function validatePushWebcamConfig($cam, $airportId, $camIndex, ?int $globalCache
     $credentialContext = "Airport '{$airportId}' webcam index {$camIndex}";
     if (!isset($pushConfig['username'])) {
         $errors[] = "{$credentialContext}: username is required";
+    } elseif (!is_string($pushConfig['username'])) {
+        $errors[] = "{$credentialContext}: username must be a string";
     } else {
         $errors = array_merge(
             $errors,
-            validatePushUploadUsername((string) $pushConfig['username'], $credentialContext)
+            validatePushUploadUsername($pushConfig['username'], $credentialContext)
         );
     }
 
     if (!isset($pushConfig['password'])) {
         $errors[] = "{$credentialContext}: password is required";
+    } elseif (!is_string($pushConfig['password'])) {
+        $errors[] = "{$credentialContext}: password must be a string";
     } else {
         $errors = array_merge(
             $errors,
-            validatePushUploadPassword((string) $pushConfig['password'], $credentialContext)
+            validatePushUploadPassword($pushConfig['password'], $credentialContext)
         );
     }
     

--- a/lib/push-webcam-validator.php
+++ b/lib/push-webcam-validator.php
@@ -8,6 +8,55 @@ require_once __DIR__ . '/logger.php';
 require_once __DIR__ . '/constants.php';
 
 /**
+ * Validate a push FTP/SFTP username (same rules as push_config.username).
+ *
+ * @return array<int, string> Error messages (empty when valid)
+ */
+function validatePushUploadUsername(string $username, string $contextLabel): array
+{
+    $errors = [];
+    if ($username === '') {
+        $errors[] = "{$contextLabel}: username is required";
+
+        return $errors;
+    }
+    if (strlen($username) > PUSH_UPLOAD_USERNAME_MAX_LENGTH) {
+        $errors[] = "{$contextLabel}: username must be " . PUSH_UPLOAD_USERNAME_MAX_LENGTH . ' characters or less';
+    }
+    if (preg_match('/\s/', $username)) {
+        $errors[] = "{$contextLabel}: username must not contain spaces";
+    }
+    if (!preg_match('/^[a-zA-Z0-9]+$/', $username)) {
+        $errors[] = "{$contextLabel}: username must be alphanumeric";
+    }
+
+    return $errors;
+}
+
+/**
+ * Validate a push FTP/SFTP password (same rules as push_config.password).
+ *
+ * @return array<int, string> Error messages (empty when valid)
+ */
+function validatePushUploadPassword(string $password, string $contextLabel): array
+{
+    $errors = [];
+    if ($password === '') {
+        $errors[] = "{$contextLabel}: password is required";
+
+        return $errors;
+    }
+    if (strlen($password) !== PUSH_UPLOAD_PASSWORD_LENGTH) {
+        $errors[] = "{$contextLabel}: password must be exactly " . PUSH_UPLOAD_PASSWORD_LENGTH . ' characters';
+    }
+    if (!preg_match('/^[a-zA-Z0-9]{' . PUSH_UPLOAD_PASSWORD_LENGTH . '}$/', $password)) {
+        $errors[] = "{$contextLabel}: password must be alphanumeric (" . PUSH_UPLOAD_PASSWORD_LENGTH . ' characters)';
+    }
+
+    return $errors;
+}
+
+/**
  * Validate push webcam configuration
  *
  * @param array $cam Camera configuration
@@ -38,35 +87,23 @@ function validatePushWebcamConfig($cam, $airportId, $camIndex, ?int $globalCache
         }
     }
     
-    // Validate username
-    if (!isset($pushConfig['username']) || empty($pushConfig['username'])) {
-        $errors[] = "Airport '{$airportId}' webcam index {$camIndex}: username is required";
+    $credentialContext = "Airport '{$airportId}' webcam index {$camIndex}";
+    if (!isset($pushConfig['username'])) {
+        $errors[] = "{$credentialContext}: username is required";
     } else {
-        $username = $pushConfig['username'];
-        // Username should be 14 characters or less, contain no spaces, and be alphanumeric (mixed case allowed)
-        if (strlen($username) > 14) {
-            $errors[] = "Airport '{$airportId}' webcam index {$camIndex}: username must be 14 characters or less";
-        }
-        if (preg_match('/\s/', $username)) {
-            $errors[] = "Airport '{$airportId}' webcam index {$camIndex}: username must not contain spaces";
-        }
-        if (!preg_match('/^[a-zA-Z0-9]+$/', $username)) {
-            $errors[] = "Airport '{$airportId}' webcam index {$camIndex}: username must be alphanumeric";
-        }
+        $errors = array_merge(
+            $errors,
+            validatePushUploadUsername((string) $pushConfig['username'], $credentialContext)
+        );
     }
-    
-    // Validate password
-    if (!isset($pushConfig['password']) || empty($pushConfig['password'])) {
-        $errors[] = "Airport '{$airportId}' webcam index {$camIndex}: password is required";
+
+    if (!isset($pushConfig['password'])) {
+        $errors[] = "{$credentialContext}: password is required";
     } else {
-        $password = $pushConfig['password'];
-        // Password should be 14 characters, alphanumeric (mixed case allowed)
-        if (strlen($password) !== 14) {
-            $errors[] = "Airport '{$airportId}' webcam index {$camIndex}: password must be exactly 14 characters";
-        }
-        if (!preg_match('/^[a-zA-Z0-9]{14}$/', $password)) {
-            $errors[] = "Airport '{$airportId}' webcam index {$camIndex}: password must be alphanumeric (14 characters)";
-        }
+        $errors = array_merge(
+            $errors,
+            validatePushUploadPassword((string) $pushConfig['password'], $credentialContext)
+        );
     }
     
     // Port is informational only - not enforced by the server (listeners are config.network_ports / defaults).

--- a/scripts/service-watchdog.sh
+++ b/scripts/service-watchdog.sh
@@ -1,137 +1,190 @@
 #!/bin/bash
-# Service Watchdog - Monitors and restarts FTP/SFTP services
-# Runs in background, checks every 30 seconds
+# Monitors vsftpd, container sshd (SFTP), and cron; evaluates upload-probe heartbeats.
+# Loop interval: WATCHDOG_LOOP_SEC (default 50). Probes publish per config interval_sec.
 
-set -e
+set -u
 
-LOG_FILE="/var/log/aviationwx/service-watchdog.log"
-MAX_RESTART_ATTEMPTS=5
-RESTART_BACKOFF_BASE=60  # Start with 60 seconds
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_SH="${SCRIPT_DIR}/upload-daemon-common.sh"
+if [ ! -f "$COMMON_SH" ]; then
+    COMMON_SH="/usr/local/libexec/aviationwx/upload-daemon-common.sh"
+fi
+if [ ! -f "$COMMON_SH" ]; then
+    echo "upload-daemon-common.sh not found" >&2
+    exit 1
+fi
+# shellcheck source=upload-daemon-common.sh
+source "$COMMON_SH"
 
-# Track restart attempts per service
+WATCHDOG_LOG_FILE="${WATCHDOG_LOG_FILE:-/var/log/aviationwx/service-watchdog.log}"
+FTPS_FAIL_STREAK_FILE="${FTPS_FAIL_STREAK_FILE:-/var/lib/aviationwx/upload-watchdog-ftps.fail-streak}"
+SFTP_FAIL_STREAK_FILE="${SFTP_FAIL_STREAK_FILE:-/var/lib/aviationwx/upload-watchdog-sftp.fail-streak}"
+FTPS_LAST_RESTART_FILE="${FTPS_LAST_RESTART_FILE:-/var/lib/aviationwx/upload-watchdog-ftps.last-restart}"
+SFTP_LAST_RESTART_FILE="${SFTP_LAST_RESTART_FILE:-/var/lib/aviationwx/upload-watchdog-sftp.last-restart}"
+
+MAX_PROCESS_RESTART_ATTEMPTS=5
+RESTART_BACKOFF_BASE=60
+
 declare -A restart_counts
 declare -A last_restart_time
+restart_counts["cron"]=0
+last_restart_time["cron"]=0
 
-# Logging function
-log_message() {
-    local level="$1"
-    shift
-    local message="$@"
-    local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
-    echo "[$timestamp] [$level] $message" >> "$LOG_FILE"
-}
-
-# Check and restart a service
-check_and_restart_service() {
-    local service_name="$1"
-    local process_name="$2"
-    local restart_cmd="$3"
-    
-    # Check if process is running
-    if pgrep -x "$process_name" > /dev/null; then
-        # Service is running - reset restart counter if it was previously down
-        if [ "${restart_counts[$service_name]}" -gt 0 ]; then
-            log_message "INFO" "Service $service_name recovered, resetting restart counter"
-            restart_counts[$service_name]=0
-            last_restart_time[$service_name]=0
+check_and_restart_cron() {
+    local current_time last_restart restart_count backoff_seconds
+    if pgrep -x cron >/dev/null 2>&1; then
+        if [ "${restart_counts[cron]:-0}" -gt 0 ]; then
+            watchdog_log "INFO" "Service cron recovered, resetting restart counter"
+            restart_counts[cron]=0
+            last_restart_time[cron]=0
         fi
         return 0
     fi
-    
-    # Service is down
-    local current_time=$(date +%s)
-    local last_restart=${last_restart_time[$service_name]:-0}
-    local restart_count=${restart_counts[$service_name]:-0}
-    
-    # Calculate backoff time
-    local backoff_seconds=$((RESTART_BACKOFF_BASE * (2 ** restart_count)))
-    if [ $backoff_seconds -gt 960 ]; then
-        backoff_seconds=960  # Cap at 16 minutes
+
+    current_time="$(date +%s)"
+    last_restart="${last_restart_time[cron]:-0}"
+    restart_count="${restart_counts[cron]:-0}"
+    backoff_seconds=$((RESTART_BACKOFF_BASE * (2 ** restart_count)))
+    if [ "$backoff_seconds" -gt 960 ]; then
+        backoff_seconds=960
     fi
-    
-    # Check if we should attempt restart (enough time has passed)
-    if [ $restart_count -ge $MAX_RESTART_ATTEMPTS ]; then
+
+    if [ "$restart_count" -ge "$MAX_PROCESS_RESTART_ATTEMPTS" ]; then
         if [ $((current_time - last_restart)) -gt 3600 ]; then
-            # Reset after 1 hour
-            log_message "INFO" "Resetting restart counter for $service_name after 1 hour"
-            restart_counts[$service_name]=0
+            restart_counts[cron]=0
             restart_count=0
         else
-            log_message "WARN" "Service $service_name is down but max restart attempts ($MAX_RESTART_ATTEMPTS) reached, waiting..."
+            watchdog_log "WARN" "cron down; max restart attempts reached"
             return 1
         fi
     fi
-    
-    # Check if backoff period has passed
-    if [ $((current_time - last_restart)) -lt $backoff_seconds ]; then
-        return 1  # Still in backoff period
+
+    if [ $((current_time - last_restart)) -lt "$backoff_seconds" ]; then
+        return 1
     fi
-    
-    # Attempt restart
-    log_message "WARN" "Service $service_name is down, attempting restart (attempt $((restart_count + 1))/$MAX_RESTART_ATTEMPTS)"
-    
-    if eval "$restart_cmd" 2>&1 | tee -a "$LOG_FILE"; then
-        restart_counts[$service_name]=$((restart_count + 1))
-        last_restart_time[$service_name]=$current_time
-        
-        # Verify service started
+
+    watchdog_log "WARN" "cron down; restart attempt $((restart_count + 1))/$MAX_PROCESS_RESTART_ATTEMPTS"
+    if cron >>"$WATCHDOG_LOG_FILE" 2>&1; then
+        restart_counts[cron]=$((restart_count + 1))
+        last_restart_time[cron]=$current_time
         sleep 2
-        if pgrep -x "$process_name" > /dev/null; then
-            log_message "INFO" "Service $service_name restarted successfully"
+        if pgrep -x cron >/dev/null 2>&1; then
+            watchdog_log "INFO" "cron restarted successfully"
             return 0
-        else
-            log_message "ERROR" "Service $service_name restart command succeeded but process not running"
-            return 1
         fi
-    else
-        log_message "ERROR" "Service $service_name restart command failed"
-        restart_counts[$service_name]=$((restart_count + 1))
-        last_restart_time[$service_name]=$current_time
-        return 1
     fi
+    restart_counts[cron]=$((restart_count + 1))
+    last_restart_time[cron]=$current_time
+    watchdog_log "ERROR" "cron restart failed"
+    return 1
 }
 
-# Initialize restart counters
-restart_counts["vsftpd"]=0
-restart_counts["sshd"]=0
-restart_counts["cron"]=0
-last_restart_time["vsftpd"]=0
-last_restart_time["sshd"]=0
-last_restart_time["cron"]=0
+# Fail closed: return 1 when probe evaluation is unhealthy.
+evaluate_probe_protocol() {
+    local protocol="$1"
+    local streak_file="$2"
+    local last_restart_file="$3"
+    local restart_fn="$4"
+    local stale_sec skipped ok epoch now age streak detail
 
-# Restart function for vsftpd
-restart_vsftpd() {
-    # Kill any existing vsftpd process
-    pkill -x vsftpd 2>/dev/null || true
-    sleep 1
-    
-    # Start vsftpd with the main config
-    if [ -f "/etc/vsftpd/vsftpd.conf" ]; then
-        vsftpd /etc/vsftpd/vsftpd.conf &
-        return $?
-    else
-        log_message "ERROR" "vsftpd.conf not found"
+    if ! command -v jq >/dev/null 2>&1; then
+        watchdog_log "ERROR" "jq required for upload probe evaluation ($protocol)"
+        log_upload_health_app "error" "upload watchdog cannot evaluate probe: jq missing" \
+            "{\"protocol\":\"${protocol}\"}"
+        increment_streak "$streak_file" >/dev/null
+        try_restart_upload_daemon "$protocol" "$streak_file" "$last_restart_file" "$restart_fn"
         return 1
     fi
+
+    stale_sec="$(read_probe_stale_sec_from_heartbeat)"
+    if ! [[ "$stale_sec" =~ ^[0-9]+$ ]]; then
+        stale_sec=75
+    fi
+
+    if [ ! -f "$UPLOAD_PROBE_STATE_FILE" ]; then
+        increment_streak "$streak_file" >/dev/null
+        watchdog_log "WARN" "upload probe heartbeat missing ($protocol)"
+        log_upload_health_app "error" "upload probe heartbeat missing" "{\"protocol\":\"${protocol}\"}"
+        try_restart_upload_daemon "$protocol" "$streak_file" "$last_restart_file" "$restart_fn"
+        return 1
+    fi
+
+    if ! jq -e . "$UPLOAD_PROBE_STATE_FILE" >/dev/null 2>&1; then
+        increment_streak "$streak_file" >/dev/null
+        watchdog_log "WARN" "upload probe heartbeat corrupt ($protocol)"
+        log_upload_health_app "error" "upload probe heartbeat corrupt" "{\"protocol\":\"${protocol}\"}"
+        try_restart_upload_daemon "$protocol" "$streak_file" "$last_restart_file" "$restart_fn"
+        return 1
+    fi
+
+    skipped="$(jq -r ".${protocol}.skipped // false" "$UPLOAD_PROBE_STATE_FILE" 2>/dev/null || echo true)"
+    if [ "$skipped" = "true" ]; then
+        reset_streak "$streak_file"
+        return 0
+    fi
+
+    ok="$(jq -r ".${protocol}.ok // false" "$UPLOAD_PROBE_STATE_FILE")"
+    epoch="$(jq -r '.epoch // 0' "$UPLOAD_PROBE_STATE_FILE")"
+    now="$(date +%s)"
+    age=$((now - epoch))
+
+    if [ "$epoch" -eq 0 ] || [ "$age" -gt "$stale_sec" ]; then
+        streak="$(increment_streak "$streak_file")"
+        watchdog_log "WARN" "${protocol} probe stale (age=${age}s stale_sec=${stale_sec} streak=${streak})"
+        log_upload_health_app "error" "upload probe heartbeat stale" \
+            "{\"protocol\":\"${protocol}\",\"age_sec\":${age},\"stale_sec\":${stale_sec},\"streak\":${streak}}"
+        ok="false"
+    elif [ "$ok" = "true" ]; then
+        reset_streak "$streak_file"
+        return 0
+    else
+        streak="$(increment_streak "$streak_file")"
+        detail="$(jq -r ".${protocol}.detail // \"\"" "$UPLOAD_PROBE_STATE_FILE")"
+        watchdog_log "WARN" "${protocol} probe failed (streak=${streak} detail=${detail})"
+        log_upload_health_app "error" "upload probe check failed" \
+            "$(jq -n --arg protocol "$protocol" --argjson streak "$streak" --arg detail "$detail" \
+                '{protocol: $protocol, streak: $streak, detail: $detail}')"
+    fi
+
+    if [ "$ok" != "true" ]; then
+        try_restart_upload_daemon "$protocol" "$streak_file" "$last_restart_file" "$restart_fn"
+        return 1
+    fi
+    return 0
 }
 
-# Main watchdog loop
-log_message "INFO" "Service watchdog started"
+handle_upload_daemon_down() {
+    local protocol="$1"
+    local process_name="$2"
+    local streak_file="$3"
+    local last_restart_file="$4"
+    local restart_fn="$5"
+
+    watchdog_log "WARN" "${protocol} process not running (${process_name})"
+    log_upload_health_app "error" "upload daemon process not running" "{\"protocol\":\"${protocol}\"}"
+    increment_streak "$streak_file" >/dev/null
+    try_restart_upload_daemon "$protocol" "$streak_file" "$last_restart_file" "$restart_fn"
+}
+
+watchdog_log "INFO" "Service watchdog started (loop=${WATCHDOG_LOOP_SEC}s)"
 
 while true; do
-    # Check vsftpd
-    if ! pgrep -x vsftpd > /dev/null; then
-        log_message "WARN" "vsftpd is down, attempting restart"
-        restart_vsftpd
+    set +e
+
+    if ! pgrep -x vsftpd >/dev/null 2>&1; then
+        handle_upload_daemon_down "ftps" "vsftpd" "$FTPS_FAIL_STREAK_FILE" "$FTPS_LAST_RESTART_FILE" restart_vsftpd_daemon
+    else
+        evaluate_probe_protocol "ftps" "$FTPS_FAIL_STREAK_FILE" "$FTPS_LAST_RESTART_FILE" restart_vsftpd_daemon
     fi
-    
-    check_and_restart_service "sshd" "sshd" "service ssh start"
-    
-    # Check and restart cron
-    if ! pgrep -x cron > /dev/null 2>&1; then
-        log_message "WARN" "Cron process not found, calling check_and_restart_service"
+
+    if ! pgrep -x sshd >/dev/null 2>&1; then
+        handle_upload_daemon_down "sftp" "sshd" "$SFTP_FAIL_STREAK_FILE" "$SFTP_LAST_RESTART_FILE" restart_container_sshd
+    else
+        evaluate_probe_protocol "sftp" "$SFTP_FAIL_STREAK_FILE" "$SFTP_LAST_RESTART_FILE" restart_container_sshd
     fi
-    check_and_restart_service "cron" "cron" "cron"
-    
-    sleep 30
+
+    check_and_restart_cron
+
+    set -u
+    sleep "$WATCHDOG_LOOP_SEC"
 done

--- a/scripts/service-watchdog.sh
+++ b/scripts/service-watchdog.sh
@@ -124,26 +124,35 @@ evaluate_probe_protocol() {
     fi
 
     ok="$(jq -r ".${protocol}.ok // false" "$UPLOAD_PROBE_STATE_FILE")"
-    epoch="$(jq -r '.epoch // 0' "$UPLOAD_PROBE_STATE_FILE")"
+    epoch="$(jq -r '.epoch // empty' "$UPLOAD_PROBE_STATE_FILE")"
     now="$(date +%s)"
-    age=$((now - epoch))
 
-    if [ "$epoch" -eq 0 ] || [ "$age" -gt "$stale_sec" ]; then
+    if ! probe_heartbeat_epoch_is_valid "$epoch"; then
         streak="$(increment_streak "$streak_file")"
-        watchdog_log "WARN" "${protocol} probe stale (age=${age}s stale_sec=${stale_sec} streak=${streak})"
-        log_upload_health_app "error" "upload probe heartbeat stale" \
-            "{\"protocol\":\"${protocol}\",\"age_sec\":${age},\"stale_sec\":${stale_sec},\"streak\":${streak}}"
+        watchdog_log "WARN" "${protocol} probe heartbeat invalid epoch (value=${epoch:-missing} streak=${streak})"
+        log_upload_health_app "error" "upload probe heartbeat invalid epoch" \
+            "$(jq -n --arg protocol "$protocol" --arg epoch "${epoch:-}" --argjson streak "$streak" \
+                '{protocol: $protocol, epoch: $epoch, streak: $streak}')"
         ok="false"
-    elif [ "$ok" = "true" ]; then
-        reset_streak "$streak_file"
-        return 0
     else
-        streak="$(increment_streak "$streak_file")"
-        detail="$(jq -r ".${protocol}.detail // \"\"" "$UPLOAD_PROBE_STATE_FILE")"
-        watchdog_log "WARN" "${protocol} probe failed (streak=${streak} detail=${detail})"
-        log_upload_health_app "error" "upload probe check failed" \
-            "$(jq -n --arg protocol "$protocol" --argjson streak "$streak" --arg detail "$detail" \
-                '{protocol: $protocol, streak: $streak, detail: $detail}')"
+        age=$((now - epoch))
+        if [ "$age" -gt "$stale_sec" ]; then
+            streak="$(increment_streak "$streak_file")"
+            watchdog_log "WARN" "${protocol} probe stale (age=${age}s stale_sec=${stale_sec} streak=${streak})"
+            log_upload_health_app "error" "upload probe heartbeat stale" \
+                "{\"protocol\":\"${protocol}\",\"age_sec\":${age},\"stale_sec\":${stale_sec},\"streak\":${streak}}"
+            ok="false"
+        elif [ "$ok" = "true" ]; then
+            reset_streak "$streak_file"
+            return 0
+        else
+            streak="$(increment_streak "$streak_file")"
+            detail="$(jq -r ".${protocol}.detail // \"\"" "$UPLOAD_PROBE_STATE_FILE")"
+            watchdog_log "WARN" "${protocol} probe failed (streak=${streak} detail=${detail})"
+            log_upload_health_app "error" "upload probe check failed" \
+                "$(jq -n --arg protocol "$protocol" --argjson streak "$streak" --arg detail "$detail" \
+                    '{protocol: $protocol, streak: $streak, detail: $detail}')"
+        fi
     fi
 
     if [ "$ok" != "true" ]; then

--- a/scripts/service-watchdog.sh
+++ b/scripts/service-watchdog.sh
@@ -117,7 +117,7 @@ evaluate_probe_protocol() {
         return 1
     fi
 
-    skipped="$(jq -r ".${protocol}.skipped // false" "$UPLOAD_PROBE_STATE_FILE" 2>/dev/null || echo true)"
+    skipped="$(jq -r ".${protocol}.skipped // false" "$UPLOAD_PROBE_STATE_FILE" 2>/dev/null || echo false)"
     if [ "$skipped" = "true" ]; then
         reset_streak "$streak_file"
         return 0

--- a/scripts/update-pasv-address.sh
+++ b/scripts/update-pasv-address.sh
@@ -174,7 +174,11 @@ log_info "Updated vsftpd.conf with new pasv_address: $NEW_IP"
 # vsftpd doesn't support config reload via SIGHUP, so we need to restart
 log_info "Restarting vsftpd to apply new pasv_address..."
 
-COMMON_SH="/usr/local/libexec/aviationwx/upload-daemon-common.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_SH="${SCRIPT_DIR}/upload-daemon-common.sh"
+if [ ! -f "$COMMON_SH" ]; then
+    COMMON_SH="/usr/local/libexec/aviationwx/upload-daemon-common.sh"
+fi
 if [[ -f "$COMMON_SH" ]]; then
     # shellcheck source=/dev/null
     source "$COMMON_SH"

--- a/scripts/update-pasv-address.sh
+++ b/scripts/update-pasv-address.sh
@@ -174,43 +174,22 @@ log_info "Updated vsftpd.conf with new pasv_address: $NEW_IP"
 # vsftpd doesn't support config reload via SIGHUP, so we need to restart
 log_info "Restarting vsftpd to apply new pasv_address..."
 
-# Get vsftpd PID and restart it
-VSFTPD_PID=$(pgrep -x vsftpd || echo "")
-if [[ -n "$VSFTPD_PID" ]]; then
-    # Kill existing vsftpd
-    kill "$VSFTPD_PID" 2>/dev/null || true
-    sleep 1
-    
-    # Wait for it to stop (max 5 seconds)
-    for i in {1..5}; do
-        if ! pgrep -x vsftpd > /dev/null 2>&1; then
-            break
+COMMON_SH="/usr/local/libexec/aviationwx/upload-daemon-common.sh"
+if [[ -f "$COMMON_SH" ]]; then
+    # shellcheck source=/dev/null
+    source "$COMMON_SH"
+    # Log PASV-driven restarts to the DDNS log, not service-watchdog.log.
+    WATCHDOG_LOG_FILE="/var/lib/aviationwx/dynamic-dns-pasv.log"
+    if restart_vsftpd_daemon "pasv_address update"; then
+        log_info "vsftpd restarted successfully with new pasv_address: $NEW_IP"
+        if [[ -n "$CURRENT_PASV" ]]; then
+            log_pasv_address_change_event "$CURRENT_PASV" "$NEW_IP" "$UPLOAD_HOSTNAME"
         fi
-        sleep 1
-    done
-    
-    # Force kill if still running
-    if pgrep -x vsftpd > /dev/null 2>&1; then
-        pkill -9 -x vsftpd 2>/dev/null || true
-        sleep 1
+        exit 0
     fi
-fi
-
-# Start vsftpd
-/usr/sbin/vsftpd /etc/vsftpd/vsftpd.conf &
-sleep 2
-
-# Verify vsftpd is running
-if pgrep -x vsftpd > /dev/null 2>&1; then
-    log_info "vsftpd restarted successfully with new pasv_address: $NEW_IP"
-    
-    # Log the change for monitoring
-    if [[ -n "$CURRENT_PASV" ]]; then
-        log_pasv_address_change_event "$CURRENT_PASV" "$NEW_IP" "$UPLOAD_HOSTNAME"
-    fi
-    
-    exit 0
-else
     log_error "Failed to restart vsftpd after PASV address update"
     exit 1
 fi
+
+log_error "upload-daemon-common.sh not found; cannot restart vsftpd safely"
+exit 1

--- a/scripts/upload-daemon-common.sh
+++ b/scripts/upload-daemon-common.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+# Shared helpers for upload health probe and service-watchdog (vsftpd / container sshd).
+# Sourced by scripts under /usr/local/libexec/aviationwx/ at runtime.
+
+UPLOAD_PROBE_INTERVAL_SEC="${UPLOAD_PROBE_INTERVAL_SEC:-30}"
+WATCHDOG_LOOP_SEC="${WATCHDOG_LOOP_SEC:-50}"
+UPLOAD_PROBE_FAIL_STREAK_THRESHOLD="${UPLOAD_PROBE_FAIL_STREAK_THRESHOLD:-2}"
+UPLOAD_DAEMON_RESTART_MIN_INTERVAL_SEC="${UPLOAD_DAEMON_RESTART_MIN_INTERVAL_SEC:-1800}"
+
+UPLOAD_PROBE_STATE_FILE="${UPLOAD_PROBE_STATE_FILE:-/var/lib/aviationwx/upload-probe.json}"
+VSFTPD_RESTART_LOCK="${VSFTPD_RESTART_LOCK:-/var/lib/aviationwx/vsftpd.restart.lock}"
+SSHD_RESTART_LOCK="${SSHD_RESTART_LOCK:-/var/lib/aviationwx/sshd.restart.lock}"
+VSFTPD_CONF="${VSFTPD_CONF:-/etc/vsftpd/vsftpd.conf}"
+
+CONFIG_PATH="${CONFIG_PATH:-/var/www/html/config/airports.json}"
+if [ -x /usr/local/bin/php ]; then
+    APP_PHP=/usr/local/bin/php
+else
+    APP_PHP="${APP_PHP:-php}"
+fi
+
+php_as_www_data() {
+    if command -v runuser >/dev/null 2>&1 && [ "$(id -u)" -eq 0 ]; then
+        runuser -u www-data -- env "CONFIG_PATH=${CONFIG_PATH}" "$APP_PHP" "$@"
+    else
+        env "CONFIG_PATH=${CONFIG_PATH}" "$APP_PHP" "$@"
+    fi
+}
+
+watchdog_log() {
+    local level="$1"
+    shift
+    local msg="$*"
+    local ts
+    ts="$(date '+%Y-%m-%d %H:%M:%S')"
+    echo "[$ts] [$level] $msg" >> "${WATCHDOG_LOG_FILE:-/var/log/aviationwx/service-watchdog.log}"
+}
+
+# Structured app.log entry for upload daemon diagnostics (no credentials in context).
+log_upload_health_app() {
+    local level="$1"
+    local message="$2"
+    local context_json="${3:-{}}"
+    AVWX_LOG_LEVEL="$level" AVWX_LOG_MSG="$message" AVWX_LOG_CTX="$context_json" \
+        php_as_www_data -r '
+            require_once "/var/www/html/lib/logger.php";
+            $ctx = json_decode(getenv("AVWX_LOG_CTX") ?: "{}", true);
+            if (!is_array($ctx)) {
+                $ctx = [];
+            }
+            aviationwx_log(
+                getenv("AVWX_LOG_LEVEL") ?: "info",
+                getenv("AVWX_LOG_MSG") ?: "",
+                $ctx,
+                "app"
+            );
+        ' 2>/dev/null || true
+}
+
+read_probe_interval_from_config() {
+    php_as_www_data -r 'require_once "/var/www/html/lib/config.php"; echo (int) getUploadHealthProbeSettings()["interval_sec"];' 2>/dev/null \
+        | tr -d '[:space:]' || echo "$UPLOAD_PROBE_INTERVAL_SEC"
+}
+
+read_probe_stale_sec_from_heartbeat() {
+    if [ -f "$UPLOAD_PROBE_STATE_FILE" ] && command -v jq >/dev/null 2>&1; then
+        local from_file
+        from_file="$(jq -r '.stale_sec // empty' "$UPLOAD_PROBE_STATE_FILE" 2>/dev/null || true)"
+        if [[ "$from_file" =~ ^[0-9]+$ ]] && [ "$from_file" -gt 0 ]; then
+            echo "$from_file"
+            return 0
+        fi
+    fi
+    php_as_www_data -r 'require_once "/var/www/html/lib/config.php"; echo (int) getUploadHealthProbeSettings()["stale_sec"];' 2>/dev/null \
+        | tr -d '[:space:]' || echo "$((UPLOAD_PROBE_INTERVAL_SEC * 2 + 15))"
+}
+
+read_int_file() {
+    local path="$1"
+    local default="${2:-0}"
+    local raw
+    if [ ! -f "$path" ]; then
+        echo "$default"
+        return 0
+    fi
+    raw="$(tr -d '[:space:]' <"$path" 2>/dev/null || echo "")"
+    if [[ "$raw" =~ ^[0-9]+$ ]]; then
+        echo "$raw"
+    else
+        echo "$default"
+    fi
+}
+
+write_int_file() {
+    local path="$1"
+    local value="$2"
+    mkdir -p "$(dirname "$path")" 2>/dev/null || true
+    printf '%s' "$value" >"$path"
+}
+
+increment_streak() {
+    local path="$1"
+    local current
+    current="$(read_int_file "$path" 0)"
+    current=$((current + 1))
+    write_int_file "$path" "$current"
+    echo "$current"
+}
+
+reset_streak() {
+    write_int_file "$1" "0"
+}
+
+can_restart_daemon() {
+    local last_restart_file="$1"
+    local now last
+    now="$(date +%s)"
+    last="$(read_int_file "$last_restart_file" 0)"
+    if [ "$last" -eq 0 ]; then
+        return 0
+    fi
+    [ $((now - last)) -ge "$UPLOAD_DAEMON_RESTART_MIN_INTERVAL_SEC" ]
+}
+
+record_daemon_restart() {
+    write_int_file "$1" "$(date +%s)"
+}
+
+restart_vsftpd_daemon() {
+    local reason="${1:-unspecified}"
+    if ! command -v flock >/dev/null 2>&1; then
+        watchdog_log "ERROR" "flock not available; skipping vsftpd restart ($reason)"
+        log_upload_health_app "error" "vsftpd restart skipped: flock unavailable" "{\"reason\":\"${reason}\"}"
+        return 1
+    fi
+    if ! flock -n "$VSFTPD_RESTART_LOCK" bash -c "
+        set -euo pipefail
+        if [ ! -f \"$VSFTPD_CONF\" ]; then
+            echo 'vsftpd.conf missing' >&2
+            exit 1
+        fi
+        pkill -x vsftpd 2>/dev/null || true
+        sleep 1
+        for _ in 1 2 3 4 5; do
+            pgrep -x vsftpd >/dev/null 2>&1 || break
+            sleep 1
+        done
+        if pgrep -x vsftpd >/dev/null 2>&1; then
+            pkill -9 -x vsftpd 2>/dev/null || true
+            sleep 1
+        fi
+        /usr/sbin/vsftpd \"$VSFTPD_CONF\" &
+        sleep 2
+        pgrep -x vsftpd >/dev/null 2>&1
+    "; then
+        watchdog_log "ERROR" "vsftpd restart failed or lock held ($reason)"
+        log_upload_health_app "error" "vsftpd restart failed" "{\"reason\":\"${reason}\"}"
+        return 1
+    fi
+    watchdog_log "INFO" "vsftpd restarted ($reason)"
+    log_upload_health_app "warning" "vsftpd restarted by upload health watchdog" "{\"reason\":\"${reason}\"}"
+    return 0
+}
+
+restart_container_sshd() {
+    local reason="${1:-unspecified}"
+    if ! command -v flock >/dev/null 2>&1; then
+        watchdog_log "ERROR" "flock not available; skipping sshd restart ($reason)"
+        log_upload_health_app "error" "container sshd restart skipped: flock unavailable" "{\"reason\":\"${reason}\"}"
+        return 1
+    fi
+    if ! flock -n "$SSHD_RESTART_LOCK" bash -c "
+        set -euo pipefail
+        if command -v service >/dev/null 2>&1; then
+            service ssh restart
+        else
+            pkill -HUP sshd 2>/dev/null || true
+        fi
+        sleep 2
+        pgrep -x sshd >/dev/null 2>&1
+    "; then
+        watchdog_log "ERROR" "container sshd restart failed or lock held ($reason)"
+        log_upload_health_app "error" "container sshd restart failed" "{\"reason\":\"${reason}\"}"
+        return 1
+    fi
+    watchdog_log "INFO" "container sshd restarted ($reason)"
+    log_upload_health_app "warning" "container sshd restarted by upload health watchdog" "{\"reason\":\"${reason}\"}"
+    return 0
+}
+
+# Throttled daemon restart after probe failure streak (shared by vsftpd and container sshd).
+try_restart_upload_daemon() {
+    local protocol="$1"
+    local streak_file="$2"
+    local last_restart_file="$3"
+    local restart_fn="$4"
+    local streak reason
+
+    streak="$(read_int_file "$streak_file" 0)"
+    if [ "$streak" -lt "$UPLOAD_PROBE_FAIL_STREAK_THRESHOLD" ]; then
+        return 1
+    fi
+    if ! can_restart_daemon "$last_restart_file"; then
+        watchdog_log "ERROR" "${protocol} unhealthy but restart throttled (streak=${streak})"
+        log_upload_health_app "error" "upload daemon restart throttled" \
+            "{\"protocol\":\"${protocol}\",\"streak\":${streak}}"
+        return 1
+    fi
+    reason="probe unhealthy streak=${streak}"
+    if "$restart_fn" "$reason"; then
+        record_daemon_restart "$last_restart_file"
+        reset_streak "$streak_file"
+        watchdog_log "INFO" "${protocol} recovered via daemon restart"
+        return 0
+    fi
+    return 1
+}

--- a/scripts/upload-daemon-common.sh
+++ b/scripts/upload-daemon-common.sh
@@ -31,9 +31,17 @@ watchdog_log() {
     local level="$1"
     shift
     local msg="$*"
-    local ts
+    local ts log_file
     ts="$(date '+%Y-%m-%d %H:%M:%S')"
-    echo "[$ts] [$level] $msg" >> "${WATCHDOG_LOG_FILE:-/var/log/aviationwx/service-watchdog.log}"
+    log_file="${WATCHDOG_LOG_FILE:-/var/log/aviationwx/service-watchdog.log}"
+    mkdir -p "$(dirname "$log_file")" 2>/dev/null || true
+    echo "[$ts] [$level] $msg" >>"$log_file"
+}
+
+ensure_aviationwx_state_dir() {
+    mkdir -p "$(dirname "$UPLOAD_PROBE_STATE_FILE")" 2>/dev/null || true
+    mkdir -p "$(dirname "$VSFTPD_RESTART_LOCK")" 2>/dev/null || true
+    mkdir -p "$(dirname "$SSHD_RESTART_LOCK")" 2>/dev/null || true
 }
 
 # Structured app.log entry for upload daemon diagnostics (no credentials in context).
@@ -134,6 +142,7 @@ record_daemon_restart() {
 
 restart_vsftpd_daemon() {
     local reason="${1:-unspecified}"
+    ensure_aviationwx_state_dir
     if ! command -v flock >/dev/null 2>&1; then
         watchdog_log "ERROR" "flock not available; skipping vsftpd restart ($reason)"
         log_upload_health_app "error" "vsftpd restart skipped: flock unavailable" "{\"reason\":\"${reason}\"}"
@@ -170,6 +179,7 @@ restart_vsftpd_daemon() {
 
 restart_container_sshd() {
     local reason="${1:-unspecified}"
+    ensure_aviationwx_state_dir
     if ! command -v flock >/dev/null 2>&1; then
         watchdog_log "ERROR" "flock not available; skipping sshd restart ($reason)"
         log_upload_health_app "error" "container sshd restart skipped: flock unavailable" "{\"reason\":\"${reason}\"}"

--- a/scripts/upload-daemon-common.sh
+++ b/scripts/upload-daemon-common.sh
@@ -62,6 +62,12 @@ read_probe_interval_from_config() {
         | tr -d '[:space:]' || echo "$UPLOAD_PROBE_INTERVAL_SEC"
 }
 
+# Returns 0 when epoch is a positive integer suitable for heartbeat age math.
+probe_heartbeat_epoch_is_valid() {
+    local epoch="$1"
+    [[ "$epoch" =~ ^[0-9]+$ ]] && [ "$epoch" -gt 0 ]
+}
+
 read_probe_stale_sec_from_heartbeat() {
     if [ -f "$UPLOAD_PROBE_STATE_FILE" ] && command -v jq >/dev/null 2>&1; then
         local from_file

--- a/scripts/upload-daemon-common.sh
+++ b/scripts/upload-daemon-common.sh
@@ -173,7 +173,7 @@ restart_vsftpd_daemon() {
         return 1
     fi
     watchdog_log "INFO" "vsftpd restarted ($reason)"
-    log_upload_health_app "warning" "vsftpd restarted by upload health watchdog" "{\"reason\":\"${reason}\"}"
+    log_upload_health_app "warning" "vsftpd restarted" "{\"reason\":\"${reason}\"}"
     return 0
 }
 

--- a/scripts/upload-probe-runner.sh
+++ b/scripts/upload-probe-runner.sh
@@ -28,7 +28,7 @@ while true; do
     if ! [[ "$interval" =~ ^[0-9]+$ ]] || [ "$interval" -lt 1 ]; then
         interval="$UPLOAD_PROBE_INTERVAL_SEC"
     fi
-    UPLOAD_PROBE_INTERVAL_SEC="$interval"
+    export UPLOAD_PROBE_INTERVAL_SEC="$interval"
 
     if [ -x "$PROBE_SCRIPT" ]; then
         "$PROBE_SCRIPT" || true

--- a/scripts/upload-probe-runner.sh
+++ b/scripts/upload-probe-runner.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Runs upload-probe.sh on config.upload_health_probe.interval_sec (default 30).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_SH="${SCRIPT_DIR}/upload-daemon-common.sh"
+if [ ! -f "$COMMON_SH" ]; then
+    COMMON_SH="/usr/local/libexec/aviationwx/upload-daemon-common.sh"
+fi
+# shellcheck source=upload-daemon-common.sh
+source "$COMMON_SH"
+
+PROBE_SCRIPT="${SCRIPT_DIR}/upload-probe.sh"
+PROBE_LOG="${PROBE_LOG:-/var/log/aviationwx/upload-probe.log}"
+
+log_probe_runner() {
+    local ts msg
+    ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    msg="$1"
+    echo "[$ts] [INFO] $msg" >>"$PROBE_LOG"
+}
+
+log_probe_runner "upload-probe-runner started"
+
+while true; do
+    interval="$(read_probe_interval_from_config)"
+    if ! [[ "$interval" =~ ^[0-9]+$ ]] || [ "$interval" -lt 1 ]; then
+        interval="$UPLOAD_PROBE_INTERVAL_SEC"
+    fi
+    UPLOAD_PROBE_INTERVAL_SEC="$interval"
+
+    if [ -x "$PROBE_SCRIPT" ]; then
+        "$PROBE_SCRIPT" || true
+    else
+        log_probe_runner "ERROR missing probe script: $PROBE_SCRIPT"
+        log_upload_health_app "error" "upload-probe-runner: probe script missing" \
+            "{\"path\":\"${PROBE_SCRIPT}\"}"
+    fi
+    sleep "$interval"
+done

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# Functional FTPS/SFTP upload probe; writes heartbeat for service-watchdog.
+# Run every interval_sec via upload-probe-runner.sh (not invoked by watchdog).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_SH="${SCRIPT_DIR}/upload-daemon-common.sh"
+if [ ! -f "$COMMON_SH" ]; then
+    COMMON_SH="/usr/local/libexec/aviationwx/upload-daemon-common.sh"
+fi
+# shellcheck source=upload-daemon-common.sh
+source "$COMMON_SH"
+
+PROBE_LOG="${PROBE_LOG:-/var/log/aviationwx/upload-probe.log}"
+PROBE_TMP_DIR="${PROBE_TMP_DIR:-/tmp/aviationwx-upload-probe}"
+PROBE_FILE_PREFIX="${UPLOAD_HEALTH_PROBE_FILE_PREFIX:-aviationwx-probe-}"
+
+log_probe() {
+    local level="$1"
+    shift
+    local ts
+    ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "[$ts] [$level] $*" >>"$PROBE_LOG"
+}
+
+write_heartbeat() {
+    local json="$1"
+    local tmp="${UPLOAD_PROBE_STATE_FILE}.tmp.$$"
+    mkdir -p "$(dirname "$UPLOAD_PROBE_STATE_FILE")" 2>/dev/null || true
+    printf '%s\n' "$json" >"$tmp"
+    chmod 600 "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$UPLOAD_PROBE_STATE_FILE"
+    chmod 600 "$UPLOAD_PROBE_STATE_FILE" 2>/dev/null || true
+}
+
+read_config_json() {
+    php_as_www_data -r 'require_once "/var/www/html/lib/config.php"; echo json_encode(getUploadHealthProbeSettings(), JSON_UNESCAPED_SLASHES);' 2>/dev/null || echo ''
+}
+
+write_disabled_heartbeat() {
+    local now_epoch now_iso interval stale_sec heartbeat
+    now_epoch="$(date +%s)"
+    now_iso="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    interval="$(read_probe_interval_from_config)"
+    if ! [[ "$interval" =~ ^[0-9]+$ ]]; then
+        interval="$UPLOAD_PROBE_INTERVAL_SEC"
+    fi
+    stale_sec="$(php_as_www_data -r 'require_once "/var/www/html/lib/config.php"; echo (int) getUploadHealthProbeSettings()["stale_sec"];' 2>/dev/null | tr -d '[:space:]' || echo "$((interval * 2 + 15))")"
+    heartbeat="$(jq -n \
+        --arg ts "$now_iso" \
+        --argjson epoch "$now_epoch" \
+        --argjson interval "$interval" \
+        --argjson stale_sec "$stale_sec" \
+        '{ts: $ts, epoch: $epoch, interval_sec: $interval, stale_sec: $stale_sec, ftps: {ok: true, skipped: true, ms: 0, detail: "disabled"}, sftp: {ok: true, skipped: true, ms: 0, detail: "disabled"}}')"
+    write_heartbeat "$heartbeat"
+}
+
+run_ftps_probe() {
+    local host="$1" port="$2" user="$3" pass="$4"
+    local ts file_name base_url start_ms end_ms elapsed
+    ts="$(date +%s)"
+    file_name="${PROBE_FILE_PREFIX}${ts}.txt"
+    mkdir -p "$PROBE_TMP_DIR"
+    printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"${PROBE_TMP_DIR}/${file_name}"
+
+    base_url="ftps://${host}:${port}/"
+    start_ms="$(date +%s 2>/dev/null || echo 0)"
+    if ! curl -sS --ftp-ssl-reqd --ftp-pasv -u "${user}:${pass}" --connect-timeout 10 --max-time 45 \
+        --upload-file "${PROBE_TMP_DIR}/${file_name}" "${base_url}${file_name}" >/dev/null 2>&1; then
+        rm -f "${PROBE_TMP_DIR}/${file_name}"
+        echo "false|0|ftps upload failed"
+        return 1
+    fi
+    if ! curl -sS --ftp-ssl-reqd --ftp-pasv -u "${user}:${pass}" --connect-timeout 10 --max-time 30 \
+        --fail -X "DELE ${file_name}" "$base_url" >/dev/null 2>&1; then
+        log_probe "WARN" "FTPS upload ok but delete failed for ${file_name}"
+    fi
+    rm -f "${PROBE_TMP_DIR}/${file_name}"
+    end_ms="$(date +%s 2>/dev/null || echo 0)"
+    elapsed=$((end_ms - start_ms))
+    if [ "$elapsed" -lt 0 ]; then
+        elapsed=0
+    fi
+    echo "true|${elapsed}|ok"
+}
+
+run_sftp_probe() {
+    local host="$1" port="$2" user="$3" pass="$4"
+    local ts file_name remote_path base_url start_ms end_ms elapsed
+    ts="$(date +%s)"
+    file_name="${PROBE_FILE_PREFIX}${ts}.txt"
+    remote_path="files/${file_name}"
+    mkdir -p "$PROBE_TMP_DIR"
+    printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"${PROBE_TMP_DIR}/${file_name}"
+
+    base_url="sftp://${host}:${port}/"
+    start_ms="$(date +%s 2>/dev/null || echo 0)"
+    if ! curl -sS -u "${user}:${pass}" --connect-timeout 10 --max-time 45 \
+        --upload-file "${PROBE_TMP_DIR}/${file_name}" "${base_url}${remote_path}" >/dev/null 2>&1; then
+        rm -f "${PROBE_TMP_DIR}/${file_name}"
+        echo "false|0|sftp upload failed"
+        return 1
+    fi
+    if ! curl -sS -u "${user}:${pass}" --connect-timeout 10 --max-time 20 \
+        --fail -X "DELE ${remote_path}" "$base_url" >/dev/null 2>&1; then
+        log_probe "WARN" "SFTP upload ok but delete failed for ${remote_path}"
+    fi
+    rm -f "${PROBE_TMP_DIR}/${file_name}"
+    end_ms="$(date +%s 2>/dev/null || echo 0)"
+    elapsed=$((end_ms - start_ms))
+    if [ "$elapsed" -lt 0 ]; then
+        elapsed=0
+    fi
+    echo "true|${elapsed}|ok"
+}
+
+main() {
+    local config enabled connect_host ftp_port sftp_port interval stale_sec
+    local ftps_user ftps_pass sftp_user sftp_pass
+    local ftps_ok ftps_ms ftps_detail sftp_ok sftp_ms sftp_detail
+    local now_iso now_epoch heartbeat ftps_skipped sftp_skipped
+
+    if ! command -v jq >/dev/null 2>&1; then
+        log_probe "ERROR" "jq required for upload probe"
+        log_upload_health_app "error" "upload probe cannot run: jq missing" '{}'
+        exit 1
+    fi
+
+    config="$(read_config_json)"
+    if [ -z "$config" ] || ! echo "$config" | jq -e . >/dev/null 2>&1; then
+        log_probe "ERROR" "could not read upload health probe config"
+        log_upload_health_app "error" "upload probe config unreadable" '{}'
+        write_disabled_heartbeat
+        exit 1
+    fi
+
+    enabled="$(echo "$config" | jq -r '.enabled // false')"
+    now_epoch="$(date +%s)"
+    now_iso="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    interval="$(echo "$config" | jq -r '.interval_sec // 30')"
+    stale_sec="$(echo "$config" | jq -r '.stale_sec // 75')"
+
+    if [ "$enabled" != "true" ]; then
+        write_disabled_heartbeat
+        exit 0
+    fi
+
+    connect_host="$(echo "$config" | jq -r '.connect_host // .upload_hostname // empty')"
+    ftp_port="$(echo "$config" | jq -r '.ftp_port')"
+    sftp_port="$(echo "$config" | jq -r '.sftp_port')"
+
+    ftps_user="$(echo "$config" | jq -r '.ftps.username // empty')"
+    ftps_pass="$(echo "$config" | jq -r '.ftps.password // empty')"
+    sftp_user="$(echo "$config" | jq -r '.sftp.username // empty')"
+    sftp_pass="$(echo "$config" | jq -r '.sftp.password // empty')"
+
+    ftps_ok="true"
+    ftps_ms=0
+    ftps_detail="skipped"
+    sftp_ok="true"
+    sftp_ms=0
+    sftp_detail="skipped"
+    ftps_skipped="false"
+    sftp_skipped="false"
+
+    if [ -n "$ftps_user" ] && [ -n "$ftps_pass" ]; then
+        IFS='|' read -r ftps_ok ftps_ms ftps_detail < <(run_ftps_probe "$connect_host" "$ftp_port" "$ftps_user" "$ftps_pass" || echo "false|0|ftps failed")
+        log_probe "INFO" "FTPS probe ok=${ftps_ok} ms=${ftps_ms} detail=${ftps_detail} host=${connect_host}"
+        if [ "$ftps_ok" != "true" ]; then
+            log_upload_health_app "error" "FTPS upload health probe failed" \
+                "$(jq -n --arg detail "$ftps_detail" --arg host "$connect_host" '{detail: $detail, connect_host: $host}')"
+        fi
+    else
+        ftps_skipped="true"
+        ftps_detail="no credentials"
+    fi
+
+    if [ -n "$sftp_user" ] && [ -n "$sftp_pass" ]; then
+        IFS='|' read -r sftp_ok sftp_ms sftp_detail < <(run_sftp_probe "$connect_host" "$sftp_port" "$sftp_user" "$sftp_pass" || echo "false|0|sftp failed")
+        log_probe "INFO" "SFTP probe ok=${sftp_ok} ms=${sftp_ms} detail=${sftp_detail} host=${connect_host}"
+        if [ "$sftp_ok" != "true" ]; then
+            log_upload_health_app "error" "SFTP upload health probe failed" \
+                "$(jq -n --arg detail "$sftp_detail" --arg host "$connect_host" '{detail: $detail, connect_host: $host}')"
+        fi
+    else
+        sftp_skipped="true"
+        sftp_detail="no credentials"
+    fi
+
+    heartbeat="$(jq -n \
+        --arg ts "$now_iso" \
+        --argjson epoch "$now_epoch" \
+        --argjson interval "$interval" \
+        --argjson stale_sec "$stale_sec" \
+        --argjson ftps_ok "$( [ "$ftps_ok" = "true" ] && echo true || echo false )" \
+        --argjson ftps_skipped "$( [ "$ftps_skipped" = "true" ] && echo true || echo false )" \
+        --argjson ftps_ms "${ftps_ms:-0}" \
+        --arg ftps_detail "$ftps_detail" \
+        --argjson sftp_ok "$( [ "$sftp_ok" = "true" ] && echo true || echo false )" \
+        --argjson sftp_skipped "$( [ "$sftp_skipped" = "true" ] && echo true || echo false )" \
+        --argjson sftp_ms "${sftp_ms:-0}" \
+        --arg sftp_detail "$sftp_detail" \
+        '{ts: $ts, epoch: $epoch, interval_sec: $interval, stale_sec: $stale_sec, ftps: {ok: $ftps_ok, skipped: $ftps_skipped, ms: $ftps_ms, detail: $ftps_detail}, sftp: {ok: $sftp_ok, skipped: $sftp_skipped, ms: $sftp_ms, detail: $sftp_detail}}')"
+
+    write_heartbeat "$heartbeat"
+
+    if [ "$ftps_ok" = "true" ] && [ "$sftp_ok" = "true" ]; then
+        exit 0
+    fi
+    exit 1
+}
+
+main "$@"

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -15,6 +15,8 @@ source "$COMMON_SH"
 PROBE_LOG="${PROBE_LOG:-/var/log/aviationwx/upload-probe.log}"
 PROBE_TMP_DIR="${PROBE_TMP_DIR:-/tmp/aviationwx-upload-probe}"
 PROBE_FILE_PREFIX="${UPLOAD_HEALTH_PROBE_FILE_PREFIX:-aviationwx-probe-}"
+PROBE_REMOTE_FILENAME="${PROBE_FILE_PREFIX}healthcheck.txt"
+PROBE_NETRC_FILE=""
 
 log_probe() {
     local level="$1"
@@ -56,27 +58,50 @@ write_disabled_heartbeat() {
     write_heartbeat "$heartbeat"
 }
 
+probe_netrc_cleanup() {
+    if [ -n "$PROBE_NETRC_FILE" ] && [ -f "$PROBE_NETRC_FILE" ]; then
+        rm -f "$PROBE_NETRC_FILE"
+    fi
+    PROBE_NETRC_FILE=""
+}
+
+probe_setup_netrc() {
+    local host="$1" user="$2" pass="$3"
+    probe_netrc_cleanup
+    mkdir -p "$PROBE_TMP_DIR"
+    PROBE_NETRC_FILE="$(mktemp "${PROBE_TMP_DIR}/curl-netrc.XXXXXX")"
+    chmod 600 "$PROBE_NETRC_FILE"
+    {
+        printf 'machine %s\n' "$host"
+        printf 'login %s\n' "$user"
+        printf 'password %s\n' "$pass"
+    } >"$PROBE_NETRC_FILE"
+}
+
 run_ftps_probe() {
     local host="$1" port="$2" user="$3" pass="$4"
-    local ts file_name base_url start_sec end_sec elapsed
-    ts="$(date +%s)"
-    file_name="${PROBE_FILE_PREFIX}${ts}.txt"
-    mkdir -p "$PROBE_TMP_DIR"
-    printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"${PROBE_TMP_DIR}/${file_name}"
-
+    local file_name base_url local_file start_sec end_sec elapsed
+    file_name="$PROBE_REMOTE_FILENAME"
+    local_file="${PROBE_TMP_DIR}/${file_name}"
     base_url="ftps://${host}:${port}/"
+    mkdir -p "$PROBE_TMP_DIR"
+    printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"$local_file"
+    trap probe_netrc_cleanup RETURN
+    probe_setup_netrc "$host" "$user" "$pass"
     start_sec="$(date +%s 2>/dev/null || echo 0)"
-    if ! curl -sS --ftp-ssl-reqd --ftp-pasv -u "${user}:${pass}" --connect-timeout 10 --max-time 45 \
-        --upload-file "${PROBE_TMP_DIR}/${file_name}" "${base_url}${file_name}" >/dev/null 2>&1; then
-        rm -f "${PROBE_TMP_DIR}/${file_name}"
+    if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc --ftp-ssl-reqd --ftp-pasv \
+        --connect-timeout 10 --max-time 45 \
+        --upload-file "$local_file" "${base_url}${file_name}" >/dev/null 2>&1; then
+        rm -f "$local_file"
         echo "false|0|ftps upload failed"
         return 1
     fi
-    if ! curl -sS --ftp-ssl-reqd --ftp-pasv -u "${user}:${pass}" --connect-timeout 10 --max-time 30 \
+    if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc --ftp-ssl-reqd --ftp-pasv \
+        --connect-timeout 10 --max-time 30 \
         --fail -X "DELE ${file_name}" "$base_url" >/dev/null 2>&1; then
         log_probe "WARN" "FTPS upload ok but delete failed for ${file_name}"
     fi
-    rm -f "${PROBE_TMP_DIR}/${file_name}"
+    rm -f "$local_file"
     end_sec="$(date +%s 2>/dev/null || echo 0)"
     elapsed=$((end_sec - start_sec))
     if [ "$elapsed" -lt 0 ]; then
@@ -87,26 +112,29 @@ run_ftps_probe() {
 
 run_sftp_probe() {
     local host="$1" port="$2" user="$3" pass="$4"
-    local ts file_name remote_path base_url start_sec end_sec elapsed
-    ts="$(date +%s)"
-    file_name="${PROBE_FILE_PREFIX}${ts}.txt"
+    local file_name remote_path base_url local_file start_sec end_sec elapsed
+    file_name="$PROBE_REMOTE_FILENAME"
     remote_path="files/${file_name}"
-    mkdir -p "$PROBE_TMP_DIR"
-    printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"${PROBE_TMP_DIR}/${file_name}"
-
+    local_file="${PROBE_TMP_DIR}/${file_name}"
     base_url="sftp://${host}:${port}/"
+    mkdir -p "$PROBE_TMP_DIR"
+    printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"$local_file"
+    trap probe_netrc_cleanup RETURN
+    probe_setup_netrc "$host" "$user" "$pass"
     start_sec="$(date +%s 2>/dev/null || echo 0)"
-    if ! curl -sS -u "${user}:${pass}" --connect-timeout 10 --max-time 45 \
-        --upload-file "${PROBE_TMP_DIR}/${file_name}" "${base_url}${remote_path}" >/dev/null 2>&1; then
-        rm -f "${PROBE_TMP_DIR}/${file_name}"
+    if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc \
+        --connect-timeout 10 --max-time 45 \
+        --upload-file "$local_file" "${base_url}${remote_path}" >/dev/null 2>&1; then
+        rm -f "$local_file"
         echo "false|0|sftp upload failed"
         return 1
     fi
-    if ! curl -sS -u "${user}:${pass}" --connect-timeout 10 --max-time 20 \
+    if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc \
+        --connect-timeout 10 --max-time 20 \
         --fail -X "DELE ${remote_path}" "$base_url" >/dev/null 2>&1; then
         log_probe "WARN" "SFTP upload ok but delete failed for ${remote_path}"
     fi
-    rm -f "${PROBE_TMP_DIR}/${file_name}"
+    rm -f "$local_file"
     end_sec="$(date +%s 2>/dev/null || echo 0)"
     elapsed=$((end_sec - start_sec))
     if [ "$elapsed" -lt 0 ]; then

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -129,11 +129,7 @@ run_sftp_probe() {
         echo "false|0|sftp upload failed"
         return 1
     fi
-    if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc \
-        --connect-timeout 10 --max-time 20 \
-        --fail -X "DELE ${remote_path}" "$base_url" >/dev/null 2>&1; then
-        log_probe "WARN" "SFTP upload ok but delete failed for ${remote_path}"
-    fi
+    # SFTP: curl -X DELE is FTP-only; stable PROBE_REMOTE_FILENAME is overwritten each run.
     rm -f "$local_file"
     end_sec="$(date +%s 2>/dev/null || echo 0)"
     elapsed=$((end_sec - start_sec))

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -52,20 +52,20 @@ write_disabled_heartbeat() {
         --argjson epoch "$now_epoch" \
         --argjson interval "$interval" \
         --argjson stale_sec "$stale_sec" \
-        '{ts: $ts, epoch: $epoch, interval_sec: $interval, stale_sec: $stale_sec, ftps: {ok: true, skipped: true, ms: 0, detail: "disabled"}, sftp: {ok: true, skipped: true, ms: 0, detail: "disabled"}}')"
+        '{ts: $ts, epoch: $epoch, interval_sec: $interval, stale_sec: $stale_sec, ftps: {ok: true, skipped: true, duration_sec: 0, detail: "disabled"}, sftp: {ok: true, skipped: true, duration_sec: 0, detail: "disabled"}}')"
     write_heartbeat "$heartbeat"
 }
 
 run_ftps_probe() {
     local host="$1" port="$2" user="$3" pass="$4"
-    local ts file_name base_url start_ms end_ms elapsed
+    local ts file_name base_url start_sec end_sec elapsed
     ts="$(date +%s)"
     file_name="${PROBE_FILE_PREFIX}${ts}.txt"
     mkdir -p "$PROBE_TMP_DIR"
     printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"${PROBE_TMP_DIR}/${file_name}"
 
     base_url="ftps://${host}:${port}/"
-    start_ms="$(date +%s 2>/dev/null || echo 0)"
+    start_sec="$(date +%s 2>/dev/null || echo 0)"
     if ! curl -sS --ftp-ssl-reqd --ftp-pasv -u "${user}:${pass}" --connect-timeout 10 --max-time 45 \
         --upload-file "${PROBE_TMP_DIR}/${file_name}" "${base_url}${file_name}" >/dev/null 2>&1; then
         rm -f "${PROBE_TMP_DIR}/${file_name}"
@@ -77,8 +77,8 @@ run_ftps_probe() {
         log_probe "WARN" "FTPS upload ok but delete failed for ${file_name}"
     fi
     rm -f "${PROBE_TMP_DIR}/${file_name}"
-    end_ms="$(date +%s 2>/dev/null || echo 0)"
-    elapsed=$((end_ms - start_ms))
+    end_sec="$(date +%s 2>/dev/null || echo 0)"
+    elapsed=$((end_sec - start_sec))
     if [ "$elapsed" -lt 0 ]; then
         elapsed=0
     fi
@@ -87,7 +87,7 @@ run_ftps_probe() {
 
 run_sftp_probe() {
     local host="$1" port="$2" user="$3" pass="$4"
-    local ts file_name remote_path base_url start_ms end_ms elapsed
+    local ts file_name remote_path base_url start_sec end_sec elapsed
     ts="$(date +%s)"
     file_name="${PROBE_FILE_PREFIX}${ts}.txt"
     remote_path="files/${file_name}"
@@ -95,7 +95,7 @@ run_sftp_probe() {
     printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"${PROBE_TMP_DIR}/${file_name}"
 
     base_url="sftp://${host}:${port}/"
-    start_ms="$(date +%s 2>/dev/null || echo 0)"
+    start_sec="$(date +%s 2>/dev/null || echo 0)"
     if ! curl -sS -u "${user}:${pass}" --connect-timeout 10 --max-time 45 \
         --upload-file "${PROBE_TMP_DIR}/${file_name}" "${base_url}${remote_path}" >/dev/null 2>&1; then
         rm -f "${PROBE_TMP_DIR}/${file_name}"
@@ -107,8 +107,8 @@ run_sftp_probe() {
         log_probe "WARN" "SFTP upload ok but delete failed for ${remote_path}"
     fi
     rm -f "${PROBE_TMP_DIR}/${file_name}"
-    end_ms="$(date +%s 2>/dev/null || echo 0)"
-    elapsed=$((end_ms - start_ms))
+    end_sec="$(date +%s 2>/dev/null || echo 0)"
+    elapsed=$((end_sec - start_sec))
     if [ "$elapsed" -lt 0 ]; then
         elapsed=0
     fi
@@ -118,7 +118,7 @@ run_sftp_probe() {
 main() {
     local config enabled connect_host ftp_port sftp_port interval stale_sec
     local ftps_user ftps_pass sftp_user sftp_pass
-    local ftps_ok ftps_ms ftps_detail sftp_ok sftp_ms sftp_detail
+    local ftps_ok ftps_duration_sec ftps_detail sftp_ok sftp_duration_sec sftp_detail
     local now_iso now_epoch heartbeat ftps_skipped sftp_skipped
 
     if ! command -v jq >/dev/null 2>&1; then
@@ -156,17 +156,17 @@ main() {
     sftp_pass="$(echo "$config" | jq -r '.sftp.password // empty')"
 
     ftps_ok="true"
-    ftps_ms=0
+    ftps_duration_sec=0
     ftps_detail="skipped"
     sftp_ok="true"
-    sftp_ms=0
+    sftp_duration_sec=0
     sftp_detail="skipped"
     ftps_skipped="false"
     sftp_skipped="false"
 
     if [ -n "$ftps_user" ] && [ -n "$ftps_pass" ]; then
-        IFS='|' read -r ftps_ok ftps_ms ftps_detail < <(run_ftps_probe "$connect_host" "$ftp_port" "$ftps_user" "$ftps_pass" || echo "false|0|ftps failed")
-        log_probe "INFO" "FTPS probe ok=${ftps_ok} ms=${ftps_ms} detail=${ftps_detail} host=${connect_host}"
+        IFS='|' read -r ftps_ok ftps_duration_sec ftps_detail < <(run_ftps_probe "$connect_host" "$ftp_port" "$ftps_user" "$ftps_pass" || echo "false|0|ftps failed")
+        log_probe "INFO" "FTPS probe ok=${ftps_ok} duration_sec=${ftps_duration_sec} detail=${ftps_detail} host=${connect_host}"
         if [ "$ftps_ok" != "true" ]; then
             log_upload_health_app "error" "FTPS upload health probe failed" \
                 "$(jq -n --arg detail "$ftps_detail" --arg host "$connect_host" '{detail: $detail, connect_host: $host}')"
@@ -177,8 +177,8 @@ main() {
     fi
 
     if [ -n "$sftp_user" ] && [ -n "$sftp_pass" ]; then
-        IFS='|' read -r sftp_ok sftp_ms sftp_detail < <(run_sftp_probe "$connect_host" "$sftp_port" "$sftp_user" "$sftp_pass" || echo "false|0|sftp failed")
-        log_probe "INFO" "SFTP probe ok=${sftp_ok} ms=${sftp_ms} detail=${sftp_detail} host=${connect_host}"
+        IFS='|' read -r sftp_ok sftp_duration_sec sftp_detail < <(run_sftp_probe "$connect_host" "$sftp_port" "$sftp_user" "$sftp_pass" || echo "false|0|sftp failed")
+        log_probe "INFO" "SFTP probe ok=${sftp_ok} duration_sec=${sftp_duration_sec} detail=${sftp_detail} host=${connect_host}"
         if [ "$sftp_ok" != "true" ]; then
             log_upload_health_app "error" "SFTP upload health probe failed" \
                 "$(jq -n --arg detail "$sftp_detail" --arg host "$connect_host" '{detail: $detail, connect_host: $host}')"
@@ -195,13 +195,13 @@ main() {
         --argjson stale_sec "$stale_sec" \
         --argjson ftps_ok "$( [ "$ftps_ok" = "true" ] && echo true || echo false )" \
         --argjson ftps_skipped "$( [ "$ftps_skipped" = "true" ] && echo true || echo false )" \
-        --argjson ftps_ms "${ftps_ms:-0}" \
+        --argjson ftps_duration_sec "${ftps_duration_sec:-0}" \
         --arg ftps_detail "$ftps_detail" \
         --argjson sftp_ok "$( [ "$sftp_ok" = "true" ] && echo true || echo false )" \
         --argjson sftp_skipped "$( [ "$sftp_skipped" = "true" ] && echo true || echo false )" \
-        --argjson sftp_ms "${sftp_ms:-0}" \
+        --argjson sftp_duration_sec "${sftp_duration_sec:-0}" \
         --arg sftp_detail "$sftp_detail" \
-        '{ts: $ts, epoch: $epoch, interval_sec: $interval, stale_sec: $stale_sec, ftps: {ok: $ftps_ok, skipped: $ftps_skipped, ms: $ftps_ms, detail: $ftps_detail}, sftp: {ok: $sftp_ok, skipped: $sftp_skipped, ms: $sftp_ms, detail: $sftp_detail}}')"
+        '{ts: $ts, epoch: $epoch, interval_sec: $interval, stale_sec: $stale_sec, ftps: {ok: $ftps_ok, skipped: $ftps_skipped, duration_sec: $ftps_duration_sec, detail: $ftps_detail}, sftp: {ok: $sftp_ok, skipped: $sftp_skipped, duration_sec: $sftp_duration_sec, detail: $sftp_detail}}')"
 
     write_heartbeat "$heartbeat"
 

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -86,8 +86,8 @@ run_ftps_probe() {
     base_url="ftps://${host}:${port}/"
     mkdir -p "$PROBE_TMP_DIR"
     printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"$local_file"
-    trap probe_netrc_cleanup RETURN
     probe_setup_netrc "$host" "$user" "$pass"
+    trap probe_netrc_cleanup RETURN
     start_sec="$(date +%s 2>/dev/null || echo 0)"
     if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc --ftp-ssl-reqd --ftp-pasv \
         --connect-timeout 10 --max-time 45 \
@@ -119,8 +119,8 @@ run_sftp_probe() {
     base_url="sftp://${host}:${port}/"
     mkdir -p "$PROBE_TMP_DIR"
     printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"$local_file"
-    trap probe_netrc_cleanup RETURN
     probe_setup_netrc "$host" "$user" "$pass"
+    trap probe_netrc_cleanup RETURN
     start_sec="$(date +%s 2>/dev/null || echo 0)"
     if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc \
         --connect-timeout 10 --max-time 45 \

--- a/tests/Unit/PushWebcamValidatorTest.php
+++ b/tests/Unit/PushWebcamValidatorTest.php
@@ -77,7 +77,7 @@ class PushWebcamValidatorTest extends TestCase
         $this->assertStringContainsString('password must be exactly 14 characters', $result['errors'][0]);
     }
 
-    public function testNonStringUsernameRejected(): void
+    public function testValidatePushWebcamConfig_NonStringUsername_ReturnsTypeError(): void
     {
         $cam = [
             'name' => 'Test Camera',
@@ -94,7 +94,7 @@ class PushWebcamValidatorTest extends TestCase
         $this->assertStringContainsString('username must be a string', implode(' ', $result['errors']));
     }
 
-    public function testNonStringPasswordRejected(): void
+    public function testValidatePushWebcamConfig_NonStringPassword_ReturnsTypeError(): void
     {
         $cam = [
             'name' => 'Test Camera',

--- a/tests/Unit/PushWebcamValidatorTest.php
+++ b/tests/Unit/PushWebcamValidatorTest.php
@@ -76,6 +76,40 @@ class PushWebcamValidatorTest extends TestCase
         $this->assertFalse($result['valid']);
         $this->assertStringContainsString('password must be exactly 14 characters', $result['errors'][0]);
     }
+
+    public function testNonStringUsernameRejected(): void
+    {
+        $cam = [
+            'name' => 'Test Camera',
+            'type' => 'push',
+            'push_config' => [
+                'username' => ['not', 'a', 'string'],
+                'password' => 'mK8pL3nQ6rT9vW',
+            ],
+        ];
+
+        $result = validatePushWebcamConfig($cam, 'kspb', 0);
+
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('username must be a string', implode(' ', $result['errors']));
+    }
+
+    public function testNonStringPasswordRejected(): void
+    {
+        $cam = [
+            'name' => 'Test Camera',
+            'type' => 'push',
+            'push_config' => [
+                'username' => 'aB3xK9mP2qR7vN',
+                'password' => 12345678901234,
+            ],
+        ];
+
+        $result = validatePushWebcamConfig($cam, 'kspb', 0);
+
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('password must be a string', implode(' ', $result['errors']));
+    }
     
     public function testProtocolFieldNotAllowed()
     {

--- a/tests/Unit/UploadHealthProbeConfigTest.php
+++ b/tests/Unit/UploadHealthProbeConfigTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for upload health probe configuration helpers.
+ */
+class UploadHealthProbeConfigTest extends TestCase
+{
+    private string $originalAppEnv;
+
+    private string $originalConfigPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalAppEnv = getenv('APP_ENV') ?: '';
+        $this->originalConfigPath = getenv('CONFIG_PATH') ?: '';
+        putenv('APP_ENV=testing');
+        $_ENV['APP_ENV'] = 'testing';
+        $_SERVER['APP_ENV'] = 'testing';
+        $this->clearConfigCache();
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('APP_ENV=' . $this->originalAppEnv);
+        $_ENV['APP_ENV'] = $this->originalAppEnv;
+        $_SERVER['APP_ENV'] = $this->originalAppEnv;
+        putenv('CONFIG_PATH=' . $this->originalConfigPath);
+        if ($this->originalConfigPath !== '') {
+            $_ENV['CONFIG_PATH'] = $this->originalConfigPath;
+            $_SERVER['CONFIG_PATH'] = $this->originalConfigPath;
+        } else {
+            unset($_ENV['CONFIG_PATH'], $_SERVER['CONFIG_PATH']);
+        }
+        $this->clearConfigCache();
+        parent::tearDown();
+    }
+
+    private function clearConfigCache(): void
+    {
+        if (function_exists('apcu_clear_cache')) {
+            apcu_clear_cache();
+        }
+    }
+
+    public function testGetUploadHealthProbeSettings_DisabledInTesting(): void
+    {
+        $settings = getUploadHealthProbeSettings();
+        $this->assertFalse($settings['enabled']);
+        $this->assertNull($settings['ftps']);
+        $this->assertNull($settings['sftp']);
+    }
+
+    public function testGetUploadHealthProbeStaleSeconds_ScalesWithInterval(): void
+    {
+        $stale = getUploadHealthProbeStaleSeconds(30);
+        $this->assertSame(75, $stale);
+        $this->assertSame(135, getUploadHealthProbeStaleSeconds(60));
+    }
+
+    public function testGetUploadHealthProbeSettings_RequiresCredentialsWhenEnabled(): void
+    {
+        $config = [
+            'config' => [
+                'base_domain' => 'example.org',
+                'upload_health_probe' => [
+                    'enabled' => true,
+                    'probe_connect_host' => '127.0.0.1',
+                    'ftps' => ['username' => 'probeftps', 'password' => 'abcdefghijklmn'],
+                    'sftp' => ['username' => 'probesftp', 'password' => 'opqrstuvwxyz12'],
+                ],
+            ],
+            'airports' => [],
+        ];
+
+        $tmp = $this->writeTempConfig($config);
+        putenv('APP_ENV=production');
+        $_ENV['APP_ENV'] = 'production';
+        $_SERVER['APP_ENV'] = 'production';
+        $this->clearConfigCache();
+
+        $settings = getUploadHealthProbeSettings();
+        @unlink($tmp);
+
+        $this->assertTrue($settings['enabled']);
+        $this->assertSame('probeftps', $settings['ftps']['username'] ?? '');
+        $this->assertSame('probesftp', $settings['sftp']['username'] ?? '');
+        $this->assertSame(30, $settings['interval_sec']);
+        $this->assertSame('127.0.0.1', $settings['connect_host']);
+        $this->assertSame(75, $settings['stale_sec']);
+    }
+
+    public function testGetUploadHealthProbeSettings_StrictEnabledRejectsTruthyNonBool(): void
+    {
+        $config = [
+            'config' => [
+                'base_domain' => 'example.org',
+                'upload_health_probe' => [
+                    'enabled' => 1,
+                    'ftps' => ['username' => 'probeftps', 'password' => 'secret'],
+                ],
+            ],
+            'airports' => [],
+        ];
+
+        $tmp = $this->writeTempConfig($config);
+        putenv('APP_ENV=production');
+        $_ENV['APP_ENV'] = 'production';
+        $_SERVER['APP_ENV'] = 'production';
+        $this->clearConfigCache();
+
+        $settings = getUploadHealthProbeSettings();
+        @unlink($tmp);
+
+        $this->assertFalse($settings['enabled']);
+    }
+
+    public function testValidateUploadHealthProbeConfig_RejectsProbeUserMatchingPushCamera(): void
+    {
+        $config = [
+            'config' => [
+                'upload_health_probe' => [
+                    'enabled' => true,
+                    'ftps' => ['username' => 'cam1user', 'password' => 'x'],
+                ],
+            ],
+            'airports' => [
+                'kspb' => [
+                    'webcams' => [
+                        [
+                            'type' => 'push',
+                            'push_config' => ['username' => 'cam1user', 'password' => 'y'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $errors = validateUploadHealthProbeConfig($config);
+        $this->assertNotEmpty($errors);
+        $this->assertStringContainsString('must not match a push camera username', implode(' ', $errors));
+    }
+
+    public function testValidateUploadHealthProbeConfig_EnabledRequiresCredentials(): void
+    {
+        $config = [
+            'config' => [
+                'upload_health_probe' => [
+                    'enabled' => true,
+                ],
+            ],
+            'airports' => [],
+        ];
+
+        $errors = validateUploadHealthProbeConfig($config);
+        $this->assertNotEmpty($errors);
+        $this->assertStringContainsString('valid ftps and/or sftp credentials', implode(' ', $errors));
+    }
+
+    public function testValidateUploadHealthProbeConfig_EnforcesPasswordShape(): void
+    {
+        $config = [
+            'config' => [
+                'upload_health_probe' => [
+                    'enabled' => true,
+                    'ftps' => ['username' => 'healthprobe1', 'password' => 'short'],
+                ],
+            ],
+            'airports' => [],
+        ];
+
+        $errors = validateUploadHealthProbeConfig($config);
+        $this->assertNotEmpty($errors);
+        $this->assertStringContainsString('password must be exactly 14 characters', implode(' ', $errors));
+    }
+
+    public function testValidateUploadHealthProbeConfig_RejectsUnknownFields(): void
+    {
+        $config = [
+            'config' => [
+                'upload_health_probe' => [
+                    'enabled' => false,
+                    'typo_field' => true,
+                ],
+            ],
+            'airports' => [],
+        ];
+
+        $errors = validateUploadHealthProbeConfig($config);
+        $this->assertStringContainsString('unknown field', implode(' ', $errors));
+    }
+
+    public function testValidateUploadHealthProbeConfig_AllowsEmptyProbeConnectHost(): void
+    {
+        $config = [
+            'config' => [
+                'upload_health_probe' => [
+                    'enabled' => false,
+                    'probe_connect_host' => '',
+                ],
+            ],
+            'airports' => [],
+        ];
+
+        $errors = validateUploadHealthProbeConfig($config);
+        $this->assertSame([], $errors);
+    }
+
+    public function testValidateAirportsJsonStructure_IncludesUploadHealthProbe(): void
+    {
+        $config = [
+            'config' => [
+                'upload_health_probe' => [
+                    'enabled' => true,
+                    'ftps' => ['username' => 'cam1user', 'password' => 'abcdefghijklmn'],
+                ],
+            ],
+            'airports' => [
+                'kspb' => [
+                    'webcams' => [
+                        [
+                            'type' => 'push',
+                            'push_config' => ['username' => 'cam1user', 'password' => 'abcdefghijklmn'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('must not match a push camera username', implode(' ', $result['errors']));
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function writeTempConfig(array $config): string
+    {
+        $tmp = sys_get_temp_dir() . '/upload-probe-config-' . uniqid('', true) . '.json';
+        file_put_contents($tmp, json_encode($config, JSON_THROW_ON_ERROR));
+        putenv('CONFIG_PATH=' . $tmp);
+        $_ENV['CONFIG_PATH'] = $tmp;
+        $_SERVER['CONFIG_PATH'] = $tmp;
+
+        return $tmp;
+    }
+}

--- a/tests/Unit/UploadHealthProbeConfigTest.php
+++ b/tests/Unit/UploadHealthProbeConfigTest.php
@@ -194,6 +194,26 @@ class UploadHealthProbeConfigTest extends TestCase
         $this->assertStringContainsString('unknown field', implode(' ', $errors));
     }
 
+    public function testValidateUploadHealthProbeConfig_RejectsNonStringCredentials(): void
+    {
+        $config = [
+            'config' => [
+                'upload_health_probe' => [
+                    'enabled' => true,
+                    'ftps' => ['username' => ['bad'], 'password' => 'abcdefghijklmn'],
+                    'sftp' => ['username' => 'probesftp12', 'password' => 12345678901234],
+                ],
+            ],
+            'airports' => [],
+        ];
+
+        $errors = validateUploadHealthProbeConfig($config);
+        $this->assertNotEmpty($errors);
+        $joined = implode(' ', $errors);
+        $this->assertStringContainsString('config.upload_health_probe.ftps: username must be a string', $joined);
+        $this->assertStringContainsString('config.upload_health_probe.sftp: password must be a string', $joined);
+    }
+
     public function testValidateUploadHealthProbeConfig_AllowsEmptyProbeConnectHost(): void
     {
         $config = [

--- a/tests/Unit/UploadHealthProbeWatchdogTest.php
+++ b/tests/Unit/UploadHealthProbeWatchdogTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class UploadHealthProbeWatchdogTest extends TestCase
 {
     #[\PHPUnit\Framework\Attributes\DataProvider('probeHeartbeatEpochProvider')]
-    public function testProbeHeartbeatEpochIsValid(string $epoch, int $expectedExitCode): void
+    public function testProbeHeartbeatEpochIsValid_VariousEpochs_MatchesExitCode(string $epoch, int $expectedExitCode): void
     {
         $common = dirname(__DIR__, 2) . '/scripts/upload-daemon-common.sh';
         $cmd = sprintf(

--- a/tests/Unit/UploadHealthProbeWatchdogTest.php
+++ b/tests/Unit/UploadHealthProbeWatchdogTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for upload health probe watchdog helpers in upload-daemon-common.sh.
+ */
+class UploadHealthProbeWatchdogTest extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('probeHeartbeatEpochProvider')]
+    public function testProbeHeartbeatEpochIsValid(string $epoch, int $expectedExitCode): void
+    {
+        $common = dirname(__DIR__, 2) . '/scripts/upload-daemon-common.sh';
+        $cmd = sprintf(
+            'bash -c %s',
+            escapeshellarg('. ' . $common . ' && probe_heartbeat_epoch_is_valid ' . escapeshellarg($epoch))
+        );
+        exec($cmd, $output, $code);
+        $this->assertSame($expectedExitCode, $code, implode("\n", $output));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: int}>
+     */
+    public static function probeHeartbeatEpochProvider(): array
+    {
+        return [
+            'positive integer' => ['1730123456', 0],
+            'zero' => ['0', 1],
+            'empty' => ['', 1],
+            'non-numeric' => ['oops', 1],
+            'float string' => ['1730123456.5', 1],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- Add functional FTPS and SFTP upload probes on a configurable interval (default 30s) with a heartbeat file for the service watchdog.
- Extend `service-watchdog.sh` to fail closed on missing or stale probe state, restart vsftpd and container sshd when needed, and throttle restarts to once per 30 minutes.
- Add `config.upload_health_probe` with schema validation (credential shape matches push cameras, dedicated probe usernames must not collide with push camera accounts).

## Commits

1. Constants for probe timing and shared upload credential limits
2. Shared `validatePushUploadUsername` / `validatePushUploadPassword` helpers
3. Config API and `validateUploadHealthProbeConfig` (runtime + structure validation)
4. `upload-probe.sh`, runner, and shared daemon restart helpers
5. Watchdog and PASV update script integration
6. Docker entrypoint, image install paths, logrotate
7. CONFIGURATION.md, OPERATIONS.md, example config snippet
8. Unit tests
9. Copilot review fixes (credential types, epoch validation, `duration_sec`, production `probe_connect_host` docs)

## Test plan

- [x] `make test-ci`
- [x] Enable `upload_health_probe` in production secrets with dedicated FTPS/SFTP probe users (not push camera usernames); run `sync-push-config`
- [x] Rebuild/restart web container; confirm `/var/lib/aviationwx/upload-probe.json` updates and `upload-probe.log` / `service-watchdog.log` look healthy
- [x] Simulate vsftpd wedge (optional): confirm watchdog restarts vsftpd after stale heartbeat with 30-minute throttle

## Production enablement

Probe runs only when `enabled` is strictly `true` in production. Production Docker uses host networking; set `probe_connect_host` to `127.0.0.1` so on-box probes hit local vsftpd/sshd (cameras still use `upload_hostname`).

```json
"upload_health_probe": {
  "enabled": true,
  "interval_sec": 30,
  "probe_connect_host": "127.0.0.1",
  "ftps": { "username": "...", "password": "..." },
  "sftp": { "username": "...", "password": "..." }
}
```

Passwords must be exactly 14 alphanumeric characters (same as push cameras).