### PR TITLE
feat(metrics): per-worker JSONL spill batching for scale

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -140,7 +140,7 @@ After a code fix, prefer a single clean `web` container restart so only the entr
 
 ### Metrics System
 
-Live counters live in APCu (per PHP-FPM worker). Each worker writes spill snapshots after requests (unique filenames under `cache/metrics/spill/{YYYY-MM-DD-HH}/{pid}_{hex}.json`) so unconsumed shards are not overwritten. The scheduler merges those shards into canonical hourly files:
+Live counters live in APCu (per PHP-FPM worker). Each worker appends one JSON line per request shutdown to a per-worker journal (`cache/metrics/spill/{YYYY-MM-DD-HH}/{pid}.jsonl`). The aggregator claims each journal via rename, merges lines into canonical hourly files, and deletes the claimed copy. Legacy per-request `{pid}_{hex}.json` shards are still merged if present from older releases.
 
 - **Hourly**: `cache/metrics/hourly/YYYY-MM-DD-HH.json`
 - **Daily**: `cache/metrics/daily/YYYY-MM-DD.json`

--- a/lib/cache-paths.php
+++ b/lib/cache-paths.php
@@ -714,8 +714,7 @@ function getMetricsSpillHourDir(string $hourId): string {
  * @param int    $pid    Process ID (FPM worker)
  * @return string Absolute path to {pid}.jsonl under the hour spill directory
  */
-function getMetricsSpillWorkerJournalPath(string $hourId, int $pid): string
-{
+function getMetricsSpillWorkerJournalPath(string $hourId, int $pid): string {
     return getMetricsSpillHourDir($hourId) . '/' . $pid . '.jsonl';
 }
 
@@ -728,8 +727,7 @@ function getMetricsSpillWorkerJournalPath(string $hourId, int $pid): string
  * @param int    $pid    Process ID (FPM worker)
  * @return string Absolute path to JSON spill file
  */
-function getMetricsSpillSnapshotPath(string $hourId, int $pid): string
-{
+function getMetricsSpillSnapshotPath(string $hourId, int $pid): string {
     $uniq = bin2hex(random_bytes(8));
 
     return getMetricsSpillHourDir($hourId) . '/' . $pid . '_' . $uniq . '.json';

--- a/lib/cache-paths.php
+++ b/lib/cache-paths.php
@@ -706,15 +706,30 @@ function getMetricsSpillHourDir(string $hourId): string {
 }
 
 /**
- * Unique JSON path for one spill snapshot (tmp+rename from PHP worker).
+ * Per-worker JSONL journal for request-shutdown spill deltas (append one line per shutdown).
  *
- * Multiple snapshots per worker per hour are expected (request shutdown); the aggregator merges and deletes each file.
+ * One file per FPM worker per UTC hour; the aggregator claims and merges the whole journal.
+ *
+ * @param string $hourId Hour identifier (metrics_get_hour_id format)
+ * @param int    $pid    Process ID (FPM worker)
+ * @return string Absolute path to {pid}.jsonl under the hour spill directory
+ */
+function getMetricsSpillWorkerJournalPath(string $hourId, int $pid): string
+{
+    return getMetricsSpillHourDir($hourId) . '/' . $pid . '.jsonl';
+}
+
+/**
+ * Legacy per-request spill shard path (pre-JSONL). Retained for orphan cleanup and tests only.
+ *
+ * @deprecated New spills use {@see getMetricsSpillWorkerJournalPath()}.
  *
  * @param string $hourId Hour identifier (metrics_get_hour_id)
- * @param int $pid Process ID (FPM worker)
+ * @param int    $pid    Process ID (FPM worker)
  * @return string Absolute path to JSON spill file
  */
-function getMetricsSpillSnapshotPath(string $hourId, int $pid): string {
+function getMetricsSpillSnapshotPath(string $hourId, int $pid): string
+{
     $uniq = bin2hex(random_bytes(8));
 
     return getMetricsSpillHourDir($hourId) . '/' . $pid . '_' . $uniq . '.json';

--- a/lib/metrics-spill-aggregator.php
+++ b/lib/metrics-spill-aggregator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Merge per-worker spill JSON snapshots into canonical hourly metrics files.
+ * Merge per-worker spill journals (JSONL) and legacy JSON shards into hourly metrics files.
  */
 
 declare(strict_types=1);
@@ -308,7 +308,7 @@ function metrics_spill_aggregator_parse_spill_file(string $path, string $expecte
 }
 
 /**
- * Remove stale spill shards that were never merged (crash / stuck worker).
+ * Remove stale spill artifacts that were never merged (legacy shards, journals, abandoned claims).
  *
  * @param array<string, mixed> $stats Stats array updated with orphans_pruned count
  * @param int|float $t0Ns Start time from hrtime(true); skips work when runtime budget exceeded
@@ -343,10 +343,10 @@ function metrics_spill_aggregator_prune_orphan_spills(array &$stats, $t0Ns): voi
             if (strpos($name, '.tmp.') !== false) {
                 continue;
             }
-            if (!str_ends_with($name, '.json') && !str_ends_with($name, '.jsonl')) {
-                continue;
-            }
-            if (strpos($name, '.merging.') !== false) {
+            $isSpillArtifact = str_ends_with($name, '.json')
+                || str_ends_with($name, '.jsonl')
+                || strpos($name, '.merging.') !== false;
+            if (!$isSpillArtifact) {
                 continue;
             }
 

--- a/lib/metrics-spill-aggregator.php
+++ b/lib/metrics-spill-aggregator.php
@@ -250,6 +250,9 @@ function metrics_spill_aggregator_list_spill_paths_for_hour(string $hourDir): ar
     }));
 
     $claimed = glob($hourDir . '/*.jsonl.merging.*') ?: [];
+    $claimed = array_values(array_filter($claimed, static function (string $p): bool {
+        return strpos(basename($p), '.tmp.') === false;
+    }));
 
     $paths = array_merge($legacy, $journals, $claimed);
     sort($paths);

--- a/lib/metrics-spill-aggregator.php
+++ b/lib/metrics-spill-aggregator.php
@@ -118,17 +118,20 @@ function metrics_run_spill_aggregator_once(): array
                 }
 
                 $consumedPath = null;
+                $journalFullyConsumed = true;
                 $mergedUnits = metrics_spill_aggregator_merge_spill_path(
                     $spillPath,
                     $hourId,
                     $hourData,
-                    $consumedPath
+                    $consumedPath,
+                    $t0Ns,
+                    $journalFullyConsumed
                 );
                 if ($mergedUnits === null || $mergedUnits < 1) {
                     continue;
                 }
 
-                if ($consumedPath !== null) {
+                if ($consumedPath !== null && $journalFullyConsumed) {
                     $pendingDeletes[] = $consumedPath;
                 }
                 $hourHadMerges = true;
@@ -260,16 +263,23 @@ function metrics_spill_aggregator_list_spill_paths_for_hour(string $hourDir): ar
  * @param string               $spillPath     Absolute spill file path
  * @param string               $hourId        UTC hour bucket id
  * @param array<string, mixed> $hourData      Hourly bucket (mutated in place)
- * @param string|null          $consumedPath  Set when merge succeeded; delete after hourly write
+ * @param string|null          $consumedPath         Set when merge succeeded; delete after hourly write
+ * @param int|float|null       $t0Ns                 Aggregator runtime anchor for per-line budget checks
+ * @param bool|null            $journalFullyConsumed False when a JSONL claim still has unread lines
  * @return int|null Delta records merged (lines for JSONL, 1 for legacy shard), or null
  */
 function metrics_spill_aggregator_merge_spill_path(
     string $spillPath,
     string $hourId,
     array &$hourData,
-    ?string &$consumedPath = null
+    ?string &$consumedPath = null,
+    $t0Ns = null,
+    ?bool &$journalFullyConsumed = null
 ): ?int {
     $consumedPath = null;
+    if ($journalFullyConsumed !== null) {
+        $journalFullyConsumed = true;
+    }
 
     if (metrics_spill_path_is_worker_journal($spillPath)) {
         $claimed = metrics_spill_journal_claim_for_merge($spillPath);
@@ -277,19 +287,27 @@ function metrics_spill_aggregator_merge_spill_path(
             return null;
         }
 
-        $lines = metrics_spill_journal_merge_claimed_into_hour_data($claimed, $hourId, $hourData);
-        if ($lines > 0) {
-            $consumedPath = $claimed;
-        }
+        $consumedPath = $claimed;
+        $lines = metrics_spill_journal_merge_claimed_into_hour_data(
+            $claimed,
+            $hourId,
+            $hourData,
+            $t0Ns,
+            $journalFullyConsumed
+        );
 
         return $lines > 0 ? $lines : null;
     }
 
     if (metrics_spill_path_is_claimed_journal($spillPath)) {
-        $lines = metrics_spill_journal_merge_claimed_into_hour_data($spillPath, $hourId, $hourData);
-        if ($lines > 0) {
-            $consumedPath = $spillPath;
-        }
+        $consumedPath = $spillPath;
+        $lines = metrics_spill_journal_merge_claimed_into_hour_data(
+            $spillPath,
+            $hourId,
+            $hourData,
+            $t0Ns,
+            $journalFullyConsumed
+        );
 
         return $lines > 0 ? $lines : null;
     }

--- a/lib/metrics-spill-aggregator.php
+++ b/lib/metrics-spill-aggregator.php
@@ -117,18 +117,19 @@ function metrics_run_spill_aggregator_once(): array
                     break;
                 }
 
-                $isJournal = metrics_spill_path_is_worker_journal($spillPath);
+                $consumedPath = null;
                 $mergedUnits = metrics_spill_aggregator_merge_spill_path(
                     $spillPath,
                     $hourId,
-                    $hourData
+                    $hourData,
+                    $consumedPath
                 );
                 if ($mergedUnits === null || $mergedUnits < 1) {
                     continue;
                 }
 
-                if (!$isJournal) {
-                    $pendingDeletes[] = $spillPath;
+                if ($consumedPath !== null) {
+                    $pendingDeletes[] = $consumedPath;
                 }
                 $hourHadMerges = true;
                 $filesMergedThisRun++;
@@ -226,7 +227,7 @@ function metrics_spill_aggregator_write_hour_bucket(
 }
 
 /**
- * List legacy .json shards and per-worker .jsonl journals for one UTC hour spill directory.
+ * List legacy .json shards, live .jsonl journals, and claimed .jsonl.merging.* files for one hour dir.
  *
  * @param string $hourDir Absolute path to spill/{hourId}
  * @return list<string> Sorted spill paths
@@ -245,7 +246,9 @@ function metrics_spill_aggregator_list_spill_paths_for_hour(string $hourDir): ar
         return metrics_spill_path_is_worker_journal($p);
     }));
 
-    $paths = array_merge($legacy, $journals);
+    $claimed = glob($hourDir . '/*.jsonl.merging.*') ?: [];
+
+    $paths = array_merge($legacy, $journals, $claimed);
     sort($paths);
 
     return $paths;
@@ -254,16 +257,20 @@ function metrics_spill_aggregator_list_spill_paths_for_hour(string $hourDir): ar
 /**
  * Merge one spill path (legacy JSON shard or worker JSONL journal) into hour bucket data.
  *
- * @param string               $spillPath Absolute spill file path
- * @param string               $hourId    UTC hour bucket id
- * @param array<string, mixed> $hourData  Hourly bucket (mutated in place)
+ * @param string               $spillPath     Absolute spill file path
+ * @param string               $hourId        UTC hour bucket id
+ * @param array<string, mixed> $hourData      Hourly bucket (mutated in place)
+ * @param string|null          $consumedPath  Set when merge succeeded; delete after hourly write
  * @return int|null Delta records merged (lines for JSONL, 1 for legacy shard), or null
  */
 function metrics_spill_aggregator_merge_spill_path(
     string $spillPath,
     string $hourId,
-    array &$hourData
+    array &$hourData,
+    ?string &$consumedPath = null
 ): ?int {
+    $consumedPath = null;
+
     if (metrics_spill_path_is_worker_journal($spillPath)) {
         $claimed = metrics_spill_journal_claim_for_merge($spillPath);
         if ($claimed === null) {
@@ -271,6 +278,18 @@ function metrics_spill_aggregator_merge_spill_path(
         }
 
         $lines = metrics_spill_journal_merge_claimed_into_hour_data($claimed, $hourId, $hourData);
+        if ($lines > 0) {
+            $consumedPath = $claimed;
+        }
+
+        return $lines > 0 ? $lines : null;
+    }
+
+    if (metrics_spill_path_is_claimed_journal($spillPath)) {
+        $lines = metrics_spill_journal_merge_claimed_into_hour_data($spillPath, $hourId, $hourData);
+        if ($lines > 0) {
+            $consumedPath = $spillPath;
+        }
 
         return $lines > 0 ? $lines : null;
     }
@@ -281,6 +300,7 @@ function metrics_spill_aggregator_merge_spill_path(
     }
 
     metrics_apply_flat_counters_to_hour_data($hourData, $parsed['counters'], true);
+    $consumedPath = $spillPath;
 
     return 1;
 }

--- a/lib/metrics-spill-aggregator.php
+++ b/lib/metrics-spill-aggregator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/cache-paths.php';
 require_once __DIR__ . '/constants.php';
 require_once __DIR__ . '/logger.php';
+require_once __DIR__ . '/metrics-spill-journal.php';
 require_once __DIR__ . '/metrics-spill-payload.php';
 require_once __DIR__ . '/metrics.php';
 
@@ -81,18 +82,10 @@ function metrics_run_spill_aggregator_once(): array
                 continue;
             }
 
-            $spillFiles = glob($hourDir . '/*.json') ?: [];
-            $spillFiles = array_values(array_filter($spillFiles, static function (string $p): bool {
-                $base = basename($p);
-
-                return strpos($base, '.tmp.') === false;
-            }));
-
+            $spillFiles = metrics_spill_aggregator_list_spill_paths_for_hour($hourDir);
             if ($spillFiles === []) {
                 continue;
             }
-
-            sort($spillFiles);
 
             $hourFile = getMetricsHourlyPath($hourId);
             $hourData = [];
@@ -111,6 +104,7 @@ function metrics_run_spill_aggregator_once(): array
             metrics_normalize_hour_bucket_for_merge($hourData, $hourId);
 
             $pendingDeletes = [];
+            $hourHadMerges = false;
             $hourBudgetExhausted = false;
 
             foreach ($spillFiles as $spillPath) {
@@ -123,18 +117,25 @@ function metrics_run_spill_aggregator_once(): array
                     break;
                 }
 
-                $parsed = metrics_spill_aggregator_parse_spill_file($spillPath, $hourId);
-                if ($parsed === null) {
+                $isJournal = metrics_spill_path_is_worker_journal($spillPath);
+                $mergedUnits = metrics_spill_aggregator_merge_spill_path(
+                    $spillPath,
+                    $hourId,
+                    $hourData
+                );
+                if ($mergedUnits === null || $mergedUnits < 1) {
                     continue;
                 }
 
-                metrics_apply_flat_counters_to_hour_data($hourData, $parsed['counters'], true);
-                $pendingDeletes[] = $spillPath;
+                if (!$isJournal) {
+                    $pendingDeletes[] = $spillPath;
+                }
+                $hourHadMerges = true;
                 $filesMergedThisRun++;
-                $stats['spills_merged']++;
+                $stats['spills_merged'] += $mergedUnits;
             }
 
-            if ($pendingDeletes === []) {
+            if (!$hourHadMerges) {
                 continue;
             }
 
@@ -225,6 +226,66 @@ function metrics_spill_aggregator_write_hour_bucket(
 }
 
 /**
+ * List legacy .json shards and per-worker .jsonl journals for one UTC hour spill directory.
+ *
+ * @param string $hourDir Absolute path to spill/{hourId}
+ * @return list<string> Sorted spill paths
+ */
+function metrics_spill_aggregator_list_spill_paths_for_hour(string $hourDir): array
+{
+    $legacy = glob($hourDir . '/*.json') ?: [];
+    $legacy = array_values(array_filter($legacy, static function (string $p): bool {
+        $base = basename($p);
+
+        return strpos($base, '.tmp.') === false;
+    }));
+
+    $journals = glob($hourDir . '/*.jsonl') ?: [];
+    $journals = array_values(array_filter($journals, static function (string $p): bool {
+        return metrics_spill_path_is_worker_journal($p);
+    }));
+
+    $paths = array_merge($legacy, $journals);
+    sort($paths);
+
+    return $paths;
+}
+
+/**
+ * Merge one spill path (legacy JSON shard or worker JSONL journal) into hour bucket data.
+ *
+ * @param string               $spillPath Absolute spill file path
+ * @param string               $hourId    UTC hour bucket id
+ * @param array<string, mixed> $hourData  Hourly bucket (mutated in place)
+ * @return int|null Delta records merged (lines for JSONL, 1 for legacy shard), or null
+ */
+function metrics_spill_aggregator_merge_spill_path(
+    string $spillPath,
+    string $hourId,
+    array &$hourData
+): ?int {
+    if (metrics_spill_path_is_worker_journal($spillPath)) {
+        $claimed = metrics_spill_journal_claim_for_merge($spillPath);
+        if ($claimed === null) {
+            return null;
+        }
+
+        $lines = metrics_spill_journal_merge_claimed_into_hour_data($claimed, $hourId, $hourData);
+
+        return $lines > 0 ? $lines : null;
+    }
+
+    $parsed = metrics_spill_aggregator_parse_spill_file($spillPath, $hourId);
+    if ($parsed === null) {
+        return null;
+    }
+
+    metrics_apply_flat_counters_to_hour_data($hourData, $parsed['counters'], true);
+
+    return 1;
+}
+
+/**
  * Read a spill shard file and return normalized counters, or null if the file is unusable.
  *
  * @param string $path Absolute path to spill JSON
@@ -282,7 +343,10 @@ function metrics_spill_aggregator_prune_orphan_spills(array &$stats, $t0Ns): voi
             if (strpos($name, '.tmp.') !== false) {
                 continue;
             }
-            if (!str_ends_with($name, '.json')) {
+            if (!str_ends_with($name, '.json') && !str_ends_with($name, '.jsonl')) {
+                continue;
+            }
+            if (strpos($name, '.merging.') !== false) {
                 continue;
             }
 

--- a/lib/metrics-spill-journal.php
+++ b/lib/metrics-spill-journal.php
@@ -6,6 +6,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/constants.php';
+require_once __DIR__ . '/logger.php';
 require_once __DIR__ . '/metrics-apply-counters.php';
 require_once __DIR__ . '/metrics-spill-payload.php';
 
@@ -39,6 +40,11 @@ function metrics_spill_journal_append_locked(string $journalPath, array $payload
 {
     $line = json_encode($payload);
     if ($line === false) {
+        aviationwx_log('warning', 'metrics spill: journal line json_encode failed', [
+            'path' => $journalPath,
+            'error' => json_last_error_msg(),
+        ], 'app');
+
         return false;
     }
     $line .= "\n";

--- a/lib/metrics-spill-journal.php
+++ b/lib/metrics-spill-journal.php
@@ -93,7 +93,18 @@ function metrics_spill_journal_claim_for_merge(string $journalPath): ?string
         return null;
     }
 
-    $claimPath = $journalPath . '.merging.' . getmypid() . '.' . bin2hex(random_bytes(4));
+    try {
+        $suffix = bin2hex(random_bytes(4));
+    } catch (Throwable $e) {
+        aviationwx_log('warning', 'metrics spill: journal claim suffix generation failed', [
+            'path' => $journalPath,
+            'error' => $e->getMessage(),
+        ], 'app');
+
+        return null;
+    }
+
+    $claimPath = $journalPath . '.merging.' . getmypid() . '.' . $suffix;
     if (@rename($journalPath, $claimPath)) {
         return $claimPath;
     }

--- a/lib/metrics-spill-journal.php
+++ b/lib/metrics-spill-journal.php
@@ -217,11 +217,26 @@ function metrics_spill_journal_rewrite_claimed_tail($fp, string $claimedPath, st
     $tmp = $claimedPath . '.tmp.tail.' . getmypid();
     if (@file_put_contents($tmp, $remainder, LOCK_EX) === false) {
         @unlink($tmp);
+        aviationwx_log('warning', 'metrics spill: journal tail temp write failed', [
+            'path' => $claimedPath,
+        ], 'app');
 
         return;
     }
 
-    @rename($tmp, $claimedPath);
+    if (@rename($tmp, $claimedPath)) {
+        return;
+    }
+
+    @unlink($tmp);
+    aviationwx_log('warning', 'metrics spill: journal tail rename failed; overwriting claim', [
+        'path' => $claimedPath,
+    ], 'app');
+    if (@file_put_contents($claimedPath, $remainder, LOCK_EX) === false) {
+        aviationwx_log('warning', 'metrics spill: journal tail overwrite failed', [
+            'path' => $claimedPath,
+        ], 'app');
+    }
 }
 
 /**

--- a/lib/metrics-spill-journal.php
+++ b/lib/metrics-spill-journal.php
@@ -114,8 +114,16 @@ function metrics_spill_journal_merge_claimed_into_hour_data(
     }
 
     $merged = 0;
+    $locked = false;
 
     try {
+        // Wait for any in-flight append on the renamed inode (worker may still hold LOCK_EX).
+        if (!flock($fp, LOCK_SH)) {
+            return 0;
+        }
+
+        $locked = true;
+
         while (($rawLine = fgets($fp)) !== false) {
             $line = trim($rawLine);
             if ($line === '') {
@@ -136,6 +144,9 @@ function metrics_spill_journal_merge_claimed_into_hour_data(
             $merged++;
         }
     } finally {
+        if ($locked) {
+            flock($fp, LOCK_UN);
+        }
         fclose($fp);
         @unlink($claimedPath);
     }

--- a/lib/metrics-spill-journal.php
+++ b/lib/metrics-spill-journal.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Per-worker JSONL spill journal: append deltas on request shutdown, claim for aggregator merge.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/constants.php';
+require_once __DIR__ . '/metrics-apply-counters.php';
+require_once __DIR__ . '/metrics-spill-payload.php';
+
+/**
+ * Build a spill payload object (same schema as legacy per-request JSON shards).
+ *
+ * @param string               $hourId   UTC metrics hour id
+ * @param int                  $pid      PHP-FPM worker PID
+ * @param array<string, int>   $counters Flat APCu counter map
+ * @return array<string, mixed>
+ */
+function metrics_spill_build_payload(string $hourId, int $pid, array $counters): array
+{
+    return [
+        'schema_version' => METRICS_SPILL_FILE_SCHEMA_VERSION,
+        'generated_at' => time(),
+        'hour_id' => $hourId,
+        'pid' => $pid,
+        'counters' => $counters,
+    ];
+}
+
+/**
+ * Append one JSON line to a worker journal under an exclusive flock.
+ *
+ * @param string               $journalPath Absolute path to {pid}.jsonl
+ * @param array<string, mixed> $payload     Output of metrics_spill_build_payload()
+ * @return bool True when the line was written
+ */
+function metrics_spill_journal_append_locked(string $journalPath, array $payload): bool
+{
+    $line = json_encode($payload);
+    if ($line === false) {
+        return false;
+    }
+    $line .= "\n";
+
+    $fp = @fopen($journalPath, 'ab');
+    if ($fp === false) {
+        return false;
+    }
+
+    try {
+        if (!flock($fp, LOCK_EX)) {
+            return false;
+        }
+
+        $written = fwrite($fp, $line);
+        if ($written !== strlen($line)) {
+            return false;
+        }
+
+        fflush($fp);
+
+        return true;
+    } finally {
+        flock($fp, LOCK_UN);
+        fclose($fp);
+    }
+}
+
+/**
+ * Atomically claim a worker journal for merge (rename away from the live append path).
+ *
+ * Workers that spill after claim create a fresh {pid}.jsonl. Returns null when missing or busy.
+ *
+ * @param string $journalPath Live journal path ({pid}.jsonl)
+ * @return string|null Absolute path to the claimed .merging copy, or null
+ */
+function metrics_spill_journal_claim_for_merge(string $journalPath): ?string
+{
+    if (!is_file($journalPath)) {
+        return null;
+    }
+
+    $claimPath = $journalPath . '.merging.' . getmypid();
+    if (@rename($journalPath, $claimPath)) {
+        return $claimPath;
+    }
+
+    return null;
+}
+
+/**
+ * Merge all valid lines from a claimed worker journal into hour bucket data.
+ *
+ * @param string               $claimedPath Renamed journal from metrics_spill_journal_claim_for_merge()
+ * @param string               $hourId      UTC hour bucket id
+ * @param array<string, mixed> $hourData    Hourly bucket (mutated in place)
+ * @return int Number of lines merged (0 when none applied)
+ */
+function metrics_spill_journal_merge_claimed_into_hour_data(
+    string $claimedPath,
+    string $hourId,
+    array &$hourData
+): int {
+    $fp = @fopen($claimedPath, 'rb');
+    if ($fp === false) {
+        return 0;
+    }
+
+    $merged = 0;
+
+    try {
+        while (($rawLine = fgets($fp)) !== false) {
+            $line = trim($rawLine);
+            if ($line === '') {
+                continue;
+            }
+
+            $data = @json_decode($line, true);
+            if (!is_array($data)) {
+                continue;
+            }
+
+            $parsed = metrics_parse_spill_payload_for_merge($data, $hourId);
+            if ($parsed === null) {
+                continue;
+            }
+
+            metrics_apply_flat_counters_to_hour_data($hourData, $parsed['counters'], true);
+            $merged++;
+        }
+    } finally {
+        fclose($fp);
+        @unlink($claimedPath);
+    }
+
+    return $merged;
+}
+
+/**
+ * Whether a spill path is a per-worker JSONL journal (not a legacy .json shard).
+ *
+ * @param string $path Absolute spill file path
+ * @return bool
+ */
+function metrics_spill_path_is_worker_journal(string $path): bool
+{
+    $base = basename($path);
+
+    return str_ends_with($base, '.jsonl')
+        && strpos($base, '.merging.') === false
+        && strpos($base, '.tmp.') === false;
+}

--- a/lib/metrics-spill-journal.php
+++ b/lib/metrics-spill-journal.php
@@ -63,9 +63,21 @@ function metrics_spill_journal_append_locked(string $journalPath, array $payload
 
         $locked = true;
 
-        $written = fwrite($fp, $line);
-        if ($written !== strlen($line)) {
+        $offset = ftell($fp);
+        if ($offset === false) {
             return false;
+        }
+
+        $lineLen = strlen($line);
+        $writtenTotal = 0;
+        while ($writtenTotal < $lineLen) {
+            $chunk = fwrite($fp, substr($line, $writtenTotal));
+            if ($chunk === false || $chunk < 1) {
+                @ftruncate($fp, $offset);
+
+                return false;
+            }
+            $writtenTotal += $chunk;
         }
 
         fflush($fp);

--- a/lib/metrics-spill-journal.php
+++ b/lib/metrics-spill-journal.php
@@ -145,7 +145,7 @@ function metrics_spill_journal_merge_claimed_into_hour_data(
             ) {
                 $budgetExhausted = true;
                 if ($merged > 0) {
-                    metrics_spill_journal_rewrite_claimed_tail($fp, $claimedPath);
+                    metrics_spill_journal_rewrite_claimed_tail($fp, $claimedPath, $rawLine);
                 }
                 break;
             }
@@ -185,14 +185,19 @@ function metrics_spill_journal_merge_claimed_into_hour_data(
 /**
  * Persist unread journal lines after a partial merge under the runtime budget.
  *
- * @param resource $fp          Open read handle positioned after the last merged line
- * @param string   $claimedPath Claimed journal path to rewrite or delete when empty
+ * @param resource $fp               Open read handle positioned after $unmergedLine
+ * @param string   $claimedPath      Claimed journal path to rewrite or delete when empty
+ * @param string   $unmergedLine     Line read when the runtime budget was exhausted (not yet merged)
  * @return void
  */
-function metrics_spill_journal_rewrite_claimed_tail($fp, string $claimedPath): void
+function metrics_spill_journal_rewrite_claimed_tail($fp, string $claimedPath, string $unmergedLine = ''): void
 {
-    $remainder = stream_get_contents($fp);
-    if ($remainder === false || $remainder === '') {
+    $tail = stream_get_contents($fp);
+    if ($tail === false) {
+        $tail = '';
+    }
+    $remainder = $unmergedLine . $tail;
+    if ($remainder === '') {
         @unlink($claimedPath);
 
         return;

--- a/lib/metrics-spill-journal.php
+++ b/lib/metrics-spill-journal.php
@@ -93,7 +93,7 @@ function metrics_spill_journal_claim_for_merge(string $journalPath): ?string
         return null;
     }
 
-    $claimPath = $journalPath . '.merging.' . getmypid();
+    $claimPath = $journalPath . '.merging.' . getmypid() . '.' . bin2hex(random_bytes(4));
     if (@rename($journalPath, $claimPath)) {
         return $claimPath;
     }

--- a/lib/metrics-spill-journal.php
+++ b/lib/metrics-spill-journal.php
@@ -48,10 +48,14 @@ function metrics_spill_journal_append_locked(string $journalPath, array $payload
         return false;
     }
 
+    $locked = false;
+
     try {
         if (!flock($fp, LOCK_EX)) {
             return false;
         }
+
+        $locked = true;
 
         $written = fwrite($fp, $line);
         if ($written !== strlen($line)) {
@@ -62,7 +66,9 @@ function metrics_spill_journal_append_locked(string $journalPath, array $payload
 
         return true;
     } finally {
-        flock($fp, LOCK_UN);
+        if ($locked) {
+            flock($fp, LOCK_UN);
+        }
         fclose($fp);
     }
 }

--- a/lib/metrics-spill-journal.php
+++ b/lib/metrics-spill-journal.php
@@ -101,7 +101,7 @@ function metrics_spill_journal_claim_for_merge(string $journalPath): ?string
  * @param string               $claimedPath Renamed journal from metrics_spill_journal_claim_for_merge()
  * @param string               $hourId      UTC hour bucket id
  * @param array<string, mixed> $hourData    Hourly bucket (mutated in place)
- * @return int Number of lines merged (0 when none applied)
+ * @return int Number of lines merged (0 when none applied). Caller deletes $claimedPath after hourly write.
  */
 function metrics_spill_journal_merge_claimed_into_hour_data(
     string $claimedPath,
@@ -148,14 +148,13 @@ function metrics_spill_journal_merge_claimed_into_hour_data(
             flock($fp, LOCK_UN);
         }
         fclose($fp);
-        @unlink($claimedPath);
     }
 
     return $merged;
 }
 
 /**
- * Whether a spill path is a per-worker JSONL journal (not a legacy .json shard).
+ * Whether a spill path is a per-worker JSONL journal (not a claim or temp file).
  *
  * @param string $path Absolute spill file path
  * @return bool
@@ -167,4 +166,15 @@ function metrics_spill_path_is_worker_journal(string $path): bool
     return str_ends_with($base, '.jsonl')
         && strpos($base, '.merging.') === false
         && strpos($base, '.tmp.') === false;
+}
+
+/**
+ * Whether a spill path is a claimed journal awaiting merge (rename from live {pid}.jsonl).
+ *
+ * @param string $path Absolute spill file path
+ * @return bool
+ */
+function metrics_spill_path_is_claimed_journal(string $path): bool
+{
+    return strpos(basename($path), '.jsonl.merging.') !== false;
 }

--- a/lib/metrics-spill-journal.php
+++ b/lib/metrics-spill-journal.php
@@ -107,13 +107,21 @@ function metrics_spill_journal_claim_for_merge(string $journalPath): ?string
  * @param string               $claimedPath Renamed journal from metrics_spill_journal_claim_for_merge()
  * @param string               $hourId      UTC hour bucket id
  * @param array<string, mixed> $hourData    Hourly bucket (mutated in place)
+ * @param int|float|null       $t0Ns                 Optional hrtime(true) anchor for runtime budget checks
+ * @param bool|null            $journalFullyConsumed Set true when every line in the claim was processed
  * @return int Number of lines merged (0 when none applied). Caller deletes $claimedPath after hourly write.
  */
 function metrics_spill_journal_merge_claimed_into_hour_data(
     string $claimedPath,
     string $hourId,
-    array &$hourData
+    array &$hourData,
+    $t0Ns = null,
+    ?bool &$journalFullyConsumed = null
 ): int {
+    if ($journalFullyConsumed !== null) {
+        $journalFullyConsumed = false;
+    }
+
     $fp = @fopen($claimedPath, 'rb');
     if ($fp === false) {
         return 0;
@@ -121,6 +129,7 @@ function metrics_spill_journal_merge_claimed_into_hour_data(
 
     $merged = 0;
     $locked = false;
+    $budgetExhausted = false;
 
     try {
         // Wait for any in-flight append on the renamed inode (worker may still hold LOCK_EX).
@@ -131,6 +140,16 @@ function metrics_spill_journal_merge_claimed_into_hour_data(
         $locked = true;
 
         while (($rawLine = fgets($fp)) !== false) {
+            if ($t0Ns !== null
+                && (hrtime(true) - $t0Ns) / 1e6 >= METRICS_SPILL_MERGE_MAX_RUNTIME_MS
+            ) {
+                $budgetExhausted = true;
+                if ($merged > 0) {
+                    metrics_spill_journal_rewrite_claimed_tail($fp, $claimedPath);
+                }
+                break;
+            }
+
             $line = trim($rawLine);
             if ($line === '') {
                 continue;
@@ -149,6 +168,10 @@ function metrics_spill_journal_merge_claimed_into_hour_data(
             metrics_apply_flat_counters_to_hour_data($hourData, $parsed['counters'], true);
             $merged++;
         }
+
+        if (!$budgetExhausted && $journalFullyConsumed !== null) {
+            $journalFullyConsumed = true;
+        }
     } finally {
         if ($locked) {
             flock($fp, LOCK_UN);
@@ -157,6 +180,32 @@ function metrics_spill_journal_merge_claimed_into_hour_data(
     }
 
     return $merged;
+}
+
+/**
+ * Persist unread journal lines after a partial merge under the runtime budget.
+ *
+ * @param resource $fp          Open read handle positioned after the last merged line
+ * @param string   $claimedPath Claimed journal path to rewrite or delete when empty
+ * @return void
+ */
+function metrics_spill_journal_rewrite_claimed_tail($fp, string $claimedPath): void
+{
+    $remainder = stream_get_contents($fp);
+    if ($remainder === false || $remainder === '') {
+        @unlink($claimedPath);
+
+        return;
+    }
+
+    $tmp = $claimedPath . '.tmp.tail.' . getmypid();
+    if (@file_put_contents($tmp, $remainder, LOCK_EX) === false) {
+        @unlink($tmp);
+
+        return;
+    }
+
+    @rename($tmp, $claimedPath);
 }
 
 /**

--- a/lib/metrics-spill-journal.php
+++ b/lib/metrics-spill-journal.php
@@ -226,11 +226,15 @@ function metrics_spill_journal_rewrite_claimed_tail($fp, string $claimedPath, st
         return;
     }
 
+    $remainderLen = strlen($remainder);
     $tmp = $claimedPath . '.tmp.tail.' . getmypid();
-    if (@file_put_contents($tmp, $remainder, LOCK_EX) === false) {
+    $tmpWritten = @file_put_contents($tmp, $remainder, LOCK_EX);
+    if ($tmpWritten === false || $tmpWritten !== $remainderLen) {
         @unlink($tmp);
         aviationwx_log('warning', 'metrics spill: journal tail temp write failed', [
             'path' => $claimedPath,
+            'expected_bytes' => $remainderLen,
+            'written_bytes' => $tmpWritten === false ? null : $tmpWritten,
         ], 'app');
 
         return;
@@ -244,9 +248,12 @@ function metrics_spill_journal_rewrite_claimed_tail($fp, string $claimedPath, st
     aviationwx_log('warning', 'metrics spill: journal tail rename failed; overwriting claim', [
         'path' => $claimedPath,
     ], 'app');
-    if (@file_put_contents($claimedPath, $remainder, LOCK_EX) === false) {
+    $overwriteWritten = @file_put_contents($claimedPath, $remainder, LOCK_EX);
+    if ($overwriteWritten === false || $overwriteWritten !== $remainderLen) {
         aviationwx_log('warning', 'metrics spill: journal tail overwrite failed', [
             'path' => $claimedPath,
+            'expected_bytes' => $remainderLen,
+            'written_bytes' => $overwriteWritten === false ? null : $overwriteWritten,
         ], 'app');
     }
 }

--- a/lib/metrics.php
+++ b/lib/metrics.php
@@ -16,7 +16,7 @@
  * 
  * Storage:
  * - APCu for real-time counters (microsecond increment)
- * - Per-worker spill JSON under cache/metrics/spill/ (shutdown on PHP-FPM workers)
+ * - Per-worker JSONL spill journals under cache/metrics/spill/ (one append per request shutdown)
  * - Scheduler merges spills into hourly/*.json via CLI (singleton lock; soft caps)
  * - Hourly, daily, weekly aggregation buckets
  * - 14-day retention with automatic cleanup
@@ -2092,16 +2092,15 @@ function metrics_prometheus_export(): array {
 // =============================================================================
 
 /**
- * Persist pending APCu counters to a spill file and reset counters on success.
+ * Persist pending APCu counters to the worker JSONL journal and reset counters on success.
  *
- * Uses a unique filename per call so successive request shutdowns do not overwrite unconsumed shards.
- * Each file holds counters accumulated since the last successful spill for this worker (delta shard).
+ * Appends one JSON line per request shutdown to CACHE_METRICS_SPILL_DIR/{hourId}/{pid}.jsonl.
+ * Each line is a delta since the previous spill on this worker. The aggregator claims the
+ * journal via rename and merges all lines into the canonical hourly file.
  *
- * Spill path: CACHE_METRICS_SPILL_DIR/{hourId}/{pid}_{uniq}.json (see cache-paths.php).
+ * Never throws: shutdown hooks must stay safe.
  *
- * Never throws: path generation uses CSPRNG (may throw under extreme failure); shutdown hooks must stay safe.
- *
- * @return bool True if nothing to write, or spill written and APCu reset
+ * @return bool True if nothing to write, or journal line appended and APCu reset
  */
 function metrics_write_spill_snapshot_and_reset_counters(): bool {
     if (!metrics_is_apcu_available()) {
@@ -2114,40 +2113,20 @@ function metrics_write_spill_snapshot_and_reset_counters(): bool {
     }
 
     try {
+        require_once __DIR__ . '/metrics-spill-journal.php';
+
         $hourId = metrics_get_hour_id();
         $pid = getmypid();
-        $target = getMetricsSpillSnapshotPath($hourId, $pid);
-        $dir = dirname($target);
+        $journalPath = getMetricsSpillWorkerJournalPath($hourId, $pid);
+        $dir = dirname($journalPath);
         if (!ensureCacheDir($dir)) {
             aviationwx_log('warning', 'metrics spill: could not create spill directory', ['dir' => $dir], 'app');
             return false;
         }
 
-        $payload = [
-            'schema_version' => METRICS_SPILL_FILE_SCHEMA_VERSION,
-            'generated_at' => time(),
-            'hour_id' => $hourId,
-            'pid' => $pid,
-            'counters' => $counters,
-        ];
-
-        $json = json_encode($payload);
-        if ($json === false) {
-            aviationwx_log('warning', 'metrics spill: json_encode failed', ['error' => json_last_error_msg()], 'app');
-            return false;
-        }
-
-        $tmpFile = $target . '.tmp.' . $pid;
-        $written = @file_put_contents($tmpFile, $json, LOCK_EX);
-        if ($written === false) {
-            @unlink($tmpFile);
-            aviationwx_log('warning', 'metrics spill: temp write failed', ['path' => $tmpFile], 'app');
-            return false;
-        }
-
-        if (!@rename($tmpFile, $target)) {
-            @unlink($tmpFile);
-            aviationwx_log('warning', 'metrics spill: rename failed', ['path' => $target], 'app');
+        $payload = metrics_spill_build_payload($hourId, $pid, $counters);
+        if (!metrics_spill_journal_append_locked($journalPath, $payload)) {
+            aviationwx_log('warning', 'metrics spill: journal append failed', ['path' => $journalPath], 'app');
             return false;
         }
 

--- a/tests/Unit/CachePathsStructureTest.php
+++ b/tests/Unit/CachePathsStructureTest.php
@@ -106,18 +106,18 @@ class CachePathsStructureTest extends TestCase
     }
 
     /**
-     * Metrics spill snapshots use unique filenames under spill/{hourId}/ so workers do not overwrite pending shards
+     * Per-worker JSONL journals use a stable {pid}.jsonl path under spill/{hourId}/
      */
-    public function testMetricsSpillSnapshotPath_IsUniquePerCall(): void
+    public function testMetricsSpillWorkerJournalPath_IsStablePerWorker(): void
     {
         $hourId = '2026-05-09-14';
         $dir = getMetricsSpillHourDir($hourId);
         $this->assertStringContainsString('spill', $dir);
         $this->assertStringContainsString($hourId, $dir);
-        $p1 = getMetricsSpillSnapshotPath($hourId, 4242);
-        $p2 = getMetricsSpillSnapshotPath($hourId, 4242);
-        $this->assertNotSame($p1, $p2);
-        $this->assertMatchesRegularExpression('#/4242_[a-f0-9]{16}\.json$#', $p1);
+        $p1 = getMetricsSpillWorkerJournalPath($hourId, 4242);
+        $p2 = getMetricsSpillWorkerJournalPath($hourId, 4242);
+        $this->assertSame($p1, $p2);
+        $this->assertMatchesRegularExpression('#/4242\.jsonl$#', $p1);
         $this->assertSame(getMetricsSpillRootDir() . '/' . $hourId, $dir);
     }
 

--- a/tests/Unit/MetricsSpillAggregatorJsonlTest.php
+++ b/tests/Unit/MetricsSpillAggregatorJsonlTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Per-worker JSONL spill journals merge into hourly metrics files.
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/cache-paths.php';
+require_once __DIR__ . '/../../lib/constants.php';
+require_once __DIR__ . '/../../lib/metrics-spill-journal.php';
+require_once __DIR__ . '/../../lib/metrics-spill-aggregator.php';
+
+class MetricsSpillAggregatorJsonlTest extends TestCase
+{
+    public function testAggregator_MergesWorkerJournalLinesIntoHourlyFile(): void
+    {
+        $hourId = '2099-03-10-08';
+        $hourDir = getMetricsSpillHourDir($hourId);
+        if (!@mkdir($hourDir, 0755, true) && !is_dir($hourDir)) {
+            $this->fail('Could not create spill hour directory');
+        }
+
+        $journal = getMetricsSpillWorkerJournalPath($hourId, 88001);
+        $lines = [
+            metrics_spill_build_payload($hourId, 88001, ['global_page_views' => 2]),
+            metrics_spill_build_payload($hourId, 88001, ['global_page_views' => 3]),
+        ];
+        $content = '';
+        foreach ($lines as $payload) {
+            $content .= json_encode($payload) . "\n";
+        }
+        $this->assertNotFalse(file_put_contents($journal, $content));
+
+        $stats = metrics_run_spill_aggregator_once();
+
+        $this->assertFalse($stats['lock_contended']);
+        $this->assertSame(2, (int) $stats['spills_merged']);
+        $this->assertFileDoesNotExist($journal);
+
+        $hourPath = getMetricsHourlyPath($hourId);
+        $this->assertFileExists($hourPath);
+        $hourJson = json_decode((string) file_get_contents($hourPath), true);
+        $this->assertIsArray($hourJson);
+        $this->assertSame(5, $hourJson['global']['page_views'] ?? null);
+
+        @unlink($hourPath);
+        @rmdir($hourDir);
+        @unlink(getMetricsAggregatorLastRunPath());
+        @unlink(getMetricsAggregatorLockPath());
+    }
+
+    public function testAggregator_MergesLegacyJsonAndWorkerJournalTogether(): void
+    {
+        $hourId = '2099-03-10-09';
+        $hourDir = getMetricsSpillHourDir($hourId);
+        if (!@mkdir($hourDir, 0755, true) && !is_dir($hourDir)) {
+            $this->fail('Could not create spill hour directory');
+        }
+
+        $legacy = $hourDir . '/legacy_shard.json';
+        $legacyPayload = [
+            'schema_version' => METRICS_SPILL_FILE_SCHEMA_VERSION,
+            'generated_at' => time(),
+            'hour_id' => $hourId,
+            'pid' => 88002,
+            'counters' => ['global_page_views' => 4],
+        ];
+        $this->assertNotFalse(file_put_contents($legacy, json_encode($legacyPayload)));
+
+        $journal = getMetricsSpillWorkerJournalPath($hourId, 88003);
+        $journalLine = metrics_spill_build_payload($hourId, 88003, ['global_page_views' => 6]);
+        $this->assertNotFalse(file_put_contents($journal, json_encode($journalLine) . "\n"));
+
+        $stats = metrics_run_spill_aggregator_once();
+
+        $this->assertGreaterThanOrEqual(2, (int) $stats['spills_merged']);
+        $hourPath = getMetricsHourlyPath($hourId);
+        $hourJson = json_decode((string) file_get_contents($hourPath), true);
+        $this->assertSame(10, $hourJson['global']['page_views'] ?? null);
+
+        @unlink($hourPath);
+        @rmdir($hourDir);
+        @unlink(getMetricsAggregatorLastRunPath());
+        @unlink(getMetricsAggregatorLockPath());
+    }
+
+    public function testJournalAppend_MultipleShutdownsAppendLinesToSameFile(): void
+    {
+        $hourId = '2099-03-10-10';
+        $journal = getMetricsSpillWorkerJournalPath($hourId, 88004);
+        $dir = dirname($journal);
+        if (!@mkdir($dir, 0755, true) && !is_dir($dir)) {
+            $this->fail('Could not create spill hour directory');
+        }
+
+        $this->assertTrue(metrics_spill_journal_append_locked(
+            $journal,
+            metrics_spill_build_payload($hourId, 88004, ['global_page_views' => 1])
+        ));
+        $this->assertTrue(metrics_spill_journal_append_locked(
+            $journal,
+            metrics_spill_build_payload($hourId, 88004, ['global_page_views' => 2])
+        ));
+
+        $raw = file_get_contents($journal);
+        $this->assertNotFalse($raw);
+        $this->assertSame(2, substr_count($raw, "\n"));
+
+        @unlink($journal);
+        @rmdir($dir);
+    }
+}

--- a/tests/Unit/MetricsSpillAggregatorOrphanPruneTest.php
+++ b/tests/Unit/MetricsSpillAggregatorOrphanPruneTest.php
@@ -35,4 +35,27 @@ class MetricsSpillAggregatorOrphanPruneTest extends TestCase
         @unlink(getMetricsAggregatorLastRunPath());
         @unlink(getMetricsAggregatorLockPath());
     }
+
+    public function testPrune_RemovesVeryOldClaimedJournal(): void
+    {
+        $oldHour = '2019-12-31-22';
+        $dir = getMetricsSpillHourDir($oldHour);
+        if (!@mkdir($dir, 0755, true) && !is_dir($dir)) {
+            $this->fail('Could not create spill hour directory');
+        }
+
+        $claimedPath = $dir . '/42.jsonl.merging.99999';
+        $this->assertNotFalse(file_put_contents($claimedPath, "{\"orphan\":true}\n"));
+        $staleMtime = time() - METRICS_SPILL_ORPHAN_MAX_AGE_SECONDS - 120;
+        $this->assertTrue(touch($claimedPath, $staleMtime));
+
+        $stats = metrics_run_spill_aggregator_once();
+        $this->assertFalse($stats['lock_contended']);
+        $this->assertGreaterThanOrEqual(1, (int) $stats['orphans_pruned']);
+        $this->assertFileDoesNotExist($claimedPath);
+
+        @rmdir($dir);
+        @unlink(getMetricsAggregatorLastRunPath());
+        @unlink(getMetricsAggregatorLockPath());
+    }
 }

--- a/tests/Unit/MetricsSpillJournalMergeBudgetTest.php
+++ b/tests/Unit/MetricsSpillJournalMergeBudgetTest.php
@@ -72,14 +72,14 @@ $claimed = getMetricsSpillHourDir($hourId) . '/77.jsonl.merging.1';
 @mkdir(dirname($claimed), 0755, true);
 
 $lines = '';
-for ($i = 1; $i <= 200; $i++) {
+for ($i = 1; $i <= 5000; $i++) {
     $payload = metrics_spill_build_payload($hourId, 77, ['global_page_views' => 1]);
     $lines .= json_encode($payload) . "\n";
 }
 file_put_contents($claimed, $lines);
 
-$hourData = metrics_new_empty_hour_bucket($hourId);
 require $root . '/lib/metrics.php';
+$hourData = metrics_new_empty_hour_bucket($hourId);
 
 $t0Ns = hrtime(true);
 $fullyConsumed = false;
@@ -104,7 +104,7 @@ if (!is_file($claimed)) {
     exit(1);
 }
 $remaining = count(file($claimed, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: []);
-if ($remaining < 1 || $remaining >= 200) {
+if ($remaining < 1 || $remaining >= 5000) {
     fwrite(STDERR, "expected unread tail, got {$remaining} lines\n");
     exit(1);
 }

--- a/tests/Unit/MetricsSpillJournalMergeBudgetTest.php
+++ b/tests/Unit/MetricsSpillJournalMergeBudgetTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Claimed journal merge respects METRICS_SPILL_MERGE_MAX_RUNTIME_MS within one file.
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class MetricsSpillJournalMergeBudgetTest extends TestCase
+{
+    /**
+     * @return array{exit: int, output: string}
+     */
+    private function runHarness(string $scriptBody): array
+    {
+        $root = dirname(__DIR__, 2);
+        $cacheId = bin2hex(random_bytes(8));
+        $tmp = sys_get_temp_dir() . '/aviationwx_journal_merge_sub_' . bin2hex(random_bytes(8)) . '.php';
+        file_put_contents($tmp, $this->harnessPreamble($cacheId) . $scriptBody);
+
+        $env = [
+            'METRICS_AGG_TEST_ROOT' => $root,
+            'METRICS_AGG_TEST_CACHE' => sys_get_temp_dir() . '/aviationwx_journal_merge_cache_' . $cacheId,
+        ];
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($tmp) . ' 2>&1';
+        $proc = proc_open($cmd, [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, null, $env);
+        $this->assertIsResource($proc);
+        fclose($pipes[0]);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($proc);
+        @unlink($tmp);
+
+        return ['exit' => $exitCode, 'output' => $out . $err];
+    }
+
+    private function harnessPreamble(string $cacheId): string
+    {
+        return <<<PHP
+<?php
+declare(strict_types=1);
+
+if (!defined('METRICS_SPILL_MERGE_MAX_RUNTIME_MS')) {
+    define('METRICS_SPILL_MERGE_MAX_RUNTIME_MS', 1);
+}
+if (!defined('CACHE_BASE_DIR')) {
+    define('CACHE_BASE_DIR', getenv('METRICS_AGG_TEST_CACHE') ?: (sys_get_temp_dir() . '/aviationwx_journal_merge_cache_{$cacheId}'));
+}
+if (!defined('AVIATIONWX_LOG_DIR')) {
+    define('AVIATIONWX_LOG_DIR', sys_get_temp_dir() . '/aviationwx_journal_merge_log_{$cacheId}');
+}
+@mkdir(CACHE_BASE_DIR, 0755, true);
+@mkdir(AVIATIONWX_LOG_DIR, 0755, true);
+@touch(AVIATIONWX_LOG_DIR . '/app.log');
+
+\$root = getenv('METRICS_AGG_TEST_ROOT');
+
+PHP;
+    }
+
+    public function testMergeClaimed_RuntimeBudget_RewritesUnreadTail(): void
+    {
+        $body = <<<'PHP'
+require $root . '/lib/cache-paths.php';
+require $root . '/lib/metrics-spill-journal.php';
+
+$hourId = '2099-05-01-10';
+$claimed = getMetricsSpillHourDir($hourId) . '/77.jsonl.merging.1';
+@mkdir(dirname($claimed), 0755, true);
+
+$lines = '';
+for ($i = 1; $i <= 200; $i++) {
+    $payload = metrics_spill_build_payload($hourId, 77, ['global_page_views' => 1]);
+    $lines .= json_encode($payload) . "\n";
+}
+file_put_contents($claimed, $lines);
+
+$hourData = metrics_new_empty_hour_bucket($hourId);
+require $root . '/lib/metrics.php';
+
+$t0Ns = hrtime(true);
+$fullyConsumed = false;
+$merged = metrics_spill_journal_merge_claimed_into_hour_data(
+    $claimed,
+    $hourId,
+    $hourData,
+    $t0Ns,
+    $fullyConsumed
+);
+
+if ($merged < 1) {
+    fwrite(STDERR, "expected partial merge, got {$merged}\n");
+    exit(1);
+}
+if ($fullyConsumed) {
+    fwrite(STDERR, "expected partial journal to remain\n");
+    exit(1);
+}
+if (!is_file($claimed)) {
+    fwrite(STDERR, "expected claimed tail file to remain\n");
+    exit(1);
+}
+$remaining = count(file($claimed, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: []);
+if ($remaining < 1 || $remaining >= 200) {
+    fwrite(STDERR, "expected unread tail, got {$remaining} lines\n");
+    exit(1);
+}
+
+echo json_encode(['ok' => true, 'merged' => $merged, 'remaining' => $remaining]);
+PHP;
+
+        $result = $this->runHarness($body);
+        $this->assertSame(0, $result['exit'], 'harness failed: ' . $result['output']);
+        $decoded = json_decode(trim($result['output']), true);
+        $this->assertIsArray($decoded);
+        $this->assertTrue($decoded['ok'] ?? false);
+    }
+}

--- a/tests/Unit/MetricsSpillSnapshotTest.php
+++ b/tests/Unit/MetricsSpillSnapshotTest.php
@@ -62,21 +62,45 @@ class MetricsSpillSnapshotTest extends TestCase
             $this->markTestSkipped('APCu not available or disabled');
         }
 
+        $hourId = metrics_get_hour_id();
         $pid = getmypid();
-        metrics_increment('global_page_views');
-        $this->assertTrue(metrics_write_spill_snapshot_and_reset_counters());
-        metrics_increment('global_page_views');
-        metrics_increment('global_page_views');
-        $this->assertTrue(metrics_write_spill_snapshot_and_reset_counters());
 
-        $pattern = getMetricsSpillRootDir() . '/*/' . $pid . '.jsonl';
-        $files = glob($pattern) ?: [];
-        $this->assertCount(1, $files);
-        $raw = file_get_contents($files[0]);
+        metrics_increment('global_page_views');
+        $this->assertTrue(metrics_write_spill_snapshot_and_reset_counters());
+        if (metrics_get_hour_id() !== $hourId) {
+            $this->cleanupPidSpillJournals($pid);
+            $this->markTestSkipped('UTC hour boundary crossed between spill writes');
+        }
+
+        metrics_increment('global_page_views');
+        metrics_increment('global_page_views');
+        $this->assertTrue(metrics_write_spill_snapshot_and_reset_counters());
+        if (metrics_get_hour_id() !== $hourId) {
+            $this->cleanupPidSpillJournals($pid);
+            $this->markTestSkipped('UTC hour boundary crossed between spill writes');
+        }
+
+        $journal = getMetricsSpillWorkerJournalPath($hourId, $pid);
+        $this->assertFileExists($journal);
+        $raw = file_get_contents($journal);
         $this->assertNotFalse($raw);
         $this->assertSame(2, substr_count($raw, "\n"));
 
-        @unlink($files[0]);
-        @rmdir(dirname($files[0]));
+        @unlink($journal);
+        @rmdir(getMetricsSpillHourDir($hourId));
+    }
+
+    /**
+     * Remove any spill journals created for a worker PID (used when skipping at hour boundaries).
+     *
+     * @param int $pid PHP worker PID
+     * @return void
+     */
+    private function cleanupPidSpillJournals(int $pid): void
+    {
+        foreach (glob(getMetricsSpillRootDir() . '/*/' . $pid . '.jsonl') ?: [] as $path) {
+            @unlink($path);
+            @rmdir(dirname($path));
+        }
     }
 }

--- a/tests/Unit/MetricsSpillSnapshotTest.php
+++ b/tests/Unit/MetricsSpillSnapshotTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Per-worker spill snapshot writes JSON and resets APCu counters (direct call; web uses shutdown hook).
+ * Per-worker spill journal writes JSONL lines and resets APCu counters (direct call; web uses shutdown hook).
  */
 
 declare(strict_types=1);
@@ -21,7 +21,7 @@ class MetricsSpillSnapshotTest extends TestCase
         }
     }
 
-    public function testWriteSpillSnapshot_PersistsCountersAndResetsApcu(): void
+    public function testWriteSpillSnapshot_AppendsJournalLineAndResetsApcu(): void
     {
         if (!function_exists('apcu_store') || !function_exists('apcu_enabled') || !@apcu_enabled()) {
             $this->markTestSkipped('APCu not available or disabled');
@@ -36,16 +36,16 @@ class MetricsSpillSnapshotTest extends TestCase
 
         $this->assertSame(0, metrics_get('global_page_views'));
 
-        // Resolve shard without assuming hour dir matches a second metrics_get_hour_id() call (hour-boundary flake).
-        $pattern = getMetricsSpillRootDir() . '/*/' . $pid . '_*.json';
+        $pattern = getMetricsSpillRootDir() . '/*/' . $pid . '.jsonl';
         $files = glob($pattern) ?: [];
-        $this->assertCount(1, $files, 'Expected exactly one spill shard for this PID');
+        $this->assertCount(1, $files, 'Expected exactly one worker journal for this PID');
         $path = $files[0];
         $this->assertFileExists($path);
 
         $raw = file_get_contents($path);
         $this->assertNotFalse($raw);
-        $data = json_decode($raw, true);
+        $line = trim(explode("\n", $raw)[0]);
+        $data = json_decode($line, true);
         $this->assertIsArray($data);
         $this->assertSame(METRICS_SPILL_FILE_SCHEMA_VERSION, $data['schema_version']);
         $this->assertIsString($data['hour_id'] ?? null);
@@ -54,5 +54,29 @@ class MetricsSpillSnapshotTest extends TestCase
 
         @unlink($path);
         @rmdir(dirname($path));
+    }
+
+    public function testWriteSpillSnapshot_MultipleCallsAppendMultipleLines(): void
+    {
+        if (!function_exists('apcu_store') || !function_exists('apcu_enabled') || !@apcu_enabled()) {
+            $this->markTestSkipped('APCu not available or disabled');
+        }
+
+        $pid = getmypid();
+        metrics_increment('global_page_views');
+        $this->assertTrue(metrics_write_spill_snapshot_and_reset_counters());
+        metrics_increment('global_page_views');
+        metrics_increment('global_page_views');
+        $this->assertTrue(metrics_write_spill_snapshot_and_reset_counters());
+
+        $pattern = getMetricsSpillRootDir() . '/*/' . $pid . '.jsonl';
+        $files = glob($pattern) ?: [];
+        $this->assertCount(1, $files);
+        $raw = file_get_contents($files[0]);
+        $this->assertNotFalse($raw);
+        $this->assertSame(2, substr_count($raw, "\n"));
+
+        @unlink($files[0]);
+        @rmdir(dirname($files[0]));
     }
 }


### PR DESCRIPTION
## Summary

- Spill path now appends one JSON line per request shutdown to `{pid}.jsonl` under each UTC hour directory instead of creating a unique `{pid}_{hex}.json` file per request.
- Aggregator claims worker journals via rename (workers create a fresh journal after claim), merges all lines into hourly JSON, and continues to support legacy `.json` shards until drained.
- Fixes aggregator skip when only JSONL journals merged (`hourHadMerges` vs `pendingDeletes`).

## Why

Spill volume scales with HTTP request count (weather polls, tiles, webcams), not visitor count. Per-request files produced thousands of shards/hour; JSONL batching reduces that to ~one file per active FPM worker per hour while keeping the same privacy-first aggregate counter model.

Builds on #115 (partial flush must be deployed first).

## Code changes

- `lib/metrics-spill-journal.php` - append, claim-for-merge, line merge helpers
- `lib/cache-paths.php` - `getMetricsSpillWorkerJournalPath()`; legacy `getMetricsSpillSnapshotPath()` retained
- `lib/metrics.php` - shutdown spill writes JSONL journal lines
- `lib/metrics-spill-aggregator.php` - merge JSONL + legacy JSON; orphan prune includes `.jsonl`
- `tests/Unit/MetricsSpillAggregatorJsonlTest.php` - journal merge, mixed legacy+JSONL, append behavior
- Updated `MetricsSpillSnapshotTest`, `CachePathsStructureTest`
- `docs/OPERATIONS.md` - spill layout documentation

## Test plan

- [x] `make test-ci`
- [x] `vendor/bin/phpunit tests/Unit/MetricsSpillAggregatorJsonlTest.php` and existing spill aggregator tests
- [x] After deploy: confirm new spills land as `{pid}.jsonl` under `cache/metrics/spill/{hour}/`
- [x] Legacy `.json` shards (if any remain) still merge; hour dirs shrink to ~worker count over time
- [x] Status page `/hr` metrics remain accurate after a busy period

## Deploy note

No manual backlog drain expected. Existing `.json` shards merge normally. New traffic uses JSONL immediately after deploy.