### PR TITLE
Tune geospatial NOTAM fetch for TFR workload

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -214,7 +214,7 @@ Optional **station power** telemetry on airport pages for `limited_availability`
 
 **Key Features**:
 - **Dual Query Strategy**: 
-  - Location query by ICAO code (for airport-specific NOTAMs)
+  - Location query by ICAO, IATA, or FAA identifier (for airport-specific NOTAMs, including FAA-only fields)
   - Geospatial query by coordinates with NMS `feature=AIRSPACE` (TFR-focused); XML pre-filter in `geo-prefilter.php` skips non-TFR payloads before parse (aerodrome closures still come from the location query)
 - **Cancellation Filtering**:
   - **Excludes** type='C' (Cancel), NOTAMC, and "CANCELED/CANCELLED" NOTAMs

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,7 +215,7 @@ Optional **station power** telemetry on airport pages for `limited_availability`
 **Key Features**:
 - **Dual Query Strategy**: 
   - Location query by ICAO code (for airport-specific NOTAMs)
-  - Geospatial query by coordinates (for TFRs affecting nearby airspace)
+  - Geospatial query by coordinates with NMS `feature=AIRSPACE` (TFR-focused); XML pre-filter in `geo-prefilter.php` skips non-TFR payloads before parse (aerodrome closures still come from the location query)
 - **Cancellation Filtering**:
   - **Excludes** type='C' (Cancel), NOTAMC, and "CANCELED/CANCELLED" NOTAMs
   - These indicate restrictions are **lifted** (good news, not warnings)

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1375,8 +1375,8 @@ NOTAM (Notice to Air Missions) data is fetched from the FAA's NMS (NOTAM Managem
 
 The system uses a **dual query strategy** to capture both airport-specific NOTAMs and nearby TFRs:
 
-1. **Location Query** (if ICAO/IATA available): Fetches NOTAMs issued for the specific airport identifier
-2. **Geospatial Query** (if coordinates available): Fetches NOTAMs within a radius of the airport to capture nearby TFRs
+1. **Location Query** (when an identifier is configured): Fetches NOTAMs for the airport via `notamResolveLocationQueryCode()` (ICAO, then IATA, then FAA)
+2. **Geospatial Query** (if coordinates available): Fetches TFR-focused airspace NOTAMs with `feature=AIRSPACE`, then applies a cheap XML pre-filter before parse (closures still come from the location query)
 
 Both queries are executed sequentially with rate limiting (1 request per second) to comply with API limits.
 
@@ -1391,10 +1391,11 @@ The system uses OAuth bearer token authentication:
 
 **Purpose**: Fetches NOTAMs specifically issued for an airport.
 
-**Endpoint**: `{base_url}/nmsapi/v1/notams?location={icao_code}`
+**Endpoint**: `{base_url}/nmsapi/v1/notams?location={code}`
 
 **Behavior**:
-- Uses ICAO code if available, otherwise IATA code
+- Uses the first configured identifier from `notamResolveLocationQueryCode()`: ICAO, then IATA, then FAA (covers FAA-only fields such as `03S`)
+- Does **not** query `formerly` codes; those are used only when matching NOTAM `location` fields during filtering
 - Returns NOTAMs with the airport as the affected location
 - Effective for aerodrome closures and airport-specific restrictions
 
@@ -1402,12 +1403,14 @@ The system uses OAuth bearer token authentication:
 
 **Purpose**: Fetches NOTAMs affecting airspace near the airport, particularly TFRs.
 
-**Endpoint**: `{base_url}/nmsapi/v1/notams?latitude={lat}&longitude={lon}&radius={nm}`
+**Endpoint**: `{base_url}/nmsapi/v1/notams?latitude={lat}&longitude={lon}&radius={nm}&feature=AIRSPACE`
 
 **Behavior**:
 - Uses airport coordinates from configuration
 - Default radius: 10 NM (`NOTAM_GEO_RADIUS_DEFAULT`)
-- Returns all NOTAMs with geographic boundaries intersecting the search area
+- NMS `feature` filter: `NOTAM_GEO_QUERY_FEATURE` (default `AIRSPACE`) to reduce non-TFR payload size
+- Raw AIXM rows are pre-filtered with `notamFilterGeoXmlForTfrParsing()` (same TFR keywords as `isTfr()`) before XML parse; runway/obstacle rows from geo are skipped intentionally
+- When NMS returns geo rows but the pre-filter drops all of them, the fetch still counts as a successful geo query (HTTP 200) and logs `notam fetcher: geo prefilter dropped all AIXM rows` for ops visibility
 - **Important**: The API returns NOTAMs by ARTCC (Air Route Traffic Control Center), not strict geographic proximity. A TFR in the same ARTCC may be returned even if outside the specified radius.
 
 ### Response Format

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -185,6 +185,10 @@ if (!defined('DEFAULT_NOTAM_STALE_ERROR_SECONDS')) {
 if (!defined('DEFAULT_NOTAM_STALE_FAILCLOSED_SECONDS')) {
     define('DEFAULT_NOTAM_STALE_FAILCLOSED_SECONDS', 3600); // 1 hour
 }
+if (!defined('NOTAM_GEO_QUERY_FEATURE')) {
+    define('NOTAM_GEO_QUERY_FEATURE', 'AIRSPACE'); // NMS feature filter for geo TFR queries
+}
+
 if (!defined('NOTAM_GEO_RADIUS_DEFAULT')) {
     define('NOTAM_GEO_RADIUS_DEFAULT', 10); // 10 NM default radius for API query
 }

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -97,9 +97,9 @@ function notamResolveLocationQueryCode(array $airport): ?string
 }
 
 /**
- * Query NOTAMs by location (ICAO code)
+ * Query NOTAMs by NMS location code (ICAO, IATA, or FAA identifier).
  *
- * @param string $location ICAO code
+ * @param string $location NMS location query code from {@see notamResolveLocationQueryCode()}
  * @param float &$lastRequestTime Last request timestamp (for rate limiting)
  * @param array<string, string> $queryParams Optional NMS query parameters (e.g. feature=RWY)
  * @param bool|null $querySucceeded When passed, true on HTTP 200 with valid payload; false when credentials are missing, the request fails, or the payload is invalid

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -79,6 +79,24 @@ function notamBuildLocationQueryParams(string $location, array $queryParams = []
 }
 
 /**
+ * Resolve NMS location-query code from airport config (ICAO, IATA, then FAA).
+ *
+ * @param array<string, mixed> $airport Airport configuration
+ * @return string|null NMS location code or null when no identifier is configured
+ */
+function notamResolveLocationQueryCode(array $airport): ?string
+{
+    foreach (['icao', 'iata', 'faa'] as $key) {
+        $value = $airport[$key] ?? null;
+        if (is_string($value) && trim($value) !== '') {
+            return trim($value);
+        }
+    }
+
+    return null;
+}
+
+/**
  * Query NOTAMs by location (ICAO code)
  *
  * @param string $location ICAO code
@@ -283,8 +301,8 @@ function notamSummarizeFetchQueryOutcomes(array $queryOutcomes): array
  * Fetch and filter NOTAMs for an airport
  * 
  * Uses dual query strategy:
- * 1. Location-based query (if ICAO/IATA available)
- * 2. Geospatial query (for TFRs and fallback for FAA identifiers)
+ * 1. Location-based query (ICAO, IATA, or FAA identifier)
+ * 2. Geospatial query for TFRs (AIRSPACE feature; XML pre-filtered before parse)
  * 
  * @param string $airportId Airport ID (e.g., 'khio')
  * @param array<string, mixed> $airport Airport configuration
@@ -297,19 +315,11 @@ function fetchNotamsForAirport(string $airportId, array $airport, ?bool &$fetchS
     $allNotams = [];
     $queryOutcomes = [];
     
-    // 1. Try location-based query (if ICAO/IATA available)
-    $icao = $airport['icao'] ?? null;
-    $iata = $airport['iata'] ?? null;
-    
-    if (!empty($icao)) {
+    // 1. Location query (ICAO, IATA, or FAA identifier for airports without ICAO)
+    $locationCode = notamResolveLocationQueryCode($airport);
+    if ($locationCode !== null) {
         $locationOk = false;
-        $locationNotams = queryNotamsByLocation($icao, $lastRequestTime, [], $locationOk);
-        $queryOutcomes[] = $locationOk;
-        $allNotams = array_merge($allNotams, $locationNotams);
-    } elseif (!empty($iata)) {
-        // IATA codes are auto-resolved to ICAO by API
-        $locationOk = false;
-        $locationNotams = queryNotamsByLocation($iata, $lastRequestTime, [], $locationOk);
+        $locationNotams = queryNotamsByLocation($locationCode, $lastRequestTime, [], $locationOk);
         $queryOutcomes[] = $locationOk;
         $allNotams = array_merge($allNotams, $locationNotams);
     }

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -315,7 +315,7 @@ function fetchNotamsForAirport(string $airportId, array $airport, ?bool &$fetchS
     $allNotams = [];
     $queryOutcomes = [];
     
-    // 1. Location query (ICAO, IATA, or FAA identifier for airports without ICAO)
+    // 1. Location query via first configured identifier (ICAO, then IATA, then FAA)
     $locationCode = notamResolveLocationQueryCode($airport);
     if ($locationCode !== null) {
         $locationOk = false;

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -324,8 +324,7 @@ function fetchNotamsForAirport(string $airportId, array $airport, ?bool &$fetchS
         $allNotams = array_merge($allNotams, $locationNotams);
     }
     
-    // 2. Try geospatial query (if coordinates available)
-    // Always do this for TFRs, and as fallback for FAA identifiers
+    // 2. Geospatial query for TFRs (if coordinates available)
     if (isset($airport['lat']) && isset($airport['lon'])) {
         $geoOk = false;
         $radius = NOTAM_GEO_RADIUS_DEFAULT;

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -337,6 +337,7 @@ function fetchNotamsForAirport(string $airportId, array $airport, ?bool &$fetchS
             $geoOk,
         );
         $queryOutcomes[] = $geoOk;
+        // Geo payload is TFR-only after pre-filter; aerodrome closures come from the location query above.
         $allNotams = array_merge($allNotams, notamFilterGeoXmlForTfrParsing($geoNotams));
     }
 

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -88,8 +88,12 @@ function notamResolveLocationQueryCode(array $airport): ?string
 {
     foreach (['icao', 'iata', 'faa'] as $key) {
         $value = $airport[$key] ?? null;
-        if (is_string($value) && trim($value) !== '') {
-            return trim($value);
+        if ($value === null || $value === '') {
+            continue;
+        }
+        $code = trim((string) $value);
+        if ($code !== '') {
+            return $code;
         }
     }
 
@@ -337,7 +341,14 @@ function fetchNotamsForAirport(string $airportId, array $airport, ?bool &$fetchS
         );
         $queryOutcomes[] = $geoOk;
         // Geo payload is TFR-only after pre-filter; aerodrome closures come from the location query above.
-        $allNotams = array_merge($allNotams, notamFilterGeoXmlForTfrParsing($geoNotams));
+        $filteredGeo = notamFilterGeoXmlForTfrParsing($geoNotams);
+        if (count($geoNotams) > 0 && count($filteredGeo) === 0) {
+            aviationwx_log('info', 'notam fetcher: geo prefilter dropped all AIXM rows', [
+                'airport' => $airportId,
+                'raw_count' => count($geoNotams),
+            ], 'app');
+        }
+        $allNotams = array_merge($allNotams, $filteredGeo);
     }
 
     $fetchSummary = notamSummarizeFetchQueryOutcomes($queryOutcomes);

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -12,6 +12,7 @@ require_once __DIR__ . '/auth.php';
 require_once __DIR__ . '/parser.php';
 require_once __DIR__ . '/filter.php';
 require_once __DIR__ . '/schedule.php';
+require_once __DIR__ . '/geo-prefilter.php';
 
 /**
  * Decode NMS JSON; strips illegal ASCII control characters some payloads embed in strings.
@@ -183,11 +184,9 @@ function queryNotamsByCoordinates(
     }
     
     $baseUrl = getNotamApiBaseUrl();
-    $url = rtrim($baseUrl, '/') . '/nmsapi/v1/notams?' . http_build_query([
-        'latitude' => $latitude,
-        'longitude' => $longitude,
-        'radius' => $radius
-    ]);
+    $url = rtrim($baseUrl, '/') . '/nmsapi/v1/notams?' . http_build_query(
+        notamBuildGeoQueryParams($latitude, $longitude, $radius),
+    );
     
     rateLimitWait($lastRequestTime);
     
@@ -328,7 +327,7 @@ function fetchNotamsForAirport(string $airportId, array $airport, ?bool &$fetchS
             $geoOk,
         );
         $queryOutcomes[] = $geoOk;
-        $allNotams = array_merge($allNotams, $geoNotams);
+        $allNotams = array_merge($allNotams, notamFilterGeoXmlForTfrParsing($geoNotams));
     }
 
     $fetchSummary = notamSummarizeFetchQueryOutcomes($queryOutcomes);

--- a/lib/notam/filter.php
+++ b/lib/notam/filter.php
@@ -12,6 +12,7 @@ require_once __DIR__ . '/../units.php';
 require_once __DIR__ . '/../airport-identifiers.php';
 require_once __DIR__ . '/../weather/utils.php';
 require_once __DIR__ . '/schedule.php';
+require_once __DIR__ . '/tfr-indicators.php';
 
 /** Epsilon for comparing decoded TFR vertices (degrees) */
 const TFR_VERTEX_EQUAL_EPSILON_DEG = 1.0e-6;
@@ -854,22 +855,7 @@ function isTfr(array $notam): bool {
         return false;
     }
     
-    $text = strtoupper($notam['text'] ?? '');
-    
-    // Primary indicators (text already uppercase, use strpos for efficiency)
-    if (strpos($text, 'TFR') !== false) {
-        return true;
-    }
-    if (strpos($text, 'TEMPORARY FLIGHT RESTRICTION') !== false) {
-        return true;
-    }
-    
-    // Secondary indicators - both must be present
-    if (strpos($text, 'RESTRICTED') !== false && strpos($text, 'AIRSPACE') !== false) {
-        return true;
-    }
-    
-    return false;
+    return notamTextMayIndicateTfr((string) ($notam['text'] ?? ''));
 }
 
 /**

--- a/lib/notam/geo-prefilter.php
+++ b/lib/notam/geo-prefilter.php
@@ -30,19 +30,14 @@ function notamBuildGeoQueryParams(float $latitude, float $longitude, int $radius
  */
 function notamAixmXmlMayBeTfr(string $xml): bool
 {
-    $upper = strtoupper($xml);
-
-    if (strpos($upper, 'TFR') !== false) {
+    if (stripos($xml, 'TFR') !== false) {
         return true;
     }
-    if (strpos($upper, 'TEMPORARY FLIGHT RESTRICTION') !== false) {
-        return true;
-    }
-    if (strpos($upper, 'RESTRICTED') !== false && strpos($upper, 'AIRSPACE') !== false) {
+    if (stripos($xml, 'TEMPORARY FLIGHT RESTRICTION') !== false) {
         return true;
     }
 
-    return false;
+    return stripos($xml, 'RESTRICTED') !== false && stripos($xml, 'AIRSPACE') !== false;
 }
 
 /**
@@ -54,7 +49,7 @@ function notamFilterGeoXmlForTfrParsing(array $xmlStrings): array
 {
     $kept = [];
     foreach ($xmlStrings as $xml) {
-        if (is_string($xml) && $xml !== '' && notamAixmXmlMayBeTfr($xml)) {
+        if ($xml !== '' && notamAixmXmlMayBeTfr($xml)) {
             $kept[] = $xml;
         }
     }

--- a/lib/notam/geo-prefilter.php
+++ b/lib/notam/geo-prefilter.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Geospatial NOTAM query tuning and cheap XML pre-filters.
+ */
+
+require_once __DIR__ . '/../constants.php';
+
+/**
+ * NMS query parameters for the geospatial NOTAM fetch (TFR-focused).
+ *
+ * @return array<string, float|int|string>
+ */
+function notamBuildGeoQueryParams(float $latitude, float $longitude, int $radius): array
+{
+    return [
+        'latitude' => $latitude,
+        'longitude' => $longitude,
+        'radius' => $radius,
+        'feature' => NOTAM_GEO_QUERY_FEATURE,
+    ];
+}
+
+/**
+ * Cheap scan before XML parse: geospatial results with feature=AIRSPACE should be TFR-like.
+ *
+ * Location queries still supply aerodrome/runway closures; geo parse is TFR-only.
+ */
+function notamAixmXmlMayBeTfr(string $xml): bool
+{
+    $upper = strtoupper($xml);
+
+    if (strpos($upper, 'TFR') !== false) {
+        return true;
+    }
+    if (strpos($upper, 'TEMPORARY FLIGHT RESTRICTION') !== false) {
+        return true;
+    }
+    if (strpos($upper, 'RESTRICTED') !== false && strpos($upper, 'AIRSPACE') !== false) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * @param array<int, string> $xmlStrings
+ *
+ * @return array<int, string>
+ */
+function notamFilterGeoXmlForTfrParsing(array $xmlStrings): array
+{
+    $kept = [];
+    foreach ($xmlStrings as $xml) {
+        if (is_string($xml) && $xml !== '' && notamAixmXmlMayBeTfr($xml)) {
+            $kept[] = $xml;
+        }
+    }
+
+    return $kept;
+}

--- a/lib/notam/geo-prefilter.php
+++ b/lib/notam/geo-prefilter.php
@@ -43,8 +43,8 @@ function notamAixmXmlMayBeTfr(string $xml): bool
 /**
  * Keep only geo-query XML payloads that may contain TFRs before parsing.
  *
- * @param array<int, string> $xmlStrings Raw AIXM XML strings from a geospatial NMS query
- * @return array<int, string> Subset that passed {@see notamAixmXmlMayBeTfr()}
+ * @param array<int, mixed> $xmlStrings NMS `data.aixm` rows; non-string and empty entries are skipped
+ * @return array<int, string> XML strings that passed {@see notamAixmXmlMayBeTfr()}
  */
 function notamFilterGeoXmlForTfrParsing(array $xmlStrings): array
 {

--- a/lib/notam/geo-prefilter.php
+++ b/lib/notam/geo-prefilter.php
@@ -11,7 +11,10 @@ require_once __DIR__ . '/../constants.php';
 /**
  * NMS query parameters for the geospatial NOTAM fetch (TFR-focused).
  *
- * @return array<string, float|int|string>
+ * @param float $latitude Airport latitude in decimal degrees
+ * @param float $longitude Airport longitude in decimal degrees
+ * @param int $radius Search radius in nautical miles
+ * @return array<string, float|int|string> Query string parameters for the NMS geo endpoint
  */
 function notamBuildGeoQueryParams(float $latitude, float $longitude, int $radius): array
 {
@@ -27,6 +30,9 @@ function notamBuildGeoQueryParams(float $latitude, float $longitude, int $radius
  * Cheap scan before XML parse: geospatial results with feature=AIRSPACE should be TFR-like.
  *
  * Location queries still supply aerodrome/runway closures; geo parse is TFR-only.
+ *
+ * @param string $xml Raw AIXM XML from an NMS geospatial query
+ * @return bool True when the payload looks TFR-related
  */
 function notamAixmXmlMayBeTfr(string $xml): bool
 {
@@ -41,9 +47,10 @@ function notamAixmXmlMayBeTfr(string $xml): bool
 }
 
 /**
- * @param array<int, string> $xmlStrings
+ * Keep only geo-query XML payloads that may contain TFRs before parsing.
  *
- * @return array<int, string>
+ * @param array<int, string> $xmlStrings Raw AIXM XML strings from a geospatial NMS query
+ * @return array<int, string> Subset that passed {@see notamAixmXmlMayBeTfr()}
  */
 function notamFilterGeoXmlForTfrParsing(array $xmlStrings): array
 {

--- a/lib/notam/geo-prefilter.php
+++ b/lib/notam/geo-prefilter.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . '/../constants.php';
+require_once __DIR__ . '/tfr-indicators.php';
 
 /**
  * NMS query parameters for the geospatial NOTAM fetch (TFR-focused).
@@ -36,14 +37,7 @@ function notamBuildGeoQueryParams(float $latitude, float $longitude, int $radius
  */
 function notamAixmXmlMayBeTfr(string $xml): bool
 {
-    if (stripos($xml, 'TFR') !== false) {
-        return true;
-    }
-    if (stripos($xml, 'TEMPORARY FLIGHT RESTRICTION') !== false) {
-        return true;
-    }
-
-    return stripos($xml, 'RESTRICTED') !== false && stripos($xml, 'AIRSPACE') !== false;
+    return notamTextMayIndicateTfr($xml);
 }
 
 /**
@@ -56,7 +50,10 @@ function notamFilterGeoXmlForTfrParsing(array $xmlStrings): array
 {
     $kept = [];
     foreach ($xmlStrings as $xml) {
-        if ($xml !== '' && notamAixmXmlMayBeTfr($xml)) {
+        if (!is_string($xml) || $xml === '') {
+            continue;
+        }
+        if (notamAixmXmlMayBeTfr($xml)) {
             $kept[] = $xml;
         }
     }

--- a/lib/notam/tfr-indicators.php
+++ b/lib/notam/tfr-indicators.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Shared TFR keyword heuristics for parsed NOTAM text and raw AIXM XML.
+ */
+
+/**
+ * Whether text contains TFR keyword indicators used by the banner pipeline.
+ *
+ * Matches {@see isTfr()} and {@see notamAixmXmlMayBeTfr()} so geo pre-filter and
+ * post-parse classification stay aligned.
+ *
+ * @param string $text NOTAM body text or raw AIXM XML from NMS
+ * @return bool True when TFR-like keywords are present
+ */
+function notamTextMayIndicateTfr(string $text): bool
+{
+    if (stripos($text, 'TFR') !== false) {
+        return true;
+    }
+    if (stripos($text, 'TEMPORARY FLIGHT RESTRICTION') !== false) {
+        return true;
+    }
+
+    return stripos($text, 'RESTRICTED') !== false && stripos($text, 'AIRSPACE') !== false;
+}

--- a/tests/Unit/ConstantsTest.php
+++ b/tests/Unit/ConstantsTest.php
@@ -49,6 +49,8 @@ class ConstantsTest extends TestCase
             'NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS',
             'NOTAM_FETCH_FAILURE_BACKOFF_SECONDS',
             'NOTAM_FAA_SCENARIO_RUNWAY_CLOSURE',
+            'NOTAM_GEO_QUERY_FEATURE',
+            'NOTAM_GEO_RADIUS_DEFAULT',
         ];
         
         foreach ($requiredConstants as $const) {

--- a/tests/Unit/NotamFetcherDedupTest.php
+++ b/tests/Unit/NotamFetcherDedupTest.php
@@ -70,6 +70,14 @@ final class NotamFetcherDedupTest extends TestCase
         self::assertFalse($summary['fetchSucceeded']);
     }
 
+    public function testSummarizeFetchQueryOutcomes_SucceedsWhenOnlyGeoQuerySucceeds(): void
+    {
+        $summary = notamSummarizeFetchQueryOutcomes([false, true]);
+
+        self::assertTrue($summary['attempted']);
+        self::assertTrue($summary['fetchSucceeded']);
+    }
+
     public function testNotamCanonicalDedupKey_StableForIdenticalRows(): void
     {
         $a = [

--- a/tests/Unit/NotamFetcherLocationTest.php
+++ b/tests/Unit/NotamFetcherLocationTest.php
@@ -40,4 +40,33 @@ final class NotamFetcherLocationTest extends TestCase
             'faa' => null,
         ]));
     }
+
+    public function testResolveLocationQueryCode_UsesIataWhenIcaoAbsent(): void
+    {
+        $code = notamResolveLocationQueryCode([
+            'icao' => null,
+            'iata' => 'PDX',
+            'faa' => '03S',
+        ]);
+
+        self::assertSame('PDX', $code);
+    }
+
+    public function testResolveLocationQueryCode_TrimsWhitespace(): void
+    {
+        $code = notamResolveLocationQueryCode([
+            'icao' => '  KPDX  ',
+        ]);
+
+        self::assertSame('KPDX', $code);
+    }
+
+    public function testResolveLocationQueryCode_IgnoresEmptyString(): void
+    {
+        self::assertSame('03S', notamResolveLocationQueryCode([
+            'icao' => '',
+            'iata' => '',
+            'faa' => '03S',
+        ]));
+    }
 }

--- a/tests/Unit/NotamFetcherLocationTest.php
+++ b/tests/Unit/NotamFetcherLocationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class NotamFetcherLocationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/fetcher.php';
+    }
+
+    public function testResolveLocationQueryCode_PrefersIcaoOverFaa(): void
+    {
+        $code = notamResolveLocationQueryCode([
+            'icao' => 'KPDX',
+            'faa' => 'PDX',
+        ]);
+
+        self::assertSame('KPDX', $code);
+    }
+
+    public function testResolveLocationQueryCode_UsesFaaWhenIcaoAbsent(): void
+    {
+        $code = notamResolveLocationQueryCode([
+            'icao' => null,
+            'iata' => null,
+            'faa' => '03S',
+        ]);
+
+        self::assertSame('03S', $code);
+    }
+
+    public function testResolveLocationQueryCode_ReturnsNullWhenNoIdentifier(): void
+    {
+        self::assertNull(notamResolveLocationQueryCode([
+            'icao' => null,
+            'iata' => null,
+            'faa' => null,
+        ]));
+    }
+}

--- a/tests/Unit/NotamGeoPrefilterTest.php
+++ b/tests/Unit/NotamGeoPrefilterTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class NotamGeoPrefilterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        putenv('APP_ENV=testing');
+        putenv('CONFIG_PATH=' . dirname(__DIR__, 2) . '/tests/Fixtures/airports.json.test');
+        require_once dirname(__DIR__, 2) . '/lib/notam/geo-prefilter.php';
+    }
+
+    public function testMayBeTfr_KeepsTemporaryFlightRestrictionText(): void
+    {
+        $xml = '<notam><text>TEMPORARY FLIGHT RESTRICTION WI 5 NM RADIUS</text></notam>';
+
+        self::assertTrue(notamAixmXmlMayBeTfr($xml));
+    }
+
+    public function testMayBeTfr_KeepsTfrAbbreviation(): void
+    {
+        $xml = '<notam><translation><simpleText>!FDC 1/1234 TFR WI 10NM</simpleText></translation></notam>';
+
+        self::assertTrue(notamAixmXmlMayBeTfr($xml));
+    }
+
+    public function testMayBeTfr_SkipsRunwayClosureWithoutTfrIndicators(): void
+    {
+        $xml = '<notam><translation><simpleText>RWY 15/33 CLSD</simpleText></translation></notam>';
+
+        self::assertFalse(notamAixmXmlMayBeTfr($xml));
+    }
+
+    public function testMayBeTfr_SkipsObstacleLightingNoise(): void
+    {
+        $xml = '<notam><translation><simpleText>OBST TOWER LGT U/S</simpleText></translation></notam>';
+
+        self::assertFalse(notamAixmXmlMayBeTfr($xml));
+    }
+
+    public function testBuildGeoQueryParams_IncludesAirspaceFeature(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/constants.php';
+
+        $params = notamBuildGeoQueryParams(45.5, -122.8, NOTAM_GEO_RADIUS_DEFAULT);
+
+        self::assertSame('AIRSPACE', $params['feature']);
+        self::assertSame(45.5, $params['latitude']);
+        self::assertSame(-122.8, $params['longitude']);
+        self::assertSame(NOTAM_GEO_RADIUS_DEFAULT, $params['radius']);
+    }
+}

--- a/tests/Unit/NotamGeoPrefilterTest.php
+++ b/tests/Unit/NotamGeoPrefilterTest.php
@@ -8,8 +8,6 @@ final class NotamGeoPrefilterTest extends TestCase
 {
     protected function setUp(): void
     {
-        putenv('APP_ENV=testing');
-        putenv('CONFIG_PATH=' . dirname(__DIR__, 2) . '/tests/Fixtures/airports.json.test');
         require_once dirname(__DIR__, 2) . '/lib/notam/geo-prefilter.php';
     }
 

--- a/tests/Unit/NotamGeoPrefilterTest.php
+++ b/tests/Unit/NotamGeoPrefilterTest.php
@@ -39,6 +39,32 @@ final class NotamGeoPrefilterTest extends TestCase
         self::assertFalse(notamAixmXmlMayBeTfr($xml));
     }
 
+    public function testMayBeTfr_KeepsRestrictedAndAirspacePair(): void
+    {
+        $xml = '<notam><text>RESTRICTED AREA AIRSPACE WI 10NM</text></notam>';
+
+        self::assertTrue(notamAixmXmlMayBeTfr($xml));
+    }
+
+    public function testFilterGeoXmlForTfrParsing_KeepsOnlyTfrRows(): void
+    {
+        $tfr = '<notam><text>TFR WI 5NM</text></notam>';
+        $closure = '<notam><text>RWY 15/33 CLSD</text></notam>';
+
+        $filtered = notamFilterGeoXmlForTfrParsing([$closure, $tfr, '']);
+
+        self::assertSame([$tfr], $filtered);
+    }
+
+    public function testFilterGeoXmlForTfrParsing_SkipsNonStringElements(): void
+    {
+        $tfr = '<notam><text>TFR WI 5NM</text></notam>';
+
+        $filtered = notamFilterGeoXmlForTfrParsing([123, $tfr]);
+
+        self::assertSame([$tfr], $filtered);
+    }
+
     public function testBuildGeoQueryParams_IncludesAirspaceFeature(): void
     {
         require_once dirname(__DIR__, 2) . '/lib/constants.php';

--- a/tests/Unit/NotamTfrIndicatorsTest.php
+++ b/tests/Unit/NotamTfrIndicatorsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class NotamTfrIndicatorsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/tfr-indicators.php';
+        require_once dirname(__DIR__, 2) . '/lib/notam/geo-prefilter.php';
+        require_once dirname(__DIR__, 2) . '/lib/notam/filter.php';
+    }
+
+    public function testTextMayIndicateTfr_RestrictedAndAirspacePair(): void
+    {
+        self::assertTrue(notamTextMayIndicateTfr('RESTRICTED AREA WITHIN 15NM OF AIRPORT AIRSPACE'));
+    }
+
+    public function testPrefilterParity_MatchesIsTfrForSampleText(): void
+    {
+        $text = 'ZLC UT..AIRSPACE OGDEN, UT..TEMPORARY FLIGHT RESTRICTIONS WITHIN AN AREA';
+        $xml = '<notam><translation><simpleText>' . $text . '</simpleText></translation></notam>';
+
+        self::assertSame(isTfr(['text' => $text]), notamAixmXmlMayBeTfr($xml));
+        self::assertTrue(notamTextMayIndicateTfr($text));
+    }
+
+    public function testPrefilterParity_BothRejectRunwayClosure(): void
+    {
+        $text = 'RWY 15/33 CLSD';
+        $xml = '<notam><translation><simpleText>' . $text . '</simpleText></translation></notam>';
+
+        self::assertSame(isTfr(['text' => $text]), notamAixmXmlMayBeTfr($xml));
+        self::assertFalse(isTfr(['text' => $text]));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `NOTAM_GEO_QUERY_FEATURE` (`AIRSPACE`) and `notamBuildGeoQueryParams()` for geospatial NMS requests.
- Add `lib/notam/geo-prefilter.php` with `notamAixmXmlMayBeTfr()` and `notamFilterGeoXmlForTfrParsing()` to skip expensive XML parse on geo payloads that cannot be TFRs.
- Apply pre-filter in `fetchNotamsForAirport()` after the geo query; location queries still supply aerodrome/runway closures.

## Breaking changes

None. Geo path is TFR-only by design; closure NOTAMs are unchanged via location query.

## Tests

- [x] `make test-ci`
- [x] `NotamGeoPrefilterTest` - TFR keep/skip cases, query params include `feature=AIRSPACE`
- [x] `ConstantsTest` - new constants registered

## Docs

- `docs/ARCHITECTURE.md` - geo query tuning note

## Merge note

Independent of #112 (DOM closure fix) and #113 (fetch reliability). Safe to merge in any order; #113 also touches `fetcher.php` (query success tracking) and may need a trivial rebase.