### PR TITLE
fix(notam): NMS empty payloads, global 429 backoff, and rate margin

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -726,17 +726,19 @@ When the bucket is empty, that source is skipped for one fetch cycle (weather ma
 
 ### NOTAM upstream rate limiting and health
 
-`lib/notam/rate-limit.php` enforces 1 request per second per NMS credential (`notam_api_client_id` + `notam_api_base_url`) using the same flock-backed token buckets as weather (`cache/upstream-limits/`). Workers wait for a token (poll `NOTAM_RATE_LIMIT_POLL_MICROSECONDS`, fail open after `NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS`) so location and geo queries for one airport still complete.
+`lib/notam/rate-limit.php` paces NMS traffic with a flock-backed token bucket (`cache/upstream-limits/`) keyed by `notam_api_client_id` + `notam_api_base_url`. The client uses `NOTAM_RATE_LIMIT_REQUESTS_PER_MINUTE` (default 54) as a margin under the documented 60/min NMS cap. Workers wait for a token (poll `NOTAM_RATE_LIMIT_POLL_MICROSECONDS`, fail open after `NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS`) so location and geo queries for one airport still complete.
+
+Location and geo requests run through `lib/notam/http.php`, which captures response headers, retries once on HTTP **429** or **503** after a capped `Retry-After` wait (`NOTAM_429_RETRY_MAX_WAIT_SECONDS`), and coordinates fleet-wide pauses via `lib/notam/circuit-breaker.php` (`global_notam_{fingerprint}` in `cache/backoff.json`). While a pause is active, new NMS calls defer without hitting the network. A successful HTTP **200** clears the pause. Default pause length without `Retry-After` is `NOTAM_GLOBAL_BACKOFF_DEFAULT_SECONDS` (60).
 
 The scheduler staggers NOTAM enqueue across the refresh window (`notamStaggerOffsetSeconds()` in `lib/notam/scheduling.php`) and starts at most `NOTAM_SCHEDULER_MAX_ENQUEUE_PER_LOOP` (default 1) new NOTAM worker per scheduler tick.
 
-**Worker pool vs enqueue cap:** `notam_worker_pool_size` limits how many NOTAM workers may run at once; the per-tick enqueue cap limits how many *new* jobs the scheduler starts each second. With the default pool size of 1, extra capacity is unused by design. Raising the pool without raising the enqueue cap (or without a higher NMS rate limit) leaves slots idle. Raising both still serializes on the shared 1 req/s NMS token bucket in `lib/notam/rate-limit.php`. Prefer `notam_worker_pool_size: 1` unless profiling shows benefit from workers overlapping non-API work (for example parse/cache while another worker waits on HTTP).
+**Worker pool vs enqueue cap:** `notam_worker_pool_size` limits how many NOTAM workers may run at once; the per-tick enqueue cap limits how many *new* jobs the scheduler starts each second. With the default pool size of 1, extra capacity is unused by design. Raising the pool without raising the enqueue cap (or without a higher NMS rate limit) leaves slots idle. Raising both still serializes on the shared NMS token bucket in `lib/notam/rate-limit.php`. Prefer `notam_worker_pool_size: 1` unless profiling shows benefit from workers overlapping non-API work (for example parse/cache while another worker waits on HTTP).
 
 HTTP **429** and other NMS outcomes increment counters in `cache/notam_health.json` via `lib/notam-health.php` (scheduler flush every 60 seconds). On the status page, expand **NOTAM Data Fetching** for per-endpoint 429 counts (location, geo, auth) in the last hour.
 
-On HTTP **429** or **503**, `lib/circuit-breaker.php` also records a shared `global_weather_{provider}_{fingerprint}` backoff key so all airports using that credential back off together. For Ambient, the global key uses the `application_key` fingerprint only; per-request throttling still checks both `api_key` and `application_key` buckets. A successful fetch clears both per-airport and global keys for that credential.
+On HTTP **429** or **503**, weather upstreams use a shared `global_weather_{provider}_{fingerprint}` backoff key in `lib/circuit-breaker.php` so all airports using that credential back off together. For Ambient, the global key uses the `application_key` fingerprint only; per-request throttling still checks both `api_key` and `application_key` buckets. A successful fetch clears both per-airport and global keys for that credential.
 
-When the upstream response includes **`Retry-After`** or **`X-RateLimit-Reset`** (Aeris-style), `UnifiedFetcher` passes those headers into the circuit breaker. Backoff uses the longer of the default strategy and the header hint, clamped to 15 minutes (`BACKOFF_MAX_RETRY_AFTER_SECONDS` in `lib/constants.php`).
+When the upstream response includes **`Retry-After`** or **`X-RateLimit-Reset`**, weather and NOTAM backoff use the header hint clamped to 15 minutes (`BACKOFF_MAX_RETRY_AFTER_SECONDS` in `lib/constants.php`).
 
 ### Backup Sources
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1419,6 +1419,8 @@ The system uses OAuth bearer token authentication:
 
 The NMS API returns NOTAMs in AIXM 5.1.1 XML format embedded within a JSON wrapper:
 - `data.aixm`: Array of AIXM XML strings, one per NOTAM
+- When there are no NOTAMs, NMS may omit `data.aixm` and return `{"status":"Success","data":{}}`
+- `notamExtractAixmRowsFromNmsResponse()` treats a missing or null `data.aixm` as an empty row list
 - Each XML string contains the full NOTAM details
 
 ---
@@ -1556,10 +1558,10 @@ Filtered NOTAMs are cached per airport:
 - **Refresh**: Configurable via `notam_refresh_seconds` (default: 600 seconds / 10 minutes). The scheduler staggers per-airport due times across the refresh window and starts at most `NOTAM_SCHEDULER_MAX_ENQUEUE_PER_LOOP` (default 1) new NOTAM worker per scheduler tick so NMS traffic stays near 1 req/s without bursting when many airports become due together.
 - **Atomic writes**: `notamWriteCacheFile()` writes a temp file then renames into place
 - **Refresh failure backoff**: `scripts/fetch-notam.php` records `cache/notam/{airport_id}.fetch-attempt` (without changing cache payload or `mtime`) when a worker refresh fails so `notamShouldEnqueueRefresh()` backs off for `NOTAM_FETCH_FAILURE_BACKOFF_SECONDS` before re-enqueueing. This applies to:
-  - **Hard NMS failure**: every attempted query fails (missing credentials, HTTP error, invalid JSON) - existing cache is preserved instead of overwriting with an empty result
+  - **Hard NMS failure**: every attempted query fails (missing credentials, HTTP error, invalid JSON, or malformed `data.aixm`) - existing cache is preserved instead of overwriting with an empty result
   - **Worker exception**: uncaught error during fetch/parse/filter
   - **Cache write failure**: NMS succeeded but `notamWriteCacheFile()` could not persist (existing cache file, if any, is left unchanged)
-- **HTTP 200 with empty `aixm`**: treated as a successful fetch; cache is updated (including to an empty `notams` list). This differs from hard failure above: an empty payload is a valid "no NOTAMs" response, not a transport error. When NMS returns rows that filter to zero (for example cancellations), the cache is also updated to empty because raw AIXM was present.
+- **HTTP 200 with no NOTAMs**: missing, null, or empty `data.aixm` is a successful fetch; cache is updated (including to an empty `notams` list). Filtered-to-zero rows (for example cancellations) also update the cache when raw AIXM was present.
 
 ### Serve-Time Status Re-validation
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1378,7 +1378,9 @@ The system uses a **dual query strategy** to capture both airport-specific NOTAM
 1. **Location Query** (when an identifier is configured): Fetches NOTAMs for the airport via `notamResolveLocationQueryCode()` (ICAO, then IATA, then FAA)
 2. **Geospatial Query** (if coordinates available): Fetches TFR-focused airspace NOTAMs with `feature=AIRSPACE`, then applies a cheap XML pre-filter before parse (closures still come from the location query)
 
-Both queries are executed sequentially. NMS rate limiting uses a shared file-backed token bucket (`lib/notam/rate-limit.php`, 1 request per second per `notam_api_client_id` + base URL) so scheduler workers in separate processes do not burst above the API cap when one airport fetch follows another. Workers **wait** for a token (up to `NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS`, then fail open) rather than skipping the fetch.
+Both queries are executed sequentially through `lib/notam/http.php`. A shared file-backed token bucket (`lib/notam/rate-limit.php`, `NOTAM_RATE_LIMIT_REQUESTS_PER_MINUTE` under the documented 60/min cap) paces outbound calls per `notam_api_client_id` + base URL. Workers wait for a token (up to `NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS`, then fail open) rather than skipping the fetch.
+
+On HTTP **429** or **503**, `lib/notam/circuit-breaker.php` records a shared `global_notam_{fingerprint}` pause for the credential. While active, location and geo queries defer without calling NMS. One in-fetch retry runs after a capped `Retry-After` wait (`NOTAM_429_RETRY_MAX_WAIT_SECONDS`) before the pause is extended.
 
 **Observability**: NMS request outcomes increment counters in `cache/notam_health.json` via `lib/notam-health.php` (scheduler flush every 60 seconds). HTTP **429** responses increment `upstream_429` and per-endpoint `upstream_429_{location|geo|auth}` counters. On the status page, expand **NOTAM Data Fetching** to see per-endpoint 429 counts for the last hour.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -90,7 +90,7 @@ Shows:
 **Interpreting signals**
 
 - **Weather Data Fetching** (system row): aggregate **HTTP fetch success** for weather sources over the last hour. It is **not** a guarantee that every airport has fresh observations. Expand the row (▶) to see per-provider **HTTP 429** counts for the last hour (`cache/weather_health.json`).
-- **NOTAM Data Fetching** (system row): aggregate NMS API success over the last hour. Expand the row to see per-endpoint 429 counts (location query, geo query, auth token) from `cache/notam_health.json`.
+- **NOTAM Data Fetching** (system row): aggregate NMS API success over the last hour. Expand the row to see per-endpoint 429 counts (location query, geo query, auth token) from `cache/notam_health.json`. Fleet-wide NMS pauses after upstream **429**/**503** are stored in `cache/backoff.json` (`global_notam_*` keys); deferred queries during a pause do not add HTTP 429 counts.
 - **Per-airport weather**: based on observation timestamps in the weather cache (same family of values as the public API).
 - **Per-airport webcams**: freshness uses **last completed frame** time on disk (aligned with the image pipeline and API), not the `current.jpg` symlink mtime alone.
 

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -207,6 +207,12 @@ if (!defined('NOTAM_RATE_LIMIT_POLL_MICROSECONDS')) {
 if (!defined('NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS')) {
     define('NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS', 30); // fail open after this wait
 }
+if (!defined('NOTAM_GLOBAL_BACKOFF_DEFAULT_SECONDS')) {
+    define('NOTAM_GLOBAL_BACKOFF_DEFAULT_SECONDS', 60); // pause all NMS calls after 429 without Retry-After
+}
+if (!defined('NOTAM_429_RETRY_MAX_WAIT_SECONDS')) {
+    define('NOTAM_429_RETRY_MAX_WAIT_SECONDS', 15); // cap in-fetch sleep before one 429 retry
+}
 // Banner: include upcoming_future NOTAMs whose first restriction window starts within this horizon
 if (!defined('NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS')) {
     define('NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS', 48 * 3600); // 48 hours

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -198,9 +198,6 @@ if (!defined('NOTAM_GEO_QUERY_FEATURE')) {
 if (!defined('NOTAM_GEO_RADIUS_DEFAULT')) {
     define('NOTAM_GEO_RADIUS_DEFAULT', 10); // 10 NM default radius for API query
 }
-if (!defined('NOTAM_RATE_LIMIT_SECONDS')) {
-    define('NOTAM_RATE_LIMIT_SECONDS', 1); // documented NMS policy (1 request per second)
-}
 if (!defined('NOTAM_RATE_LIMIT_REQUESTS_PER_MINUTE')) {
     define('NOTAM_RATE_LIMIT_REQUESTS_PER_MINUTE', 54); // client-side margin under the 60/min cap
 }

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -199,7 +199,10 @@ if (!defined('NOTAM_GEO_RADIUS_DEFAULT')) {
     define('NOTAM_GEO_RADIUS_DEFAULT', 10); // 10 NM default radius for API query
 }
 if (!defined('NOTAM_RATE_LIMIT_SECONDS')) {
-    define('NOTAM_RATE_LIMIT_SECONDS', 1); // 1 request per second (NMS API policy)
+    define('NOTAM_RATE_LIMIT_SECONDS', 1); // documented NMS policy (1 request per second)
+}
+if (!defined('NOTAM_RATE_LIMIT_REQUESTS_PER_MINUTE')) {
+    define('NOTAM_RATE_LIMIT_REQUESTS_PER_MINUTE', 54); // client-side margin under the 60/min cap
 }
 if (!defined('NOTAM_RATE_LIMIT_POLL_MICROSECONDS')) {
     define('NOTAM_RATE_LIMIT_POLL_MICROSECONDS', 100_000); // 100ms while waiting for token

--- a/lib/notam/auth.php
+++ b/lib/notam/auth.php
@@ -19,6 +19,13 @@ require_once __DIR__ . '/../notam-health.php';
  * @return string|null Bearer token on success, null on failure
  */
 function getNotamBearerToken(): ?string {
+    if (isset($GLOBALS['notamTestBearerToken'])
+        && is_string($GLOBALS['notamTestBearerToken'])
+        && $GLOBALS['notamTestBearerToken'] !== ''
+    ) {
+        return $GLOBALS['notamTestBearerToken'];
+    }
+
     $clientId = getNotamApiClientId();
     $clientSecret = getNotamApiClientSecret();
     $baseUrl = getNotamApiBaseUrl();

--- a/lib/notam/circuit-breaker.php
+++ b/lib/notam/circuit-breaker.php
@@ -53,13 +53,17 @@ function checkNotamGlobalBackoff(?int $now = null): array
     }
 
     clearstatcache(true, $backoffFile);
-    $backoffData = @json_decode((string) file_get_contents($backoffFile), true) ?: [];
+    $decoded = @json_decode((string) file_get_contents($backoffFile), true);
+    $backoffData = is_array($decoded) ? $decoded : [];
     $key = notamGlobalBackoffKey();
     if (!isset($backoffData[$key])) {
         return $default;
     }
 
     $state = $backoffData[$key];
+    if (!is_array($state)) {
+        return $default;
+    }
     $failures = (int) ($state['failures'] ?? 0);
     $nextAllowed = (int) ($state['next_allowed_time'] ?? 0);
 
@@ -143,11 +147,16 @@ function notamGlobalBackoffSetUntil(int $nextAllowedTime, ?int $now = null, ?int
     }
 
     $content = @stream_get_contents($fp);
-    $backoffData = ($content !== false && $content !== '')
-        ? (@json_decode($content, true) ?: [])
-        : [];
+    $decoded = ($content !== false && $content !== '')
+        ? @json_decode($content, true)
+        : null;
+    $backoffData = is_array($decoded) ? $decoded : [];
 
-    $existingNext = (int) ($backoffData[$key]['next_allowed_time'] ?? 0);
+    $existingNext = 0;
+    $existingState = $backoffData[$key] ?? null;
+    if (is_array($existingState)) {
+        $existingNext = (int) ($existingState['next_allowed_time'] ?? 0);
+    }
     $nextAllowedTime = max($nextAllowedTime, $existingNext);
     $backoffSeconds = max(0, $nextAllowedTime - $now);
 

--- a/lib/notam/circuit-breaker.php
+++ b/lib/notam/circuit-breaker.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Shared NMS credential backoff after upstream rate-limit responses.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../cache-paths.php';
+require_once __DIR__ . '/../circuit-breaker.php';
+require_once __DIR__ . '/../constants.php';
+require_once __DIR__ . '/rate-limit.php';
+
+/**
+ * Backoff key for the configured NMS API credential.
+ */
+function notamGlobalBackoffKey(): string
+{
+    return 'global_notam_' . notamRateLimitFingerprint();
+}
+
+/**
+ * Whether an HTTP status should pause all NMS traffic for this credential.
+ */
+function notamGlobalBackoffShouldRecord(?int $httpCode): bool
+{
+    return $httpCode === 429 || $httpCode === HTTP_STATUS_SERVICE_UNAVAILABLE;
+}
+
+/**
+ * Check whether NMS requests should be deferred for this credential.
+ *
+ * @param int|null $now Reference Unix timestamp for tests
+ * @return array{skip: bool, reason: string, backoff_remaining: int, failures: int, last_failure_reason: string|null}
+ */
+function checkNotamGlobalBackoff(?int $now = null): array
+{
+    $default = [
+        'skip' => false,
+        'reason' => '',
+        'backoff_remaining' => 0,
+        'failures' => 0,
+        'last_failure_reason' => null,
+    ];
+
+    if (!ensureCacheDir(CACHE_BASE_DIR)) {
+        return $default;
+    }
+
+    $now = $now ?? time();
+    $backoffFile = CACHE_BACKOFF_FILE;
+    if (!file_exists($backoffFile)) {
+        return $default;
+    }
+
+    clearstatcache(true, $backoffFile);
+    $backoffData = @json_decode((string) file_get_contents($backoffFile), true) ?: [];
+    $key = notamGlobalBackoffKey();
+    if (!isset($backoffData[$key])) {
+        return $default;
+    }
+
+    $state = $backoffData[$key];
+    $failures = (int) ($state['failures'] ?? 0);
+    $nextAllowed = (int) ($state['next_allowed_time'] ?? 0);
+
+    if ($failures < CIRCUIT_BREAKER_FAILURE_THRESHOLD || $nextAllowed <= $now) {
+        return $default;
+    }
+
+    return [
+        'skip' => true,
+        'reason' => 'global_nms_backoff',
+        'backoff_remaining' => $nextAllowed - $now,
+        'failures' => $failures,
+        'last_failure_reason' => $state['last_failure_reason'] ?? null,
+    ];
+}
+
+/**
+ * Pause all NMS requests until Retry-After, default backoff, or existing deadline (whichever is latest).
+ *
+ * @param int|null $httpCode HTTP status from NMS
+ * @param array<string, string>|null $responseHeaders Lowercase upstream headers
+ * @param int|null $now Reference Unix timestamp for tests
+ */
+function recordNotamGlobalRateLimitFailure(
+    ?int $httpCode,
+    ?array $responseHeaders = null,
+    ?int $now = null
+): void {
+    if (!notamGlobalBackoffShouldRecord($httpCode) || !ensureCacheDir(CACHE_BASE_DIR)) {
+        return;
+    }
+
+    $now = $now ?? time();
+    $headers = $responseHeaders ?? [];
+    $backoffSeconds = circuitBreakerComputeBackoffSeconds(1, 'transient', $httpCode, $headers, $now);
+    if (weatherBackoffOverrideSeconds($httpCode, $headers, $now) === null) {
+        $backoffSeconds = max($backoffSeconds, NOTAM_GLOBAL_BACKOFF_DEFAULT_SECONDS);
+    }
+
+    notamGlobalBackoffSetUntil($now + $backoffSeconds, $now, $httpCode);
+}
+
+/**
+ * Clear shared NMS backoff after a successful upstream response.
+ */
+function clearNotamGlobalBackoff(): void
+{
+    if (!ensureCacheDir(CACHE_BASE_DIR)) {
+        return;
+    }
+
+    recordCircuitBreakerSuccessBase(notamGlobalBackoffKey(), CACHE_BACKOFF_FILE);
+}
+
+/**
+ * Persist a fleet-wide NMS pause with circuit-open failure count.
+ *
+ * @param int $nextAllowedTime Unix timestamp when NMS calls may resume
+ * @param int|null $now Reference Unix timestamp for tests
+ * @param int|null $httpCode HTTP status that triggered the pause
+ */
+function notamGlobalBackoffSetUntil(int $nextAllowedTime, ?int $now = null, ?int $httpCode = null): void
+{
+    if (!ensureCacheDir(CACHE_BASE_DIR)) {
+        return;
+    }
+
+    $now = $now ?? time();
+    $key = notamGlobalBackoffKey();
+    $backoffFile = CACHE_BACKOFF_FILE;
+
+    $fp = @fopen($backoffFile, 'c+');
+    if ($fp === false) {
+        return;
+    }
+
+    if (!@flock($fp, LOCK_EX)) {
+        @fclose($fp);
+
+        return;
+    }
+
+    $content = @stream_get_contents($fp);
+    $backoffData = ($content !== false && $content !== '')
+        ? (@json_decode($content, true) ?: [])
+        : [];
+
+    $existingNext = (int) ($backoffData[$key]['next_allowed_time'] ?? 0);
+    $nextAllowedTime = max($nextAllowedTime, $existingNext);
+    $backoffSeconds = max(0, $nextAllowedTime - $now);
+
+    $backoffData[$key] = [
+        'failures' => CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+        'next_allowed_time' => $nextAllowedTime,
+        'last_attempt' => $now,
+        'backoff_seconds' => $backoffSeconds,
+        'last_http_code' => $httpCode,
+        'last_error_time' => $now,
+        'last_failure_reason' => $httpCode !== null ? "HTTP {$httpCode}" : 'NMS rate limit',
+    ];
+
+    @ftruncate($fp, 0);
+    @rewind($fp);
+    @fwrite($fp, json_encode($backoffData, JSON_PRETTY_PRINT));
+    @fflush($fp);
+    @flock($fp, LOCK_UN);
+    @fclose($fp);
+}

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -86,6 +86,28 @@ function notamExtractAixmRowsFromNmsResponse(?array $data): ?array
 }
 
 /**
+ * Log diagnostic context when NMS returns HTTP 200 but the body cannot be parsed.
+ *
+ * @param string $endpoint Health endpoint key (location, geo)
+ * @param array<string, mixed> $context Query-specific fields (location, lat/lon, etc.)
+ * @param string $response Raw HTTP body
+ * @param array<string, mixed>|null $data Decoded JSON when decode succeeded
+ */
+function notamLogInvalidNmsPayload(
+    string $endpoint,
+    array $context,
+    string $response,
+    ?array $data,
+): void {
+    aviationwx_log('warning', 'notam fetcher: invalid NMS payload', array_merge($context, [
+        'endpoint' => $endpoint,
+        'http_code' => 200,
+        'nms_status' => is_array($data) ? ($data['status'] ?? null) : null,
+        'response_prefix' => substr($response, 0, 200),
+    ]), 'app');
+}
+
+/**
  * Block until the shared NMS credential may issue another NOTAM API request.
  *
  * Coordinates across scheduler worker processes (not just this fetch). The
@@ -238,6 +260,7 @@ function queryNotamsByLocation(
     $data = notamDecodeNmsJsonResponse($response);
     $aixmRows = notamExtractAixmRowsFromNmsResponse($data);
     if ($aixmRows === null) {
+        notamLogInvalidNmsPayload('location', ['location' => $location], $response, $data);
         notamHealthTrackRequest('location', false, $httpCode);
         if ($reportQueryOutcome) {
             $querySucceeded = false;
@@ -312,6 +335,11 @@ function queryNotamsByCoordinates(
     $data = notamDecodeNmsJsonResponse($response);
     $aixmRows = notamExtractAixmRowsFromNmsResponse($data);
     if ($aixmRows === null) {
+        notamLogInvalidNmsPayload('geo', [
+            'latitude' => $latitude,
+            'longitude' => $longitude,
+            'radius' => $radius,
+        ], $response, $data);
         notamHealthTrackRequest('geo', false, $httpCode);
         if ($reportQueryOutcome) {
             $querySucceeded = false;

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -32,6 +32,36 @@ function notamDecodeNmsJsonResponse(string $response): ?array {
 }
 
 /**
+ * Extract AIXM XML rows from decoded NMS JSON.
+ *
+ * NMS omits `data.aixm` when there are no NOTAMs (`{"status":"Success","data":{}}`).
+ *
+ * @param array<string, mixed>|null $data Decoded NMS JSON body
+ * @return array<int, string>|null Row list; empty when NMS reports no NOTAMs; null when payload is invalid
+ */
+function notamExtractAixmRowsFromNmsResponse(?array $data): ?array
+{
+    if ($data === null || !isset($data['data']) || !is_array($data['data'])) {
+        return null;
+    }
+
+    if (!array_key_exists('aixm', $data['data'])) {
+        return [];
+    }
+
+    $aixm = $data['data']['aixm'];
+    if ($aixm === null) {
+        return [];
+    }
+
+    if (!is_array($aixm)) {
+        return null;
+    }
+
+    return $aixm;
+}
+
+/**
  * Block until the shared NMS credential may issue another NOTAM API request.
  *
  * Coordinates across scheduler worker processes (not just this fetch). The
@@ -103,7 +133,7 @@ function notamResolveLocationQueryCode(array $airport): ?string
  * @param string $location NMS location query code from {@see notamResolveLocationQueryCode()}
  * @param float &$lastRequestTime Last request timestamp (for rate limiting)
  * @param array<string, string> $queryParams Optional NMS query parameters (e.g. feature=RWY)
- * @param bool|null $querySucceeded When passed, true on HTTP 200 with valid payload; false when credentials are missing, the request fails, or the payload is invalid
+ * @param bool|null $querySucceeded When passed, true on HTTP 200 with a valid NMS payload (including an empty NOTAM list); false on credential, transport, or payload errors
  * @return array<int, string> Array of AIXM XML strings
  */
 function queryNotamsByLocation(
@@ -160,7 +190,8 @@ function queryNotamsByLocation(
     }
     
     $data = notamDecodeNmsJsonResponse($response);
-    if ($data === null || !isset($data['data']['aixm']) || !is_array($data['data']['aixm'])) {
+    $aixmRows = notamExtractAixmRowsFromNmsResponse($data);
+    if ($aixmRows === null) {
         notamHealthTrackRequest('location', false, $httpCode);
         if ($reportQueryOutcome) {
             $querySucceeded = false;
@@ -174,8 +205,8 @@ function queryNotamsByLocation(
     if ($reportQueryOutcome) {
         $querySucceeded = true;
     }
-    
-    return $data['data']['aixm'];
+
+    return $aixmRows;
 }
 
 /**
@@ -185,7 +216,7 @@ function queryNotamsByLocation(
  * @param float $longitude Longitude in decimal degrees
  * @param int $radius Radius in nautical miles
  * @param float &$lastRequestTime Last request timestamp (for rate limiting)
- * @param bool|null $querySucceeded When passed, true on HTTP 200 with valid payload; false when credentials are missing, the request fails, or the payload is invalid
+ * @param bool|null $querySucceeded When passed, true on HTTP 200 with a valid NMS payload (including an empty NOTAM list); false on credential, transport, or payload errors
  * @return array Array of AIXM XML strings
  */
 function queryNotamsByCoordinates(
@@ -247,7 +278,8 @@ function queryNotamsByCoordinates(
     }
     
     $data = notamDecodeNmsJsonResponse($response);
-    if ($data === null || !isset($data['data']['aixm']) || !is_array($data['data']['aixm'])) {
+    $aixmRows = notamExtractAixmRowsFromNmsResponse($data);
+    if ($aixmRows === null) {
         notamHealthTrackRequest('geo', false, $httpCode);
         if ($reportQueryOutcome) {
             $querySucceeded = false;
@@ -261,8 +293,8 @@ function queryNotamsByCoordinates(
     if ($reportQueryOutcome) {
         $querySucceeded = true;
     }
-    
-    return $data['data']['aixm'];
+
+    return $aixmRows;
 }
 
 /**

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -33,6 +33,25 @@ function notamDecodeNmsJsonResponse(string $response): ?array {
 }
 
 /**
+ * Whether decoded NMS JSON reports a successful query.
+ *
+ * @param array<string, mixed>|null $data Decoded NMS JSON body
+ */
+function notamNmsResponseIndicatesSuccess(?array $data): bool
+{
+    if ($data === null) {
+        return false;
+    }
+
+    $status = $data['status'] ?? null;
+    if (!is_string($status)) {
+        return false;
+    }
+
+    return strcasecmp(trim($status), 'Success') === 0;
+}
+
+/**
  * Extract AIXM XML rows from decoded NMS JSON.
  *
  * NMS omits `data.aixm` when there are no NOTAMs (`{"status":"Success","data":{}}`).
@@ -42,7 +61,11 @@ function notamDecodeNmsJsonResponse(string $response): ?array {
  */
 function notamExtractAixmRowsFromNmsResponse(?array $data): ?array
 {
-    if ($data === null || !isset($data['data']) || !is_array($data['data'])) {
+    if (!notamNmsResponseIndicatesSuccess($data)) {
+        return null;
+    }
+
+    if (!isset($data['data']) || !is_array($data['data'])) {
         return null;
     }
 

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -159,7 +159,7 @@ function notamResolveLocationQueryCode(array $airport): ?string
  * @param array<string, mixed> $logContext Log context fields
  * @param array{deferred?: bool, http_code?: int|null, error?: string} $queryResult Result from notamExecuteNmsQuery()
  * @param bool $reportQueryOutcome Whether to update $querySucceeded
- * @param bool|null $querySucceeded Outcome flag passed by caller
+ * @param bool|null $querySucceeded Outcome flag passed by caller (true success, false hard failure, null deferred)
  */
 function notamRecordNmsQueryFailure(
     string $endpoint,
@@ -169,12 +169,16 @@ function notamRecordNmsQueryFailure(
     bool $reportQueryOutcome,
     ?bool &$querySucceeded,
 ): void {
-    if ($reportQueryOutcome) {
-        $querySucceeded = false;
+    if (($queryResult['deferred'] ?? false) === true) {
+        if ($reportQueryOutcome) {
+            $querySucceeded = null;
+        }
+
+        return;
     }
 
-    if (($queryResult['deferred'] ?? false) === true) {
-        return;
+    if ($reportQueryOutcome) {
+        $querySucceeded = false;
     }
 
     $httpCode = $queryResult['http_code'] ?? null;
@@ -191,7 +195,7 @@ function notamRecordNmsQueryFailure(
  * @param string $location NMS location query code from {@see notamResolveLocationQueryCode()}
  * @param float &$lastRequestTime Last request timestamp (for rate limiting)
  * @param array<string, string> $queryParams Optional NMS query parameters (e.g. feature=RWY)
- * @param bool|null $querySucceeded When passed, true on HTTP 200 with a valid NMS payload (including an empty NOTAM list); false on credential, transport, or payload errors
+ * @param bool|null $querySucceeded When passed, true on HTTP 200 with a valid NMS payload (including an empty NOTAM list); false on credential, transport, or payload errors; null when deferred by global backoff
  * @return array<int, string> Array of AIXM XML strings
  */
 function queryNotamsByLocation(
@@ -258,7 +262,7 @@ function queryNotamsByLocation(
  * @param float $longitude Longitude in decimal degrees
  * @param int $radius Radius in nautical miles
  * @param float &$lastRequestTime Last request timestamp (for rate limiting)
- * @param bool|null $querySucceeded When passed, true on HTTP 200 with a valid NMS payload (including an empty NOTAM list); false on credential, transport, or payload errors
+ * @param bool|null $querySucceeded When passed, true on HTTP 200 with a valid NMS payload (including an empty NOTAM list); false on credential, transport, or payload errors; null when deferred by global backoff
  * @return array Array of AIXM XML strings
  */
 function queryNotamsByCoordinates(
@@ -352,17 +356,20 @@ function deduplicateNotams(array $notams): array {
 /**
  * Aggregate per-query NMS outcomes for dual location + geo fetches.
  *
- * @param list<bool> $queryOutcomes Success flag for each attempted query (in order)
- * @return array{attempted: bool, fetchSucceeded: bool}
+ * @param list<bool|null> $queryOutcomes Per-query outcome (true success, false hard failure, null deferred)
+ * @return array{attempted: bool, fetchSucceeded: bool, allDeferred: bool}
  */
 function notamSummarizeFetchQueryOutcomes(array $queryOutcomes): array
 {
     $attempted = $queryOutcomes !== [];
     $anySucceeded = in_array(true, $queryOutcomes, true);
+    $anyHardFailure = in_array(false, $queryOutcomes, true);
+    $allDeferred = $attempted && !$anySucceeded && !$anyHardFailure;
 
     return [
         'attempted' => $attempted,
         'fetchSucceeded' => $attempted && $anySucceeded,
+        'allDeferred' => $allDeferred,
     ];
 }
 
@@ -376,10 +383,17 @@ function notamSummarizeFetchQueryOutcomes(array $queryOutcomes): array
  * @param string $airportId Airport ID (e.g., 'khio')
  * @param array<string, mixed> $airport Airport configuration
  * @param bool|null $fetchSucceeded When passed, true when at least one NMS query succeeds; false when no query runs or every attempted query fails
+ * @param bool|null $fetchAllDeferred When passed, true when every attempted query was deferred by global NMS backoff
  * @return array<int, array<string, mixed>> Filtered NOTAMs with notam_type and status
  */
-function fetchNotamsForAirport(string $airportId, array $airport, ?bool &$fetchSucceeded = null): array {
+function fetchNotamsForAirport(
+    string $airportId,
+    array $airport,
+    ?bool &$fetchSucceeded = null,
+    ?bool &$fetchAllDeferred = null,
+): array {
     $reportFetchOutcome = func_num_args() >= 3;
+    $reportAllDeferred = func_num_args() >= 4;
     $lastRequestTime = 0.0;
     $allNotams = [];
     $queryOutcomes = [];
@@ -419,6 +433,9 @@ function fetchNotamsForAirport(string $airportId, array $airport, ?bool &$fetchS
     $fetchSummary = notamSummarizeFetchQueryOutcomes($queryOutcomes);
     if ($reportFetchOutcome) {
         $fetchSucceeded = $fetchSummary['fetchSucceeded'];
+    }
+    if ($reportAllDeferred) {
+        $fetchAllDeferred = $fetchSummary['allDeferred'];
     }
     
     // 3. Parse XML to structured data

--- a/lib/notam/fetcher.php
+++ b/lib/notam/fetcher.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/filter.php';
 require_once __DIR__ . '/schedule.php';
 require_once __DIR__ . '/geo-prefilter.php';
 require_once __DIR__ . '/rate-limit.php';
+require_once __DIR__ . '/http.php';
 require_once __DIR__ . '/../notam-health.php';
 
 /**
@@ -128,6 +129,40 @@ function notamResolveLocationQueryCode(array $airport): ?string
 }
 
 /**
+ * Record a failed NMS query attempt for health metrics and logs.
+ *
+ * @param string $endpoint Health endpoint key (location, geo)
+ * @param string $logMessage Structured log message
+ * @param array<string, mixed> $logContext Log context fields
+ * @param array{deferred?: bool, http_code?: int|null, error?: string} $queryResult Result from notamExecuteNmsQuery()
+ * @param bool $reportQueryOutcome Whether to update $querySucceeded
+ * @param bool|null $querySucceeded Outcome flag passed by caller
+ */
+function notamRecordNmsQueryFailure(
+    string $endpoint,
+    string $logMessage,
+    array $logContext,
+    array $queryResult,
+    bool $reportQueryOutcome,
+    ?bool &$querySucceeded,
+): void {
+    if ($reportQueryOutcome) {
+        $querySucceeded = false;
+    }
+
+    if (($queryResult['deferred'] ?? false) === true) {
+        return;
+    }
+
+    $httpCode = $queryResult['http_code'] ?? null;
+    notamHealthTrackRequest($endpoint, false, is_int($httpCode) ? $httpCode : null);
+    aviationwx_log('warning', $logMessage, array_merge($logContext, [
+        'http_code' => $httpCode,
+        'error' => $queryResult['error'] ?? '',
+    ]), 'app');
+}
+
+/**
  * Query NOTAMs by NMS location code (ICAO, IATA, or FAA identifier).
  *
  * @param string $location NMS location query code from {@see notamResolveLocationQueryCode()}
@@ -155,40 +190,24 @@ function queryNotamsByLocation(
     $baseUrl = getNotamApiBaseUrl();
     $params = notamBuildLocationQueryParams($location, $queryParams);
     $url = rtrim($baseUrl, '/') . '/nmsapi/v1/notams?' . http_build_query($params);
-    
-    rateLimitWait($lastRequestTime);
-    
-    $ch = curl_init();
-    curl_setopt_array($ch, [
-        CURLOPT_URL => $url,
-        CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_TIMEOUT => 30,
-        CURLOPT_CONNECTTIMEOUT => 10,
-        CURLOPT_HTTPHEADER => [
-            'Authorization: Bearer ' . $token,
-            'nmsResponseFormat: AIXM',
-            'Accept: application/json'
-        ],
-    ]);
-    
-    $response = curl_exec($ch);
-    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    $error = curl_error($ch);
-    
-    if ($httpCode !== 200 || $response === false) {
-        notamHealthTrackRequest('location', false, is_int($httpCode) ? $httpCode : null);
-        aviationwx_log('warning', 'notam fetcher: location query failed', [
-            'location' => $location,
-            'http_code' => $httpCode,
-            'error' => $error
-        ], 'app');
-        if ($reportQueryOutcome) {
-            $querySucceeded = false;
-        }
+
+    $queryResult = notamExecuteNmsQuery($url, 'location', $lastRequestTime, $token);
+    if (!$queryResult['ok']) {
+        notamRecordNmsQueryFailure(
+            'location',
+            'notam fetcher: location query failed',
+            ['location' => $location],
+            $queryResult,
+            $reportQueryOutcome,
+            $querySucceeded,
+        );
 
         return [];
     }
-    
+
+    $response = $queryResult['body'];
+    $httpCode = (int) ($queryResult['http_code'] ?? 0);
+
     $data = notamDecodeNmsJsonResponse($response);
     $aixmRows = notamExtractAixmRowsFromNmsResponse($data);
     if ($aixmRows === null) {
@@ -241,42 +260,28 @@ function queryNotamsByCoordinates(
     $url = rtrim($baseUrl, '/') . '/nmsapi/v1/notams?' . http_build_query(
         notamBuildGeoQueryParams($latitude, $longitude, $radius),
     );
-    
-    rateLimitWait($lastRequestTime);
-    
-    $ch = curl_init();
-    curl_setopt_array($ch, [
-        CURLOPT_URL => $url,
-        CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_TIMEOUT => 30,
-        CURLOPT_CONNECTTIMEOUT => 10,
-        CURLOPT_HTTPHEADER => [
-            'Authorization: Bearer ' . $token,
-            'nmsResponseFormat: AIXM',
-            'Accept: application/json'
-        ],
-    ]);
-    
-    $response = curl_exec($ch);
-    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    $error = curl_error($ch);
-    
-    if ($httpCode !== 200 || $response === false) {
-        notamHealthTrackRequest('geo', false, is_int($httpCode) ? $httpCode : null);
-        aviationwx_log('warning', 'notam fetcher: geospatial query failed', [
-            'latitude' => $latitude,
-            'longitude' => $longitude,
-            'radius' => $radius,
-            'http_code' => $httpCode,
-            'error' => $error
-        ], 'app');
-        if ($reportQueryOutcome) {
-            $querySucceeded = false;
-        }
+
+    $queryResult = notamExecuteNmsQuery($url, 'geo', $lastRequestTime, $token);
+    if (!$queryResult['ok']) {
+        notamRecordNmsQueryFailure(
+            'geo',
+            'notam fetcher: geospatial query failed',
+            [
+                'latitude' => $latitude,
+                'longitude' => $longitude,
+                'radius' => $radius,
+            ],
+            $queryResult,
+            $reportQueryOutcome,
+            $querySucceeded,
+        );
 
         return [];
     }
-    
+
+    $response = $queryResult['body'];
+    $httpCode = (int) ($queryResult['http_code'] ?? 0);
+
     $data = notamDecodeNmsJsonResponse($response);
     $aixmRows = notamExtractAixmRowsFromNmsResponse($data);
     if ($aixmRows === null) {

--- a/lib/notam/http.php
+++ b/lib/notam/http.php
@@ -151,6 +151,7 @@ function notamExecuteNmsQuery(string $url, string $endpoint, float &$lastRequest
 
         $isRateLimit = notamGlobalBackoffShouldRecord($httpCode);
         if ($isRateLimit && $attempts === 1) {
+            notamHealthTrackRequest($endpoint, false, $httpCode);
             $waitSeconds = notamCompute429RetryWaitSeconds($httpCode, $headers);
             notamSleepFor429Retry($waitSeconds);
             notamRateLimitAcquire();

--- a/lib/notam/http.php
+++ b/lib/notam/http.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * NMS HTTP client: global backoff gate, header capture, and one bounded 429 retry.
+ * NMS HTTP client: global backoff gate, header capture, and one bounded 429/503 retry.
  */
 
 declare(strict_types=1);
@@ -27,7 +27,7 @@ function notamCompute429RetryWaitSeconds(int $httpCode, array $responseHeaders):
 }
 
 /**
- * Sleep before an in-fetch 429 retry (no-op in tests when notamTestSkipSleep is set).
+ * Sleep before an in-fetch 429/503 retry (no-op in tests when notamTestSkipSleep is set).
  */
 function notamSleepFor429Retry(int $seconds): void
 {
@@ -103,7 +103,7 @@ function notamPerformNmsHttpGet(string $url, string $bearerToken): array
 }
 
 /**
- * Execute one NMS GET with rate limiting, global backoff, and one 429 retry.
+ * Execute one NMS GET with rate limiting, global backoff, and one bounded 429/503 retry.
  *
  * @param string $endpoint Health endpoint key (location, geo, auth)
  * @param float $lastRequestTime Updated to microtime(true) after each notamRateLimitAcquire()

--- a/lib/notam/http.php
+++ b/lib/notam/http.php
@@ -120,11 +120,6 @@ function notamExecuteNmsQuery(string $url, string $endpoint, float &$lastRequest
 {
     $backoff = checkNotamGlobalBackoff();
     if ($backoff['skip']) {
-        aviationwx_log('info', 'notam fetcher: deferred during global NMS backoff', [
-            'endpoint' => $endpoint,
-            'backoff_remaining' => $backoff['backoff_remaining'],
-        ], 'app');
-
         return [
             'ok' => false,
             'deferred' => true,

--- a/lib/notam/http.php
+++ b/lib/notam/http.php
@@ -81,6 +81,7 @@ function notamPerformNmsHttpGet(string $url, string $bearerToken): array
     $body = curl_exec($ch);
     $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
     $error = curl_error($ch);
+    unset($ch);
 
     return [
         'body' => $body,

--- a/lib/notam/http.php
+++ b/lib/notam/http.php
@@ -95,7 +95,7 @@ function notamPerformNmsHttpGet(string $url, string $bearerToken): array
  * Execute one NMS GET with rate limiting, global backoff, and one 429 retry.
  *
  * @param string $endpoint Health endpoint key (location, geo, auth)
- * @param float $lastRequestTime Updated by rateLimitWait()
+ * @param float $lastRequestTime Updated to microtime(true) after each notamRateLimitAcquire()
  * @return array{
  *   ok: bool,
  *   deferred: bool,

--- a/lib/notam/http.php
+++ b/lib/notam/http.php
@@ -53,10 +53,19 @@ function notamPerformNmsHttpGet(string $url, string $bearerToken): array
             return ['body' => false, 'http_code' => 0, 'headers' => [], 'error' => 'invalid test handler'];
         }
 
+        $rawHeaders = is_array($result['headers'] ?? null) ? $result['headers'] : [];
+        $headers = [];
+        foreach ($rawHeaders as $name => $value) {
+            if (!is_string($name) || !is_scalar($value)) {
+                continue;
+            }
+            $headers[strtolower(trim($name))] = trim((string) $value);
+        }
+
         return [
             'body' => $result['body'] ?? false,
             'http_code' => (int) ($result['http_code'] ?? 0),
-            'headers' => is_array($result['headers'] ?? null) ? $result['headers'] : [],
+            'headers' => $headers,
             'error' => (string) ($result['error'] ?? ''),
         ];
     }

--- a/lib/notam/http.php
+++ b/lib/notam/http.php
@@ -10,15 +10,17 @@ require_once __DIR__ . '/../logger.php';
 require_once __DIR__ . '/../weather-backoff-headers.php';
 require_once __DIR__ . '/circuit-breaker.php';
 require_once __DIR__ . '/rate-limit.php';
+require_once __DIR__ . '/../notam-health.php';
 
 /**
- * Seconds to sleep before one in-fetch 429 retry (capped).
+ * Seconds to sleep before one in-fetch 429/503 retry (capped).
  *
+ * @param int $httpCode Upstream HTTP status (429 or 503)
  * @param array<string, string> $responseHeaders Lowercase upstream headers
  */
-function notamCompute429RetryWaitSeconds(array $responseHeaders): int
+function notamCompute429RetryWaitSeconds(int $httpCode, array $responseHeaders): int
 {
-    $override = weatherBackoffOverrideSeconds(429, $responseHeaders);
+    $override = weatherBackoffOverrideSeconds($httpCode, $responseHeaders);
     $wait = $override ?? BACKOFF_BASE_RATE_LIMIT;
 
     return min(max(1, $wait), NOTAM_429_RETRY_MAX_WAIT_SECONDS);
@@ -149,7 +151,7 @@ function notamExecuteNmsQuery(string $url, string $endpoint, float &$lastRequest
 
         $isRateLimit = notamGlobalBackoffShouldRecord($httpCode);
         if ($isRateLimit && $attempts === 1) {
-            $waitSeconds = notamCompute429RetryWaitSeconds($headers);
+            $waitSeconds = notamCompute429RetryWaitSeconds($httpCode, $headers);
             notamSleepFor429Retry($waitSeconds);
             notamRateLimitAcquire();
             $lastRequestTime = microtime(true);

--- a/lib/notam/http.php
+++ b/lib/notam/http.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * NMS HTTP client: global backoff gate, header capture, and one bounded 429 retry.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../constants.php';
+require_once __DIR__ . '/../logger.php';
+require_once __DIR__ . '/../weather-backoff-headers.php';
+require_once __DIR__ . '/circuit-breaker.php';
+require_once __DIR__ . '/rate-limit.php';
+
+/**
+ * Seconds to sleep before one in-fetch 429 retry (capped).
+ *
+ * @param array<string, string> $responseHeaders Lowercase upstream headers
+ */
+function notamCompute429RetryWaitSeconds(array $responseHeaders): int
+{
+    $override = weatherBackoffOverrideSeconds(429, $responseHeaders);
+    $wait = $override ?? BACKOFF_BASE_RATE_LIMIT;
+
+    return min(max(1, $wait), NOTAM_429_RETRY_MAX_WAIT_SECONDS);
+}
+
+/**
+ * Sleep before an in-fetch 429 retry (no-op in tests when notamTestSkipSleep is set).
+ */
+function notamSleepFor429Retry(int $seconds): void
+{
+    if (!empty($GLOBALS['notamTestSkipSleep'])) {
+        $GLOBALS['notamTestSleepAccumulatedSeconds'] = (int) ($GLOBALS['notamTestSleepAccumulatedSeconds'] ?? 0) + $seconds;
+
+        return;
+    }
+
+    sleep($seconds);
+}
+
+/**
+ * Perform one NMS HTTP GET (overridable in tests via notamTestNmsHttpHandler).
+ *
+ * @return array{body: string|false, http_code: int, headers: array<string, string>, error: string}
+ */
+function notamPerformNmsHttpGet(string $url, string $bearerToken): array
+{
+    if (isset($GLOBALS['notamTestNmsHttpHandler']) && is_callable($GLOBALS['notamTestNmsHttpHandler'])) {
+        $result = ($GLOBALS['notamTestNmsHttpHandler'])($url, $bearerToken);
+        if (!is_array($result)) {
+            return ['body' => false, 'http_code' => 0, 'headers' => [], 'error' => 'invalid test handler'];
+        }
+
+        return [
+            'body' => $result['body'] ?? false,
+            'http_code' => (int) ($result['http_code'] ?? 0),
+            'headers' => is_array($result['headers'] ?? null) ? $result['headers'] : [],
+            'error' => (string) ($result['error'] ?? ''),
+        ];
+    }
+
+    $responseHeaders = [];
+    $headerCollector = static function ($ch, string $line) use (&$responseHeaders): int {
+        return circuitBreakerCollectCurlHeaderLine($responseHeaders, $line);
+    };
+
+    $ch = curl_init();
+    curl_setopt_array($ch, [
+        CURLOPT_URL => $url,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT => 30,
+        CURLOPT_CONNECTTIMEOUT => 10,
+        CURLOPT_HTTPHEADER => [
+            'Authorization: Bearer ' . $bearerToken,
+            'nmsResponseFormat: AIXM',
+            'Accept: application/json',
+        ],
+        CURLOPT_HEADERFUNCTION => $headerCollector,
+    ]);
+
+    $body = curl_exec($ch);
+    $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $error = curl_error($ch);
+
+    return [
+        'body' => $body,
+        'http_code' => $httpCode,
+        'headers' => $responseHeaders,
+        'error' => $error,
+    ];
+}
+
+/**
+ * Execute one NMS GET with rate limiting, global backoff, and one 429 retry.
+ *
+ * @param string $endpoint Health endpoint key (location, geo, auth)
+ * @param float $lastRequestTime Updated by rateLimitWait()
+ * @return array{
+ *   ok: bool,
+ *   deferred: bool,
+ *   http_code: int|null,
+ *   body: string|false,
+ *   headers: array<string, string>,
+ *   error: string
+ * }
+ */
+function notamExecuteNmsQuery(string $url, string $endpoint, float &$lastRequestTime, string $bearerToken): array
+{
+    $backoff = checkNotamGlobalBackoff();
+    if ($backoff['skip']) {
+        aviationwx_log('info', 'notam fetcher: deferred during global NMS backoff', [
+            'endpoint' => $endpoint,
+            'backoff_remaining' => $backoff['backoff_remaining'],
+        ], 'app');
+
+        return [
+            'ok' => false,
+            'deferred' => true,
+            'http_code' => null,
+            'body' => false,
+            'headers' => [],
+            'error' => '',
+        ];
+    }
+
+    notamRateLimitAcquire();
+    $lastRequestTime = microtime(true);
+
+    $attempts = 0;
+    while ($attempts < 2) {
+        $attempts++;
+        $response = notamPerformNmsHttpGet($url, $bearerToken);
+        $httpCode = $response['http_code'];
+        $headers = $response['headers'];
+
+        if ($httpCode === 200 && $response['body'] !== false) {
+            clearNotamGlobalBackoff();
+
+            return [
+                'ok' => true,
+                'deferred' => false,
+                'http_code' => $httpCode,
+                'body' => $response['body'],
+                'headers' => $headers,
+                'error' => $response['error'],
+            ];
+        }
+
+        $isRateLimit = notamGlobalBackoffShouldRecord($httpCode);
+        if ($isRateLimit && $attempts === 1) {
+            $waitSeconds = notamCompute429RetryWaitSeconds($headers);
+            notamSleepFor429Retry($waitSeconds);
+            notamRateLimitAcquire();
+            $lastRequestTime = microtime(true);
+
+            continue;
+        }
+
+        if ($isRateLimit) {
+            recordNotamGlobalRateLimitFailure($httpCode, $headers);
+        }
+
+        return [
+            'ok' => false,
+            'deferred' => false,
+            'http_code' => $httpCode > 0 ? $httpCode : null,
+            'body' => $response['body'],
+            'headers' => $headers,
+            'error' => $response['error'],
+        ];
+    }
+
+    return [
+        'ok' => false,
+        'deferred' => false,
+        'http_code' => null,
+        'body' => false,
+        'headers' => [],
+        'error' => 'unexpected retry loop exit',
+    ];
+}

--- a/lib/notam/http.php
+++ b/lib/notam/http.php
@@ -76,6 +76,15 @@ function notamPerformNmsHttpGet(string $url, string $bearerToken): array
     };
 
     $ch = curl_init();
+    if ($ch === false) {
+        return [
+            'body' => false,
+            'http_code' => 0,
+            'headers' => [],
+            'error' => 'curl_init failed',
+        ];
+    }
+
     curl_setopt_array($ch, [
         CURLOPT_URL => $url,
         CURLOPT_RETURNTRANSFER => true,

--- a/lib/notam/rate-limit.php
+++ b/lib/notam/rate-limit.php
@@ -114,7 +114,7 @@ function notamRateLimitAcquire(): void
 
     $fingerprint = notamRateLimitFingerprint();
 
-    $rpm = (int) (60 / max(NOTAM_RATE_LIMIT_SECONDS, 1));
+    $rpm = NOTAM_RATE_LIMIT_REQUESTS_PER_MINUTE;
     $burst = 1;
     $deadline = microtime(true) + NOTAM_RATE_LIMIT_MAX_WAIT_SECONDS;
 

--- a/lib/notam/scheduler-queue.php
+++ b/lib/notam/scheduler-queue.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/scheduling.php';
 require_once __DIR__ . '/cache.php';
+require_once __DIR__ . '/circuit-breaker.php';
 
 /**
  * Choose airports to refresh this scheduler tick (oldest cache first, capped).
@@ -29,6 +30,10 @@ function notamSelectAirportsToEnqueue(
     }
 
     $now = $now ?? time();
+    if (checkNotamGlobalBackoff($now)['skip']) {
+        return [];
+    }
+
     $eligible = [];
 
     foreach ($airportIds as $airportId) {

--- a/scripts/fetch-notam.php
+++ b/scripts/fetch-notam.php
@@ -65,6 +65,7 @@ function processAirportNotam(string $airportId, string $invocationId, bool $expe
 
     try {
         $fetchSucceeded = false;
+        $fetchAllDeferred = false;
         if (defined('AVIATIONWX_NOTAM_TEST_FETCH_THROW') && AVIATIONWX_NOTAM_TEST_FETCH_THROW !== '') {
             throw new RuntimeException((string) AVIATIONWX_NOTAM_TEST_FETCH_THROW);
         }
@@ -74,7 +75,16 @@ function processAirportNotam(string $airportId, string $invocationId, bool $expe
                 ? (array) AVIATIONWX_NOTAM_TEST_FETCH_NOTAMS
                 : [];
         } else {
-            $notams = fetchNotamsForAirport($airportId, $airport, $fetchSucceeded);
+            $notams = fetchNotamsForAirport($airportId, $airport, $fetchSucceeded, $fetchAllDeferred);
+        }
+
+        if ($fetchAllDeferred) {
+            aviationwx_log('info', 'notam fetch: deferred during global NMS backoff', [
+                'invocation_id' => $invocationId,
+                'airport' => $airportId,
+            ], 'app');
+
+            return true;
         }
 
         if (!$fetchSucceeded) {

--- a/tests/Unit/NotamFetchReliabilityTest.php
+++ b/tests/Unit/NotamFetchReliabilityTest.php
@@ -125,8 +125,38 @@ final class NotamFetchReliabilityTest extends TestCase
         self::assertFileExists(dirname($cacheFile) . '/kspb.fetch-attempt');
     }
 
+    public function testProcessAirportNotam_SkipsFetchAttemptWhenAllQueriesDeferred(): void
+    {
+        $cacheFile = $this->cacheDir . '/kspb.json';
+        $original = [
+            'fetched_at' => 1700000000,
+            'airport' => 'kspb',
+            'notams' => [['id' => 'keep-me', 'text' => 'RWY CLSD']],
+            'status' => 'success',
+        ];
+        file_put_contents($cacheFile, json_encode($original, JSON_THROW_ON_ERROR));
+
+        $backoffRoot = sys_get_temp_dir() . '/aviationwx-notam-backoff-' . bin2hex(random_bytes(4));
+        mkdir($backoffRoot, 0755, true);
+
+        try {
+            $result = $this->runProcessAirportNotamSubprocess($cacheFile, [
+                'global_backoff' => true,
+                'backoff_root' => $backoffRoot,
+            ]);
+
+            self::assertTrue($result['success']);
+            self::assertFileDoesNotExist(dirname($cacheFile) . '/kspb.fetch-attempt');
+            $after = json_decode((string) file_get_contents($cacheFile), true, 512, JSON_THROW_ON_ERROR);
+            self::assertSame('keep-me', $after['notams'][0]['id']);
+            self::assertSame(1700000000, $after['fetched_at']);
+        } finally {
+            $this->removeTree($backoffRoot);
+        }
+    }
+
     /**
-     * @param array{fetch_succeeded?: bool, force_write_fail?: bool, fetch_throw?: string} $options
+     * @param array{fetch_succeeded?: bool, force_write_fail?: bool, fetch_throw?: string, global_backoff?: bool, backoff_root?: string} $options
      * @return array{success: bool, output: string}
      */
     private function runProcessAirportNotamSubprocess(string $cacheFile, array $options = []): array
@@ -157,6 +187,16 @@ if (getenv('NOTAM_TEST_FORCE_WRITE_FAIL') === '1') {
     define('AVIATIONWX_NOTAM_TEST_FORCE_WRITE_FAIL', true);
 }
 require getenv('NOTAM_TEST_ROOT') . '/scripts/fetch-notam.php';
+if (getenv('NOTAM_TEST_GLOBAL_BACKOFF') === '1') {
+    $GLOBALS['upstreamRateLimitTestRoot'] = getenv('NOTAM_TEST_BACKOFF_ROOT');
+    $GLOBALS['notamRateLimitTestClientId'] = 'client-http';
+    $GLOBALS['notamRateLimitTestClientSecret'] = 'secret-http';
+    $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
+    $GLOBALS['notamTestBearerToken'] = 'test-token';
+    $GLOBALS['notamTestSkipSleep'] = true;
+    notamRateLimitTestForceEnforcement();
+    recordNotamGlobalRateLimitFailure(429, null, time());
+}
 $ok = processAirportNotam('kspb', 'test-invocation', false);
 echo json_encode(['success' => $ok], JSON_THROW_ON_ERROR);
 
@@ -176,6 +216,10 @@ PHP;
         }
         if (!empty($options['force_write_fail'])) {
             $env['NOTAM_TEST_FORCE_WRITE_FAIL'] = '1';
+        }
+        if (!empty($options['global_backoff'])) {
+            $env['NOTAM_TEST_GLOBAL_BACKOFF'] = '1';
+            $env['NOTAM_TEST_BACKOFF_ROOT'] = (string) ($options['backoff_root'] ?? '');
         }
         $proc = proc_open([PHP_BINARY, $tmp], [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, null, $env);
         self::assertIsResource($proc);

--- a/tests/Unit/NotamFetchReliabilityTest.php
+++ b/tests/Unit/NotamFetchReliabilityTest.php
@@ -147,6 +147,7 @@ final class NotamFetchReliabilityTest extends TestCase
 
             self::assertTrue($result['success']);
             self::assertFileDoesNotExist(dirname($cacheFile) . '/kspb.fetch-attempt');
+            self::assertFileExists($backoffRoot . '/backoff.json');
             $after = json_decode((string) file_get_contents($cacheFile), true, 512, JSON_THROW_ON_ERROR);
             self::assertSame('keep-me', $after['notams'][0]['id']);
             self::assertSame(1700000000, $after['fetched_at']);
@@ -176,6 +177,9 @@ if (!defined('AVIATIONWX_LOG_DIR')) {
 @touch(AVIATIONWX_LOG_DIR . '/app.log');
 define('AVIATIONWX_NOTAM_CACHE_DIR', getenv('NOTAM_TEST_CACHE_DIR'));
 define('AVIATIONWX_FETCH_NOTAM_LOAD_ONLY', true);
+if (getenv('NOTAM_TEST_GLOBAL_BACKOFF') === '1') {
+    define('CACHE_BASE_DIR', getenv('NOTAM_TEST_BACKOFF_ROOT'));
+}
 if (($throw = getenv('NOTAM_TEST_FETCH_THROW')) !== false && $throw !== '') {
     define('AVIATIONWX_NOTAM_TEST_FETCH_THROW', $throw);
 }
@@ -188,7 +192,6 @@ if (getenv('NOTAM_TEST_FORCE_WRITE_FAIL') === '1') {
 }
 require getenv('NOTAM_TEST_ROOT') . '/scripts/fetch-notam.php';
 if (getenv('NOTAM_TEST_GLOBAL_BACKOFF') === '1') {
-    $GLOBALS['upstreamRateLimitTestRoot'] = getenv('NOTAM_TEST_BACKOFF_ROOT');
     $GLOBALS['notamRateLimitTestClientId'] = 'client-http';
     $GLOBALS['notamRateLimitTestClientSecret'] = 'secret-http';
     $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';

--- a/tests/Unit/NotamFetcherDedupTest.php
+++ b/tests/Unit/NotamFetcherDedupTest.php
@@ -76,6 +76,25 @@ final class NotamFetcherDedupTest extends TestCase
 
         self::assertTrue($summary['attempted']);
         self::assertTrue($summary['fetchSucceeded']);
+        self::assertFalse($summary['allDeferred']);
+    }
+
+    public function testSummarizeFetchQueryOutcomes_AllDeferredWhenEveryQueryDeferred(): void
+    {
+        $summary = notamSummarizeFetchQueryOutcomes([null, null]);
+
+        self::assertTrue($summary['attempted']);
+        self::assertFalse($summary['fetchSucceeded']);
+        self::assertTrue($summary['allDeferred']);
+    }
+
+    public function testSummarizeFetchQueryOutcomes_NotAllDeferredWhenMixedWithHardFailure(): void
+    {
+        $summary = notamSummarizeFetchQueryOutcomes([null, false]);
+
+        self::assertTrue($summary['attempted']);
+        self::assertFalse($summary['fetchSucceeded']);
+        self::assertFalse($summary['allDeferred']);
     }
 
     public function testNotamCanonicalDedupKey_StableForIdenticalRows(): void

--- a/tests/Unit/NotamGlobalBackoffTest.php
+++ b/tests/Unit/NotamGlobalBackoffTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AviationWX\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Shared NMS credential backoff after HTTP 429/503.
+ *
+ * @covers ::notamGlobalBackoffKey
+ * @covers ::checkNotamGlobalBackoff
+ * @covers ::recordNotamGlobalRateLimitFailure
+ * @covers ::clearNotamGlobalBackoff
+ */
+final class NotamGlobalBackoffTest extends TestCase
+{
+    private string $backoffFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/../../lib/cache-paths.php';
+        require_once __DIR__ . '/../../lib/constants.php';
+        require_once __DIR__ . '/../../lib/notam/rate-limit.php';
+        require_once __DIR__ . '/../../lib/notam/circuit-breaker.php';
+
+        $GLOBALS['notamRateLimitTestClientId'] = 'client-backoff';
+        $GLOBALS['notamRateLimitTestClientSecret'] = 'secret-backoff';
+        $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
+
+        $this->backoffFile = CACHE_BACKOFF_FILE;
+        ensureCacheDir(dirname($this->backoffFile));
+        $this->clearBackoffKey();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clearBackoffKey();
+        unset(
+            $GLOBALS['notamRateLimitTestClientId'],
+            $GLOBALS['notamRateLimitTestClientSecret'],
+            $GLOBALS['notamRateLimitTestBaseUrl']
+        );
+        parent::tearDown();
+    }
+
+    public function testGlobalBackoffKey_StableForSameCredential(): void
+    {
+        $this->assertSame(notamGlobalBackoffKey(), notamGlobalBackoffKey());
+        $this->assertStringStartsWith('global_notam_', notamGlobalBackoffKey());
+    }
+
+    public function testCheck_ReturnsOpenWhenBackoffActive(): void
+    {
+        $now = 1_700_000_000;
+        recordNotamGlobalRateLimitFailure(429, null, $now);
+
+        $result = checkNotamGlobalBackoff($now + 10);
+        $this->assertTrue($result['skip']);
+        $this->assertSame('global_nms_backoff', $result['reason']);
+        $this->assertGreaterThan(0, $result['backoff_remaining']);
+    }
+
+    public function testCheck_ReturnsClosedAfterBackoffExpires(): void
+    {
+        $now = 1_700_000_000;
+        recordNotamGlobalRateLimitFailure(429, ['retry-after' => '5'], $now);
+
+        $result = checkNotamGlobalBackoff($now + 6);
+        $this->assertFalse($result['skip']);
+    }
+
+    public function testRecord_UsesRetryAfterHeaderWhenPresent(): void
+    {
+        $now = 1_700_000_000;
+        recordNotamGlobalRateLimitFailure(429, ['retry-after' => '120'], $now);
+
+        $result = checkNotamGlobalBackoff($now + 30);
+        $this->assertTrue($result['skip']);
+        $this->assertGreaterThanOrEqual(80, $result['backoff_remaining']);
+    }
+
+    public function testRecord_DefaultBackoffWhenHeaderMissing(): void
+    {
+        $now = 1_700_000_000;
+        recordNotamGlobalRateLimitFailure(429, null, $now);
+
+        $result = checkNotamGlobalBackoff($now + 30);
+        $this->assertTrue($result['skip']);
+        $this->assertGreaterThanOrEqual(
+            NOTAM_GLOBAL_BACKOFF_DEFAULT_SECONDS - 30,
+            $result['backoff_remaining']
+        );
+    }
+
+    public function testRecord_ExtendsExistingBackoffToLaterDeadline(): void
+    {
+        $now = 1_700_000_000;
+        recordNotamGlobalRateLimitFailure(429, ['retry-after' => '30'], $now);
+        recordNotamGlobalRateLimitFailure(429, ['retry-after' => '120'], $now + 5);
+
+        $result = checkNotamGlobalBackoff($now + 10);
+        $this->assertTrue($result['skip']);
+        $this->assertGreaterThanOrEqual(100, $result['backoff_remaining']);
+    }
+
+    public function testRecord_IgnoresNonRateLimitStatusCodes(): void
+    {
+        recordNotamGlobalRateLimitFailure(500, null, 1_700_000_000);
+
+        $this->assertFalse(checkNotamGlobalBackoff(1_700_000_000)['skip']);
+    }
+
+    public function testClear_RemovesActiveBackoff(): void
+    {
+        $now = 1_700_000_000;
+        recordNotamGlobalRateLimitFailure(429, null, $now);
+        clearNotamGlobalBackoff();
+
+        $this->assertFalse(checkNotamGlobalBackoff($now)['skip']);
+    }
+
+    private function clearBackoffKey(): void
+    {
+        clearNotamGlobalBackoff();
+        if (!file_exists($this->backoffFile)) {
+            return;
+        }
+
+        $data = json_decode((string) file_get_contents($this->backoffFile), true);
+        if (!is_array($data)) {
+            return;
+        }
+
+        unset($data[notamGlobalBackoffKey()]);
+        if ($data === []) {
+            @unlink($this->backoffFile);
+        } else {
+            file_put_contents($this->backoffFile, json_encode($data, JSON_PRETTY_PRINT), LOCK_EX);
+        }
+    }
+}

--- a/tests/Unit/NotamGlobalBackoffTest.php
+++ b/tests/Unit/NotamGlobalBackoffTest.php
@@ -122,6 +122,59 @@ final class NotamGlobalBackoffTest extends TestCase
         $this->assertFalse(checkNotamGlobalBackoff($now)['skip']);
     }
 
+    public function testCheck_TreatsScalarBackoffFileAsInactive(): void
+    {
+        file_put_contents($this->backoffFile, '"corrupted"', LOCK_EX);
+        clearstatcache();
+
+        $this->assertFalse(checkNotamGlobalBackoff(1_700_000_000)['skip']);
+    }
+
+    public function testCheck_TreatsMalformedEntryAsInactive(): void
+    {
+        file_put_contents(
+            $this->backoffFile,
+            json_encode([notamGlobalBackoffKey() => 'not-an-array'], JSON_PRETTY_PRINT),
+            LOCK_EX
+        );
+        clearstatcache();
+
+        $this->assertFalse(checkNotamGlobalBackoff(1_700_000_000)['skip']);
+    }
+
+    public function testSetUntil_RecoversFromScalarBackoffFile(): void
+    {
+        file_put_contents($this->backoffFile, '"corrupted"', LOCK_EX);
+        clearstatcache();
+
+        $now = 1_700_000_000;
+        recordNotamGlobalRateLimitFailure(429, null, $now);
+
+        $result = checkNotamGlobalBackoff($now + 10);
+        $this->assertTrue($result['skip']);
+
+        $decoded = json_decode((string) file_get_contents($this->backoffFile), true);
+        $this->assertIsArray($decoded);
+        $this->assertIsArray($decoded[notamGlobalBackoffKey()] ?? null);
+    }
+
+    public function testSetUntil_RecoversFromMalformedExistingEntry(): void
+    {
+        file_put_contents(
+            $this->backoffFile,
+            json_encode([notamGlobalBackoffKey() => 'not-an-array'], JSON_PRETTY_PRINT),
+            LOCK_EX
+        );
+        clearstatcache();
+
+        $now = 1_700_000_000;
+        recordNotamGlobalRateLimitFailure(429, ['retry-after' => '30'], $now);
+
+        $result = checkNotamGlobalBackoff($now + 10);
+        $this->assertTrue($result['skip']);
+        $this->assertGreaterThanOrEqual(15, $result['backoff_remaining']);
+    }
+
     private function clearBackoffKey(): void
     {
         clearNotamGlobalBackoff();

--- a/tests/Unit/NotamNmsHttpTest.php
+++ b/tests/Unit/NotamNmsHttpTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * NMS HTTP execution with global backoff, header capture, and one 429 retry.
+ * NMS HTTP execution with global backoff, header capture, and one bounded 429/503 retry.
  *
  * @covers ::notamExecuteNmsQuery
  * @covers ::notamPerformNmsHttpGet
@@ -28,6 +28,9 @@ final class NotamNmsHttpTest extends TestCase
         $GLOBALS['notamTestSkipSleep'] = true;
         $GLOBALS['notamTestSleepAccumulatedSeconds'] = 0;
         $GLOBALS['notamTestBearerToken'] = 'test-token';
+        $GLOBALS['notamRateLimitTestSkipSleep'] = true;
+        $GLOBALS['notamRateLimitTestPollMicroseconds'] = 50_000;
+        $GLOBALS['upstreamRateLimitTestNow'] = 1_700_000_000.0;
 
         require_once dirname(__DIR__, 2) . '/lib/notam/http.php';
         require_once dirname(__DIR__, 2) . '/lib/notam/circuit-breaker.php';
@@ -46,6 +49,9 @@ final class NotamNmsHttpTest extends TestCase
             $GLOBALS['notamRateLimitTestClientSecret'],
             $GLOBALS['notamRateLimitTestBaseUrl'],
             $GLOBALS['notamRateLimitTestForceEnforcement'],
+            $GLOBALS['notamRateLimitTestSkipSleep'],
+            $GLOBALS['notamRateLimitTestPollMicroseconds'],
+            $GLOBALS['upstreamRateLimitTestNow'],
             $GLOBALS['notamTestSkipSleep'],
             $GLOBALS['notamTestSleepAccumulatedSeconds'],
             $GLOBALS['notamTestNmsHttpHandler'],

--- a/tests/Unit/NotamNmsHttpTest.php
+++ b/tests/Unit/NotamNmsHttpTest.php
@@ -84,7 +84,7 @@ final class NotamNmsHttpTest extends TestCase
     public function testExecuteNmsQuery_429Then200OnRetrySucceeds(): void
     {
         $calls = 0;
-        $GLOBALS['notamTestNmsHttpHandler'] = static function () use (&$calls): array {
+        $GLOBALS['notamTestNmsHttpHandler'] = static function (string $url, string $bearerToken) use (&$calls): array {
             $calls++;
 
             return $calls === 1
@@ -109,7 +109,7 @@ final class NotamNmsHttpTest extends TestCase
 
     public function testExecuteNmsQuery_Double429RecordsGlobalBackoff(): void
     {
-        $GLOBALS['notamTestNmsHttpHandler'] = static function (): array {
+        $GLOBALS['notamTestNmsHttpHandler'] = static function (string $url, string $bearerToken): array {
             return ['body' => 'busy', 'http_code' => 429, 'headers' => ['retry-after' => '1'], 'error' => ''];
         };
 
@@ -130,7 +130,7 @@ final class NotamNmsHttpTest extends TestCase
     {
         recordNotamGlobalRateLimitFailure(429, ['retry-after' => '1'], time() - 120);
 
-        $GLOBALS['notamTestNmsHttpHandler'] = static function (): array {
+        $GLOBALS['notamTestNmsHttpHandler'] = static function (string $url, string $bearerToken): array {
             return [
                 'body' => '{"status":"Success","data":{"aixm":[]}}',
                 'http_code' => 200,
@@ -163,7 +163,7 @@ final class NotamNmsHttpTest extends TestCase
         require_once dirname(__DIR__, 2) . '/lib/notam/fetcher.php';
 
         $GLOBALS['notamTestBearerToken'] = 'token-test';
-        $GLOBALS['notamTestNmsHttpHandler'] = static function (): array {
+        $GLOBALS['notamTestNmsHttpHandler'] = static function (string $url, string $bearerToken): array {
             return [
                 'body' => '{"status":"Success","data":{}}',
                 'http_code' => 200,

--- a/tests/Unit/NotamNmsHttpTest.php
+++ b/tests/Unit/NotamNmsHttpTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
  * @covers ::notamExecuteNmsQuery
  * @covers ::notamPerformNmsHttpGet
  * @covers ::notamCompute429RetryWaitSeconds
+ * @covers ::notamLogInvalidNmsPayload
  */
 final class NotamNmsHttpTest extends TestCase
 {
@@ -210,5 +211,26 @@ final class NotamNmsHttpTest extends TestCase
 
         $this->assertFalse($fetchSucceeded);
         $this->assertTrue($fetchAllDeferred);
+    }
+
+    public function testQueryNotamsByLocation_FailsWhenHttp200HasNonSuccessPayload(): void
+    {
+        clearNotamGlobalBackoff();
+
+        $GLOBALS['notamTestNmsHttpHandler'] = static function (string $url, string $bearerToken): array {
+            return [
+                'body' => '{"status":"Error","data":{}}',
+                'http_code' => 200,
+                'headers' => [],
+                'error' => '',
+            ];
+        };
+
+        $lastRequestTime = 0.0;
+        $querySucceeded = true;
+        $rows = queryNotamsByLocation('OR81', $lastRequestTime, [], $querySucceeded);
+
+        $this->assertSame([], $rows);
+        $this->assertFalse($querySucceeded);
     }
 }

--- a/tests/Unit/NotamNmsHttpTest.php
+++ b/tests/Unit/NotamNmsHttpTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * NMS HTTP execution with global backoff, header capture, and one 429 retry.
+ *
+ * @covers ::notamExecuteNmsQuery
+ * @covers ::notamPerformNmsHttpGet
+ * @covers ::notamCompute429RetryWaitSeconds
+ */
+final class NotamNmsHttpTest extends TestCase
+{
+    private ?string $testRoot = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testRoot = sys_get_temp_dir() . '/notam-http-' . bin2hex(random_bytes(4));
+        mkdir($this->testRoot, 0755, true);
+        $GLOBALS['upstreamRateLimitTestRoot'] = $this->testRoot;
+        $GLOBALS['notamRateLimitTestClientId'] = 'client-http';
+        $GLOBALS['notamRateLimitTestClientSecret'] = 'secret-http';
+        $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
+        $GLOBALS['notamTestSkipSleep'] = true;
+        $GLOBALS['notamTestSleepAccumulatedSeconds'] = 0;
+
+        require_once dirname(__DIR__, 2) . '/lib/notam/http.php';
+        require_once dirname(__DIR__, 2) . '/lib/notam/circuit-breaker.php';
+
+        notamRateLimitTestForceEnforcement();
+        clearNotamGlobalBackoff();
+    }
+
+    protected function tearDown(): void
+    {
+        clearNotamGlobalBackoff();
+        unset(
+            $GLOBALS['upstreamRateLimitTestRoot'],
+            $GLOBALS['notamRateLimitTestClientId'],
+            $GLOBALS['notamRateLimitTestClientSecret'],
+            $GLOBALS['notamRateLimitTestBaseUrl'],
+            $GLOBALS['notamRateLimitTestForceEnforcement'],
+            $GLOBALS['notamTestSkipSleep'],
+            $GLOBALS['notamTestSleepAccumulatedSeconds'],
+            $GLOBALS['notamTestNmsHttpHandler']
+        );
+        if ($this->testRoot !== null && is_dir($this->testRoot)) {
+            $files = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($this->testRoot, FilesystemIterator::SKIP_DOTS),
+                RecursiveIteratorIterator::CHILD_FIRST
+            );
+            foreach ($files as $file) {
+                if ($file->isDir()) {
+                    rmdir($file->getPathname());
+                } else {
+                    unlink($file->getPathname());
+                }
+            }
+            rmdir($this->testRoot);
+        }
+        parent::tearDown();
+    }
+
+    public function testExecuteNmsQuery_DeferredWhenGlobalBackoffActive(): void
+    {
+        recordNotamGlobalRateLimitFailure(429, null, time());
+
+        $lastRequestTime = 0.0;
+        $result = notamExecuteNmsQuery(
+            'https://example.test/nmsapi/v1/notams?location=OR81',
+            'location',
+            $lastRequestTime,
+            'test-token',
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertTrue($result['deferred']);
+        $this->assertNull($result['http_code']);
+    }
+
+    public function testExecuteNmsQuery_429Then200OnRetrySucceeds(): void
+    {
+        $calls = 0;
+        $GLOBALS['notamTestNmsHttpHandler'] = static function () use (&$calls): array {
+            $calls++;
+
+            return $calls === 1
+                ? ['body' => 'busy', 'http_code' => 429, 'headers' => ['retry-after' => '2'], 'error' => '']
+                : ['body' => '{"status":"Success","data":{}}', 'http_code' => 200, 'headers' => [], 'error' => ''];
+        };
+
+        $lastRequestTime = 0.0;
+        $result = notamExecuteNmsQuery(
+            'https://example.test/nmsapi/v1/notams?location=OR81',
+            'location',
+            $lastRequestTime,
+            'test-token',
+        );
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(200, $result['http_code']);
+        $this->assertSame(2, $calls);
+        $this->assertSame(2, $GLOBALS['notamTestSleepAccumulatedSeconds']);
+        $this->assertFalse(checkNotamGlobalBackoff()['skip']);
+    }
+
+    public function testExecuteNmsQuery_Double429RecordsGlobalBackoff(): void
+    {
+        $GLOBALS['notamTestNmsHttpHandler'] = static function (): array {
+            return ['body' => 'busy', 'http_code' => 429, 'headers' => ['retry-after' => '1'], 'error' => ''];
+        };
+
+        $lastRequestTime = 0.0;
+        $result = notamExecuteNmsQuery(
+            'https://example.test/nmsapi/v1/notams?location=OR81',
+            'location',
+            $lastRequestTime,
+            'test-token',
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(429, $result['http_code']);
+        $this->assertTrue(checkNotamGlobalBackoff()['skip']);
+    }
+
+    public function testExecuteNmsQuery_SuccessClearsGlobalBackoff(): void
+    {
+        recordNotamGlobalRateLimitFailure(429, ['retry-after' => '1'], time() - 120);
+
+        $GLOBALS['notamTestNmsHttpHandler'] = static function (): array {
+            return [
+                'body' => '{"status":"Success","data":{"aixm":[]}}',
+                'http_code' => 200,
+                'headers' => [],
+                'error' => '',
+            ];
+        };
+
+        $lastRequestTime = 0.0;
+        $result = notamExecuteNmsQuery(
+            'https://example.test/nmsapi/v1/notams?location=OR81',
+            'location',
+            $lastRequestTime,
+            'test-token',
+        );
+
+        $this->assertTrue($result['ok']);
+        $this->assertFalse(checkNotamGlobalBackoff()['skip']);
+    }
+
+    public function testCompute429RetryWaitSeconds_ClampsToConfiguredMax(): void
+    {
+        $wait = notamCompute429RetryWaitSeconds(['retry-after' => '120']);
+
+        $this->assertSame(NOTAM_429_RETRY_MAX_WAIT_SECONDS, $wait);
+    }
+
+    public function testQueryNotamsByLocation_UsesEmptyDataObjectAsSuccess(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/fetcher.php';
+
+        $GLOBALS['notamTestBearerToken'] = 'token-test';
+        $GLOBALS['notamTestNmsHttpHandler'] = static function (): array {
+            return [
+                'body' => '{"status":"Success","data":{}}',
+                'http_code' => 200,
+                'headers' => [],
+                'error' => '',
+            ];
+        };
+
+        $lastRequestTime = 0.0;
+        $querySucceeded = false;
+        $rows = queryNotamsByLocation('OR81', $lastRequestTime, [], $querySucceeded);
+
+        $this->assertSame([], $rows);
+        $this->assertTrue($querySucceeded);
+    }
+}

--- a/tests/Unit/NotamNmsHttpTest.php
+++ b/tests/Unit/NotamNmsHttpTest.php
@@ -157,9 +157,16 @@ final class NotamNmsHttpTest extends TestCase
 
     public function testCompute429RetryWaitSeconds_ClampsToConfiguredMax(): void
     {
-        $wait = notamCompute429RetryWaitSeconds(['retry-after' => '120']);
+        $wait = notamCompute429RetryWaitSeconds(429, ['retry-after' => '120']);
 
         $this->assertSame(NOTAM_429_RETRY_MAX_WAIT_SECONDS, $wait);
+    }
+
+    public function testCompute429RetryWaitSeconds_UsesHttpCodeFor503(): void
+    {
+        $wait = notamCompute429RetryWaitSeconds(503, ['retry-after' => '9']);
+
+        $this->assertSame(9, $wait);
     }
 
     public function testQueryNotamsByLocation_UsesEmptyDataObjectAsSuccess(): void

--- a/tests/Unit/NotamNmsHttpTest.php
+++ b/tests/Unit/NotamNmsHttpTest.php
@@ -26,9 +26,11 @@ final class NotamNmsHttpTest extends TestCase
         $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
         $GLOBALS['notamTestSkipSleep'] = true;
         $GLOBALS['notamTestSleepAccumulatedSeconds'] = 0;
+        $GLOBALS['notamTestBearerToken'] = 'test-token';
 
         require_once dirname(__DIR__, 2) . '/lib/notam/http.php';
         require_once dirname(__DIR__, 2) . '/lib/notam/circuit-breaker.php';
+        require_once dirname(__DIR__, 2) . '/lib/notam/fetcher.php';
 
         notamRateLimitTestForceEnforcement();
         clearNotamGlobalBackoff();
@@ -45,7 +47,8 @@ final class NotamNmsHttpTest extends TestCase
             $GLOBALS['notamRateLimitTestForceEnforcement'],
             $GLOBALS['notamTestSkipSleep'],
             $GLOBALS['notamTestSleepAccumulatedSeconds'],
-            $GLOBALS['notamTestNmsHttpHandler']
+            $GLOBALS['notamTestNmsHttpHandler'],
+            $GLOBALS['notamTestBearerToken']
         );
         if ($this->testRoot !== null && is_dir($this->testRoot)) {
             $files = new RecursiveIteratorIterator(
@@ -178,5 +181,34 @@ final class NotamNmsHttpTest extends TestCase
 
         $this->assertSame([], $rows);
         $this->assertTrue($querySucceeded);
+    }
+
+    public function testQueryNotamsByLocation_DeferredSetsQuerySucceededNull(): void
+    {
+        recordNotamGlobalRateLimitFailure(429, null, time());
+
+        $lastRequestTime = 0.0;
+        $querySucceeded = false;
+        $rows = queryNotamsByLocation('OR81', $lastRequestTime, [], $querySucceeded);
+
+        $this->assertSame([], $rows);
+        $this->assertNull($querySucceeded);
+    }
+
+    public function testFetchNotamsForAirport_AllDeferredWhenGlobalBackoffBlocksQueries(): void
+    {
+        recordNotamGlobalRateLimitFailure(429, null, time());
+
+        $config = loadConfig();
+        $this->assertIsArray($config);
+        $airport = $config['airports']['kspb'] ?? null;
+        $this->assertIsArray($airport);
+
+        $fetchSucceeded = true;
+        $fetchAllDeferred = false;
+        fetchNotamsForAirport('kspb', $airport, $fetchSucceeded, $fetchAllDeferred);
+
+        $this->assertFalse($fetchSucceeded);
+        $this->assertTrue($fetchAllDeferred);
     }
 }

--- a/tests/Unit/NotamNmsHttpTest.php
+++ b/tests/Unit/NotamNmsHttpTest.php
@@ -111,6 +111,36 @@ final class NotamNmsHttpTest extends TestCase
         $this->assertFalse(checkNotamGlobalBackoff()['skip']);
     }
 
+    public function testExecuteNmsQuery_429Then200RecordsUpstream429InHealth(): void
+    {
+        $healthFile = $this->testRoot . '/notam_health.json';
+        $GLOBALS['notamHealthTestCacheFile'] = $healthFile;
+        require_once dirname(__DIR__, 2) . '/lib/notam-health.php';
+
+        $calls = 0;
+        $GLOBALS['notamTestNmsHttpHandler'] = static function (string $url, string $bearerToken) use (&$calls): array {
+            $calls++;
+
+            return $calls === 1
+                ? ['body' => 'busy', 'http_code' => 429, 'headers' => ['retry-after' => '2'], 'error' => '']
+                : ['body' => '{"status":"Success","data":{}}', 'http_code' => 200, 'headers' => [], 'error' => ''];
+        };
+
+        $lastRequestTime = 0.0;
+        $result = notamExecuteNmsQuery(
+            'https://example.test/nmsapi/v1/notams?location=OR81',
+            'location',
+            $lastRequestTime,
+            'test-token',
+        );
+
+        $this->assertTrue($result['ok']);
+        notamHealthFlush();
+
+        $status = notamHealthGetStatus();
+        $this->assertSame(1, $status['metrics']['upstream_429_last_hour'] ?? null);
+    }
+
     public function testExecuteNmsQuery_Double429RecordsGlobalBackoff(): void
     {
         $GLOBALS['notamTestNmsHttpHandler'] = static function (string $url, string $bearerToken): array {

--- a/tests/Unit/NotamNmsHttpTest.php
+++ b/tests/Unit/NotamNmsHttpTest.php
@@ -111,6 +111,29 @@ final class NotamNmsHttpTest extends TestCase
         $this->assertFalse(checkNotamGlobalBackoff()['skip']);
     }
 
+    public function testExecuteNmsQuery_NormalizesMixedCaseTestHandlerHeaders(): void
+    {
+        $calls = 0;
+        $GLOBALS['notamTestNmsHttpHandler'] = static function (string $url, string $bearerToken) use (&$calls): array {
+            $calls++;
+
+            return $calls === 1
+                ? ['body' => 'busy', 'http_code' => 429, 'headers' => ['Retry-After' => '7'], 'error' => '']
+                : ['body' => '{"status":"Success","data":{}}', 'http_code' => 200, 'headers' => [], 'error' => ''];
+        };
+
+        $lastRequestTime = 0.0;
+        $result = notamExecuteNmsQuery(
+            'https://example.test/nmsapi/v1/notams?location=OR81',
+            'location',
+            $lastRequestTime,
+            'test-token',
+        );
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(7, $GLOBALS['notamTestSleepAccumulatedSeconds']);
+    }
+
     public function testExecuteNmsQuery_429Then200RecordsUpstream429InHealth(): void
     {
         $healthFile = $this->testRoot . '/notam_health.json';

--- a/tests/Unit/NotamNmsResponseTest.php
+++ b/tests/Unit/NotamNmsResponseTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * NMS JSON payload parsing for location and geo queries.
+ *
+ * @covers ::notamExtractAixmRowsFromNmsResponse
+ * @covers ::notamDecodeNmsJsonResponse
+ */
+final class NotamNmsResponseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/fetcher.php';
+    }
+
+    public function testExtract_EmptyDataObject_ReturnsEmptyList(): void
+    {
+        $rows = notamExtractAixmRowsFromNmsResponse([
+            'status' => 'Success',
+            'data' => [],
+        ]);
+
+        self::assertSame([], $rows);
+    }
+
+    public function testExtract_EmptyAixmArray_ReturnsEmptyList(): void
+    {
+        $rows = notamExtractAixmRowsFromNmsResponse([
+            'status' => 'Success',
+            'data' => ['aixm' => []],
+        ]);
+
+        self::assertSame([], $rows);
+    }
+
+    public function testExtract_AixmNull_ReturnsEmptyList(): void
+    {
+        $rows = notamExtractAixmRowsFromNmsResponse([
+            'status' => 'Success',
+            'data' => ['aixm' => null],
+        ]);
+
+        self::assertSame([], $rows);
+    }
+
+    public function testExtract_AixmRows_ReturnsRows(): void
+    {
+        $xml = '<AIXM xmlns="http://www.aixm.aero/schema/5.1.1"><hasMember/></AIXM>';
+        $rows = notamExtractAixmRowsFromNmsResponse([
+            'status' => 'Success',
+            'data' => ['aixm' => [$xml]],
+        ]);
+
+        self::assertSame([$xml], $rows);
+    }
+
+    public function testExtract_NullInput_ReturnsNull(): void
+    {
+        self::assertNull(notamExtractAixmRowsFromNmsResponse(null));
+    }
+
+    public function testExtract_MissingDataKey_ReturnsNull(): void
+    {
+        self::assertNull(notamExtractAixmRowsFromNmsResponse(['status' => 'Success']));
+    }
+
+    public function testExtract_DataNotArray_ReturnsNull(): void
+    {
+        self::assertNull(notamExtractAixmRowsFromNmsResponse([
+            'status' => 'Success',
+            'data' => 'invalid',
+        ]));
+    }
+
+    public function testExtract_AixmNotArray_ReturnsNull(): void
+    {
+        self::assertNull(notamExtractAixmRowsFromNmsResponse([
+            'status' => 'Success',
+            'data' => ['aixm' => 'not-an-array'],
+        ]));
+    }
+
+    public function testDecode_ProductionEmptySuccessPayload_ParsesForExtract(): void
+    {
+        $decoded = notamDecodeNmsJsonResponse('{"status":"Success","data":{}}');
+
+        self::assertIsArray($decoded);
+        self::assertSame([], notamExtractAixmRowsFromNmsResponse($decoded));
+    }
+}

--- a/tests/Unit/NotamNmsResponseTest.php
+++ b/tests/Unit/NotamNmsResponseTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
  * NMS JSON payload parsing for location and geo queries.
  *
  * @covers ::notamExtractAixmRowsFromNmsResponse
+ * @covers ::notamNmsResponseIndicatesSuccess
  * @covers ::notamDecodeNmsJsonResponse
  */
 final class NotamNmsResponseTest extends TestCase
@@ -81,6 +82,14 @@ final class NotamNmsResponseTest extends TestCase
         self::assertNull(notamExtractAixmRowsFromNmsResponse([
             'status' => 'Success',
             'data' => ['aixm' => 'not-an-array'],
+        ]));
+    }
+
+    public function testExtract_NonSuccessStatus_ReturnsNull(): void
+    {
+        self::assertNull(notamExtractAixmRowsFromNmsResponse([
+            'status' => 'Error',
+            'data' => [],
         ]));
     }
 

--- a/tests/Unit/NotamObservabilityTest.php
+++ b/tests/Unit/NotamObservabilityTest.php
@@ -38,7 +38,19 @@ final class NotamObservabilityTest extends TestCase
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['notamHealthTestCacheFile']);
+        unset(
+            $GLOBALS['notamHealthTestCacheFile'],
+            $GLOBALS['notamTestBearerToken'],
+            $GLOBALS['notamTestNmsHttpHandler'],
+            $GLOBALS['notamRateLimitTestClientId'],
+            $GLOBALS['notamRateLimitTestClientSecret'],
+            $GLOBALS['notamRateLimitTestBaseUrl'],
+            $GLOBALS['upstreamRateLimitTestRoot'],
+            $GLOBALS['notamRateLimitTestSkipSleep'],
+            $GLOBALS['notamRateLimitTestPollMicroseconds'],
+            $GLOBALS['upstreamRateLimitTestNow'],
+            $GLOBALS['notamRateLimitTestForceEnforcement'],
+        );
 
         if ($this->cacheRoot !== null && is_dir($this->cacheRoot)) {
             $files = glob($this->cacheRoot . '/*') ?: [];
@@ -96,14 +108,38 @@ final class NotamObservabilityTest extends TestCase
         $this->assertArrayHasKey('providers', $decoded);
     }
 
-    public function testNotamHealthTrackRequest_EmptyNmsPayloadCountsAsLocationSuccess(): void
+    public function testQueryNotamsByLocation_EmptySuccessPayloadRecordsLocationHealthSuccess(): void
     {
+        require_once __DIR__ . '/../../lib/notam/http.php';
+        require_once __DIR__ . '/../../lib/notam/circuit-breaker.php';
         require_once __DIR__ . '/../../lib/notam/fetcher.php';
 
-        $rows = notamExtractAixmRowsFromNmsResponse(['status' => 'Success', 'data' => []]);
-        $this->assertSame([], $rows);
+        $GLOBALS['notamTestBearerToken'] = 'token-obs';
+        $GLOBALS['notamTestNmsHttpHandler'] = static function (string $url, string $bearerToken): array {
+            return [
+                'body' => '{"status":"Success","data":{}}',
+                'http_code' => 200,
+                'headers' => [],
+                'error' => '',
+            ];
+        };
+        $GLOBALS['notamRateLimitTestClientId'] = 'client-obs';
+        $GLOBALS['notamRateLimitTestClientSecret'] = 'secret-obs';
+        $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
+        $GLOBALS['upstreamRateLimitTestRoot'] = $this->cacheRoot;
+        $GLOBALS['notamRateLimitTestSkipSleep'] = true;
+        $GLOBALS['notamRateLimitTestPollMicroseconds'] = 50_000;
+        $GLOBALS['upstreamRateLimitTestNow'] = 1_700_000_000.0;
+        notamRateLimitTestForceEnforcement();
+        clearNotamGlobalBackoff();
 
-        notamHealthTrackRequest('location', true, 200);
+        $lastRequestTime = 0.0;
+        $querySucceeded = false;
+        $rows = queryNotamsByLocation('OR81', $lastRequestTime, [], $querySucceeded);
+
+        $this->assertSame([], $rows);
+        $this->assertTrue($querySucceeded);
+
         notamHealthFlush();
 
         $providers = notamHealthGetProviders();

--- a/tests/Unit/NotamObservabilityTest.php
+++ b/tests/Unit/NotamObservabilityTest.php
@@ -95,4 +95,24 @@ final class NotamObservabilityTest extends TestCase
         $this->assertArrayHasKey('health', $decoded);
         $this->assertArrayHasKey('providers', $decoded);
     }
+
+    public function testNotamHealthTrackRequest_EmptyNmsPayloadCountsAsLocationSuccess(): void
+    {
+        require_once __DIR__ . '/../../lib/notam/fetcher.php';
+
+        $rows = notamExtractAixmRowsFromNmsResponse(['status' => 'Success', 'data' => []]);
+        $this->assertSame([], $rows);
+
+        notamHealthTrackRequest('location', true, 200);
+        notamHealthFlush();
+
+        $providers = notamHealthGetProviders();
+        $byId = [];
+        foreach ($providers as $row) {
+            $byId[$row['id']] = $row;
+        }
+
+        $this->assertSame(100, $byId['location']['success_rate'] ?? null);
+        $this->assertSame(1, $byId['location']['attempts'] ?? null);
+    }
 }

--- a/tests/Unit/NotamRateLimitTest.php
+++ b/tests/Unit/NotamRateLimitTest.php
@@ -152,4 +152,12 @@ final class NotamRateLimitTest extends TestCase
         $this->assertSame($t0, (float) $GLOBALS['upstreamRateLimitTestNow']);
         $this->assertSame(0, count(glob($this->testRoot . '/*/*.json') ?: []));
     }
+
+    public function testNotamRateLimitRequestsPerMinute_HasSafetyMarginUnderDocumentedCap(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/constants.php';
+
+        $this->assertSame(54, NOTAM_RATE_LIMIT_REQUESTS_PER_MINUTE);
+        $this->assertLessThan(60, NOTAM_RATE_LIMIT_REQUESTS_PER_MINUTE);
+    }
 }

--- a/tests/Unit/NotamSchedulerQueueTest.php
+++ b/tests/Unit/NotamSchedulerQueueTest.php
@@ -93,4 +93,30 @@ final class NotamSchedulerQueueTest extends TestCase
 
         $this->assertCount(2, $selected);
     }
+
+    public function testSelectAirportsToEnqueue_ReturnsEmptyWhenGlobalBackoffActive(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/notam/circuit-breaker.php';
+        require_once dirname(__DIR__, 2) . '/lib/notam/scheduler-queue.php';
+
+        $GLOBALS['notamRateLimitTestClientId'] = 'client-sched';
+        $GLOBALS['notamRateLimitTestClientSecret'] = 'secret-sched';
+        $GLOBALS['notamRateLimitTestBaseUrl'] = 'https://example.test/nms';
+
+        try {
+            recordNotamGlobalRateLimitFailure(429, null, time());
+            touch(notamCacheFilePath('stale'), time() - 10_000);
+
+            $selected = notamSelectAirportsToEnqueue(['stale'], 60, 5, time());
+
+            $this->assertSame([], $selected);
+        } finally {
+            clearNotamGlobalBackoff();
+            unset(
+                $GLOBALS['notamRateLimitTestClientId'],
+                $GLOBALS['notamRateLimitTestClientSecret'],
+                $GLOBALS['notamRateLimitTestBaseUrl'],
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Treat NMS HTTP 200 responses with missing `data.aixm` as an empty NOTAM list so location health and cache refresh match documented behavior.
- Add fleet-wide NMS backoff on upstream 429/503, header capture, and one bounded in-fetch retry before extending the pause.
- Pace outbound NMS calls at 54 req/min (margin under the documented 60/min cap).

## Commits
1. `fix(notam): treat NMS empty data object as successful fetch`
2. `feat(notam): add shared NMS backoff after upstream 429/503`
3. `feat(notam): retry once on NMS 429 with header-aware backoff`
4. `feat(notam): add client-side NMS rate margin and document backoff`

## Test plan
- [x] `make test-ci`
- [x] Deploy and confirm NOTAM location success on status page moves toward ~100%
- [x] Confirm geo 429 counts drop after deploy during normal load
- [x] Verify `global_notam_*` entries appear in `cache/backoff.json` briefly after an NMS 429, then clear on success