### PR TITLE
Reduce upstream 429s and improve ops visibility for weather and NOTAM

### DIFF
--- a/config/airports.json.example
+++ b/config/airports.json.example
@@ -79,6 +79,7 @@
     "image_variants": ["thumb", "small", "medium", "large"],
     "notam_refresh_seconds": 600,
     "notam_cache_ttl_seconds": 3600,
+    "_comment_notam_worker_pool": "notam_worker_pool_size: concurrent NOTAM fetch workers. Keep at 1 unless profiling shows benefit; NMS allows 1 req/s and the scheduler enqueues at most one new NOTAM job per tick (see docs/CONFIGURATION.md).",
     "notam_worker_pool_size": 1,
     "_comment_station_power": "station_power_worker_pool_size: concurrent workers for scripts/fetch-station-power.php (VRM installation stats). Per-airport station_power block requires limited_availability true; see docs/CONFIGURATION.md.",
     "station_power_worker_pool_size": 1,

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,7 +10,7 @@ The **Public API** (`https://api.aviationwx.org/v1/...`) is the supported integr
 > **Canonical Public API base URL (public deployment):** `https://api.aviationwx.org/v1`  
 > Self-hosted deployments may set `config.public_api.canonical_base_url` so docs match their origin.
 
-**Production health snapshot:** `GET /v1/operations` returns a scheduler-built JSON summary (system and Public API health caches, weather and variant health, capacity metrics, optional scrubbed log fingerprints). It is intended for operators and support tooling, not for flight-critical minute-by-minute data. The scheduler writes `cache/operations_snapshot.json`; if the job stalls, responses may be served with `snapshot_meta.freshness` set to `stale` for up to 30 minutes.
+**Production health snapshot:** `GET /v1/operations` returns a scheduler-built JSON summary (system and Public API health caches, weather, NOTAM, and variant health in `data_plane`, capacity metrics, optional scrubbed log fingerprints). It is intended for operators and support tooling, not for flight-critical minute-by-minute data. The scheduler writes `cache/operations_snapshot.json`; if the job stalls, responses may be served with `snapshot_meta.freshness` set to `stale` for up to 30 minutes.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,6 +32,7 @@ aviationwx.org/
 │   ├── scheduler-daemon-lock.php # Exclusive flock helper for scheduler.php (no path unlink)
 │   ├── circuit-breaker.php   # Circuit breaker for API failures
 │   ├── weather-health.php    # Upstream fetch health counters (weather_health.json)
+│   ├── notam-health.php      # NMS NOTAM fetch health counters (notam_health.json)
 │   ├── upstream-rate-limit.php # Per-credential upstream token bucket (flock)
 │   ├── metar-bulk.php        # AWC national METAR bulk ingest and per-station slices
 │   ├── nws-points-cache.php  # NWS /points grid lookup TTL cache
@@ -431,7 +432,7 @@ Check cache for requested image
 ### NOTAM Data Flow
 
 ```
-Scheduler Daemon (runs per notam_refresh_seconds, default 600s)
+Scheduler Daemon (runs per notam_refresh_seconds, default 600s; staggered enqueue)
   ↓
 fetch-notam.php --worker {airport}
   ↓

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -43,7 +43,7 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 | `scheduler_config_reload_seconds` | `60` | Config reload check interval |
 | `weather_worker_pool_size` | `5` | Concurrent weather workers. After upstream throttles and METAR bulk are enabled, consider lowering this if you still see upstream 429s or throttle skips in `cache/weather_health.json`; raise only when fetches are consistently fast and under provider limits. |
 | `webcam_worker_pool_size` | `5` | Concurrent webcam workers |
-| `notam_worker_pool_size` | `1` | Concurrent NOTAM workers |
+| `notam_worker_pool_size` | `1` | Concurrent NOTAM worker processes. **Keep at 1** in most deployments: NMS allows 1 req/s and the scheduler starts at most one new NOTAM job per tick (`NOTAM_SCHEDULER_MAX_ENQUEUE_PER_LOOP`). Values greater than 1 do not increase parallel NMS API calls; they only let additional workers stay in flight while others wait on rate limits or finish parsing. `validateAirportsJsonStructure()` warns when this is set above 1. |
 | `station_power_worker_pool_size` | `1` | Concurrent station power fetch workers (`fetch-station-power.php`) |
 | `station_power_refresh_seconds` | `900` (15 min) | Default dashboard poll interval for `/api/station-power.php` (minimum 60; overridable per airport) |
 | `worker_timeout_seconds` | `90` | Worker process timeout |
@@ -729,6 +729,8 @@ When the bucket is empty, that source is skipped for one fetch cycle (weather ma
 `lib/notam/rate-limit.php` enforces 1 request per second per NMS credential (`notam_api_client_id` + `notam_api_base_url`) using the same flock-backed token buckets as weather (`cache/upstream-limits/`). Workers wait for a token (poll `NOTAM_RATE_LIMIT_POLL_MICROSECONDS`, fail open after `NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS`) so location and geo queries for one airport still complete.
 
 The scheduler staggers NOTAM enqueue across the refresh window (`notamStaggerOffsetSeconds()` in `lib/notam/scheduling.php`) and starts at most `NOTAM_SCHEDULER_MAX_ENQUEUE_PER_LOOP` (default 1) new NOTAM worker per scheduler tick.
+
+**Worker pool vs enqueue cap:** `notam_worker_pool_size` limits how many NOTAM workers may run at once; the per-tick enqueue cap limits how many *new* jobs the scheduler starts each second. With the default pool size of 1, extra capacity is unused by design. Raising the pool without raising the enqueue cap (or without a higher NMS rate limit) leaves slots idle. Raising both still serializes on the shared 1 req/s NMS token bucket in `lib/notam/rate-limit.php`. Prefer `notam_worker_pool_size: 1` unless profiling shows benefit from workers overlapping non-API work (for example parse/cache while another worker waits on HTTP).
 
 HTTP **429** and other NMS outcomes increment counters in `cache/notam_health.json` via `lib/notam-health.php` (scheduler flush every 60 seconds). On the status page, expand **NOTAM Data Fetching** for per-endpoint 429 counts (location, geo, auth) in the last hour.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -38,7 +38,7 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 | `cleanup_push_upload_debris_max_age_seconds` | `10800` (3 hours) | Optional: minimum file age (mtime) before a non-allowed extension is deleted from push FTP/SFTP inboxes. Integer **600--604800** (10 minutes to 7 days). Hourly `scripts/cleanup-push-upload-debris.php` and the daily `cleanup-cache.php` step use this value. |
 | `weather_refresh_default` | `60` | Default weather refresh (seconds) |
 | `metar_refresh_seconds` | `60` | METAR refresh interval (min: 60) |
-| `notam_refresh_seconds` | `600` | NOTAM refresh interval |
+| `notam_refresh_seconds` | `600` | NOTAM refresh interval (10 minutes; lower urgency than weather) |
 | `minimum_refresh_seconds` | `5` | Minimum allowed refresh interval |
 | `scheduler_config_reload_seconds` | `60` | Config reload check interval |
 | `weather_worker_pool_size` | `5` | Concurrent weather workers. After upstream throttles and METAR bulk are enabled, consider lowering this if you still see upstream 429s or throttle skips in `cache/weather_health.json`; raise only when fetches are consistently fast and under provider limits. |
@@ -718,11 +718,21 @@ The scheduler also refreshes the shared AWC METAR bulk gzip when **more than one
 
 `lib/upstream-rate-limit.php` applies a file-backed token bucket per provider and credential fingerprint before outbound weather API calls (`cache/upstream-limits/`). Limits are defined in `lib/constants.php` (`UPSTREAM_RATE_LIMIT_*` per provider). Shared API keys (for example Tempest `api_key`) share one bucket across all airports using that key. Keyless sources use per-station identity in the fingerprint (`station_id` for AWOSnet, SWOB, NWS, METAR HTTP; `base_url` + `airport_id` for `aviationwx_api`).
 
-When the bucket is empty, that source is skipped for one fetch cycle (weather may be stale until the next refresh). If `cache/upstream-limits/` cannot be written, the limiter **fails open** (requests proceed) and logs `upstream rate limit state unavailable`. Monitor those warnings and `upstream_rate_limit_fail_open` counters in `cache/weather_health.json` (refreshed by the scheduler). HTTP **429** responses from weather upstreams increment `upstream_429` and per-provider `upstream_429_{source}` counters (also exposed per source on the status bundle). PHPUnit and mock mode skip throttling.
+**Ambient Weather** uses two coordinated buckets per request: `api_key` (1 req/s, burst 1) and `application_key` (3 req/s shared across all stations using that developer key, burst 3). HTTP **429** global backoff for Ambient coordinates on `application_key` so all airports under one developer key back off together. **WeatherLink** burst is capped at 3 (upstream allows 10 req/s per API key). **NWS** burst is capped at 2 because api.weather.gov limits are undisclosed.
+
+When the bucket is empty, that source is skipped for one fetch cycle (weather may be stale until the next refresh). If `cache/upstream-limits/` cannot be written, the limiter **fails open** (requests proceed) and logs `upstream rate limit state unavailable`. Monitor those warnings and `upstream_rate_limit_fail_open` counters in `cache/weather_health.json` (refreshed by the scheduler). HTTP **429** responses from weather upstreams increment `upstream_429` and per-provider `upstream_429_{source}` counters. On the status page, expand **Weather Data Fetching** to see per-provider 429 counts for the last hour. PHPUnit and mock mode skip throttling.
 
 `metarResolveStationResponse()` in `lib/weather/adapter/metar-v1.php` reports outcomes as `METAR_RESOLVE_*` constants (`ok`, `throttled`, `circuit_open`, `http_failed`, `invalid_station`). Only `http_failed` and `invalid_station` count as fetch failures for the per-airport METAR circuit breaker; `throttled` is a self-throttle skip for one cycle.
 
-On HTTP **429** or **503**, `lib/circuit-breaker.php` also records a shared `global_weather_{provider}_{fingerprint}` backoff key (same fingerprint rules as upstream throttling) so all airports using that credential back off together. A successful fetch clears both per-airport and global keys for that credential.
+### NOTAM upstream rate limiting and health
+
+`lib/notam/rate-limit.php` enforces 1 request per second per NMS credential (`notam_api_client_id` + `notam_api_base_url`) using the same flock-backed token buckets as weather (`cache/upstream-limits/`). Workers wait for a token (poll `NOTAM_RATE_LIMIT_POLL_MICROSECONDS`, fail open after `NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS`) so location and geo queries for one airport still complete.
+
+The scheduler staggers NOTAM enqueue across the refresh window (`notamStaggerOffsetSeconds()` in `lib/notam/scheduling.php`) and starts at most `NOTAM_SCHEDULER_MAX_ENQUEUE_PER_LOOP` (default 1) new NOTAM worker per scheduler tick.
+
+HTTP **429** and other NMS outcomes increment counters in `cache/notam_health.json` via `lib/notam-health.php` (scheduler flush every 60 seconds). On the status page, expand **NOTAM Data Fetching** for per-endpoint 429 counts (location, geo, auth) in the last hour.
+
+On HTTP **429** or **503**, `lib/circuit-breaker.php` also records a shared `global_weather_{provider}_{fingerprint}` backoff key so all airports using that credential back off together. For Ambient, the global key uses the `application_key` fingerprint only; per-request throttling still checks both `api_key` and `application_key` buckets. A successful fetch clears both per-airport and global keys for that credential.
 
 When the upstream response includes **`Retry-After`** or **`X-RateLimit-Reset`** (Aeris-style), `UnifiedFetcher` passes those headers into the circuit breaker. Backoff uses the longer of the default strategy and the header hint, clamped to 15 minutes (`BACKOFF_MAX_RETRY_AFTER_SECONDS` in `lib/constants.php`).
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -35,7 +35,7 @@ The system uses **parallel fetching** for all configured sources:
 - **Sources Fetched**: All sources configured in the `weather_sources` array
 - **Circuit Breaker**: Each source has per-airport circuit breaker protection; HTTP 429/503 also open a shared `global_weather_{provider}_{credential fingerprint}` key so airports sharing one API key back off together. When present, `Retry-After` / `X-RateLimit-Reset` from the failed response extend backoff (up to 15 minutes).
 - **NWS points cache**: `api.weather.gov/points/{lat},{lon}` responses are cached under `cache/nws-points/` (12-hour TTL) via `lib/nws-points-cache.php`. The scheduler starts `scripts/refresh-nws-points.php` on `NWS_POINTS_REFRESH_INTERVAL_SECONDS` to warm stale entries for airports with an NWS `weather_sources` entry and coordinates (`lib/nws-points-refresh.php`). Station observations still use the direct `/stations/{id}/observations/latest` path.
-- **Upstream throttle**: Before `curl_multi_add_handle`, `lib/upstream-rate-limit.php` enforces a per-credential token bucket (flock under `cache/upstream-limits/`). When the budget is exhausted, that source is skipped for the current fetch cycle only. METAR uses `metarResolveStationResponse()` (mock, bulk slice, then HTTP); bulk is tried before the per-airport METAR HTTP circuit gate. Throttle and circuit-open outcomes are not recorded as fetch failures. Throttle skips, upstream HTTP 429 responses (per-station METAR HTTP fallback and AWC national bulk gzip download), fail-open I/O, and METAR bulk download failures are counted in `cache/weather_health.json` via `lib/weather-health.php`. Throttle skip logs include `fingerprint_prefix` only (no raw API keys). METAR bulk refresh writes `cache/metar-bulk/meta.json` and logs `metar_bulk_age_seconds` on successful ingest.
+- **Upstream throttle**: Before `curl_multi_add_handle`, `lib/upstream-rate-limit.php` enforces a per-credential token bucket (flock under `cache/upstream-limits/`). When the budget is exhausted, that source is skipped for the current fetch cycle only. METAR uses `metarResolveStationResponse()` (mock, bulk slice, then HTTP); bulk is tried before the per-airport METAR HTTP circuit gate. Throttle and circuit-open outcomes are not recorded as fetch failures. Throttle skips, upstream HTTP 429 responses (per-station METAR HTTP fallback and AWC national bulk gzip download), fail-open I/O, and METAR bulk download failures are counted in `cache/weather_health.json` via `lib/weather-health.php`. The status page **Weather Data Fetching** row shows aggregate health; expand it for per-provider HTTP 429 counts in the last hour. Throttle skip logs include `fingerprint_prefix` only (no raw API keys). METAR bulk refresh writes `cache/metar-bulk/meta.json` and logs `metar_bulk_age_seconds` on successful ingest.
 - **Parallel Execution**: All sources are fetched concurrently for maximum speed
 - **Freshness Selection**: Handled during aggregation (freshest data wins for each field)
 
@@ -1378,7 +1378,9 @@ The system uses a **dual query strategy** to capture both airport-specific NOTAM
 1. **Location Query** (when an identifier is configured): Fetches NOTAMs for the airport via `notamResolveLocationQueryCode()` (ICAO, then IATA, then FAA)
 2. **Geospatial Query** (if coordinates available): Fetches TFR-focused airspace NOTAMs with `feature=AIRSPACE`, then applies a cheap XML pre-filter before parse (closures still come from the location query)
 
-Both queries are executed sequentially with rate limiting (1 request per second) to comply with API limits.
+Both queries are executed sequentially. NMS rate limiting uses a shared file-backed token bucket (`lib/notam/rate-limit.php`, 1 request per second per `notam_api_client_id` + base URL) so scheduler workers in separate processes do not burst above the API cap when one airport fetch follows another. Workers **wait** for a token (up to `NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS`, then fail open) rather than skipping the fetch.
+
+**Observability**: NMS request outcomes increment counters in `cache/notam_health.json` via `lib/notam-health.php` (scheduler flush every 60 seconds). HTTP **429** responses increment `upstream_429` and per-endpoint `upstream_429_{location|geo|auth}` counters. On the status page, expand **NOTAM Data Fetching** to see per-endpoint 429 counts for the last hour.
 
 ### NMS API Authentication
 
@@ -1551,7 +1553,7 @@ Each NOTAM is classified by temporal status (`classifyNotamDisplayStatusAt()` in
 Filtered NOTAMs are cached per airport:
 - **Location**: `cache/notam/{airport_id}.json` (via `notamCacheFilePath()`)
 - **Content**: Array of filtered NOTAMs with status
-- **Refresh**: Configurable via `notam_refresh_seconds` (default: 600 seconds / 10 minutes)
+- **Refresh**: Configurable via `notam_refresh_seconds` (default: 600 seconds / 10 minutes). The scheduler staggers per-airport due times across the refresh window and starts at most `NOTAM_SCHEDULER_MAX_ENQUEUE_PER_LOOP` (default 1) new NOTAM worker per scheduler tick so NMS traffic stays near 1 req/s without bursting when many airports become due together.
 - **Atomic writes**: `notamWriteCacheFile()` writes a temp file then renames into place
 - **Refresh failure backoff**: `scripts/fetch-notam.php` records `cache/notam/{airport_id}.fetch-attempt` (without changing cache payload or `mtime`) when a worker refresh fails so `notamShouldEnqueueRefresh()` backs off for `NOTAM_FETCH_FAILURE_BACKOFF_SECONDS` before re-enqueueing. This applies to:
   - **Hard NMS failure**: every attempted query fails (missing credentials, HTTP error, invalid JSON) - existing cache is preserved instead of overwriting with an empty result

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -89,7 +89,8 @@ Shows:
 
 **Interpreting signals**
 
-- **Weather Data Fetching** (system row): aggregate **HTTP fetch success** for weather sources over the last hour. It is **not** a guarantee that every airport has fresh observations.
+- **Weather Data Fetching** (system row): aggregate **HTTP fetch success** for weather sources over the last hour. It is **not** a guarantee that every airport has fresh observations. Expand the row (▶) to see per-provider **HTTP 429** counts for the last hour (`cache/weather_health.json`).
+- **NOTAM Data Fetching** (system row): aggregate NMS API success over the last hour. Expand the row to see per-endpoint 429 counts (location query, geo query, auth token) from `cache/notam_health.json`.
 - **Per-airport weather**: based on observation timestamps in the weather cache (same family of values as the public API).
 - **Per-airport webcams**: freshness uses **last completed frame** time on disk (aligned with the image pipeline and API), not the `current.jpg` symlink mtime alone.
 

--- a/lib/circuit-breaker.php
+++ b/lib/circuit-breaker.php
@@ -333,7 +333,7 @@ function weatherGlobalCircuitBreakerKey(string $provider, array $sourceConfig): 
 {
     require_once __DIR__ . '/upstream-rate-limit.php';
 
-    return 'global_weather_' . $provider . '_' . upstreamRateFingerprint($provider, $sourceConfig);
+    return 'global_weather_' . $provider . '_' . upstreamRateGlobalCredentialFingerprint($provider, $sourceConfig);
 }
 
 /**

--- a/lib/config.php
+++ b/lib/config.php
@@ -1252,7 +1252,7 @@ function getWorkerTimeout(): int {
  * @return int Refresh interval in seconds (default: 600 = 10 minutes)
  */
 function getNotamRefreshSeconds(): int {
-    return (int)getGlobalConfig('notam_refresh_seconds', 600);
+    return (int)getGlobalConfig('notam_refresh_seconds', NOTAM_REFRESH_DEFAULT);
 }
 
 /**

--- a/lib/config.php
+++ b/lib/config.php
@@ -4160,6 +4160,11 @@ function validateAirportsJsonStructure(array $config): array {
             if (isset($cfg['notam_worker_pool_size'])) {
                 if (!is_int($cfg['notam_worker_pool_size']) || $cfg['notam_worker_pool_size'] < 1) {
                     $errors[] = "config.notam_worker_pool_size must be a positive integer";
+                } elseif ($cfg['notam_worker_pool_size'] > 1) {
+                    $warnings[] = 'config.notam_worker_pool_size > 1 rarely improves NOTAM refresh: NMS allows 1 req/s, '
+                        . 'and the scheduler enqueues at most NOTAM_SCHEDULER_MAX_ENQUEUE_PER_LOOP (1) new worker '
+                        . 'per tick. Extra pool slots only overlap parse/cache work with in-flight workers. '
+                        . 'Keep at 1 unless profiling shows a benefit.';
                 }
             }
 

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -169,6 +169,12 @@ if (!defined('RATE_LIMIT_WEBCAM_WINDOW')) {
 if (!defined('NOTAM_REFRESH_DEFAULT')) {
     define('NOTAM_REFRESH_DEFAULT', 600); // 10 minutes
 }
+if (!defined('NOTAM_SCHEDULER_STAGGER_WINDOW_FRACTION')) {
+    define('NOTAM_SCHEDULER_STAGGER_WINDOW_FRACTION', 10); // spread across interval/10
+}
+if (!defined('NOTAM_SCHEDULER_MAX_ENQUEUE_PER_LOOP')) {
+    define('NOTAM_SCHEDULER_MAX_ENQUEUE_PER_LOOP', 1); // low urgency: one new fetch per scheduler tick
+}
 if (!defined('NOTAM_CACHE_TTL_DEFAULT')) {
     define('NOTAM_CACHE_TTL_DEFAULT', 3600); // 1 hour
 }
@@ -193,7 +199,13 @@ if (!defined('NOTAM_GEO_RADIUS_DEFAULT')) {
     define('NOTAM_GEO_RADIUS_DEFAULT', 10); // 10 NM default radius for API query
 }
 if (!defined('NOTAM_RATE_LIMIT_SECONDS')) {
-    define('NOTAM_RATE_LIMIT_SECONDS', 1); // 1 request per second
+    define('NOTAM_RATE_LIMIT_SECONDS', 1); // 1 request per second (NMS API policy)
+}
+if (!defined('NOTAM_RATE_LIMIT_POLL_MICROSECONDS')) {
+    define('NOTAM_RATE_LIMIT_POLL_MICROSECONDS', 100_000); // 100ms while waiting for token
+}
+if (!defined('NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS')) {
+    define('NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS', 30); // fail open after this wait
 }
 // Banner: include upcoming_future NOTAMs whose first restriction window starts within this horizon
 if (!defined('NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS')) {
@@ -602,11 +614,18 @@ if (!defined('UPSTREAM_RATE_LIMIT_TEMPEST_RPM')) {
 if (!defined('UPSTREAM_RATE_LIMIT_TEMPEST_BURST')) {
     define('UPSTREAM_RATE_LIMIT_TEMPEST_BURST', 10);
 }
-if (!defined('UPSTREAM_RATE_LIMIT_AMBIENT_RPM')) {
-    define('UPSTREAM_RATE_LIMIT_AMBIENT_RPM', 60);
+// Ambient: 1 req/s per user apiKey, 3 req/s per developer applicationKey (upstream policy)
+if (!defined('UPSTREAM_RATE_LIMIT_AMBIENT_API_KEY_RPM')) {
+    define('UPSTREAM_RATE_LIMIT_AMBIENT_API_KEY_RPM', 60);
 }
-if (!defined('UPSTREAM_RATE_LIMIT_AMBIENT_BURST')) {
-    define('UPSTREAM_RATE_LIMIT_AMBIENT_BURST', 10);
+if (!defined('UPSTREAM_RATE_LIMIT_AMBIENT_API_KEY_BURST')) {
+    define('UPSTREAM_RATE_LIMIT_AMBIENT_API_KEY_BURST', 1);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_AMBIENT_APPLICATION_KEY_RPM')) {
+    define('UPSTREAM_RATE_LIMIT_AMBIENT_APPLICATION_KEY_RPM', 180);
+}
+if (!defined('UPSTREAM_RATE_LIMIT_AMBIENT_APPLICATION_KEY_BURST')) {
+    define('UPSTREAM_RATE_LIMIT_AMBIENT_APPLICATION_KEY_BURST', 3);
 }
 if (!defined('UPSTREAM_RATE_LIMIT_PWSWEATHER_RPM')) {
     define('UPSTREAM_RATE_LIMIT_PWSWEATHER_RPM', 60);
@@ -618,7 +637,7 @@ if (!defined('UPSTREAM_RATE_LIMIT_WEATHERLINK_RPM')) {
     define('UPSTREAM_RATE_LIMIT_WEATHERLINK_RPM', 60);
 }
 if (!defined('UPSTREAM_RATE_LIMIT_WEATHERLINK_BURST')) {
-    define('UPSTREAM_RATE_LIMIT_WEATHERLINK_BURST', 10);
+    define('UPSTREAM_RATE_LIMIT_WEATHERLINK_BURST', 3);
 }
 if (!defined('UPSTREAM_RATE_LIMIT_SYNOPTIC_RPM')) {
     define('UPSTREAM_RATE_LIMIT_SYNOPTIC_RPM', 60);
@@ -637,7 +656,7 @@ if (!defined('UPSTREAM_RATE_LIMIT_NWS_RPM')) {
     define('UPSTREAM_RATE_LIMIT_NWS_RPM', 60);
 }
 if (!defined('UPSTREAM_RATE_LIMIT_NWS_BURST')) {
-    define('UPSTREAM_RATE_LIMIT_NWS_BURST', 10);
+    define('UPSTREAM_RATE_LIMIT_NWS_BURST', 2);
 }
 
 // NWS /points/{lat},{lon} metadata cache (stable grid mapping; reduces repeat calls)

--- a/lib/metar-bulk.php
+++ b/lib/metar-bulk.php
@@ -728,6 +728,10 @@ function metarBulkRefreshRun(): array
     }
 
     $result['ok'] = true;
+    if (!function_exists('weatherHealthTrackMetarBulkDownloadSuccess')) {
+        require_once __DIR__ . '/weather-health.php';
+    }
+    weatherHealthTrackMetarBulkDownloadSuccess();
     aviationwx_log('info', 'metar_bulk: refresh complete', [
         'fetched_at' => $fetchedAt,
         'metar_bulk_age_seconds' => metarBulkSnapshotAgeSeconds($fetchedAt),

--- a/lib/notam-health.php
+++ b/lib/notam-health.php
@@ -1,0 +1,446 @@
+<?php
+/**
+ * NOTAM Health Tracking
+ *
+ * Tracks NMS API request outcomes by writing directly to cache file.
+ * Uses file locking for thread safety across scheduler worker processes.
+ *
+ * Health status is recomputed only during scheduler flush (every 60s), not on
+ * every tracking call, to avoid impacting NOTAM fetch performance.
+ *
+ * Usage:
+ *   notamHealthTrackRequest('location', true, 200);
+ *   notamHealthTrackRequest('geo', false, 429);
+ *   notamHealthFlush();
+ */
+
+require_once __DIR__ . '/cache-paths.php';
+require_once __DIR__ . '/logger.php';
+
+if (!defined('NOTAM_HEALTH_CACHE_FILE')) {
+    define('NOTAM_HEALTH_CACHE_FILE', CACHE_BASE_DIR . '/notam_health.json');
+}
+
+/**
+ * Path to NOTAM health JSON (supports PHPUnit via $GLOBALS['notamHealthTestCacheFile']).
+ */
+function getNotamHealthCacheFilePath(): string
+{
+    if (isset($GLOBALS['notamHealthTestCacheFile'])
+        && is_string($GLOBALS['notamHealthTestCacheFile'])
+        && $GLOBALS['notamHealthTestCacheFile'] !== ''
+    ) {
+        return $GLOBALS['notamHealthTestCacheFile'];
+    }
+
+    return NOTAM_HEALTH_CACHE_FILE;
+}
+
+/**
+ * Ensure the NOTAM health cache directory exists.
+ *
+ * @return bool True when the directory exists or was created
+ */
+function notamHealthEnsureCacheDirectory(): bool
+{
+    $cacheDir = dirname(getNotamHealthCacheFilePath());
+    if (ensureCacheDir($cacheDir)) {
+        return true;
+    }
+
+    aviationwx_log('warning', 'notam health: failed to create cache directory', [
+        'dir' => $cacheDir,
+    ], 'app');
+
+    return false;
+}
+
+/**
+ * Human-readable label for an NMS endpoint key.
+ *
+ * @param string $endpoint Endpoint key (location, geo, auth)
+ * @return string Display label
+ */
+function notamHealthEndpointDisplayName(string $endpoint): string
+{
+    return match ($endpoint) {
+        'location' => 'NMS location query',
+        'geo' => 'NMS geo query',
+        'auth' => 'NMS auth token',
+        default => 'NMS ' . str_replace('_', ' ', $endpoint),
+    };
+}
+
+/**
+ * Increment upstream HTTP failure counters shared by NMS request paths.
+ *
+ * @param array<string, int> $counters Counter map to update in place
+ * @param int|null $httpCode HTTP status when available
+ * @param string|null $endpoint Endpoint key for per-endpoint buckets
+ */
+function notamHealthIncrementHttpFailureCounters(array &$counters, ?int $httpCode, ?string $endpoint = null): void
+{
+    if ($httpCode === null) {
+        return;
+    }
+
+    if ($httpCode === 429) {
+        $counters['upstream_429'] = 1;
+        if ($endpoint !== null && $endpoint !== '') {
+            $counters["upstream_429_{$endpoint}"] = 1;
+        }
+    } elseif ($httpCode >= 400 && $httpCode < 500) {
+        if ($endpoint !== null && $endpoint !== '') {
+            $counters["http_4xx_{$endpoint}"] = 1;
+        }
+    } elseif ($httpCode >= 500) {
+        if ($endpoint !== null && $endpoint !== '') {
+            $counters["http_5xx_{$endpoint}"] = 1;
+        }
+    }
+}
+
+/**
+ * Track an NMS API request outcome.
+ *
+ * @param string $endpoint Endpoint key (location, geo, auth)
+ * @param bool $success Whether the request succeeded
+ * @param int|null $httpCode HTTP status code when available
+ */
+function notamHealthTrackRequest(string $endpoint, bool $success, ?int $httpCode = null): void
+{
+    $safeEndpoint = preg_replace('/[^a-z0-9_]/', '', strtolower($endpoint)) ?? '';
+    if ($safeEndpoint === '') {
+        return;
+    }
+
+    $now = time();
+    $currentHour = gmdate('Y-m-d-H', $now);
+
+    $counters = [
+        "attempts_{$safeEndpoint}" => 1,
+        'total_attempts' => 1,
+    ];
+
+    if ($success) {
+        $counters["successes_{$safeEndpoint}"] = 1;
+        $counters['total_successes'] = 1;
+    } else {
+        $counters["failures_{$safeEndpoint}"] = 1;
+        $counters['total_failures'] = 1;
+        notamHealthIncrementHttpFailureCounters($counters, $httpCode, $safeEndpoint);
+    }
+
+    notamHealthAtomicUpdate($currentHour, $counters, $now);
+}
+
+/**
+ * Atomically update the NOTAM health cache file.
+ *
+ * @param string $currentHour Current hour bucket key (Y-m-d-H)
+ * @param array<string, int> $counters Counters to increment
+ * @param int $now Current timestamp
+ */
+function notamHealthAtomicUpdate(string $currentHour, array $counters, int $now): bool
+{
+    if (!notamHealthEnsureCacheDirectory()) {
+        return false;
+    }
+
+    $fp = @fopen(getNotamHealthCacheFilePath(), 'c+');
+    if ($fp === false) {
+        aviationwx_log('warning', 'notam health: failed to open cache file', [
+            'file' => getNotamHealthCacheFilePath(),
+        ], 'app');
+
+        return false;
+    }
+
+    if (!@flock($fp, LOCK_EX | LOCK_NB)) {
+        @fclose($fp);
+
+        return false;
+    }
+
+    $content = @stream_get_contents($fp);
+    $data = [];
+    if ($content !== false && $content !== '') {
+        $data = @json_decode($content, true) ?: [];
+    }
+
+    if (!isset($data['hourly_buckets'])) {
+        $data['hourly_buckets'] = [];
+    }
+
+    if (!isset($data['hourly_buckets'][$currentHour])) {
+        $data['hourly_buckets'][$currentHour] = [];
+    }
+
+    foreach ($counters as $key => $value) {
+        if (!isset($data['hourly_buckets'][$currentHour][$key])) {
+            $data['hourly_buckets'][$currentHour][$key] = 0;
+        }
+        $data['hourly_buckets'][$currentHour][$key] += $value;
+    }
+
+    $data['last_fetch'] = $now;
+    $data['last_update'] = $now;
+    $data['current_hour'] = $currentHour;
+
+    $twoHoursAgo = gmdate('Y-m-d-H', $now - 7200);
+    foreach (array_keys($data['hourly_buckets']) as $hourKey) {
+        if ($hourKey < $twoHoursAgo) {
+            unset($data['hourly_buckets'][$hourKey]);
+        }
+    }
+
+    @ftruncate($fp, 0);
+    @fseek($fp, 0);
+    $written = @fwrite($fp, json_encode($data, JSON_PRETTY_PRINT));
+
+    @flock($fp, LOCK_UN);
+    @fclose($fp);
+
+    if ($written === false) {
+        aviationwx_log('warning', 'notam health: failed to write cache file', [
+            'file' => getNotamHealthCacheFilePath(),
+        ], 'app');
+
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Flush NOTAM health data (prune old buckets and recompute status).
+ */
+function notamHealthFlush(): bool
+{
+    if (!notamHealthEnsureCacheDirectory()) {
+        return false;
+    }
+
+    $now = time();
+
+    if (!file_exists(getNotamHealthCacheFilePath())) {
+        $data = [
+            'hourly_buckets' => [],
+            'current_hour' => gmdate('Y-m-d-H', $now),
+            'last_flush' => $now,
+            'health' => notamHealthComputeStatus([]),
+            'providers' => [],
+        ];
+
+        return @file_put_contents(getNotamHealthCacheFilePath(), json_encode($data, JSON_PRETTY_PRINT), LOCK_EX) !== false;
+    }
+
+    $fp = @fopen(getNotamHealthCacheFilePath(), 'c+');
+    if ($fp === false) {
+        return false;
+    }
+
+    if (!@flock($fp, LOCK_EX)) {
+        @fclose($fp);
+
+        return false;
+    }
+
+    $content = @stream_get_contents($fp);
+    $data = [];
+    if ($content !== false && $content !== '') {
+        $data = @json_decode($content, true) ?: [];
+    }
+
+    $twoHoursAgo = gmdate('Y-m-d-H', $now - 7200);
+    if (isset($data['hourly_buckets'])) {
+        foreach (array_keys($data['hourly_buckets']) as $hourKey) {
+            if ($hourKey < $twoHoursAgo) {
+                unset($data['hourly_buckets'][$hourKey]);
+            }
+        }
+    }
+
+    $data['last_flush'] = $now;
+    $data['current_hour'] = gmdate('Y-m-d-H', $now);
+    $data['health'] = notamHealthComputeStatus($data);
+    $data['providers'] = notamHealthComputeProviderStatus($data);
+
+    @ftruncate($fp, 0);
+    @fseek($fp, 0);
+    @fwrite($fp, json_encode($data, JSON_PRETTY_PRINT));
+
+    @flock($fp, LOCK_UN);
+    @fclose($fp);
+
+    return true;
+}
+
+/**
+ * Compute overall health status from aggregated data.
+ *
+ * @param array<string, mixed> $data Aggregated NOTAM health data
+ * @return array<string, mixed> Health status array
+ */
+function notamHealthComputeStatus(array $data): array
+{
+    $health = [
+        'name' => 'NOTAM Data Fetching',
+        'status' => 'operational',
+        'message' => 'NMS API responding normally',
+        'lastChanged' => $data['last_fetch'] ?? 0,
+        'metrics' => [],
+    ];
+
+    $oneHourAgo = gmdate('Y-m-d-H', time() - 3600);
+    $totals = [
+        'total_attempts' => 0,
+        'total_successes' => 0,
+        'total_failures' => 0,
+        'upstream_429' => 0,
+    ];
+
+    foreach ($data['hourly_buckets'] ?? [] as $hourKey => $bucket) {
+        if ($hourKey >= $oneHourAgo) {
+            foreach ($totals as $key => &$value) {
+                $value += $bucket[$key] ?? 0;
+            }
+        }
+    }
+
+    $successRate = $totals['total_attempts'] > 0
+        ? $totals['total_successes'] / $totals['total_attempts']
+        : 1.0;
+
+    if ($totals['upstream_429'] > 0) {
+        $health['status'] = 'degraded';
+        $health['message'] = sprintf('%d NMS HTTP 429 response(s) in last hour', $totals['upstream_429']);
+    } elseif ($totals['total_attempts'] > 0 && $successRate < 0.5) {
+        $health['status'] = 'down';
+        $health['message'] = sprintf('Low NMS success rate: %.1f%%', $successRate * 100);
+    } elseif ($totals['total_attempts'] > 0 && $successRate < 0.8) {
+        $health['status'] = 'degraded';
+        $health['message'] = sprintf('Degraded NMS success rate: %.1f%%', $successRate * 100);
+    } elseif ($totals['total_attempts'] === 0) {
+        $health['status'] = 'degraded';
+        $health['message'] = 'No recent NOTAM fetch activity';
+    }
+
+    $health['metrics'] = [
+        'success_rate' => round($successRate * 100, 1),
+        'total_attempts_last_hour' => $totals['total_attempts'],
+        'total_successes_last_hour' => $totals['total_successes'],
+        'total_failures_last_hour' => $totals['total_failures'],
+        'upstream_429_last_hour' => $totals['upstream_429'],
+    ];
+
+    return $health;
+}
+
+/**
+ * Compute per-endpoint provider status for the status page.
+ *
+ * @param array<string, mixed> $data Aggregated NOTAM health data
+ * @return list<array<string, mixed>> Provider rows sorted by upstream 429 count
+ */
+function notamHealthComputeProviderStatus(array $data): array
+{
+    $oneHourAgo = gmdate('Y-m-d-H', time() - 3600);
+    $endpoints = ['location', 'geo', 'auth'];
+    $providers = [];
+
+    foreach ($endpoints as $endpoint) {
+        $attempts = 0;
+        $successes = 0;
+        $failures = 0;
+        $upstream429 = 0;
+
+        foreach ($data['hourly_buckets'] ?? [] as $hourKey => $bucket) {
+            if ($hourKey >= $oneHourAgo) {
+                $attempts += $bucket["attempts_{$endpoint}"] ?? 0;
+                $successes += $bucket["successes_{$endpoint}"] ?? 0;
+                $failures += $bucket["failures_{$endpoint}"] ?? 0;
+                $upstream429 += $bucket["upstream_429_{$endpoint}"] ?? 0;
+            }
+        }
+
+        if ($attempts === 0) {
+            continue;
+        }
+
+        $providers[] = [
+            'id' => $endpoint,
+            'name' => notamHealthEndpointDisplayName($endpoint),
+            'upstream_429' => $upstream429,
+            'attempts' => $attempts,
+            'success_rate' => round(($successes / $attempts) * 100, 1),
+        ];
+    }
+
+    usort($providers, static function (array $a, array $b): int {
+        $cmp = ($b['upstream_429'] ?? 0) <=> ($a['upstream_429'] ?? 0);
+        if ($cmp !== 0) {
+            return $cmp;
+        }
+
+        return ($b['attempts'] ?? 0) <=> ($a['attempts'] ?? 0);
+    });
+
+    return $providers;
+}
+
+/**
+ * Get NOTAM health status (for status page).
+ *
+ * @return array<string, mixed> Health status
+ */
+function notamHealthGetStatus(): array
+{
+    $default = [
+        'name' => 'NOTAM Data Fetching',
+        'status' => 'operational',
+        'message' => 'No data available',
+        'lastChanged' => 0,
+        'metrics' => [],
+    ];
+
+    if (!file_exists(getNotamHealthCacheFilePath())) {
+        return $default;
+    }
+
+    $content = @file_get_contents(getNotamHealthCacheFilePath());
+    if ($content === false) {
+        return $default;
+    }
+
+    $data = @json_decode($content, true);
+    if (!is_array($data) || !isset($data['health'])) {
+        return $default;
+    }
+
+    return $data['health'];
+}
+
+/**
+ * Get per-endpoint provider breakdown (for status page).
+ *
+ * @return list<array<string, mixed>> Provider rows
+ */
+function notamHealthGetProviders(): array
+{
+    if (!file_exists(getNotamHealthCacheFilePath())) {
+        return [];
+    }
+
+    $content = @file_get_contents(getNotamHealthCacheFilePath());
+    if ($content === false) {
+        return [];
+    }
+
+    $data = @json_decode($content, true);
+    if (!is_array($data) || !isset($data['providers']) || !is_array($data['providers'])) {
+        return [];
+    }
+
+    return $data['providers'];
+}

--- a/lib/notam-health.php
+++ b/lib/notam-health.php
@@ -390,11 +390,33 @@ function notamHealthComputeProviderStatus(array $data): array
 }
 
 /**
+ * Read and decode the NOTAM health cache file.
+ *
+ * @return array<string, mixed>|null Decoded cache or null when missing/unreadable
+ */
+function notamHealthLoadCache(): ?array
+{
+    if (!file_exists(getNotamHealthCacheFilePath())) {
+        return null;
+    }
+
+    $content = @file_get_contents(getNotamHealthCacheFilePath());
+    if ($content === false) {
+        return null;
+    }
+
+    $data = @json_decode($content, true);
+
+    return is_array($data) ? $data : null;
+}
+
+/**
  * Get NOTAM health status (for status page).
  *
+ * @param array<string, mixed>|null $cache Preloaded cache from notamHealthLoadCache()
  * @return array<string, mixed> Health status
  */
-function notamHealthGetStatus(): array
+function notamHealthGetStatus(?array $cache = null): array
 {
     $default = [
         'name' => 'NOTAM Data Fetching',
@@ -404,17 +426,8 @@ function notamHealthGetStatus(): array
         'metrics' => [],
     ];
 
-    if (!file_exists(getNotamHealthCacheFilePath())) {
-        return $default;
-    }
-
-    $content = @file_get_contents(getNotamHealthCacheFilePath());
-    if ($content === false) {
-        return $default;
-    }
-
-    $data = @json_decode($content, true);
-    if (!is_array($data) || !isset($data['health'])) {
+    $data = $cache ?? notamHealthLoadCache();
+    if ($data === null || !isset($data['health'])) {
         return $default;
     }
 
@@ -424,21 +437,13 @@ function notamHealthGetStatus(): array
 /**
  * Get per-endpoint provider breakdown (for status page).
  *
+ * @param array<string, mixed>|null $cache Preloaded cache from notamHealthLoadCache()
  * @return list<array<string, mixed>> Provider rows
  */
-function notamHealthGetProviders(): array
+function notamHealthGetProviders(?array $cache = null): array
 {
-    if (!file_exists(getNotamHealthCacheFilePath())) {
-        return [];
-    }
-
-    $content = @file_get_contents(getNotamHealthCacheFilePath());
-    if ($content === false) {
-        return [];
-    }
-
-    $data = @json_decode($content, true);
-    if (!is_array($data) || !isset($data['providers']) || !is_array($data['providers'])) {
+    $data = $cache ?? notamHealthLoadCache();
+    if ($data === null || !isset($data['providers']) || !is_array($data['providers'])) {
         return [];
     }
 

--- a/lib/notam/auth.php
+++ b/lib/notam/auth.php
@@ -8,6 +8,7 @@
 require_once __DIR__ . '/../logger.php';
 require_once __DIR__ . '/../config.php';
 require_once __DIR__ . '/../constants.php';
+require_once __DIR__ . '/../notam-health.php';
 
 /**
  * Get OAuth2 bearer token for NMS API
@@ -64,6 +65,7 @@ function getNotamBearerToken(): ?string {
     $error = curl_error($ch);
     
     if ($httpCode !== 200 || $response === false) {
+        notamHealthTrackRequest('auth', false, is_int($httpCode) ? $httpCode : null);
         aviationwx_log('error', 'notam auth: failed to get token', [
             'http_code' => $httpCode,
             'error' => $error
@@ -73,11 +75,14 @@ function getNotamBearerToken(): ?string {
     
     $data = json_decode($response, true);
     if (!isset($data['access_token'])) {
+        notamHealthTrackRequest('auth', false, $httpCode);
         aviationwx_log('error', 'notam auth: invalid token response', [
             'response' => substr($response, 0, 200)
         ], 'app', true);
         return null;
     }
+
+    notamHealthTrackRequest('auth', true, $httpCode);
     
     $token = $data['access_token'];
     $expiresIn = isset($data['expires_in']) ? (int)$data['expires_in'] : 1799; // Default 30 minutes

--- a/lib/notam/cache.php
+++ b/lib/notam/cache.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../logger.php';
 require_once __DIR__ . '/../constants.php';
+require_once __DIR__ . '/scheduling.php';
 
 /**
  * Directory for per-airport NOTAM JSON cache files.
@@ -16,6 +17,13 @@ require_once __DIR__ . '/../constants.php';
  */
 function notamCacheDirectory(): string
 {
+    if (isset($GLOBALS['notamCacheTestDirectory'])
+        && is_string($GLOBALS['notamCacheTestDirectory'])
+        && $GLOBALS['notamCacheTestDirectory'] !== ''
+    ) {
+        return rtrim($GLOBALS['notamCacheTestDirectory'], '/');
+    }
+
     if (defined('AVIATIONWX_NOTAM_CACHE_DIR')) {
         return rtrim((string) AVIATIONWX_NOTAM_CACHE_DIR, '/');
     }
@@ -133,7 +141,7 @@ function notamShouldEnqueueRefresh(string $airportId, int $refreshInterval, ?int
     $now = $now ?? time();
     $cacheFile = notamCacheFilePath($airportId);
     $cacheAge = is_file($cacheFile) ? ($now - (int) filemtime($cacheFile)) : PHP_INT_MAX;
-    if ($cacheAge < $refreshInterval) {
+    if ($cacheAge < notamRequiredCacheAgeSeconds($airportId, $refreshInterval)) {
         return false;
     }
 

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -13,6 +13,8 @@ require_once __DIR__ . '/parser.php';
 require_once __DIR__ . '/filter.php';
 require_once __DIR__ . '/schedule.php';
 require_once __DIR__ . '/geo-prefilter.php';
+require_once __DIR__ . '/rate-limit.php';
+require_once __DIR__ . '/../notam-health.php';
 
 /**
  * Decode NMS JSON; strips illegal ASCII control characters some payloads embed in strings.
@@ -30,21 +32,16 @@ function notamDecodeNmsJsonResponse(string $response): ?array {
 }
 
 /**
- * Rate limit wait - ensures we don't exceed 1 request per second
- * 
- * @param float &$lastRequestTime Last request timestamp (passed by reference)
- * @return void
+ * Block until the shared NMS credential may issue another NOTAM API request.
+ *
+ * Coordinates across scheduler worker processes (not just this fetch). The
+ * $lastRequestTime parameter is retained for backward compatibility.
+ *
+ * @param float &$lastRequestTime Updated to microtime after a token is acquired
  */
 function rateLimitWait(float &$lastRequestTime): void {
-    $now = microtime(true);
-    $elapsed = $now - $lastRequestTime;
-    if ($elapsed < NOTAM_RATE_LIMIT_SECONDS) {
-        $waitTime = NOTAM_RATE_LIMIT_SECONDS - $elapsed;
-        usleep((int)($waitTime * 1000000));
-        $lastRequestTime = microtime(true);
-    } else {
-        $lastRequestTime = $now;
-    }
+    notamRateLimitAcquire();
+    $lastRequestTime = microtime(true);
 }
 
 /**
@@ -149,6 +146,7 @@ function queryNotamsByLocation(
     $error = curl_error($ch);
     
     if ($httpCode !== 200 || $response === false) {
+        notamHealthTrackRequest('location', false, is_int($httpCode) ? $httpCode : null);
         aviationwx_log('warning', 'notam fetcher: location query failed', [
             'location' => $location,
             'http_code' => $httpCode,
@@ -163,12 +161,15 @@ function queryNotamsByLocation(
     
     $data = notamDecodeNmsJsonResponse($response);
     if ($data === null || !isset($data['data']['aixm']) || !is_array($data['data']['aixm'])) {
+        notamHealthTrackRequest('location', false, $httpCode);
         if ($reportQueryOutcome) {
             $querySucceeded = false;
         }
 
         return [];
     }
+
+    notamHealthTrackRequest('location', true, $httpCode);
 
     if ($reportQueryOutcome) {
         $querySucceeded = true;
@@ -230,6 +231,7 @@ function queryNotamsByCoordinates(
     $error = curl_error($ch);
     
     if ($httpCode !== 200 || $response === false) {
+        notamHealthTrackRequest('geo', false, is_int($httpCode) ? $httpCode : null);
         aviationwx_log('warning', 'notam fetcher: geospatial query failed', [
             'latitude' => $latitude,
             'longitude' => $longitude,
@@ -246,12 +248,15 @@ function queryNotamsByCoordinates(
     
     $data = notamDecodeNmsJsonResponse($response);
     if ($data === null || !isset($data['data']['aixm']) || !is_array($data['data']['aixm'])) {
+        notamHealthTrackRequest('geo', false, $httpCode);
         if ($reportQueryOutcome) {
             $querySucceeded = false;
         }
 
         return [];
     }
+
+    notamHealthTrackRequest('geo', true, $httpCode);
 
     if ($reportQueryOutcome) {
         $querySucceeded = true;

--- a/lib/notam/rate-limit.php
+++ b/lib/notam/rate-limit.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Cross-process NMS NOTAM API rate limiting (1 req/s shared credential).
+ *
+ * Scheduler workers each run fetchNotamsForAirport() in separate processes; a
+ * per-process sleep is not enough when one worker finishes and the next starts
+ * immediately. Uses the same flock-backed token buckets as weather upstream limits.
+ */
+
+require_once __DIR__ . '/../constants.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../logger.php';
+require_once __DIR__ . '/../upstream-rate-limit.php';
+
+/**
+ * Stable fingerprint for the configured NMS API credential (no secrets in logs).
+ *
+ * @return string 64-char hex digest
+ */
+function notamRateLimitFingerprint(): string
+{
+    $clientId = isset($GLOBALS['notamRateLimitTestClientId'])
+        && is_string($GLOBALS['notamRateLimitTestClientId'])
+        ? $GLOBALS['notamRateLimitTestClientId']
+        : getNotamApiClientId();
+    $baseUrl = isset($GLOBALS['notamRateLimitTestBaseUrl'])
+        && is_string($GLOBALS['notamRateLimitTestBaseUrl'])
+        ? $GLOBALS['notamRateLimitTestBaseUrl']
+        : getNotamApiBaseUrl();
+
+    $material = [
+        'client_id' => trim($clientId),
+        'base_url' => trim($baseUrl),
+    ];
+    ksort($material);
+
+    return hash('sha256', 'notam_nms' . "\n" . json_encode($material, JSON_UNESCAPED_UNICODE));
+}
+
+/**
+ * Poll interval while waiting for a NOTAM API token (microseconds).
+ */
+function notamRateLimitPollMicroseconds(): int
+{
+    if (isset($GLOBALS['notamRateLimitTestPollMicroseconds'])
+        && is_int($GLOBALS['notamRateLimitTestPollMicroseconds'])
+    ) {
+        return $GLOBALS['notamRateLimitTestPollMicroseconds'];
+    }
+
+    return NOTAM_RATE_LIMIT_POLL_MICROSECONDS;
+}
+
+/**
+ * Whether NOTAM rate limiting should enforce buckets in the current environment.
+ */
+function notamRateLimitShouldEnforce(): bool
+{
+    if (!empty($GLOBALS['notamRateLimitTestForceEnforcement'])) {
+        return true;
+    }
+
+    return !isTestMode() && !shouldMockExternalServices();
+}
+
+/**
+ * PHPUnit only: enforce NOTAM buckets while APP_ENV=testing.
+ */
+function notamRateLimitTestForceEnforcement(): void
+{
+    $GLOBALS['notamRateLimitTestForceEnforcement'] = true;
+}
+
+/**
+ * PHPUnit only: restore default test-mode bypass for NOTAM throttling.
+ */
+function notamRateLimitTestClearForceEnforcement(): void
+{
+    unset($GLOBALS['notamRateLimitTestForceEnforcement']);
+}
+
+/**
+ * Block until one NMS NOTAM request token is available (or fail open on timeout).
+ *
+ * Waits rather than skipping so location + geo queries for one airport still complete.
+ */
+function notamRateLimitAcquire(): void
+{
+    if (!notamRateLimitShouldEnforce()) {
+        return;
+    }
+
+    $fingerprint = notamRateLimitFingerprint();
+    if ($fingerprint === hash('sha256', 'notam_nms' . "\n" . json_encode([], JSON_UNESCAPED_UNICODE))) {
+        // No client_id/base_url configured; fetch will fail at auth anyway.
+        return;
+    }
+
+    $rpm = (int) (60 / max(NOTAM_RATE_LIMIT_SECONDS, 1));
+    $burst = 1;
+    $deadline = microtime(true) + NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS;
+
+    while (microtime(true) < $deadline) {
+        if (upstreamRateTryTake($fingerprint, $rpm, $burst)) {
+            return;
+        }
+
+        if (!empty($GLOBALS['notamRateLimitTestSkipSleep'])) {
+            if (isset($GLOBALS['upstreamRateLimitTestNow']) && is_numeric($GLOBALS['upstreamRateLimitTestNow'])) {
+                $GLOBALS['upstreamRateLimitTestNow'] = (float) $GLOBALS['upstreamRateLimitTestNow']
+                    + (notamRateLimitPollMicroseconds() / 1_000_000);
+            }
+
+            continue;
+        }
+
+        usleep(notamRateLimitPollMicroseconds());
+    }
+
+    aviationwx_log('warning', 'notam rate limit wait timed out, allowing request', [
+        'fingerprint_prefix' => substr($fingerprint, 0, 8),
+        'max_wait_seconds' => NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS,
+    ], 'app');
+}

--- a/lib/notam/rate-limit.php
+++ b/lib/notam/rate-limit.php
@@ -38,6 +38,23 @@ function notamRateLimitFingerprint(): string
 }
 
 /**
+ * Whether NOTAM API credentials are configured (auth would succeed).
+ */
+function notamRateLimitCredentialsConfigured(): bool
+{
+    $clientId = isset($GLOBALS['notamRateLimitTestClientId'])
+        && is_string($GLOBALS['notamRateLimitTestClientId'])
+        ? $GLOBALS['notamRateLimitTestClientId']
+        : getNotamApiClientId();
+    $clientSecret = isset($GLOBALS['notamRateLimitTestClientSecret'])
+        && is_string($GLOBALS['notamRateLimitTestClientSecret'])
+        ? $GLOBALS['notamRateLimitTestClientSecret']
+        : getNotamApiClientSecret();
+
+    return trim($clientId) !== '' && trim($clientSecret) !== '';
+}
+
+/**
  * Poll interval while waiting for a NOTAM API token (microseconds).
  */
 function notamRateLimitPollMicroseconds(): int
@@ -90,11 +107,12 @@ function notamRateLimitAcquire(): void
         return;
     }
 
-    $fingerprint = notamRateLimitFingerprint();
-    if ($fingerprint === hash('sha256', 'notam_nms' . "\n" . json_encode([], JSON_UNESCAPED_UNICODE))) {
-        // No client_id/base_url configured; fetch will fail at auth anyway.
+    if (!notamRateLimitCredentialsConfigured()) {
+        // Missing credentials; fetch will fail at auth anyway.
         return;
     }
+
+    $fingerprint = notamRateLimitFingerprint();
 
     $rpm = (int) (60 / max(NOTAM_RATE_LIMIT_SECONDS, 1));
     $burst = 1;

--- a/lib/notam/rate-limit.php
+++ b/lib/notam/rate-limit.php
@@ -30,7 +30,7 @@ function notamRateLimitFingerprint(): string
 
     $material = [
         'client_id' => trim($clientId),
-        'base_url' => trim($baseUrl),
+        'base_url' => rtrim(trim($baseUrl), '/'),
     ];
     ksort($material);
 

--- a/lib/notam/scheduler-queue.php
+++ b/lib/notam/scheduler-queue.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTAM scheduler queue helpers - spread low-urgency refreshes across time.
+ */
+
+require_once __DIR__ . '/scheduling.php';
+require_once __DIR__ . '/cache.php';
+
+/**
+ * Choose airports to refresh this scheduler tick (oldest cache first, capped).
+ *
+ * @param list<string> $airportIds Enabled airport config keys to consider
+ * @param int $refreshInterval Configured refresh interval in seconds
+ * @param int $maxEnqueue Maximum jobs to return
+ * @param int|null $now Optional Unix timestamp for tests
+ * @return list<string> Airport ids to pass to the NOTAM worker pool
+ */
+function notamSelectAirportsToEnqueue(
+    array $airportIds,
+    int $refreshInterval,
+    int $maxEnqueue,
+    ?int $now = null
+): array {
+    if ($maxEnqueue <= 0 || $airportIds === []) {
+        return [];
+    }
+
+    $now = $now ?? time();
+    $eligible = [];
+
+    foreach ($airportIds as $airportId) {
+        if (!is_string($airportId) || $airportId === '') {
+            continue;
+        }
+        if (!notamShouldEnqueueRefresh($airportId, $refreshInterval, $now)) {
+            continue;
+        }
+
+        $cacheFile = notamCacheFilePath($airportId);
+        $cacheMtime = is_file($cacheFile) ? (int) filemtime($cacheFile) : 0;
+        $eligible[] = [
+            'id' => $airportId,
+            'mtime' => $cacheMtime,
+        ];
+    }
+
+    usort($eligible, static function (array $a, array $b): int {
+        return $a['mtime'] <=> $b['mtime'];
+    });
+
+    return array_slice(array_column($eligible, 'id'), 0, $maxEnqueue);
+}

--- a/lib/notam/scheduling.php
+++ b/lib/notam/scheduling.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTAM refresh timing helpers (stagger offsets, no cache I/O).
+ */
+
+require_once __DIR__ . '/../constants.php';
+
+/**
+ * Per-airport offset within the refresh window (stable from airport id).
+ *
+ * @param string $airportId Airport config key
+ * @param int $refreshInterval Configured refresh interval in seconds
+ * @return int Additional seconds of cache age required before enqueue
+ */
+function notamStaggerOffsetSeconds(string $airportId, int $refreshInterval): int
+{
+    $slots = max(1, (int) ($refreshInterval / NOTAM_SCHEDULER_STAGGER_WINDOW_FRACTION));
+    $hash = sprintf('%u', crc32(strtolower(trim($airportId))));
+
+    return (int) ($hash % $slots);
+}
+
+/**
+ * Minimum cache age before this airport is eligible for a scheduler refresh.
+ *
+ * @param string $airportId Airport config key
+ * @param int $refreshInterval Configured refresh interval in seconds
+ * @return int Required cache age in seconds (interval + stagger)
+ */
+function notamRequiredCacheAgeSeconds(string $airportId, int $refreshInterval): int
+{
+    return $refreshInterval + notamStaggerOffsetSeconds($airportId, $refreshInterval);
+}
+
+/**
+ * Maximum NOTAM worker jobs to start per scheduler loop iteration.
+ */
+function notamSchedulerMaxEnqueuePerLoop(): int
+{
+    return NOTAM_SCHEDULER_MAX_ENQUEUE_PER_LOOP;
+}

--- a/lib/operations-snapshot.php
+++ b/lib/operations-snapshot.php
@@ -340,6 +340,10 @@ function operations_snapshot_verbose_detail_warranted(array $data): bool {
     if (is_array($var) && (($var['status'] ?? '') !== 'operational')) {
         return true;
     }
+    $notam = $dp['notam'] ?? null;
+    if (is_array($notam) && (($notam['status'] ?? '') !== 'operational')) {
+        return true;
+    }
     $summary = isset($dp['airport_summary']) && is_array($dp['airport_summary']) ? $dp['airport_summary'] : [];
     $counts = isset($summary['counts']) && is_array($summary['counts']) ? $summary['counts'] : [];
     $bad = (int) ($counts['degraded'] ?? 0) + (int) ($counts['down'] ?? 0);
@@ -353,6 +357,10 @@ function operations_snapshot_verbose_detail_warranted(array $data): bool {
     }
     $m = is_array($wx) && isset($wx['metrics']) && is_array($wx['metrics']) ? $wx['metrics'] : [];
     if ((int) ($m['circuit_open_events_last_hour'] ?? 0) > 0) {
+        return true;
+    }
+    $nm = is_array($notam) && isset($notam['metrics']) && is_array($notam['metrics']) ? $notam['metrics'] : [];
+    if ((int) ($nm['upstream_429_last_hour'] ?? 0) > 0) {
         return true;
     }
     return false;

--- a/lib/operations-snapshot.php
+++ b/lib/operations-snapshot.php
@@ -511,6 +511,25 @@ function operations_snapshot_build(string $cacheBaseDir, array $options = []): a
 
     $circuitBySource = is_array($weatherFull) ? operations_snapshot_weather_circuit_by_source($weatherFull) : [];
 
+    $notamPath = $cacheBaseDir . '/notam_health.json';
+    $notamHealth = [
+        'name' => 'NOTAM Data Fetching',
+        'status' => 'operational',
+        'message' => 'No data available',
+        'lastChanged' => 0,
+        'metrics' => [],
+    ];
+    $notamFull = [];
+    if (is_readable($notamPath)) {
+        $n = @file_get_contents($notamPath);
+        if ($n !== false) {
+            $notamFull = json_decode($n, true);
+            if (is_array($notamFull) && isset($notamFull['health']) && is_array($notamFull['health'])) {
+                $notamHealth = $notamFull['health'];
+            }
+        }
+    }
+
     return [
         'snapshot_meta' => [
             'schema_version' => OPERATIONS_SNAPSHOT_SCHEMA_VERSION,
@@ -527,6 +546,7 @@ function operations_snapshot_build(string $cacheBaseDir, array $options = []): a
                 'counts' => $airSummary['counts'],
             ],
             'weather' => $weatherHealth,
+            'notam' => $notamHealth,
             'variant' => $variantHealth,
         ],
         'capacity_layer' => [

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -297,16 +297,18 @@ function checkSystemHealth(): array {
     $health['components']['variant_generation'] = $variantHealth;
     
     // Uses cached data from weather-health.php
-    $weatherDataHealth = weatherHealthGetStatus();
-    $weatherProviders = weatherHealthGetProviderBreakdown();
+    $weatherCache = weatherHealthLoadCache();
+    $weatherDataHealth = weatherHealthGetStatus($weatherCache);
+    $weatherProviders = weatherHealthGetProviderBreakdown($weatherCache);
     if ($weatherProviders !== []) {
         $weatherDataHealth['providers'] = $weatherProviders;
     }
 
     $health['components']['weather_fetching'] = $weatherDataHealth;
 
-    $notamDataHealth = notamHealthGetStatus();
-    $notamProviders = notamHealthGetProviders();
+    $notamCache = notamHealthLoadCache();
+    $notamDataHealth = notamHealthGetStatus($notamCache);
+    $notamProviders = notamHealthGetProviders($notamCache);
     if ($notamProviders !== []) {
         $notamDataHealth['providers'] = $notamProviders;
     }

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -26,6 +26,7 @@ require_once __DIR__ . '/circuit-breaker.php';
 require_once __DIR__ . '/runways.php';
 require_once __DIR__ . '/variant-health.php';
 require_once __DIR__ . '/weather-health.php';
+require_once __DIR__ . '/notam-health.php';
 require_once __DIR__ . '/weather/outage-detection.php';
 
 /**
@@ -297,18 +298,20 @@ function checkSystemHealth(): array {
     
     // Uses cached data from weather-health.php
     $weatherDataHealth = weatherHealthGetStatus();
-    
-    $weatherSources = weatherHealthGetSources();
-    if (!empty($weatherSources)) {
-        $sourceSummary = [];
-        foreach ($weatherSources as $type => $sourceData) {
-            $rate = $sourceData['metrics']['success_rate'] ?? 100;
-            $sourceSummary[] = ucfirst($type) . ': ' . $rate . '%';
-        }
-        $weatherDataHealth['source_summary'] = implode(' · ', $sourceSummary);
+    $weatherProviders = weatherHealthGetProviderBreakdown();
+    if ($weatherProviders !== []) {
+        $weatherDataHealth['providers'] = $weatherProviders;
     }
-    
+
     $health['components']['weather_fetching'] = $weatherDataHealth;
+
+    $notamDataHealth = notamHealthGetStatus();
+    $notamProviders = notamHealthGetProviders();
+    if ($notamProviders !== []) {
+        $notamDataHealth['providers'] = $notamProviders;
+    }
+
+    $health['components']['notam_fetching'] = $notamDataHealth;
     
     // Runway cache (FAA/OurAirports)
     $runwayCacheHealth = checkRunwayCacheHealth($config);

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -324,8 +324,8 @@ function upstreamRateLimitStateFilePath(string $fingerprint): string
  * @param int $rpm Sustained requests per minute
  * @param int $burst Maximum burst size
  * @param float|null $now Injectable Unix timestamp for tests
- * @param bool|null $consumed When provided, set true only if a token was persisted
- * @return bool True when a token was consumed; false when budget exhausted
+ * @param bool|null $consumed When the 5th argument is passed, set to true only if a token was persisted
+ * @return bool True when the request may proceed (including fail-open without consuming a token); false when budget is exhausted. Use $consumed to tell whether a token was actually persisted.
  */
 function upstreamRateTryTake(
     string $fingerprint,

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -334,7 +334,8 @@ function upstreamRateTryTake(
     ?float $now = null,
     ?bool &$consumed = null
 ): bool {
-    if ($consumed !== null) {
+    $trackConsumed = func_num_args() >= 5;
+    if ($trackConsumed) {
         $consumed = false;
     }
 
@@ -417,8 +418,8 @@ function upstreamRateTryTake(
     flock($fp, LOCK_UN);
     fclose($fp);
 
-    if ($consumed !== null && $result['allowed']) {
-        $consumed = true;
+    if ($trackConsumed) {
+        $consumed = $result['allowed'];
     }
 
     return $result['allowed'];

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -433,7 +433,7 @@ function upstreamRateTryTake(
  * @param string $fingerprint From upstreamRateFingerprint()
  * @param int $burst Maximum burst size
  */
-function upstreamRateRefund(string $fingerprint, int $rpm, int $burst): void
+function upstreamRateRefund(string $fingerprint, int $burst): void
 {
     $stateFile = upstreamRateLimitStateFilePath($fingerprint);
     $stateDir = dirname($stateFile);
@@ -576,7 +576,7 @@ function upstreamRateLimitConsumeForSource(array $source): array
         $consumed = false;
         if (!upstreamRateTryTake($scope['fingerprint'], $scope['rpm'], $scope['burst'], null, $consumed)) {
             foreach (array_reverse($takenScopes) as $prior) {
-                upstreamRateRefund($prior['fingerprint'], $prior['rpm'], $prior['burst']);
+                upstreamRateRefund($prior['fingerprint'], $prior['burst']);
             }
 
             return [

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -389,9 +389,9 @@ function upstreamRateTryTake(
     }
 
     $result = upstreamRateTokenBucketComputeTake($tokens, $lastRefill, $rpm, $burst, $now);
+    $preTakeTokens = $tokens;
+    $preTakeLastRefill = $lastRefill;
 
-    rewind($fp);
-    ftruncate($fp, 0);
     $payload = json_encode([
         'tokens' => $result['tokens'],
         'last_refill' => $result['last_refill'],
@@ -403,16 +403,40 @@ function upstreamRateTryTake(
         flock($fp, LOCK_UN);
         fclose($fp);
 
-        return $result['allowed'];
+        return true;
     }
 
-    $written = @fwrite($fp, $payload);
+    rewind($fp);
+    ftruncate($fp, 0);
+    if (!empty($GLOBALS['upstreamRateLimitTestForcePersistFailure'])) {
+        $written = false;
+    } else {
+        $written = @fwrite($fp, $payload);
+    }
     @fflush($fp);
-    if ($written === false) {
+
+    $persisted = is_int($written) && $written === strlen($payload);
+    if (!$persisted) {
         aviationwx_log('warning', 'upstream rate limit state write failed, allowing request', [
             'fingerprint_prefix' => substr($fingerprint, 0, 8),
             'file' => $stateFile,
         ], 'app');
+
+        $restorePayload = json_encode([
+            'tokens' => $preTakeTokens,
+            'last_refill' => $preTakeLastRefill,
+        ], JSON_UNESCAPED_UNICODE);
+        if ($restorePayload !== false) {
+            rewind($fp);
+            ftruncate($fp, 0);
+            @fwrite($fp, $restorePayload);
+            @fflush($fp);
+        }
+
+        flock($fp, LOCK_UN);
+        fclose($fp);
+
+        return true;
     }
 
     flock($fp, LOCK_UN);

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -397,11 +397,9 @@ function upstreamRateTryTake(
         'last_refill' => $result['last_refill'],
     ], JSON_UNESCAPED_UNICODE);
     if ($payload === false) {
-        aviationwx_log('warning', 'upstream rate limit state encode failed, allowing request', [
-            'fingerprint_prefix' => substr($fingerprint, 0, 8),
-        ], 'app');
         flock($fp, LOCK_UN);
         fclose($fp);
+        upstreamRateLimitRecordFailOpen('state_encode_failed', $fingerprint);
 
         return true;
     }
@@ -417,11 +415,6 @@ function upstreamRateTryTake(
 
     $persisted = is_int($written) && $written === strlen($payload);
     if (!$persisted) {
-        aviationwx_log('warning', 'upstream rate limit state write failed, allowing request', [
-            'fingerprint_prefix' => substr($fingerprint, 0, 8),
-            'file' => $stateFile,
-        ], 'app');
-
         $restorePayload = json_encode([
             'tokens' => $preTakeTokens,
             'last_refill' => $preTakeLastRefill,
@@ -435,6 +428,7 @@ function upstreamRateTryTake(
 
         flock($fp, LOCK_UN);
         fclose($fp);
+        upstreamRateLimitRecordFailOpen('state_write_failed', $fingerprint, ['file' => $stateFile]);
 
         return true;
     }

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -277,6 +277,27 @@ function upstreamRateTokenBucketComputeTake(
 }
 
 /**
+ * Pure token-bucket refund step (testable without filesystem).
+ *
+ * @param float $tokens Current token balance after a prior take
+ * @param float $lastRefill Unix timestamp of last refill
+ * @param int $burst Maximum bucket size
+ * @return array{tokens: float, last_refill: float}
+ */
+function upstreamRateTokenBucketComputeRefund(
+    float $tokens,
+    float $lastRefill,
+    int $burst
+): array {
+    $burst = max(1, $burst);
+
+    return [
+        'tokens' => min((float) $burst, $tokens + 1.0),
+        'last_refill' => $lastRefill,
+    ];
+}
+
+/**
  * Resolve on-disk state path for a fingerprint (test hook via $GLOBALS).
  */
 function upstreamRateLimitStateFilePath(string $fingerprint): string
@@ -303,10 +324,20 @@ function upstreamRateLimitStateFilePath(string $fingerprint): string
  * @param int $rpm Sustained requests per minute
  * @param int $burst Maximum burst size
  * @param float|null $now Injectable Unix timestamp for tests
+ * @param bool|null $consumed When provided, set true only if a token was persisted
  * @return bool True when a token was consumed; false when budget exhausted
  */
-function upstreamRateTryTake(string $fingerprint, int $rpm, int $burst, ?float $now = null): bool
-{
+function upstreamRateTryTake(
+    string $fingerprint,
+    int $rpm,
+    int $burst,
+    ?float $now = null,
+    ?bool &$consumed = null
+): bool {
+    if ($consumed !== null) {
+        $consumed = false;
+    }
+
     if ($now === null && isset($GLOBALS['upstreamRateLimitTestNow']) && is_numeric($GLOBALS['upstreamRateLimitTestNow'])) {
         $now = (float) $GLOBALS['upstreamRateLimitTestNow'];
     }
@@ -386,7 +417,98 @@ function upstreamRateTryTake(string $fingerprint, int $rpm, int $burst, ?float $
     flock($fp, LOCK_UN);
     fclose($fp);
 
+    if ($consumed !== null && $result['allowed']) {
+        $consumed = true;
+    }
+
     return $result['allowed'];
+}
+
+/**
+ * Return one token to a bucket after a failed multi-scope take (compensating transaction).
+ *
+ * Best-effort: I/O failure leaves the bucket unchanged (slightly conservative).
+ *
+ * @param string $fingerprint From upstreamRateFingerprint()
+ * @param int $burst Maximum burst size
+ */
+function upstreamRateRefund(string $fingerprint, int $rpm, int $burst): void
+{
+    $stateFile = upstreamRateLimitStateFilePath($fingerprint);
+    $stateDir = dirname($stateFile);
+    if (!is_dir($stateDir) && !@mkdir($stateDir, 0755, true) && !is_dir($stateDir)) {
+        aviationwx_log('warning', 'upstream rate limit refund skipped, state dir unavailable', [
+            'dir' => $stateDir,
+            'fingerprint_prefix' => substr($fingerprint, 0, 8),
+        ], 'app');
+
+        return;
+    }
+
+    $fp = @fopen($stateFile, 'c+');
+    if ($fp === false) {
+        aviationwx_log('warning', 'upstream rate limit refund skipped, state file unavailable', [
+            'file' => $stateFile,
+            'fingerprint_prefix' => substr($fingerprint, 0, 8),
+        ], 'app');
+
+        return;
+    }
+
+    if (!@flock($fp, LOCK_EX)) {
+        @fclose($fp);
+        aviationwx_log('warning', 'upstream rate limit refund skipped, flock failed', [
+            'file' => $stateFile,
+            'fingerprint_prefix' => substr($fingerprint, 0, 8),
+        ], 'app');
+
+        return;
+    }
+
+    $tokens = (float) $burst;
+    $lastRefill = 0.0;
+    $fileSize = @filesize($stateFile);
+    if ($fileSize !== false && $fileSize > 0) {
+        rewind($fp);
+        $content = @stream_get_contents($fp);
+        if ($content !== false && $content !== '') {
+            $decoded = json_decode($content, true);
+            if (is_array($decoded)) {
+                $tokens = (float) ($decoded['tokens'] ?? $burst);
+                $lastRefill = (float) ($decoded['last_refill'] ?? 0.0);
+            }
+        }
+    }
+
+    $result = upstreamRateTokenBucketComputeRefund($tokens, $lastRefill, $burst);
+
+    rewind($fp);
+    ftruncate($fp, 0);
+    $payload = json_encode([
+        'tokens' => $result['tokens'],
+        'last_refill' => $result['last_refill'],
+    ], JSON_UNESCAPED_UNICODE);
+    if ($payload === false) {
+        flock($fp, LOCK_UN);
+        fclose($fp);
+        aviationwx_log('warning', 'upstream rate limit refund encode failed', [
+            'fingerprint_prefix' => substr($fingerprint, 0, 8),
+        ], 'app');
+
+        return;
+    }
+
+    $written = @fwrite($fp, $payload);
+    @fflush($fp);
+    if ($written === false) {
+        aviationwx_log('warning', 'upstream rate limit refund write failed', [
+            'fingerprint_prefix' => substr($fingerprint, 0, 8),
+            'file' => $stateFile,
+        ], 'app');
+    }
+
+    flock($fp, LOCK_UN);
+    fclose($fp);
 }
 
 /**
@@ -447,13 +569,25 @@ function upstreamRateLimitConsumeForSource(array $source): array
     }
 
     $prefix = null;
+    $takenScopes = [];
+
     foreach ($scopes as $scope) {
-        if (!upstreamRateTryTake($scope['fingerprint'], $scope['rpm'], $scope['burst'])) {
+        $consumed = false;
+        if (!upstreamRateTryTake($scope['fingerprint'], $scope['rpm'], $scope['burst'], null, $consumed)) {
+            foreach (array_reverse($takenScopes) as $prior) {
+                upstreamRateRefund($prior['fingerprint'], $prior['rpm'], $prior['burst']);
+            }
+
             return [
                 'allowed' => false,
                 'fingerprint_prefix' => substr($scope['fingerprint'], 0, 8),
             ];
         }
+
+        if ($consumed) {
+            $takenScopes[] = $scope;
+        }
+
         if ($prefix === null) {
             $prefix = substr($scope['fingerprint'], 0, 8);
         }

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -82,7 +82,110 @@ function upstreamRateFingerprint(string $provider, array $sourceConfig): string
     ksort($material);
 
     $canonical = $provider . "\n" . json_encode($material, JSON_UNESCAPED_UNICODE);
+
     return hash('sha256', $canonical);
+}
+
+/**
+ * Stable SHA-256 fingerprint for one rate-limit scope (subset of credential fields).
+ *
+ * Scoped fingerprints use a distinct canonical prefix so they do not collide with
+ * upstreamRateFingerprint() bucket paths for the same provider.
+ *
+ * @param string $provider Weather source type
+ * @param string $scope Scope label (e.g. api_key, application_key)
+ * @param array<string, mixed> $sourceConfig Source block from weather_sources
+ * @param list<string> $fieldNames Fields to include in this scope
+ * @return string 64-char hex digest
+ */
+function upstreamRateFingerprintForScope(
+    string $provider,
+    string $scope,
+    array $sourceConfig,
+    array $fieldNames
+): string {
+    $material = [];
+    foreach ($fieldNames as $field) {
+        if (!isset($sourceConfig[$field]) || !is_string($sourceConfig[$field])) {
+            continue;
+        }
+        $value = trim($sourceConfig[$field]);
+        if ($value === '') {
+            continue;
+        }
+        $material[$field] = $value;
+    }
+    ksort($material);
+
+    $canonical = $provider . '/' . $scope . "\n" . json_encode($material, JSON_UNESCAPED_UNICODE);
+
+    return hash('sha256', $canonical);
+}
+
+/**
+ * Fingerprint for global 429/503 circuit-breaker coordination across airports.
+ *
+ * Ambient coordinates on developer application_key because that is the shared upstream cap.
+ *
+ * @param string $provider Weather source type
+ * @param array<string, mixed> $sourceConfig Source block from weather_sources
+ * @return string 64-char hex digest
+ */
+function upstreamRateGlobalCredentialFingerprint(string $provider, array $sourceConfig): string
+{
+    return match ($provider) {
+        'ambient' => upstreamRateFingerprintForScope(
+            'ambient',
+            'application_key',
+            $sourceConfig,
+            ['application_key']
+        ),
+        default => upstreamRateFingerprint($provider, $sourceConfig),
+    };
+}
+
+/**
+ * Token buckets that must all allow a request for this source (AND across scopes).
+ *
+ * @param array<string, mixed> $source weather_sources entry (must include type)
+ * @return list<array{scope: string, fingerprint: string, rpm: int, burst: int}>
+ */
+function upstreamRateLimitScopesForSource(array $source): array
+{
+    $provider = $source['type'] ?? '';
+    if (!is_string($provider) || $provider === '') {
+        return [];
+    }
+
+    return match ($provider) {
+        'ambient' => [
+            [
+                'scope' => 'api_key',
+                'fingerprint' => upstreamRateFingerprintForScope('ambient', 'api_key', $source, ['api_key']),
+                'rpm' => UPSTREAM_RATE_LIMIT_AMBIENT_API_KEY_RPM,
+                'burst' => UPSTREAM_RATE_LIMIT_AMBIENT_API_KEY_BURST,
+            ],
+            [
+                'scope' => 'application_key',
+                'fingerprint' => upstreamRateFingerprintForScope('ambient', 'application_key', $source, ['application_key']),
+                'rpm' => UPSTREAM_RATE_LIMIT_AMBIENT_APPLICATION_KEY_RPM,
+                'burst' => UPSTREAM_RATE_LIMIT_AMBIENT_APPLICATION_KEY_BURST,
+            ],
+        ],
+        default => (static function () use ($provider, $source): array {
+            $policy = upstreamRateLimitPolicyForProvider($provider);
+            if ($policy['rpm'] <= 0 || $policy['burst'] <= 0) {
+                return [];
+            }
+
+            return [[
+                'scope' => 'credential',
+                'fingerprint' => upstreamRateFingerprint($provider, $source),
+                'rpm' => $policy['rpm'],
+                'burst' => $policy['burst'],
+            ]];
+        })(),
+    };
 }
 
 /**
@@ -99,8 +202,8 @@ function upstreamRateLimitPolicyForProvider(string $provider): array
             'burst' => UPSTREAM_RATE_LIMIT_TEMPEST_BURST,
         ],
         'ambient' => [
-            'rpm' => UPSTREAM_RATE_LIMIT_AMBIENT_RPM,
-            'burst' => UPSTREAM_RATE_LIMIT_AMBIENT_BURST,
+            'rpm' => UPSTREAM_RATE_LIMIT_AMBIENT_API_KEY_RPM,
+            'burst' => UPSTREAM_RATE_LIMIT_AMBIENT_API_KEY_BURST,
         ],
         'pwsweather' => [
             'rpm' => UPSTREAM_RATE_LIMIT_PWSWEATHER_RPM,
@@ -204,6 +307,9 @@ function upstreamRateLimitStateFilePath(string $fingerprint): string
  */
 function upstreamRateTryTake(string $fingerprint, int $rpm, int $burst, ?float $now = null): bool
 {
+    if ($now === null && isset($GLOBALS['upstreamRateLimitTestNow']) && is_numeric($GLOBALS['upstreamRateLimitTestNow'])) {
+        $now = (float) $GLOBALS['upstreamRateLimitTestNow'];
+    }
     $now = $now ?? microtime(true);
     $stateFile = upstreamRateLimitStateFilePath($fingerprint);
     $stateDir = dirname($stateFile);
@@ -335,14 +441,23 @@ function upstreamRateLimitConsumeForSource(array $source): array
         return ['allowed' => true, 'fingerprint_prefix' => null];
     }
 
-    $policy = upstreamRateLimitPolicyForProvider($provider);
-    if ($policy['rpm'] <= 0 || $policy['burst'] <= 0) {
+    $scopes = upstreamRateLimitScopesForSource($source);
+    if ($scopes === []) {
         return ['allowed' => true, 'fingerprint_prefix' => null];
     }
 
-    $fingerprint = upstreamRateFingerprint($provider, $source);
-    $prefix = substr($fingerprint, 0, 8);
-    $allowed = upstreamRateTryTake($fingerprint, $policy['rpm'], $policy['burst']);
+    $prefix = null;
+    foreach ($scopes as $scope) {
+        if (!upstreamRateTryTake($scope['fingerprint'], $scope['rpm'], $scope['burst'])) {
+            return [
+                'allowed' => false,
+                'fingerprint_prefix' => substr($scope['fingerprint'], 0, 8),
+            ];
+        }
+        if ($prefix === null) {
+            $prefix = substr($scope['fingerprint'], 0, 8);
+        }
+    }
 
-    return ['allowed' => $allowed, 'fingerprint_prefix' => $prefix];
+    return ['allowed' => true, 'fingerprint_prefix' => $prefix];
 }

--- a/lib/weather-health.php
+++ b/lib/weather-health.php
@@ -192,6 +192,8 @@ function weatherHealthTrackMetarBulkDownloadFailure(?int $httpCode): void
 
     $counters = [
         'metar_bulk_download_failures' => 1,
+        'attempts_metar_bulk' => 1,
+        'failures_metar_bulk' => 1,
     ];
     weatherHealthIncrementHttpFailureCounters($counters, $httpCode, 'metar_bulk');
 
@@ -561,4 +563,131 @@ function weatherHealthGetSources(): array
     }
 
     return $data['sources'];
+}
+
+/**
+ * Display name for a weather provider key used in upstream 429 breakdown.
+ *
+ * @param string $provider Provider key from hourly bucket counters
+ * @return string Human-readable label
+ */
+function weatherHealthProviderDisplayName(string $provider): string
+{
+    if ($provider === 'metar_bulk') {
+        return 'METAR bulk (AWC national gzip)';
+    }
+
+    require_once __DIR__ . '/weather/utils.php';
+
+    $info = getWeatherSourceInfo($provider);
+    if ($info !== null) {
+        return $info['name'];
+    }
+
+    return ucfirst(str_replace('_', ' ', $provider));
+}
+
+/**
+ * Build per-provider rows for status page upstream 429 breakdown.
+ *
+ * @return list<array<string, mixed>> Provider rows sorted by upstream 429 count
+ */
+function weatherHealthGetProviderBreakdown(): array
+{
+    if (!file_exists(getWeatherHealthCacheFilePath())) {
+        return [];
+    }
+
+    $content = @file_get_contents(getWeatherHealthCacheFilePath());
+    if ($content === false) {
+        return [];
+    }
+
+    $data = @json_decode($content, true);
+    if (!is_array($data)) {
+        return [];
+    }
+
+    $oneHourAgo = gmdate('Y-m-d-H', time() - 3600);
+    $byProvider = [];
+
+    foreach ($data['hourly_buckets'] ?? [] as $hourKey => $bucket) {
+        if ($hourKey < $oneHourAgo) {
+            continue;
+        }
+
+        foreach ($bucket as $key => $value) {
+            if (!is_string($key) || !is_numeric($value)) {
+                continue;
+            }
+
+            if (preg_match('/^attempts_(.+)$/', $key, $matches) === 1) {
+                $provider = $matches[1];
+                if (!isset($byProvider[$provider])) {
+                    $byProvider[$provider] = [
+                        'attempts' => 0,
+                        'successes' => 0,
+                        'upstream_429' => 0,
+                    ];
+                }
+                $byProvider[$provider]['attempts'] += (int) $value;
+                continue;
+            }
+
+            if (preg_match('/^successes_(.+)$/', $key, $matches) === 1) {
+                $provider = $matches[1];
+                if (!isset($byProvider[$provider])) {
+                    $byProvider[$provider] = [
+                        'attempts' => 0,
+                        'successes' => 0,
+                        'upstream_429' => 0,
+                    ];
+                }
+                $byProvider[$provider]['successes'] += (int) $value;
+                continue;
+            }
+
+            if (preg_match('/^upstream_429_(.+)$/', $key, $matches) === 1) {
+                $provider = $matches[1];
+                if (!isset($byProvider[$provider])) {
+                    $byProvider[$provider] = [
+                        'attempts' => 0,
+                        'successes' => 0,
+                        'upstream_429' => 0,
+                    ];
+                }
+                $byProvider[$provider]['upstream_429'] += (int) $value;
+            }
+        }
+    }
+
+    $providers = [];
+    foreach ($byProvider as $providerId => $stats) {
+        if ($stats['attempts'] === 0 && $stats['upstream_429'] === 0) {
+            continue;
+        }
+
+        if ($stats['attempts'] === 0) {
+            $stats['attempts'] = $stats['upstream_429'];
+        }
+
+        $providers[] = [
+            'id' => $providerId,
+            'name' => weatherHealthProviderDisplayName($providerId),
+            'upstream_429' => $stats['upstream_429'],
+            'attempts' => $stats['attempts'],
+            'success_rate' => round(($stats['successes'] / $stats['attempts']) * 100, 1),
+        ];
+    }
+
+    usort($providers, static function (array $a, array $b): int {
+        $cmp = ($b['upstream_429'] ?? 0) <=> ($a['upstream_429'] ?? 0);
+        if ($cmp !== 0) {
+            return $cmp;
+        }
+
+        return ($b['attempts'] ?? 0) <=> ($a['attempts'] ?? 0);
+    });
+
+    return $providers;
 }

--- a/lib/weather-health.php
+++ b/lib/weather-health.php
@@ -200,6 +200,22 @@ function weatherHealthTrackMetarBulkDownloadFailure(?int $httpCode): void
     weatherHealthAtomicUpdate($currentHour, $counters, $now);
 }
 
+/**
+ * Track a successful AWC national METAR bulk gzip refresh (scheduler worker).
+ */
+function weatherHealthTrackMetarBulkDownloadSuccess(): void
+{
+    $now = time();
+    $currentHour = gmdate('Y-m-d-H', $now);
+
+    $counters = [
+        'attempts_metar_bulk' => 1,
+        'successes_metar_bulk' => 1,
+    ];
+
+    weatherHealthAtomicUpdate($currentHour, $counters, $now);
+}
+
 // =============================================================================
 // FILE I/O FUNCTIONS
 // =============================================================================

--- a/lib/weather-health.php
+++ b/lib/weather-health.php
@@ -510,11 +510,33 @@ function weatherHealthComputeSourceStatus(array $data): array
 }
 
 /**
+ * Read and decode the weather health cache file.
+ *
+ * @return array<string, mixed>|null Decoded cache or null when missing/unreadable
+ */
+function weatherHealthLoadCache(): ?array
+{
+    if (!file_exists(getWeatherHealthCacheFilePath())) {
+        return null;
+    }
+
+    $content = @file_get_contents(getWeatherHealthCacheFilePath());
+    if ($content === false) {
+        return null;
+    }
+
+    $data = @json_decode($content, true);
+
+    return is_array($data) ? $data : null;
+}
+
+/**
  * Get weather health status (for status page).
  *
+ * @param array<string, mixed>|null $cache Preloaded cache from weatherHealthLoadCache()
  * @return array<string, mixed> Health status
  */
-function weatherHealthGetStatus(): array
+function weatherHealthGetStatus(?array $cache = null): array
 {
     $default = [
         'name' => 'Weather Data Fetching',
@@ -524,17 +546,8 @@ function weatherHealthGetStatus(): array
         'metrics' => [],
     ];
 
-    if (!file_exists(getWeatherHealthCacheFilePath())) {
-        return $default;
-    }
-
-    $content = @file_get_contents(getWeatherHealthCacheFilePath());
-    if ($content === false) {
-        return $default;
-    }
-
-    $data = @json_decode($content, true);
-    if (!is_array($data) || !isset($data['health'])) {
+    $data = $cache ?? weatherHealthLoadCache();
+    if ($data === null || !isset($data['health'])) {
         return $default;
     }
 
@@ -590,21 +603,13 @@ function weatherHealthProviderDisplayName(string $provider): string
 /**
  * Build per-provider rows for status page upstream 429 breakdown.
  *
+ * @param array<string, mixed>|null $cache Preloaded cache from weatherHealthLoadCache()
  * @return list<array<string, mixed>> Provider rows sorted by upstream 429 count
  */
-function weatherHealthGetProviderBreakdown(): array
+function weatherHealthGetProviderBreakdown(?array $cache = null): array
 {
-    if (!file_exists(getWeatherHealthCacheFilePath())) {
-        return [];
-    }
-
-    $content = @file_get_contents(getWeatherHealthCacheFilePath());
-    if ($content === false) {
-        return [];
-    }
-
-    $data = @json_decode($content, true);
-    if (!is_array($data)) {
+    $data = $cache ?? weatherHealthLoadCache();
+    if ($data === null) {
         return [];
     }
 

--- a/pages/status.php
+++ b/pages/status.php
@@ -1000,7 +1000,9 @@ if (php_sapi_name() === 'cli') {
                                         class="component-expand-btn"
                                         aria-expanded="false"
                                         aria-controls="component-providers-<?php echo (int) $componentIndex; ?>"
+                                        aria-label="Show per-provider HTTP 429 counts for <?php echo htmlspecialchars($component['name']); ?>"
                                         data-component-toggle="<?php echo (int) $componentIndex; ?>"
+                                        data-component-name="<?php echo htmlspecialchars($component['name'], ENT_QUOTES, 'UTF-8'); ?>"
                                         title="Show per-provider HTTP 429 counts">
                                     <span class="expand-icon" aria-hidden="true">▶</span>
                                 </button>
@@ -1509,12 +1511,21 @@ if (php_sapi_name() === 'cli') {
                     return;
                 }
                 var isExpanded = btn.getAttribute('aria-expanded') === 'true';
+                var componentName = btn.getAttribute('data-component-name') || 'component';
                 if (isExpanded) {
                     btn.setAttribute('aria-expanded', 'false');
+                    btn.setAttribute(
+                        'aria-label',
+                        'Show per-provider HTTP 429 counts for ' + componentName
+                    );
                     panel.classList.remove('expanded');
                     panel.classList.add('collapsed');
                 } else {
                     btn.setAttribute('aria-expanded', 'true');
+                    btn.setAttribute(
+                        'aria-label',
+                        'Hide per-provider HTTP 429 counts for ' + componentName
+                    );
                     panel.classList.remove('collapsed');
                     panel.classList.add('expanded');
                 }

--- a/pages/status.php
+++ b/pages/status.php
@@ -464,6 +464,74 @@ if (php_sapi_name() === 'cli') {
         .component-item:last-child {
             border-bottom: none;
         }
+
+        .component-item-expandable .component-name {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .component-expand-btn {
+            border: none;
+            background: transparent;
+            padding: 0;
+            cursor: pointer;
+            line-height: 1;
+            color: #6b7280;
+        }
+
+        .component-expand-btn .expand-icon {
+            display: inline-block;
+            transition: transform 0.2s;
+            font-size: 0.75rem;
+        }
+
+        .component-expand-btn[aria-expanded="true"] .expand-icon {
+            transform: rotate(90deg);
+        }
+
+        .component-providers {
+            margin-top: 0.5rem;
+            overflow: hidden;
+            transition: max-height 0.25s ease-out;
+        }
+
+        .component-providers.collapsed {
+            max-height: 0;
+            margin-top: 0;
+        }
+
+        .component-providers.expanded {
+            max-height: 1200px;
+        }
+
+        .component-provider-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.8rem;
+            color: #666;
+        }
+
+        .component-provider-table th,
+        .component-provider-table td {
+            padding: 0.2rem 0.5rem 0.2rem 0;
+            text-align: left;
+            border-bottom: 1px solid #f3f4f6;
+        }
+
+        .component-provider-table th {
+            font-weight: 600;
+            color: #888;
+        }
+
+        .component-provider-table tr:last-child td {
+            border-bottom: none;
+        }
+
+        .component-provider-429-warn {
+            color: #b45309;
+            font-weight: 600;
+        }
         
         .component-info {
             flex: 1;
@@ -917,10 +985,28 @@ if (php_sapi_name() === 'cli') {
                 </div>
                 
                 <ul class="component-list">
-                    <?php foreach ($systemHealth['components'] as $component): ?>
-                    <li class="component-item">
+                    <?php foreach ($systemHealth['components'] as $componentIndex => $component): ?>
+                    <?php
+                    $componentProviders = (isset($component['providers']) && is_array($component['providers']))
+                        ? $component['providers']
+                        : [];
+                    $hasProviderBreakdown = $componentProviders !== [];
+                    ?>
+                    <li class="component-item<?php echo $hasProviderBreakdown ? ' component-item-expandable' : ''; ?>">
                         <div class="component-info">
-                            <div class="component-name"><?php echo htmlspecialchars($component['name']); ?></div>
+                            <div class="component-name">
+                                <?php if ($hasProviderBreakdown): ?>
+                                <button type="button"
+                                        class="component-expand-btn"
+                                        aria-expanded="false"
+                                        aria-controls="component-providers-<?php echo (int) $componentIndex; ?>"
+                                        data-component-toggle="<?php echo (int) $componentIndex; ?>"
+                                        title="Show per-provider HTTP 429 counts">
+                                    <span class="expand-icon" aria-hidden="true">▶</span>
+                                </button>
+                                <?php endif; ?>
+                                <span><?php echo htmlspecialchars($component['name']); ?></span>
+                            </div>
                             <div class="component-message"><?php echo htmlspecialchars($component['message']); ?></div>
                             <?php if (isset($component['metrics']) && is_array($component['metrics']) && !empty($component['metrics'])): ?>
                             <div class="component-metrics" style="margin-top: 0.25rem; font-size: 0.8rem; color: #888;">
@@ -937,6 +1023,34 @@ if (php_sapi_name() === 'cli') {
                                 }
                                 echo htmlspecialchars(implode(' · ', $metricParts));
                                 ?>
+                            </div>
+                            <?php endif; ?>
+                            <?php if ($hasProviderBreakdown): ?>
+                            <div class="component-providers collapsed" id="component-providers-<?php echo (int) $componentIndex; ?>">
+                                <table class="component-provider-table">
+                                    <thead>
+                                        <tr>
+                                            <th scope="col">Provider</th>
+                                            <th scope="col">429 (1h)</th>
+                                            <th scope="col">Attempts</th>
+                                            <th scope="col">Success</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <?php foreach ($componentProviders as $providerRow): ?>
+                                        <?php
+                                        $provider429 = (int) ($providerRow['upstream_429'] ?? 0);
+                                        $provider429Class = $provider429 > 0 ? ' component-provider-429-warn' : '';
+                                        ?>
+                                        <tr>
+                                            <td><?php echo htmlspecialchars((string) ($providerRow['name'] ?? '')); ?></td>
+                                            <td class="<?php echo trim($provider429Class); ?>"><?php echo $provider429; ?></td>
+                                            <td><?php echo (int) ($providerRow['attempts'] ?? 0); ?></td>
+                                            <td><?php echo htmlspecialchars((string) ($providerRow['success_rate'] ?? 0)); ?>%</td>
+                                        </tr>
+                                        <?php endforeach; ?>
+                                    </tbody>
+                                </table>
                             </div>
                             <?php endif; ?>
                             <?php if (isset($component['lastChanged']) && $component['lastChanged'] > 0): ?>
@@ -1387,6 +1501,33 @@ if (php_sapi_name() === 'cli') {
             }
 
             window.toggleAirport = toggleAirport;
+
+            function toggleComponentProviders(componentIndex) {
+                var btn = document.querySelector('.component-expand-btn[data-component-toggle="' + componentIndex + '"]');
+                var panel = document.getElementById('component-providers-' + componentIndex);
+                if (!btn || !panel) {
+                    return;
+                }
+                var isExpanded = btn.getAttribute('aria-expanded') === 'true';
+                if (isExpanded) {
+                    btn.setAttribute('aria-expanded', 'false');
+                    panel.classList.remove('expanded');
+                    panel.classList.add('collapsed');
+                } else {
+                    btn.setAttribute('aria-expanded', 'true');
+                    panel.classList.remove('collapsed');
+                    panel.classList.add('expanded');
+                }
+            }
+
+            document.querySelectorAll('.component-expand-btn[data-component-toggle]').forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    var idx = btn.getAttribute('data-component-toggle');
+                    if (idx !== null && idx !== '') {
+                        toggleComponentProviders(idx);
+                    }
+                });
+            });
 
             document.querySelectorAll('.airport-card-header[data-airport-toggle]').forEach(function (hdr) {
                 hdr.addEventListener('click', function () {

--- a/pages/status.php
+++ b/pages/status.php
@@ -985,12 +985,13 @@ if (php_sapi_name() === 'cli') {
                 </div>
                 
                 <ul class="component-list">
-                    <?php foreach ($systemHealth['components'] as $componentIndex => $component): ?>
+                    <?php foreach ($systemHealth['components'] as $componentKey => $component): ?>
                     <?php
                     $componentProviders = (isset($component['providers']) && is_array($component['providers']))
                         ? $component['providers']
                         : [];
                     $hasProviderBreakdown = $componentProviders !== [];
+                    $componentKeyEscaped = htmlspecialchars((string) $componentKey, ENT_QUOTES, 'UTF-8');
                     ?>
                     <li class="component-item<?php echo $hasProviderBreakdown ? ' component-item-expandable' : ''; ?>">
                         <div class="component-info">
@@ -999,9 +1000,9 @@ if (php_sapi_name() === 'cli') {
                                 <button type="button"
                                         class="component-expand-btn"
                                         aria-expanded="false"
-                                        aria-controls="component-providers-<?php echo (int) $componentIndex; ?>"
+                                        aria-controls="component-providers-<?php echo $componentKeyEscaped; ?>"
                                         aria-label="Show per-provider HTTP 429 counts for <?php echo htmlspecialchars($component['name']); ?>"
-                                        data-component-toggle="<?php echo (int) $componentIndex; ?>"
+                                        data-component-toggle="<?php echo $componentKeyEscaped; ?>"
                                         data-component-name="<?php echo htmlspecialchars($component['name'], ENT_QUOTES, 'UTF-8'); ?>"
                                         title="Show per-provider HTTP 429 counts">
                                     <span class="expand-icon" aria-hidden="true">▶</span>
@@ -1028,7 +1029,7 @@ if (php_sapi_name() === 'cli') {
                             </div>
                             <?php endif; ?>
                             <?php if ($hasProviderBreakdown): ?>
-                            <div class="component-providers collapsed" id="component-providers-<?php echo (int) $componentIndex; ?>">
+                            <div class="component-providers collapsed" id="component-providers-<?php echo $componentKeyEscaped; ?>">
                                 <table class="component-provider-table">
                                     <thead>
                                         <tr>

--- a/pages/status.php
+++ b/pages/status.php
@@ -1036,7 +1036,7 @@ if (php_sapi_name() === 'cli') {
                                             <th scope="col">Provider</th>
                                             <th scope="col">429 (1h)</th>
                                             <th scope="col">Attempts</th>
-                                            <th scope="col">Success</th>
+                                            <th scope="col">Success %</th>
                                         </tr>
                                     </thead>
                                     <tbody>

--- a/scripts/scheduler.php
+++ b/scripts/scheduler.php
@@ -30,6 +30,7 @@ require_once __DIR__ . '/../lib/process-pool.php';
 require_once __DIR__ . '/../lib/webcam-format-generation.php';
 require_once __DIR__ . '/../lib/metrics.php';
 require_once __DIR__ . '/../lib/weather-health.php';
+require_once __DIR__ . '/../lib/notam-health.php';
 require_once __DIR__ . '/../lib/worker-timeout.php';
 require_once __DIR__ . '/../lib/webcam-schedule-queue.php';
 require_once __DIR__ . '/../lib/runways.php';
@@ -478,26 +479,30 @@ while ($running) {
             }
         }
         
-        // Process NOTAM updates (non-blocking)
+        // Process NOTAM updates (non-blocking, spread across time - lower urgency than weather/webcams)
         if ($notamPool !== null && isset($config['airports'])) {
-            require_once __DIR__ . '/../lib/notam/cache.php';
+            require_once __DIR__ . '/../lib/notam/scheduler-queue.php';
 
+            $refreshInterval = getNotamRefreshSeconds();
+            $minRefresh = getMinimumRefreshInterval();
+            $refreshInterval = max($minRefresh, $refreshInterval);
+
+            $notamCandidateIds = [];
             foreach ($config['airports'] as $airportId => $airport) {
                 if (!is_array($airport) || !isAirportEnabled($airport) || isAirportInMaintenance($airport)) {
                     continue;
                 }
+                $notamCandidateIds[] = (string) $airportId;
+            }
 
-                // Get refresh interval
-                $refreshInterval = getNotamRefreshSeconds();
-                
-                // Enforce minimum (configurable)
-                $minRefresh = getMinimumRefreshInterval();
-                $refreshInterval = max($minRefresh, $refreshInterval);
-                
-                if (notamShouldEnqueueRefresh($airportId, $refreshInterval, $now)) {
-                    // Non-blocking: add to pool (ProcessPool handles duplicates)
-                    $notamPool->addJob([$airportId]);
-                }
+            $notamToEnqueue = notamSelectAirportsToEnqueue(
+                $notamCandidateIds,
+                $refreshInterval,
+                notamSchedulerMaxEnqueuePerLoop(),
+                $now
+            );
+            foreach ($notamToEnqueue as $notamAirportId) {
+                $notamPool->addJob([$notamAirportId]);
             }
         }
 
@@ -652,7 +657,9 @@ while ($running) {
         // Variant health APCu flush runs via variant_health_flush_via_http() on METRICS_FLUSH_INTERVAL_SECONDS above.
         // This pre-computes weather fetch health so status page doesn't check file ages
         if (($now - $lastWeatherHealthUpdate) >= 60) {
-            if (weatherHealthFlush()) {
+            $weatherFlushed = weatherHealthFlush();
+            $notamFlushed = notamHealthFlush();
+            if ($weatherFlushed || $notamFlushed) {
                 $lastWeatherHealthUpdate = $now;
             }
         }

--- a/tests/Integration/StatusPageIntegrationTest.php
+++ b/tests/Integration/StatusPageIntegrationTest.php
@@ -146,6 +146,37 @@ class StatusPageIntegrationTest extends TestCase
             "Status page should contain at least one system component"
         );
     }
+
+    /**
+     * Upstream health rows and expandable provider breakdown markup.
+     */
+    public function testStatusPage_ContainsUpstreamHealthComponents()
+    {
+        $response = $this->makeRequest('?status=1');
+
+        if ($response['http_code'] == 0 || $response['http_code'] != 200) {
+            $this->markTestSkipped('Endpoint not available');
+            return;
+        }
+
+        $body = $response['body'];
+
+        $this->assertStringContainsString(
+            'Weather Data Fetching',
+            $body,
+            'Status page should list Weather Data Fetching system component'
+        );
+        $this->assertStringContainsString(
+            'NOTAM Data Fetching',
+            $body,
+            'Status page should list NOTAM Data Fetching system component'
+        );
+        $this->assertStringContainsString(
+            'data-component-toggle',
+            $body,
+            'Status page should ship expandable provider breakdown script hooks'
+        );
+    }
     
     /**
      * Test status page via routing (status subdomain or query parameter)

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -4552,6 +4552,19 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('notam_worker_pool_size', implode(' ', $result['errors']));
     }
 
+    public function testNotamWorkerPoolSize_GreaterThanOne_WarnsButRemainsValid()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['notam_worker_pool_size'] = 3;
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], 'notam_worker_pool_size = 3 should remain valid');
+        $this->assertNotEmpty($result['warnings'] ?? []);
+        $this->assertStringContainsString(
+            'notam_worker_pool_size > 1',
+            implode(' ', $result['warnings'])
+        );
+    }
+
     /**
      * Test notam_api_client_id validation
      */

--- a/tests/Unit/GlobalWeatherCircuitBreakerTest.php
+++ b/tests/Unit/GlobalWeatherCircuitBreakerTest.php
@@ -47,6 +47,32 @@ final class GlobalWeatherCircuitBreakerTest extends TestCase
         );
     }
 
+    public function testGlobalKey_SameAmbientApplicationKeyDifferentUserApiKeys_ReturnsSameKey(): void
+    {
+        $sharedApp = 'shared-developer-app';
+        $sourceA = ['type' => 'ambient', 'api_key' => 'user-a', 'application_key' => $sharedApp];
+        $sourceB = ['type' => 'ambient', 'api_key' => 'user-b', 'application_key' => $sharedApp];
+
+        $this->assertSame(
+            weatherGlobalCircuitBreakerKey('ambient', $sourceA),
+            weatherGlobalCircuitBreakerKey('ambient', $sourceB)
+        );
+    }
+
+    public function testCheckWeatherCircuitBreaker_AmbientGlobalOpenDifferentAirport_Skips(): void
+    {
+        $sourceA = ['type' => 'ambient', 'api_key' => 'user-a', 'application_key' => 'shared-app'];
+        $sourceB = ['type' => 'ambient', 'api_key' => 'user-b', 'application_key' => 'shared-app'];
+
+        for ($i = 0; $i < CIRCUIT_BREAKER_FAILURE_THRESHOLD; $i++) {
+            recordWeatherFailure(self::AIRPORT_A, 'ambient', 'transient', 429, null, $sourceA);
+        }
+
+        $result = checkWeatherCircuitBreaker(self::AIRPORT_B, 'ambient', $sourceB);
+        $this->assertTrue($result['skip']);
+        $this->assertSame('global_circuit_open', $result['reason']);
+    }
+
     public function testCheckWeatherCircuitBreaker_GlobalOpenDifferentAirport_Skips(): void
     {
         $source = ['type' => 'tempest', 'api_key' => 'global-test-key', 'station_id' => '99'];
@@ -135,6 +161,7 @@ final class GlobalWeatherCircuitBreakerTest extends TestCase
             self::AIRPORT_A . '_weather_',
             self::AIRPORT_B . '_weather_',
             'global_weather_tempest_',
+            'global_weather_ambient_',
         ];
         $changed = false;
         foreach (array_keys($data) as $key) {

--- a/tests/Unit/NotamObservabilityTest.php
+++ b/tests/Unit/NotamObservabilityTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AviationWX\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * NMS NOTAM upstream health counters.
+ *
+ * @covers ::getNotamHealthCacheFilePath
+ * @covers ::notamHealthEnsureCacheDirectory
+ * @covers ::notamHealthTrackRequest
+ * @covers ::notamHealthFlush
+ * @covers ::notamHealthGetStatus
+ * @covers ::notamHealthGetProviders
+ * @covers ::notamHealthEndpointDisplayName
+ */
+final class NotamObservabilityTest extends TestCase
+{
+    private ?string $cacheRoot = null;
+
+    private ?string $healthCacheFile = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cacheRoot = sys_get_temp_dir() . '/notam-obs-' . bin2hex(random_bytes(4));
+        mkdir($this->cacheRoot, 0755, true);
+
+        $this->healthCacheFile = $this->cacheRoot . '/notam_health.json';
+        $GLOBALS['notamHealthTestCacheFile'] = $this->healthCacheFile;
+
+        require_once __DIR__ . '/../../lib/cache-paths.php';
+        require_once __DIR__ . '/../../lib/notam-health.php';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['notamHealthTestCacheFile']);
+
+        if ($this->cacheRoot !== null && is_dir($this->cacheRoot)) {
+            $files = glob($this->cacheRoot . '/*') ?: [];
+            foreach ($files as $file) {
+                if (is_file($file)) {
+                    unlink($file);
+                }
+            }
+            @rmdir($this->cacheRoot);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testNotamHealthTrackRequest_429IncrementsUpstreamCounter(): void
+    {
+        notamHealthTrackRequest('location', false, 429);
+        notamHealthFlush();
+
+        $status = notamHealthGetStatus();
+        $metrics = $status['metrics'] ?? [];
+        $this->assertSame(1, $metrics['upstream_429_last_hour'] ?? null);
+        $this->assertSame('degraded', $status['status'] ?? null);
+        $this->assertStringContainsString('429', (string) ($status['message'] ?? ''));
+    }
+
+    public function testNotamHealthGetProviders_IncludesEndpointBreakdown(): void
+    {
+        notamHealthTrackRequest('location', false, 429);
+        notamHealthTrackRequest('geo', true, 200);
+        notamHealthFlush();
+
+        $providers = notamHealthGetProviders();
+        $this->assertCount(2, $providers);
+
+        $byId = [];
+        foreach ($providers as $row) {
+            $byId[$row['id']] = $row;
+        }
+
+        $this->assertSame(1, $byId['location']['upstream_429'] ?? null);
+        $this->assertSame(0, $byId['geo']['upstream_429'] ?? null);
+        $this->assertSame('NMS location query', $byId['location']['name'] ?? null);
+    }
+
+    public function testNotamHealthFlush_CreatesCacheWhenMissing(): void
+    {
+        $this->assertFileDoesNotExist($this->healthCacheFile);
+        $this->assertTrue(notamHealthFlush());
+        $this->assertFileExists($this->healthCacheFile);
+
+        $decoded = json_decode((string) file_get_contents($this->healthCacheFile), true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('health', $decoded);
+        $this->assertArrayHasKey('providers', $decoded);
+    }
+}

--- a/tests/Unit/NotamRateLimitTest.php
+++ b/tests/Unit/NotamRateLimitTest.php
@@ -65,6 +65,20 @@ final class NotamRateLimitTest extends TestCase
         $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', notamRateLimitFingerprint());
     }
 
+    public function testNotamRateLimitFingerprint_TrailingSlashOnBaseUrl_MatchesWithoutSlash(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/rate-limit.php';
+
+        $GLOBALS['notamRateLimitTestClientId'] = 'client-a';
+        $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
+        $withoutSlash = notamRateLimitFingerprint();
+
+        $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms/';
+        $withSlash = notamRateLimitFingerprint();
+
+        $this->assertSame($withoutSlash, $withSlash);
+    }
+
     public function testNotamRateLimitAcquire_SecondRequestWithinOneSecondWaits(): void
     {
         require_once dirname(__DIR__, 2) . '/lib/notam/rate-limit.php';

--- a/tests/Unit/NotamRateLimitTest.php
+++ b/tests/Unit/NotamRateLimitTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Cross-process NMS NOTAM API rate limiting (1 req/s).
+ */
+final class NotamRateLimitTest extends TestCase
+{
+    private ?string $testRoot = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testRoot = sys_get_temp_dir() . '/notam-rate-limit-test-' . bin2hex(random_bytes(4));
+        mkdir($this->testRoot, 0755, true);
+        $GLOBALS['upstreamRateLimitTestRoot'] = $this->testRoot;
+        putenv('APP_ENV=testing');
+        $_ENV['APP_ENV'] = 'testing';
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $GLOBALS['upstreamRateLimitTestRoot'],
+            $GLOBALS['notamRateLimitTestForceEnforcement'],
+            $GLOBALS['notamRateLimitTestSkipSleep'],
+            $GLOBALS['upstreamRateLimitTestNow'],
+            $GLOBALS['notamRateLimitTestPollMicroseconds'],
+            $GLOBALS['notamRateLimitTestClientId'],
+            $GLOBALS['notamRateLimitTestBaseUrl']
+        );
+        if ($this->testRoot !== null && is_dir($this->testRoot)) {
+            $files = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($this->testRoot, FilesystemIterator::SKIP_DOTS),
+                RecursiveIteratorIterator::CHILD_FIRST
+            );
+            foreach ($files as $file) {
+                if ($file->isDir()) {
+                    rmdir($file->getPathname());
+                } else {
+                    unlink($file->getPathname());
+                }
+            }
+            rmdir($this->testRoot);
+        }
+        parent::tearDown();
+    }
+
+    public function testNotamRateLimitFingerprint_SameCredential_ReturnsStableHash(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/rate-limit.php';
+
+        $GLOBALS['notamRateLimitTestClientId'] = 'client-a';
+        $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
+
+        $this->assertSame(
+            notamRateLimitFingerprint(),
+            notamRateLimitFingerprint()
+        );
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', notamRateLimitFingerprint());
+    }
+
+    public function testNotamRateLimitAcquire_SecondRequestWithinOneSecondWaits(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/rate-limit.php';
+
+        notamRateLimitTestForceEnforcement();
+        $GLOBALS['notamRateLimitTestSkipSleep'] = true;
+        $GLOBALS['notamRateLimitTestPollMicroseconds'] = 50_000;
+        $GLOBALS['notamRateLimitTestClientId'] = 'client-a';
+        $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
+
+        $t0 = 1_700_000_000.0;
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0;
+        notamRateLimitAcquire();
+
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0 + 0.2;
+        notamRateLimitAcquire();
+
+        $this->assertGreaterThanOrEqual($t0 + 1.0, (float) $GLOBALS['upstreamRateLimitTestNow']);
+    }
+
+    public function testRateLimitWait_UsesGlobalAcquireNotOnlyLocalClock(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/fetcher.php';
+
+        notamRateLimitTestForceEnforcement();
+        $GLOBALS['notamRateLimitTestSkipSleep'] = true;
+        $GLOBALS['notamRateLimitTestPollMicroseconds'] = 100_000;
+        $GLOBALS['notamRateLimitTestClientId'] = 'client-b';
+        $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
+
+        $t0 = 1_700_000_100.0;
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0;
+        $lastRequestTime = 0.0;
+        rateLimitWait($lastRequestTime);
+
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0 + 0.1;
+        rateLimitWait($lastRequestTime);
+
+        $this->assertGreaterThanOrEqual($t0 + 1.0, (float) $GLOBALS['upstreamRateLimitTestNow']);
+    }
+
+    public function testNotamRateLimitAcquire_TestModeBypassWithoutForce(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/rate-limit.php';
+
+        $GLOBALS['notamRateLimitTestClientId'] = 'client-c';
+        $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
+
+        $t0 = 1_700_000_200.0;
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0;
+        notamRateLimitAcquire();
+        notamRateLimitAcquire();
+
+        $this->assertSame($t0, (float) $GLOBALS['upstreamRateLimitTestNow']);
+        $this->assertSame(0, count(glob($this->testRoot . '/*/*.json') ?: []));
+    }
+}

--- a/tests/Unit/NotamRateLimitTest.php
+++ b/tests/Unit/NotamRateLimitTest.php
@@ -30,6 +30,7 @@ final class NotamRateLimitTest extends TestCase
             $GLOBALS['upstreamRateLimitTestNow'],
             $GLOBALS['notamRateLimitTestPollMicroseconds'],
             $GLOBALS['notamRateLimitTestClientId'],
+            $GLOBALS['notamRateLimitTestClientSecret'],
             $GLOBALS['notamRateLimitTestBaseUrl']
         );
         if ($this->testRoot !== null && is_dir($this->testRoot)) {
@@ -54,6 +55,7 @@ final class NotamRateLimitTest extends TestCase
         require_once dirname(__DIR__, 2) . '/lib/notam/rate-limit.php';
 
         $GLOBALS['notamRateLimitTestClientId'] = 'client-a';
+        $GLOBALS['notamRateLimitTestClientSecret'] = 'secret-a';
         $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
 
         $this->assertSame(
@@ -71,6 +73,7 @@ final class NotamRateLimitTest extends TestCase
         $GLOBALS['notamRateLimitTestSkipSleep'] = true;
         $GLOBALS['notamRateLimitTestPollMicroseconds'] = 50_000;
         $GLOBALS['notamRateLimitTestClientId'] = 'client-a';
+        $GLOBALS['notamRateLimitTestClientSecret'] = 'secret-a';
         $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
 
         $t0 = 1_700_000_000.0;
@@ -91,6 +94,7 @@ final class NotamRateLimitTest extends TestCase
         $GLOBALS['notamRateLimitTestSkipSleep'] = true;
         $GLOBALS['notamRateLimitTestPollMicroseconds'] = 100_000;
         $GLOBALS['notamRateLimitTestClientId'] = 'client-b';
+        $GLOBALS['notamRateLimitTestClientSecret'] = 'secret-b';
         $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
 
         $t0 = 1_700_000_100.0;
@@ -104,11 +108,26 @@ final class NotamRateLimitTest extends TestCase
         $this->assertGreaterThanOrEqual($t0 + 1.0, (float) $GLOBALS['upstreamRateLimitTestNow']);
     }
 
+    public function testNotamRateLimitAcquire_MissingCredentials_SkipsBucket(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/rate-limit.php';
+
+        notamRateLimitTestForceEnforcement();
+        $GLOBALS['notamRateLimitTestClientId'] = '';
+        $GLOBALS['notamRateLimitTestClientSecret'] = '';
+        $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
+
+        notamRateLimitAcquire();
+
+        $this->assertSame(0, count(glob($this->testRoot . '/*/*.json') ?: []));
+    }
+
     public function testNotamRateLimitAcquire_TestModeBypassWithoutForce(): void
     {
         require_once dirname(__DIR__, 2) . '/lib/notam/rate-limit.php';
 
         $GLOBALS['notamRateLimitTestClientId'] = 'client-c';
+        $GLOBALS['notamRateLimitTestClientSecret'] = 'secret-c';
         $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
 
         $t0 = 1_700_000_200.0;

--- a/tests/Unit/NotamSchedulerQueueTest.php
+++ b/tests/Unit/NotamSchedulerQueueTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * NOTAM scheduler spreading (stagger + low-urgency enqueue cap).
+ */
+final class NotamSchedulerQueueTest extends TestCase
+{
+    private string $cacheDir = '';
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir() . '/notam-sched-queue-' . bin2hex(random_bytes(4));
+        mkdir($this->cacheDir, 0755, true);
+        $GLOBALS['notamCacheTestDirectory'] = $this->cacheDir;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['notamCacheTestDirectory']);
+        if ($this->cacheDir !== '' && is_dir($this->cacheDir)) {
+            foreach (scandir($this->cacheDir) ?: [] as $item) {
+                if ($item === '.' || $item === '..') {
+                    continue;
+                }
+                @unlink($this->cacheDir . '/' . $item);
+            }
+            @rmdir($this->cacheDir);
+        }
+    }
+
+    public function testStaggerOffset_SpreadsAcrossRefreshWindow(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/scheduling.php';
+
+        $interval = 600;
+        $maxSlot = (int) ($interval / NOTAM_SCHEDULER_STAGGER_WINDOW_FRACTION);
+        $offsets = [];
+        foreach (['kspb', 'kpfc', '28u', 'or81', 'cyav'] as $id) {
+            $offsets[] = notamStaggerOffsetSeconds($id, $interval);
+        }
+
+        foreach ($offsets as $offset) {
+            $this->assertGreaterThanOrEqual(0, $offset);
+            $this->assertLessThan($maxSlot, $offset);
+        }
+        $this->assertGreaterThan(1, count(array_unique($offsets)));
+    }
+
+    public function testShouldEnqueueRefresh_RequiresRefreshIntervalPlusStagger(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/cache.php';
+
+        $now = 1_700_000_000;
+        $interval = 600;
+        $stagger = notamStaggerOffsetSeconds('kspb', $interval);
+        touch(notamCacheFilePath('kspb'), $now - $interval - $stagger + 5);
+
+        $this->assertFalse(notamShouldEnqueueRefresh('kspb', $interval, $now));
+
+        touch(notamCacheFilePath('kspb'), $now - $interval - $stagger - 1);
+        $this->assertTrue(notamShouldEnqueueRefresh('kspb', $interval, $now));
+    }
+
+    public function testSelectAirportsToEnqueue_PrioritizesOldestCache(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/scheduler-queue.php';
+
+        $now = 1_700_100_000;
+        $interval = 60;
+        touch(notamCacheFilePath('newer'), $now - 500);
+        touch(notamCacheFilePath('older'), $now - 5000);
+
+        $selected = notamSelectAirportsToEnqueue(['newer', 'older'], $interval, 1, $now);
+
+        $this->assertSame(['older'], $selected);
+    }
+
+    public function testSelectAirportsToEnqueue_CapsBurstWhenManyAreDue(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/scheduler-queue.php';
+
+        $now = 1_700_200_000;
+        $interval = 60;
+        foreach (['a', 'b', 'c', 'd'] as $id) {
+            touch(notamCacheFilePath($id), $now - 10_000);
+        }
+
+        $selected = notamSelectAirportsToEnqueue(['a', 'b', 'c', 'd'], $interval, 2, $now);
+
+        $this->assertCount(2, $selected);
+    }
+}

--- a/tests/Unit/OperationsSnapshotTest.php
+++ b/tests/Unit/OperationsSnapshotTest.php
@@ -128,6 +128,39 @@ class OperationsSnapshotTest extends TestCase
         $this->assertTrue(operations_snapshot_verbose_detail_warranted($data));
     }
 
+    public function testVerboseDetailWarranted_whenNotamDegraded(): void
+    {
+        $data = [
+            'uptime_layer' => ['system' => ['status' => 'operational'], 'public_api' => ['status' => 'operational']],
+            'data_plane' => [
+                'airport_summary' => ['counts' => ['degraded' => 0, 'down' => 0]],
+                'weather' => ['status' => 'operational', 'metrics' => []],
+                'notam' => ['status' => 'degraded', 'message' => 'NMS HTTP 429', 'metrics' => []],
+                'variant' => ['status' => 'operational'],
+            ],
+            'details' => ['log_fingerprints' => []],
+        ];
+        $this->assertTrue(operations_snapshot_verbose_detail_warranted($data));
+    }
+
+    public function testVerboseDetailWarranted_whenNotamUpstream429Metrics(): void
+    {
+        $data = [
+            'uptime_layer' => ['system' => ['status' => 'operational'], 'public_api' => ['status' => 'operational']],
+            'data_plane' => [
+                'airport_summary' => ['counts' => ['degraded' => 0, 'down' => 0]],
+                'weather' => ['status' => 'operational', 'metrics' => []],
+                'notam' => [
+                    'status' => 'operational',
+                    'metrics' => ['upstream_429_last_hour' => 2],
+                ],
+                'variant' => ['status' => 'operational'],
+            ],
+            'details' => ['log_fingerprints' => []],
+        ];
+        $this->assertTrue(operations_snapshot_verbose_detail_warranted($data));
+    }
+
     public function testVerboseDetailWarranted_falseWhenAllOperational(): void
     {
         $data = [

--- a/tests/Unit/UpstreamObservabilityTest.php
+++ b/tests/Unit/UpstreamObservabilityTest.php
@@ -48,7 +48,13 @@ final class UpstreamObservabilityTest extends TestCase
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['metarBulkTestCacheRoot'], $GLOBALS['weatherHealthTestCacheFile']);
+        unset(
+            $GLOBALS['metarBulkTestCacheRoot'],
+            $GLOBALS['weatherHealthTestCacheFile'],
+            $GLOBALS['upstreamRateLimitTestRoot'],
+            $GLOBALS['upstreamRateLimitTestForcePersistFailure'],
+            $GLOBALS['upstreamRateLimitTestForceEnforcement']
+        );
 
         if ($this->cacheRoot !== null && is_dir($this->cacheRoot)) {
             $files = new \RecursiveIteratorIterator(
@@ -205,6 +211,34 @@ final class UpstreamObservabilityTest extends TestCase
         $this->assertSame('degraded', $status['status'] ?? null);
         $this->assertStringContainsString('fail-open', (string) ($status['message'] ?? ''));
         $this->assertSame(1, $status['metrics']['upstream_rate_limit_fail_open_last_hour'] ?? null);
+    }
+
+    public function testUpstreamRateTryTake_PersistFailure_RecordsFailOpenCounter(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        upstreamRateLimitTestForceEnforcement();
+        $GLOBALS['upstreamRateLimitTestForcePersistFailure'] = true;
+
+        $consumed = false;
+        $this->assertTrue(upstreamRateTryTake(
+            hash('sha256', 'persist_fail_obs_' . bin2hex(random_bytes(4))),
+            60,
+            1,
+            1_700_000_000.0,
+            $consumed
+        ));
+        $this->assertFalse($consumed);
+
+        weatherHealthFlush();
+        $status = weatherHealthGetStatus();
+        $this->assertGreaterThanOrEqual(
+            1,
+            $status['metrics']['upstream_rate_limit_fail_open_last_hour'] ?? 0
+        );
+
+        upstreamRateLimitTestClearForceEnforcement();
+        unset($GLOBALS['upstreamRateLimitTestForcePersistFailure']);
     }
 
     public function testWeatherHealthFlush_CreatesCacheWhenMissing(): void

--- a/tests/Unit/UpstreamObservabilityTest.php
+++ b/tests/Unit/UpstreamObservabilityTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework\TestCase;
  * @covers ::weatherHealthFlush
  * @covers ::weatherHealthGetStatus
  * @covers ::weatherHealthGetSources
+ * @covers ::weatherHealthGetProviderBreakdown
+ * @covers ::weatherHealthProviderDisplayName
  */
 final class UpstreamObservabilityTest extends TestCase
 {
@@ -248,5 +250,26 @@ final class UpstreamObservabilityTest extends TestCase
         $decoded = json_decode((string) file_get_contents($this->healthCacheFile), true);
         $this->assertIsArray($decoded);
         $this->assertArrayNotHasKey($oldHour, $decoded['hourly_buckets'] ?? []);
+    }
+
+    public function testWeatherHealthGetProviderBreakdown_SortsByUpstream429(): void
+    {
+        weatherHealthTrackFetch('kspb', 'ambient', false, 429);
+        weatherHealthTrackFetch('kspb', 'ambient', false, 429);
+        weatherHealthTrackFetch('kspb', 'tempest', true, 200);
+        weatherHealthTrackMetarBulkDownloadFailure(429);
+        weatherHealthFlush();
+
+        $providers = weatherHealthGetProviderBreakdown();
+        $this->assertNotEmpty($providers);
+        $this->assertSame('ambient', $providers[0]['id'] ?? null);
+        $this->assertSame(2, $providers[0]['upstream_429'] ?? null);
+
+        $byId = [];
+        foreach ($providers as $row) {
+            $byId[$row['id']] = $row;
+        }
+        $this->assertSame(1, $byId['metar_bulk']['upstream_429'] ?? null);
+        $this->assertSame('METAR bulk (AWC national gzip)', $byId['metar_bulk']['name'] ?? null);
     }
 }

--- a/tests/Unit/UpstreamObservabilityTest.php
+++ b/tests/Unit/UpstreamObservabilityTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
  * @covers ::weatherHealthEnsureCacheDirectory
  * @covers ::weatherHealthTrackFetch
  * @covers ::weatherHealthTrackMetarBulkDownloadFailure
+ * @covers ::weatherHealthTrackMetarBulkDownloadSuccess
  * @covers ::weatherHealthTrackUpstreamThrottleSkip
  * @covers ::weatherHealthTrackUpstreamRateLimitFailOpen
  * @covers ::weatherHealthFlush
@@ -250,6 +251,22 @@ final class UpstreamObservabilityTest extends TestCase
         $decoded = json_decode((string) file_get_contents($this->healthCacheFile), true);
         $this->assertIsArray($decoded);
         $this->assertArrayNotHasKey($oldHour, $decoded['hourly_buckets'] ?? []);
+    }
+
+    public function testWeatherHealthTrackMetarBulkDownloadSuccess_ProviderBreakdownIncludesSuccesses(): void
+    {
+        weatherHealthTrackMetarBulkDownloadSuccess();
+        weatherHealthTrackMetarBulkDownloadFailure(429);
+        weatherHealthFlush();
+
+        $providers = weatherHealthGetProviderBreakdown();
+        $byId = [];
+        foreach ($providers as $row) {
+            $byId[$row['id']] = $row;
+        }
+
+        $this->assertSame(2, $byId['metar_bulk']['attempts'] ?? null);
+        $this->assertSame(50.0, $byId['metar_bulk']['success_rate'] ?? null);
     }
 
     public function testWeatherHealthGetProviderBreakdown_SortsByUpstream429(): void

--- a/tests/Unit/UpstreamRateLimitTest.php
+++ b/tests/Unit/UpstreamRateLimitTest.php
@@ -23,7 +23,10 @@ final class UpstreamRateLimitTest extends TestCase
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['upstreamRateLimitTestRoot']);
+        unset(
+            $GLOBALS['upstreamRateLimitTestRoot'],
+            $GLOBALS['upstreamRateLimitTestForcePersistFailure']
+        );
         if ($this->testRoot !== null && is_dir($this->testRoot)) {
             $files = new \RecursiveIteratorIterator(
                 new \RecursiveDirectoryIterator($this->testRoot, \FilesystemIterator::SKIP_DOTS),
@@ -149,6 +152,24 @@ final class UpstreamRateLimitTest extends TestCase
 
         $t0 = 1_700_000_000.0;
         $this->assertFalse(upstreamRateTryTake($fingerprint, 60, 3, $t0));
+    }
+
+    public function testTryTake_PersistFailure_FailsOpenWithoutConsumedFlag(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $fingerprint = hash('sha256', 'persist-failure-test');
+        $t0 = 1_700_000_100.0;
+        $consumed = false;
+
+        $GLOBALS['upstreamRateLimitTestForcePersistFailure'] = true;
+        $this->assertTrue(upstreamRateTryTake($fingerprint, 60, 1, $t0, $consumed));
+        $this->assertFalse($consumed);
+
+        unset($GLOBALS['upstreamRateLimitTestForcePersistFailure']);
+        $consumed = false;
+        $this->assertTrue(upstreamRateTryTake($fingerprint, 60, 1, $t0, $consumed));
+        $this->assertTrue($consumed);
     }
 
     public function testFingerprint_Metar_DifferentStationIds_ReturnsDifferentHash(): void

--- a/tests/Unit/UpstreamRateLimitTest.php
+++ b/tests/Unit/UpstreamRateLimitTest.php
@@ -272,6 +272,63 @@ final class UpstreamRateLimitTest extends TestCase
         unset($GLOBALS['upstreamRateLimitTestNow']);
     }
 
+    public function testConsumeForSource_Ambient_PartialDenyRefundsEarlierScopeTokens(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        upstreamRateLimitTestForceEnforcement();
+        $t0 = 1_700_000_000.0;
+        $sharedApp = 'shared-developer-key';
+        $deniedSource = [
+            'type' => 'ambient',
+            'api_key' => 'user-d',
+            'application_key' => $sharedApp,
+        ];
+
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0;
+        foreach (
+            [
+                ['type' => 'ambient', 'api_key' => 'user-a', 'application_key' => $sharedApp],
+                ['type' => 'ambient', 'api_key' => 'user-b', 'application_key' => $sharedApp],
+                ['type' => 'ambient', 'api_key' => 'user-c', 'application_key' => $sharedApp],
+            ] as $source
+        ) {
+            $this->assertTrue(upstreamRateLimitConsumeForSource($source)['allowed']);
+        }
+
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0;
+        $this->assertFalse(upstreamRateLimitConsumeForSource($deniedSource)['allowed']);
+
+        $apiFingerprint = upstreamRateFingerprintForScope(
+            'ambient',
+            'api_key',
+            $deniedSource,
+            ['api_key']
+        );
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0;
+        $this->assertTrue(
+            upstreamRateTryTake(
+                $apiFingerprint,
+                UPSTREAM_RATE_LIMIT_AMBIENT_API_KEY_RPM,
+                UPSTREAM_RATE_LIMIT_AMBIENT_API_KEY_BURST,
+                $t0
+            ),
+            'api_key token should be refunded when application_key scope denies the take'
+        );
+
+        upstreamRateLimitTestClearForceEnforcement();
+        unset($GLOBALS['upstreamRateLimitTestNow']);
+    }
+
+    public function testTokenBucketComputeRefund_CapsAtBurst(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $result = upstreamRateTokenBucketComputeRefund(2.0, 100.0, 3);
+        $this->assertSame(3.0, $result['tokens']);
+        $this->assertSame(100.0, $result['last_refill']);
+    }
+
     public function testConsumeForSource_Ambient_ApiKeyScopeAllowsOnePerSecond(): void
     {
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';

--- a/tests/Unit/UpstreamRateLimitTest.php
+++ b/tests/Unit/UpstreamRateLimitTest.php
@@ -189,4 +189,154 @@ final class UpstreamRateLimitTest extends TestCase
         $this->assertSame(UPSTREAM_RATE_LIMIT_TEMPEST_RPM, $policy['rpm']);
         $this->assertSame(UPSTREAM_RATE_LIMIT_TEMPEST_BURST, $policy['burst']);
     }
+
+    public function testFingerprint_Ambient_ApplicationKeyScope_IgnoresApiKey(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $sharedApp = 'app-key-shared';
+        $a = upstreamRateFingerprintForScope('ambient', 'application_key', [
+            'api_key' => 'user-key-a',
+            'application_key' => $sharedApp,
+        ], ['application_key']);
+        $b = upstreamRateFingerprintForScope('ambient', 'application_key', [
+            'api_key' => 'user-key-b',
+            'application_key' => $sharedApp,
+        ], ['application_key']);
+        $this->assertSame($a, $b);
+    }
+
+    public function testFingerprint_Ambient_ApiKeyScope_IgnoresApplicationKey(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $sharedUser = 'user-key-shared';
+        $a = upstreamRateFingerprintForScope('ambient', 'api_key', [
+            'api_key' => $sharedUser,
+            'application_key' => 'app-a',
+        ], ['api_key']);
+        $b = upstreamRateFingerprintForScope('ambient', 'api_key', [
+            'api_key' => $sharedUser,
+            'application_key' => 'app-b',
+        ], ['api_key']);
+        $this->assertSame($a, $b);
+    }
+
+    public function testScopesForSource_Ambient_ReturnsApiKeyAndApplicationKeyBuckets(): void
+    {
+        require_once __DIR__ . '/../../lib/constants.php';
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $scopes = upstreamRateLimitScopesForSource([
+            'type' => 'ambient',
+            'api_key' => 'user-1',
+            'application_key' => 'app-1',
+        ]);
+
+        $this->assertCount(2, $scopes);
+        $this->assertSame('api_key', $scopes[0]['scope']);
+        $this->assertSame(UPSTREAM_RATE_LIMIT_AMBIENT_API_KEY_RPM, $scopes[0]['rpm']);
+        $this->assertSame(UPSTREAM_RATE_LIMIT_AMBIENT_API_KEY_BURST, $scopes[0]['burst']);
+        $this->assertSame('application_key', $scopes[1]['scope']);
+        $this->assertSame(UPSTREAM_RATE_LIMIT_AMBIENT_APPLICATION_KEY_RPM, $scopes[1]['rpm']);
+        $this->assertSame(UPSTREAM_RATE_LIMIT_AMBIENT_APPLICATION_KEY_BURST, $scopes[1]['burst']);
+    }
+
+    public function testConsumeForSource_Ambient_ApplicationKeyScopeLimitsSharedDeveloperKey(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        upstreamRateLimitTestForceEnforcement();
+        $t0 = 1_700_000_000.0;
+        $sharedApp = 'shared-developer-key';
+        $stations = [
+            ['type' => 'ambient', 'api_key' => 'user-a', 'application_key' => $sharedApp],
+            ['type' => 'ambient', 'api_key' => 'user-b', 'application_key' => $sharedApp],
+            ['type' => 'ambient', 'api_key' => 'user-c', 'application_key' => $sharedApp],
+        ];
+
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0;
+        foreach ($stations as $source) {
+            $this->assertTrue(upstreamRateLimitConsumeForSource($source)['allowed']);
+        }
+
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0;
+        $fourth = upstreamRateLimitConsumeForSource([
+            'type' => 'ambient',
+            'api_key' => 'user-d',
+            'application_key' => $sharedApp,
+        ]);
+        $this->assertFalse($fourth['allowed']);
+
+        upstreamRateLimitTestClearForceEnforcement();
+        unset($GLOBALS['upstreamRateLimitTestNow']);
+    }
+
+    public function testConsumeForSource_Ambient_ApiKeyScopeAllowsOnePerSecond(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        upstreamRateLimitTestForceEnforcement();
+        $source = [
+            'type' => 'ambient',
+            'api_key' => 'solo-user',
+            'application_key' => 'solo-app',
+        ];
+        $t0 = 1_700_000_000.0;
+
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0;
+        $this->assertTrue(upstreamRateLimitConsumeForSource($source)['allowed']);
+
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0;
+        $this->assertFalse(upstreamRateLimitConsumeForSource($source)['allowed']);
+
+        $GLOBALS['upstreamRateLimitTestNow'] = $t0 + 1.0;
+        $this->assertTrue(upstreamRateLimitConsumeForSource($source)['allowed']);
+
+        upstreamRateLimitTestClearForceEnforcement();
+        unset($GLOBALS['upstreamRateLimitTestNow']);
+    }
+
+    public function testGlobalCredentialFingerprint_Ambient_UsesApplicationKeyScope(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $app = 'developer-app-key';
+        $a = upstreamRateGlobalCredentialFingerprint('ambient', [
+            'api_key' => 'user-a',
+            'application_key' => $app,
+        ]);
+        $b = upstreamRateGlobalCredentialFingerprint('ambient', [
+            'api_key' => 'user-b',
+            'application_key' => $app,
+        ]);
+        $this->assertSame($a, $b);
+        $this->assertNotSame(
+            $a,
+            upstreamRateGlobalCredentialFingerprint('ambient', [
+                'api_key' => 'user-a',
+                'application_key' => 'other-app',
+            ])
+        );
+    }
+
+    public function testPolicyForProvider_WeatherLink_BurstMatchesPerSecondUpstreamCap(): void
+    {
+        require_once __DIR__ . '/../../lib/constants.php';
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $policy = upstreamRateLimitPolicyForProvider('weatherlink_v2');
+        $this->assertSame(UPSTREAM_RATE_LIMIT_WEATHERLINK_RPM, $policy['rpm']);
+        $this->assertSame(UPSTREAM_RATE_LIMIT_WEATHERLINK_BURST, $policy['burst']);
+        $this->assertLessThanOrEqual(3, $policy['burst']);
+    }
+
+    public function testPolicyForProvider_Nws_BurstIsConservativeForUndisclosedLimits(): void
+    {
+        require_once __DIR__ . '/../../lib/constants.php';
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $policy = upstreamRateLimitPolicyForProvider('nws');
+        $this->assertLessThanOrEqual(2, $policy['burst']);
+    }
 }


### PR DESCRIPTION
## Summary

- Coordinate Ambient Weather upstream limits across per-station `api_key` (1 req/s) and shared `application_key` (3 req/s) buckets; align global 429 circuit breaker on `application_key`; refund tokens when a later scope denies a multi-scope take.
- Pace NMS NOTAM traffic with cross-process 1 req/s rate limiting, staggered scheduler enqueue, and `notam_health.json` counters.
- Expose per-provider HTTP 429 breakdown on the status page (expandable rows for Weather and NOTAM Data Fetching) and include NOTAM health in the operations snapshot verbose gate.

## Deploy notes

- **Ambient global breaker fingerprint changed** - existing `global_weather_ambient_*` backoff keys reset once on deploy (benign).
- **New token buckets** under `cache/upstream-limits/` - a brief `upstream_throttle_skips` spike is possible while buckets settle.
- **No config change required** if production already uses `notam_refresh_seconds: 600` and `notam_worker_pool_size: 1`.
- `validateAirportsJsonStructure()` warns (non-fatal) when `notam_worker_pool_size > 1`.

## Test plan

- [x] `make test-ci`
- [x] After deploy: `jq '.health.metrics.upstream_429_last_hour' cache/weather_health.json` trends toward 0 for Ambient
- [x] After deploy: `jq '.health.metrics.upstream_429_last_hour' cache/notam_health.json` for NMS 429 visibility
- [x] Status page: expand **Weather Data Fetching** and **NOTAM Data Fetching** rows (▶) once fetch activity exists
- [x] `make config-check` or `php scripts/validate-airports-json.php` shows pool-size warning only when configured > 1