### PR TITLE
Fix NOTAM banner clipping effective dates on mobile

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -356,17 +356,23 @@ body {
 .notam-time-range {
     font-size: 13px;
     opacity: 0.9;
-    flex-shrink: 0;
-    white-space: nowrap;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-wrap: break-word;
 }
 
-/* Responsive: stack on narrow screens */
+/* Responsive: stack time range on its own row on narrow screens */
 @media (max-width: 600px) {
     .notam-line {
         padding: 12px 15px;
     }
-    
+
+    .notam-message {
+        min-width: 0;
+    }
+
     .notam-time-range {
+        flex-basis: 100%;
         width: 100%;
         margin-top: 4px;
         padding-left: 24px;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -356,7 +356,7 @@ body {
 .notam-time-range {
     font-size: 13px;
     opacity: 0.9;
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     min-width: 0;
     overflow-wrap: break-word;
 }

--- a/tests/Unit/NotamBannerStylesTest.php
+++ b/tests/Unit/NotamBannerStylesTest.php
@@ -90,9 +90,9 @@ class NotamBannerStylesTest extends TestCase
         $rule = $this->extractRuleBlock($css, '.notam-time-range');
         $this->assertNotSame('', $rule, 'Expected .notam-time-range rule in styles.css');
 
-        $this->assertStringNotContainsString('white-space: nowrap', $rule);
-        $this->assertStringContainsString('overflow-wrap: break-word', $rule);
-        $this->assertStringContainsString('min-width: 0', $rule);
+        $this->assertDoesNotMatchRegularExpression('/white-space\s*:\s*nowrap\b/', $rule);
+        $this->assertMatchesRegularExpression('/overflow-wrap\s*:\s*break-word/', $rule);
+        $this->assertMatchesRegularExpression('/min-width\s*:\s*0\b/', $rule);
     }
 
     public function testNotamTimeRange_MobileBlockStacksOnOwnRow(): void

--- a/tests/Unit/NotamBannerStylesTest.php
+++ b/tests/Unit/NotamBannerStylesTest.php
@@ -82,10 +82,31 @@ class NotamBannerStylesTest extends TestCase
         return '';
     }
 
+    /**
+     * @return string Absolute path to the main stylesheet
+     */
+    private function stylesCssPath(): string
+    {
+        return dirname(__DIR__, 2) . '/public/css/styles.css';
+    }
+
+    /**
+     * @return string styles.css contents
+     */
+    private function loadStylesCss(): string
+    {
+        $path = $this->stylesCssPath();
+        $this->assertFileExists($path);
+
+        $css = file_get_contents($path);
+        $this->assertIsString($css);
+
+        return $css;
+    }
+
     public function testNotamTimeRange_AllowsWrappingForLongEffectiveDates(): void
     {
-        $css = file_get_contents(dirname(__DIR__, 2) . '/public/css/styles.css');
-        $this->assertIsString($css);
+        $css = $this->loadStylesCss();
 
         $rule = $this->extractRuleBlock($css, '.notam-time-range');
         $this->assertNotSame('', $rule, 'Expected .notam-time-range rule in styles.css');
@@ -97,8 +118,7 @@ class NotamBannerStylesTest extends TestCase
 
     public function testNotamTimeRange_MobileBlockStacksOnOwnRow(): void
     {
-        $css = file_get_contents(dirname(__DIR__, 2) . '/public/css/styles.css');
-        $this->assertIsString($css);
+        $css = $this->loadStylesCss();
 
         $media = $this->extractAtRuleBlock(
             $css,

--- a/tests/Unit/NotamBannerStylesTest.php
+++ b/tests/Unit/NotamBannerStylesTest.php
@@ -18,12 +18,12 @@ class NotamBannerStylesTest extends TestCase
      */
     private function extractRuleBlock(string $css, string $selector): string
     {
-        $needle = $selector . ' {';
-        $start = strpos($css, $needle);
-        if ($start === false) {
+        $pattern = '/' . preg_quote($selector, '/') . '\s*\{/';
+        if (!preg_match($pattern, $css, $matches, PREG_OFFSET_CAPTURE)) {
             return '';
         }
 
+        $start = $matches[0][1];
         $brace = strpos($css, '{', $start);
         if ($brace === false) {
             return '';

--- a/tests/Unit/NotamBannerStylesTest.php
+++ b/tests/Unit/NotamBannerStylesTest.php
@@ -92,7 +92,7 @@ class NotamBannerStylesTest extends TestCase
 
         $this->assertDoesNotMatchRegularExpression('/white-space\s*:\s*nowrap\b/', $rule);
         $this->assertMatchesRegularExpression('/overflow-wrap\s*:\s*break-word/', $rule);
-        $this->assertMatchesRegularExpression('/min-width\s*:\s*0\b/', $rule);
+        $this->assertMatchesRegularExpression('/min-width\s*:\s*0(px)?\b/', $rule);
     }
 
     public function testNotamTimeRange_MobileBlockStacksOnOwnRow(): void

--- a/tests/Unit/NotamBannerStylesTest.php
+++ b/tests/Unit/NotamBannerStylesTest.php
@@ -46,6 +46,42 @@ class NotamBannerStylesTest extends TestCase
         return '';
     }
 
+    /**
+     * Extract a full @-rule block (for example @media) using brace balancing.
+     *
+     * @param string $css        Full stylesheet contents
+     * @param string $atRuleNeedle Substring that identifies the rule (e.g. "@media (max-width: 600px)")
+     * @return string Rule block including the @ prefix and braces, or empty when missing
+     */
+    private function extractAtRuleBlock(string $css, string $atRuleNeedle): string
+    {
+        $start = strpos($css, $atRuleNeedle);
+        if ($start === false) {
+            return '';
+        }
+
+        $brace = strpos($css, '{', $start);
+        if ($brace === false) {
+            return '';
+        }
+
+        $depth = 0;
+        $len = strlen($css);
+        for ($i = $brace; $i < $len; $i++) {
+            $ch = $css[$i];
+            if ($ch === '{') {
+                $depth++;
+            } elseif ($ch === '}') {
+                $depth--;
+                if ($depth === 0) {
+                    return substr($css, $start, $i - $start + 1);
+                }
+            }
+        }
+
+        return '';
+    }
+
     public function testNotamTimeRange_AllowsWrappingForLongEffectiveDates(): void
     {
         $css = file_get_contents(dirname(__DIR__, 2) . '/public/css/styles.css');
@@ -64,9 +100,11 @@ class NotamBannerStylesTest extends TestCase
         $css = file_get_contents(dirname(__DIR__, 2) . '/public/css/styles.css');
         $this->assertIsString($css);
 
-        $this->assertMatchesRegularExpression(
-            '/@media\s*\(max-width:\s*600px\)\s*\{[^}]*\.notam-time-range\s*\{[^}]*flex-basis:\s*100%/s',
-            $css
-        );
+        $media = $this->extractAtRuleBlock($css, '@media (max-width: 600px)');
+        $this->assertNotSame('', $media, 'Expected mobile NOTAM @media block in styles.css');
+
+        $rule = $this->extractRuleBlock($media, '.notam-time-range');
+        $this->assertNotSame('', $rule, 'Expected .notam-time-range rule inside mobile @media block');
+        $this->assertMatchesRegularExpression('/flex-basis\s*:\s*100%/', $rule);
     }
 }

--- a/tests/Unit/NotamBannerStylesTest.php
+++ b/tests/Unit/NotamBannerStylesTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * NOTAM banner layout rules in styles.css (mobile text wrapping).
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class NotamBannerStylesTest extends TestCase
+{
+    /**
+     * Extract the first CSS rule block for a selector (stops at the closing brace).
+     *
+     * @param string $css    Full stylesheet contents
+     * @param string $selector Selector including leading dot
+     * @return string Rule block including braces, or empty string when missing
+     */
+    private function extractRuleBlock(string $css, string $selector): string
+    {
+        $needle = $selector . ' {';
+        $start = strpos($css, $needle);
+        if ($start === false) {
+            return '';
+        }
+
+        $brace = strpos($css, '{', $start);
+        if ($brace === false) {
+            return '';
+        }
+
+        $depth = 0;
+        $len = strlen($css);
+        for ($i = $brace; $i < $len; $i++) {
+            $ch = $css[$i];
+            if ($ch === '{') {
+                $depth++;
+            } elseif ($ch === '}') {
+                $depth--;
+                if ($depth === 0) {
+                    return substr($css, $start, $i - $start + 1);
+                }
+            }
+        }
+
+        return '';
+    }
+
+    public function testNotamTimeRange_AllowsWrappingForLongEffectiveDates(): void
+    {
+        $css = file_get_contents(dirname(__DIR__, 2) . '/public/css/styles.css');
+        $this->assertIsString($css);
+
+        $rule = $this->extractRuleBlock($css, '.notam-time-range');
+        $this->assertNotSame('', $rule, 'Expected .notam-time-range rule in styles.css');
+
+        $this->assertStringNotContainsString('white-space: nowrap', $rule);
+        $this->assertStringContainsString('overflow-wrap: break-word', $rule);
+        $this->assertStringContainsString('min-width: 0', $rule);
+    }
+
+    public function testNotamTimeRange_MobileBlockStacksOnOwnRow(): void
+    {
+        $css = file_get_contents(dirname(__DIR__, 2) . '/public/css/styles.css');
+        $this->assertIsString($css);
+
+        $this->assertMatchesRegularExpression(
+            '/@media\s*\(max-width:\s*600px\)\s*\{[^}]*\.notam-time-range\s*\{[^}]*flex-basis:\s*100%/s',
+            $css
+        );
+    }
+}

--- a/tests/Unit/NotamBannerStylesTest.php
+++ b/tests/Unit/NotamBannerStylesTest.php
@@ -49,17 +49,17 @@ class NotamBannerStylesTest extends TestCase
     /**
      * Extract a full @-rule block (for example @media) using brace balancing.
      *
-     * @param string $css        Full stylesheet contents
-     * @param string $atRuleNeedle Substring that identifies the rule (e.g. "@media (max-width: 600px)")
+     * @param string $css            Full stylesheet contents
+     * @param string $headerPattern  Regex from the @ through the opening brace (no delimiters)
      * @return string Rule block including the @ prefix and braces, or empty when missing
      */
-    private function extractAtRuleBlock(string $css, string $atRuleNeedle): string
+    private function extractAtRuleBlock(string $css, string $headerPattern): string
     {
-        $start = strpos($css, $atRuleNeedle);
-        if ($start === false) {
+        if (!preg_match('/' . $headerPattern . '/', $css, $matches, PREG_OFFSET_CAPTURE)) {
             return '';
         }
 
+        $start = $matches[0][1];
         $brace = strpos($css, '{', $start);
         if ($brace === false) {
             return '';
@@ -100,7 +100,10 @@ class NotamBannerStylesTest extends TestCase
         $css = file_get_contents(dirname(__DIR__, 2) . '/public/css/styles.css');
         $this->assertIsString($css);
 
-        $media = $this->extractAtRuleBlock($css, '@media (max-width: 600px)');
+        $media = $this->extractAtRuleBlock(
+            $css,
+            '@media\s*\(\s*max-width\s*:\s*600px\s*\)\s*\{'
+        );
         $this->assertNotSame('', $media, 'Expected mobile NOTAM @media block in styles.css');
 
         $rule = $this->extractRuleBlock($media, '.notam-time-range');


### PR DESCRIPTION
## Summary

On KPFC (and any airport with a long effective window), the orange upcoming NOTAM banner clipped the date/time text on narrow screens. `.notam-time-range` had `white-space: nowrap` and `flex-shrink: 0`, so the string from `formatNotamTimeRange()` overflowed instead of wrapping.

This change lets the time range wrap and stack on its own row below 600px. Active, upcoming, and scheduled NOTAM banners all share that class, so they get the same fix. Maintenance and data-outage banners were checked separately - they already wrap and did not need changes.

## Changes

- `public/css/styles.css` - remove nowrap on `.notam-time-range`, add `overflow-wrap`, mobile stack rules
- `tests/Unit/NotamBannerStylesTest.php` - regression guard so we do not reintroduce nowrap on the time range

## Test plan

- [x] `make test-ci`
- [x] Spot-check KPFC (or any site with a long NOTAM window) on a phone-width viewport - effective dates should wrap, not clip