### PR TITLE
Add contributions.enabled master feature gate

### DIFF
--- a/config/airports.json.example
+++ b/config/airports.json.example
@@ -91,6 +91,14 @@
     
     "_comment_geomag": "NOAA NCEI geomagnetic API key for automatic magnetic declination lookup. Register at https://www.ngdc.noaa.gov/geomag/CalcSurvey.shtml. When set, declination is fetched for airports without magnetic_declination override.",
     "geomag_api_key": "",
+
+    "_comment_contributions": "Master gate for Stripe sponsorship/contribute UX. Default false for OSS forks. Production secrets enable when ops console is live.",
+    "contributions": {
+      "enabled": false,
+      "platform_annual_goal_usd": 5000,
+      "goal_history": [],
+      "airport_goals": {}
+    },
     
     "default_preferences": {
       "time_format": "12hr",

--- a/lib/config.php
+++ b/lib/config.php
@@ -196,9 +196,10 @@ function isProduction(): bool {
  * Whether Stripe-backed contributions / sponsorship UX is enabled for this deployment.
  *
  * Master gate for all sponsor OSS code paths. Default false when key absent (fork-safe).
+ * Strict boolean check on enabled prevents accidental activation via truthy JSON values.
  *
  * @param array<string, mixed>|null $config Loaded config from loadConfig(); loaded when null
- * @return bool True when config.contributions.enabled is true
+ * @return bool True only when config.contributions.enabled is explicitly true
  */
 function isContributionsEnabled(?array $config = null): bool
 {

--- a/lib/config.php
+++ b/lib/config.php
@@ -193,6 +193,30 @@ function isProduction(): bool {
 }
 
 /**
+ * Whether Stripe-backed contributions / sponsorship UX is enabled for this deployment.
+ *
+ * Master gate for all sponsor OSS code paths. Default false when key absent (fork-safe).
+ *
+ * @param array<string, mixed>|null $config Loaded config from loadConfig(); loaded when null
+ * @return bool True when config.contributions.enabled is true
+ */
+function isContributionsEnabled(?array $config = null): bool
+{
+    if ($config === null) {
+        $config = loadConfig();
+    }
+    if ($config === null || !isset($config['config']['contributions'])) {
+        return false;
+    }
+    $block = $config['config']['contributions'];
+    if (!is_array($block)) {
+        return false;
+    }
+
+    return !empty($block['enabled']);
+}
+
+/**
  * Returns whether the HTTP host is the main site (apex or www), not a feature or airport subdomain.
  *
  * Compares case-insensitively against getBaseDomain() so config casing does not affect routing.

--- a/lib/config.php
+++ b/lib/config.php
@@ -213,7 +213,7 @@ function isContributionsEnabled(?array $config = null): bool
         return false;
     }
 
-    return !empty($block['enabled']);
+    return isset($block['enabled']) && $block['enabled'] === true;
 }
 
 /**

--- a/tests/Unit/ContributionsConfigTest.php
+++ b/tests/Unit/ContributionsConfigTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../lib/config.php';
@@ -38,8 +39,28 @@ class ContributionsConfigTest extends TestCase
         ]));
     }
 
-    public function testIsContributionsEnabled_NullParam_UsesLoadConfigWhenUnset(): void
+    #[DataProvider('nonBooleanEnabledProvider')]
+    public function testIsContributionsEnabled_NonBooleanEnabled_ReturnsFalse(mixed $enabled): void
     {
-        self::assertFalse(isContributionsEnabled(null));
+        self::assertFalse(isContributionsEnabled([
+            'config' => [
+                'contributions' => [
+                    'enabled' => $enabled,
+                ],
+            ],
+        ]));
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function nonBooleanEnabledProvider(): array
+    {
+        return [
+            'string false' => ['false'],
+            'string one' => ['1'],
+            'integer one' => [1],
+            'string true' => ['true'],
+        ];
     }
 }

--- a/tests/Unit/ContributionsConfigTest.php
+++ b/tests/Unit/ContributionsConfigTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/config.php';
+
+/**
+ * Tests for contributions feature gate (isContributionsEnabled).
+ */
+class ContributionsConfigTest extends TestCase
+{
+    public function testDisabledWhenKeyAbsent(): void
+    {
+        self::assertFalse(isContributionsEnabled(['config' => []]));
+    }
+
+    public function testDisabledWhenEnabledFalse(): void
+    {
+        self::assertFalse(isContributionsEnabled([
+            'config' => [
+                'contributions' => [
+                    'enabled' => false,
+                ],
+            ],
+        ]));
+    }
+
+    public function testEnabledWhenEnabledTrue(): void
+    {
+        self::assertTrue(isContributionsEnabled([
+            'config' => [
+                'contributions' => [
+                    'enabled' => true,
+                ],
+            ],
+        ]));
+    }
+
+    public function testNullConfigReturnsFalse(): void
+    {
+        self::assertFalse(isContributionsEnabled(null));
+    }
+}

--- a/tests/Unit/ContributionsConfigTest.php
+++ b/tests/Unit/ContributionsConfigTest.php
@@ -11,12 +11,12 @@ require_once __DIR__ . '/../../lib/config.php';
  */
 class ContributionsConfigTest extends TestCase
 {
-    public function testDisabledWhenKeyAbsent(): void
+    public function testIsContributionsEnabled_KeyAbsent_ReturnsFalse(): void
     {
         self::assertFalse(isContributionsEnabled(['config' => []]));
     }
 
-    public function testDisabledWhenEnabledFalse(): void
+    public function testIsContributionsEnabled_EnabledFalse_ReturnsFalse(): void
     {
         self::assertFalse(isContributionsEnabled([
             'config' => [
@@ -27,7 +27,7 @@ class ContributionsConfigTest extends TestCase
         ]));
     }
 
-    public function testEnabledWhenEnabledTrue(): void
+    public function testIsContributionsEnabled_EnabledTrue_ReturnsTrue(): void
     {
         self::assertTrue(isContributionsEnabled([
             'config' => [
@@ -38,7 +38,7 @@ class ContributionsConfigTest extends TestCase
         ]));
     }
 
-    public function testNullConfigReturnsFalse(): void
+    public function testIsContributionsEnabled_NullParam_UsesLoadConfigWhenUnset(): void
     {
         self::assertFalse(isContributionsEnabled(null));
     }

--- a/tests/Unit/ContributionsConfigTest.php
+++ b/tests/Unit/ContributionsConfigTest.php
@@ -7,9 +7,6 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../lib/config.php';
 
-/**
- * Tests for contributions feature gate (isContributionsEnabled).
- */
 class ContributionsConfigTest extends TestCase
 {
     public function testIsContributionsEnabled_KeyAbsent_ReturnsFalse(): void


### PR DESCRIPTION
## Summary
- Adds `isContributionsEnabled()` in `lib/config.php` as the master gate for all Stripe sponsorship/contribute OSS paths.
- Documents `config.contributions` in `airports.json.example` (default `enabled: false` for forks).
- Unit tests in `ContributionsConfigTest.php`.

## Context
Part of the ops console / funding launch plan. **Do not merge** until the private ops console has been reviewed and tested.

## Test plan
- [x] `vendor/bin/phpunit tests/Unit/ContributionsConfigTest.php`
- [x] Full `make test-ci` before merge