### PR TITLE
fix(metrics): flush partial spill merge when per-run budget is hit

### DIFF
--- a/lib/metrics-spill-aggregator.php
+++ b/lib/metrics-spill-aggregator.php
@@ -15,6 +15,8 @@ require_once __DIR__ . '/metrics.php';
  * Run one spill merge pass under a non-blocking singleton lock.
  *
  * Respects METRICS_SPILL_MERGE_MAX_FILES_PER_RUN and METRICS_SPILL_MERGE_MAX_RUNTIME_MS.
+ * When the budget is hit mid-hour, merged counters are written to the hourly file and consumed
+ * spill shards are deleted so the next pass can continue the same UTC bucket (avoids stuck backlogs).
  *
  * @return array<string, mixed> Telemetry keys: lock_contended (bool), hours_touched (int),
  *         hourly_writes (int), spills_merged (int), spills_deleted (int), orphans_pruned (int),
@@ -109,13 +111,16 @@ function metrics_run_spill_aggregator_once(): array
             metrics_normalize_hour_bucket_for_merge($hourData, $hourId);
 
             $pendingDeletes = [];
+            $hourBudgetExhausted = false;
 
             foreach ($spillFiles as $spillPath) {
                 if ($filesMergedThisRun >= METRICS_SPILL_MERGE_MAX_FILES_PER_RUN) {
-                    break 2;
+                    $hourBudgetExhausted = true;
+                    break;
                 }
                 if (metrics_spill_aggregator_runtime_ms($t0Ns) >= METRICS_SPILL_MERGE_MAX_RUNTIME_MS) {
-                    break 2;
+                    $hourBudgetExhausted = true;
+                    break;
                 }
 
                 $parsed = metrics_spill_aggregator_parse_spill_file($spillPath, $hourId);
@@ -133,28 +138,7 @@ function metrics_run_spill_aggregator_once(): array
                 continue;
             }
 
-            $hourData['last_flush'] = time();
-
-            $jsonPayload = json_encode($hourData, JSON_PRETTY_PRINT);
-            if ($jsonPayload === false) {
-                $stats['errors'][] = 'json_encode_failed:' . $hourId;
-
-                continue;
-            }
-
-            $tmpFile = $hourFile . '.tmp.aggr.' . getmypid();
-            $written = @file_put_contents($tmpFile, $jsonPayload, LOCK_EX);
-            if ($written === false) {
-                @unlink($tmpFile);
-                $stats['errors'][] = 'hourly_tmp_write_failed:' . $hourId;
-
-                continue;
-            }
-
-            if (!@rename($tmpFile, $hourFile)) {
-                @unlink($tmpFile);
-                $stats['errors'][] = 'hourly_rename_failed:' . $hourId;
-
+            if (!metrics_spill_aggregator_write_hour_bucket($hourData, $hourFile, $hourId, $stats)) {
                 continue;
             }
 
@@ -167,7 +151,14 @@ function metrics_run_spill_aggregator_once(): array
                 }
             }
 
-            @rmdir($hourDir);
+            if (count(glob($hourDir . '/*.json') ?: []) === 0) {
+                @rmdir($hourDir);
+            }
+
+            // Persist partial hour progress before stopping; next pass continues the same bucket.
+            if ($hourBudgetExhausted) {
+                break;
+            }
         }
 
         metrics_spill_aggregator_prune_orphan_spills($stats, $t0Ns);
@@ -189,6 +180,49 @@ function metrics_run_spill_aggregator_once(): array
 function metrics_spill_aggregator_runtime_ms($t0Ns): float
 {
     return (hrtime(true) - $t0Ns) / 1e6;
+}
+
+/**
+ * Atomically write merged hour bucket JSON to the canonical hourly metrics path.
+ *
+ * @param array<string, mixed> $hourData Merged bucket (last_flush set here)
+ * @param string               $hourFile Target hourly JSON path
+ * @param string               $hourId   UTC hour id for error telemetry
+ * @param array<string, mixed> $stats    Stats array; errors[] appended on failure
+ * @return bool True when the hourly file was written
+ */
+function metrics_spill_aggregator_write_hour_bucket(
+    array $hourData,
+    string $hourFile,
+    string $hourId,
+    array &$stats
+): bool {
+    $hourData['last_flush'] = time();
+
+    $jsonPayload = json_encode($hourData, JSON_PRETTY_PRINT);
+    if ($jsonPayload === false) {
+        $stats['errors'][] = 'json_encode_failed:' . $hourId;
+
+        return false;
+    }
+
+    $tmpFile = $hourFile . '.tmp.aggr.' . getmypid();
+    $written = @file_put_contents($tmpFile, $jsonPayload, LOCK_EX);
+    if ($written === false) {
+        @unlink($tmpFile);
+        $stats['errors'][] = 'hourly_tmp_write_failed:' . $hourId;
+
+        return false;
+    }
+
+    if (!@rename($tmpFile, $hourFile)) {
+        @unlink($tmpFile);
+        $stats['errors'][] = 'hourly_rename_failed:' . $hourId;
+
+        return false;
+    }
+
+    return true;
 }
 
 /**

--- a/lib/metrics-spill-aggregator.php
+++ b/lib/metrics-spill-aggregator.php
@@ -151,9 +151,8 @@ function metrics_run_spill_aggregator_once(): array
                 }
             }
 
-            if (count(glob($hourDir . '/*.json') ?: []) === 0) {
-                @rmdir($hourDir);
-            }
+            // rmdir succeeds only when the hour dir is empty; no glob scan (large backlogs are costly).
+            @rmdir($hourDir);
 
             // Persist partial hour progress before stopping; next pass continues the same bucket.
             if ($hourBudgetExhausted) {

--- a/tests/Unit/MetricsSpillAggregatorBudgetTest.php
+++ b/tests/Unit/MetricsSpillAggregatorBudgetTest.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Spill aggregator must persist partial hour progress when per-run file/runtime budget is hit.
+ *
+ * Regression: break 2 discarded merged counters and left spills undeleted when one hour exceeded
+ * METRICS_SPILL_MERGE_MAX_FILES_PER_RUN (production: status page hourly metrics stuck at zero).
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class MetricsSpillAggregatorBudgetTest extends TestCase
+{
+    /**
+     * @return array{exit: int, output: string}
+     */
+    private function runAggregatorHarness(string $scriptBody): array
+    {
+        $root = dirname(__DIR__, 2);
+        $cacheId = bin2hex(random_bytes(8));
+        $tmp = sys_get_temp_dir() . '/aviationwx_metrics_agg_sub_' . bin2hex(random_bytes(8)) . '.php';
+        file_put_contents($tmp, $this->harnessPreamble($cacheId) . $scriptBody);
+
+        $env = [
+            'METRICS_AGG_TEST_ROOT' => $root,
+            'METRICS_AGG_TEST_CACHE' => sys_get_temp_dir() . '/aviationwx_metrics_agg_cache_' . $cacheId,
+        ];
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($tmp) . ' 2>&1';
+        $proc = proc_open($cmd, [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, null, $env);
+        $this->assertIsResource($proc);
+        fclose($pipes[0]);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($proc);
+        @unlink($tmp);
+
+        return ['exit' => $exitCode, 'output' => $out . $err];
+    }
+
+    private function harnessPreamble(string $cacheId): string
+    {
+        return <<<PHP
+<?php
+declare(strict_types=1);
+
+if (!defined('METRICS_SPILL_MERGE_MAX_FILES_PER_RUN')) {
+    define('METRICS_SPILL_MERGE_MAX_FILES_PER_RUN', 3);
+}
+if (!defined('METRICS_SPILL_MERGE_MAX_RUNTIME_MS')) {
+    define('METRICS_SPILL_MERGE_MAX_RUNTIME_MS', 30000);
+}
+if (!defined('CACHE_BASE_DIR')) {
+    define('CACHE_BASE_DIR', getenv('METRICS_AGG_TEST_CACHE') ?: (sys_get_temp_dir() . '/aviationwx_metrics_agg_cache_{$cacheId}'));
+}
+if (!defined('AVIATIONWX_LOG_DIR')) {
+    define('AVIATIONWX_LOG_DIR', sys_get_temp_dir() . '/aviationwx_metrics_agg_log_{$cacheId}');
+}
+@mkdir(CACHE_BASE_DIR, 0755, true);
+@mkdir(AVIATIONWX_LOG_DIR, 0755, true);
+@touch(AVIATIONWX_LOG_DIR . '/app.log');
+
+\$root = getenv('METRICS_AGG_TEST_ROOT');
+
+PHP;
+    }
+
+    /**
+     * Production regression: first pass must write hourly file and delete consumed spills.
+     */
+    public function testPartialFlush_WritesHourlyAndDeletesConsumedSpillsWhenBudgetHit(): void
+    {
+        $body = <<<'PHP'
+require $root . '/lib/cache-paths.php';
+require $root . '/lib/metrics-spill-aggregator.php';
+
+$hourId = '2099-06-01-13';
+$hourDir = getMetricsSpillHourDir($hourId);
+@mkdir($hourDir, 0755, true);
+
+for ($i = 1; $i <= 5; $i++) {
+    $payload = [
+        'schema_version' => METRICS_SPILL_FILE_SCHEMA_VERSION,
+        'generated_at' => time(),
+        'hour_id' => $hourId,
+        'pid' => 60000 + $i,
+        'counters' => ['global_page_views' => 1],
+    ];
+    file_put_contents($hourDir . '/shard_' . $i . '.json', json_encode($payload));
+}
+
+$first = metrics_run_spill_aggregator_once();
+if ((int) ($first['hours_touched'] ?? 0) !== 1) {
+    fwrite(STDERR, 'expected hours_touched=1 on partial pass, got ' . json_encode($first) . PHP_EOL);
+    exit(1);
+}
+if ((int) ($first['spills_merged'] ?? 0) !== 3) {
+    fwrite(STDERR, 'expected spills_merged=3 on partial pass, got ' . json_encode($first) . PHP_EOL);
+    exit(1);
+}
+if ((int) ($first['spills_deleted'] ?? 0) !== 3) {
+    fwrite(STDERR, 'expected spills_deleted=3 on partial pass, got ' . json_encode($first) . PHP_EOL);
+    exit(1);
+}
+
+$hourPath = getMetricsHourlyPath($hourId);
+if (!is_file($hourPath)) {
+    fwrite(STDERR, "hourly file missing after partial pass\n");
+    exit(1);
+}
+$hourJson = json_decode((string) file_get_contents($hourPath), true);
+if (!is_array($hourJson) || (int) ($hourJson['global']['page_views'] ?? 0) !== 3) {
+    fwrite(STDERR, 'expected 3 page_views after partial pass' . PHP_EOL);
+    exit(1);
+}
+
+$remaining = glob($hourDir . '/*.json') ?: [];
+if (count($remaining) !== 2) {
+    fwrite(STDERR, 'expected 2 remaining spill files, got ' . count($remaining) . PHP_EOL);
+    exit(1);
+}
+if (!is_dir($hourDir)) {
+    fwrite(STDERR, "hour dir removed while spills remain\n");
+    exit(1);
+}
+
+$second = metrics_run_spill_aggregator_once();
+if ((int) ($second['spills_merged'] ?? 0) !== 2 || (int) ($second['spills_deleted'] ?? 0) !== 2) {
+    fwrite(STDERR, 'second pass did not finish hour: ' . json_encode($second) . PHP_EOL);
+    exit(1);
+}
+$hourJson = json_decode((string) file_get_contents($hourPath), true);
+if ((int) ($hourJson['global']['page_views'] ?? 0) !== 5) {
+    fwrite(STDERR, 'expected 5 page_views after second pass' . PHP_EOL);
+    exit(1);
+}
+
+echo json_encode(['ok' => true]);
+PHP;
+
+        $result = $this->runAggregatorHarness($body);
+        $this->assertSame(0, $result['exit'], 'harness failed: ' . $result['output']);
+        $decoded = json_decode(trim($result['output']), true);
+        $this->assertIsArray($decoded);
+        $this->assertTrue($decoded['ok'] ?? false);
+    }
+
+    /**
+     * Oldest hour bucket is completed before budget stops the pass on a later hour.
+     */
+    public function testPartialFlush_CompletesEarlierHourBeforeStoppingOnLaterHour(): void
+    {
+        $body = <<<'PHP'
+require $root . '/lib/cache-paths.php';
+require $root . '/lib/metrics-spill-aggregator.php';
+
+function write_spill(string $hourId, string $name, int $views): void {
+    $dir = getMetricsSpillHourDir($hourId);
+    @mkdir($dir, 0755, true);
+    $payload = [
+        'schema_version' => METRICS_SPILL_FILE_SCHEMA_VERSION,
+        'generated_at' => time(),
+        'hour_id' => $hourId,
+        'pid' => 70001,
+        'counters' => ['global_page_views' => $views],
+    ];
+    file_put_contents($dir . '/' . $name . '.json', json_encode($payload));
+}
+
+$hourA = '2099-06-01-10';
+$hourB = '2099-06-01-11';
+write_spill($hourA, 'a1', 4);
+write_spill($hourA, 'a2', 6);
+write_spill($hourB, 'b1', 2);
+write_spill($hourB, 'b2', 3);
+
+$stats = metrics_run_spill_aggregator_once();
+if ((int) ($stats['hours_touched'] ?? 0) < 1) {
+    fwrite(STDERR, 'expected at least one hour touched: ' . json_encode($stats) . PHP_EOL);
+    exit(1);
+}
+
+$pathA = getMetricsHourlyPath($hourA);
+$jsonA = json_decode((string) file_get_contents($pathA), true);
+if ((int) ($jsonA['global']['page_views'] ?? 0) !== 10) {
+    fwrite(STDERR, 'hour A should be fully merged (10 views)' . PHP_EOL);
+    exit(1);
+}
+
+$dirB = getMetricsSpillHourDir($hourB);
+$remainingB = glob($dirB . '/*.json') ?: [];
+if (count($remainingB) !== 1) {
+    fwrite(STDERR, 'hour B should have one spill remaining, got ' . count($remainingB) . PHP_EOL);
+    exit(1);
+}
+$pathB = getMetricsHourlyPath($hourB);
+if (!is_file($pathB)) {
+    fwrite(STDERR, "hour B hourly file missing after partial merge\n");
+    exit(1);
+}
+$jsonB = json_decode((string) file_get_contents($pathB), true);
+if ((int) ($jsonB['global']['page_views'] ?? 0) !== 2) {
+    fwrite(STDERR, 'hour B should have 2 views from partial merge' . PHP_EOL);
+    exit(1);
+}
+
+echo json_encode(['ok' => true]);
+PHP;
+
+        $result = $this->runAggregatorHarness($body);
+        $this->assertSame(0, $result['exit'], 'harness failed: ' . $result['output']);
+    }
+
+    public function testWriteHourBucket_FailsClosedWhenTargetDirectoryMissing(): void
+    {
+        require_once __DIR__ . '/../../lib/cache-paths.php';
+        require_once __DIR__ . '/../../lib/constants.php';
+        require_once __DIR__ . '/../../lib/metrics-spill-aggregator.php';
+
+        $hourId = '2099-06-01-14';
+        $hourData = metrics_new_empty_hour_bucket($hourId);
+        $missingDir = sys_get_temp_dir() . '/aviationwx_metrics_missing_hourly_' . bin2hex(random_bytes(6));
+        $hourFile = $missingDir . '/no-such-parent/' . $hourId . '.json';
+        $stats = ['errors' => []];
+
+        $ok = metrics_spill_aggregator_write_hour_bucket($hourData, $hourFile, $hourId, $stats);
+
+        $this->assertFalse($ok);
+        $this->assertContains('hourly_tmp_write_failed:' . $hourId, $stats['errors']);
+        $this->assertFileDoesNotExist($hourFile);
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes a production outage where status page hourly page views showed **0/hr** while weekly totals remained non-zero.
- Root cause: when a UTC hour accumulated more spill shards than `METRICS_SPILL_MERGE_MAX_FILES_PER_RUN` (2000), the aggregator used `break 2`, which discarded in-memory merges **without** writing `cache/metrics/hourly/*.json` or deleting consumed shards. The scheduler then re-merged the same 2000 files every 90s with `hours_touched: 0` and `spills_deleted: 0`.
- The aggregator now flushes partial hour progress (write hourly file + delete merged shards) before yielding on file/runtime budget, and only removes the spill hour directory when no `.json` shards remain.

## Code changes

- `lib/metrics-spill-aggregator.php`
  - Replace `break 2` with inner `break` plus post-loop hourly flush.
  - Extract `metrics_spill_aggregator_write_hour_bucket()` for atomic hourly writes (same tmp+rename behavior as before).
  - Guard `rmdir($hourDir)` until the spill directory is empty.
- `tests/Unit/MetricsSpillAggregatorBudgetTest.php`
  - Subprocess harness with a low per-run file cap reproduces the production regression.
  - Asserts partial pass writes hourly JSON and deletes consumed spills (the old bug left both at zero).
  - Asserts multi-hour ordering: earlier hour completes before budget stops a later hour.
  - Direct test for `metrics_spill_aggregator_write_hour_bucket()` fail-closed when the target path is not writable.

## Test plan

- [x] `make test-ci` (local)
- [x] `vendor/bin/phpunit tests/Unit/MetricsSpillAggregatorBudgetTest.php` and existing spill aggregator tests
- [x] After deploy on production, drain backlog:

```bash
for n in $(seq 1 30); do
  docker exec aviationwx-web php /var/www/html/scripts/aggregate-metrics-spills.php
  sleep 2
done
docker exec aviationwx-web php /var/www/html/scripts/fetch-status-metrics.php
```

- [x] Confirm `aggregator_last_run.json` shows `hours_touched` > 0 and `spills_deleted` growing
- [x] Confirm `cache/metrics/hourly/2026-06-09-{13,14,15,16}.json` exist with non-zero `page_views`
- [x] Confirm status.aviationwx.org `/hr` values recover

## Follow-up (separate PR)

Per-request spill shards still scale with HTTP volume (~6k/hour observed). After this hotfix, consider per-worker batching (JSONL append) to reduce aggregator load under higher session counts.