### PR TITLE
Lint inline PHP-page JavaScript in full

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,6 +56,9 @@ module.exports = defineConfig([
                 "WEBCAM_REFRESH_SECONDS": "readonly",
                 // Cross-file: defined by public/js/exif-timestamp.js
                 "ExifTimestamp": "readonly",
+                // Cross-file namespace: created by public/js/units.js and
+                // public/js/weather-timestamp-utils.js
+                "AviationWX": "readonly",
                 // Disable Node.js-specific globals that don't exist in browser
                 // Only disable globals that are Node-only (not in browser)
                 ...Object.fromEntries(
@@ -136,6 +139,17 @@ module.exports = defineConfig([
         "no-implicit-globals": "off",
         "curly": "off",
         "no-use-before-define": "off",
+    },
+},
+{
+    // The inline bootstrap in pages/airport.php is the one place that
+    // DECLARES the dashboard globals listed in languageOptions.globals
+    // (every other file only reads them). Same-scope duplicate detection
+    // stays on via no-redeclare with builtinGlobals disabled.
+    files: ["pages/airport.php"],
+    rules: {
+        "no-redeclare": ["error", { builtinGlobals: false }],
+        "no-implicit-globals": "off",
     },
 }]);
 

--- a/pages/airport.php
+++ b/pages/airport.php
@@ -348,9 +348,9 @@ if ($themeCookie === 'dark') {
             
             // Check if it's currently night (evening civil twilight until morning civil twilight)
             function isNightTime() {
-                if (!nightData || !nightData.timezone) return false;
-                if (nightData.polarNight) return true;
-                if (nightData.nightStartHour === undefined || nightData.nightEndHour === undefined) return false;
+                if (!nightData || !nightData.timezone) { return false; }
+                if (nightData.polarNight) { return true; }
+                if (nightData.nightStartHour === undefined || nightData.nightEndHour === undefined) { return false; }
                 var currentMins = nightData.currentHour * 60 + nightData.currentMin;
                 var nightStartMins = nightData.nightStartHour * 60 + nightData.nightStartMin;
                 var nightEndMins = nightData.nightEndHour * 60 + nightData.nightEndMin;
@@ -364,7 +364,7 @@ if ($themeCookie === 'dark') {
             // Legacy support: convert old preferences
             if (!themePref) {
                 var oldNightPref = getCookie('aviationwx_night_mode');
-                if (oldNightPref === 'off') themePref = 'day';
+                if (oldNightPref === 'off') { themePref = 'day'; }
             }
             
             // Note: 'night' preference is now valid (manually selected by user)
@@ -659,7 +659,7 @@ if ($themeCookie === 'dark') {
                 try {
                     const flag = sessionStorage.getItem('aviationwx-cleanup-in-progress');
                     sessionStorage.clear();
-                    if (flag) sessionStorage.setItem('aviationwx-cleanup-in-progress', flag);
+                    if (flag) { sessionStorage.setItem('aviationwx-cleanup-in-progress', flag); }
                 } catch(e) {}
                 
                 // Unregister service workers

--- a/pages/error-404-airport.php
+++ b/pages/error-404-airport.php
@@ -974,7 +974,7 @@ Best regards,
             var selectedIndex = -1;
             var searchTimeout = null;
             
-            if (!searchInput || !dropdown) return;
+            if (!searchInput || !dropdown) { return; }
             
             function navigateToAirport(airportId) {
                 var protocol = window.location.protocol;
@@ -983,7 +983,7 @@ Best regards,
             }
             
             function searchAirports(query) {
-                if (!query || query.length < 2) return [];
+                if (!query || query.length < 2) { return []; }
                 
                 var queryLower = query.toLowerCase().trim();
                 var results = [];
@@ -1009,8 +1009,8 @@ Best regards,
                                 (b.icao && b.icao.toLowerCase() === queryLower) ||
                                 (b.iata && b.iata.toLowerCase() === queryLower);
                     
-                    if (aExact && !bExact) return -1;
-                    if (!aExact && bExact) return 1;
+                    if (aExact && !bExact) { return -1; }
+                    if (!aExact && bExact) { return 1; }
                     return a.name.localeCompare(b.name);
                 });
                 
@@ -1117,13 +1117,13 @@ Best regards,
                     }
                 } else if (e.key === 'Enter') {
                     e.preventDefault();
+                    var airportId = null;
                     if (selectedIndex >= 0 && selectedIndex < items.length) {
-                        var airportId = items[selectedIndex].dataset.airportId;
-                        if (airportId) navigateToAirport(airportId);
+                        airportId = items[selectedIndex].dataset.airportId;
                     } else if (items.length === 1) {
-                        var airportId = items[0].dataset.airportId;
-                        if (airportId) navigateToAirport(airportId);
+                        airportId = items[0].dataset.airportId;
                     }
+                    if (airportId) { navigateToAirport(airportId); }
                 } else if (e.key === 'Escape') {
                     dropdown.classList.remove('show');
                     searchInput.blur();

--- a/pages/error-404.php
+++ b/pages/error-404.php
@@ -490,7 +490,7 @@ $canonicalUrl = 'https://aviationwx.org/';
             var selectedIndex = -1;
             var searchTimeout = null;
             
-            if (!searchInput || !dropdown) return;
+            if (!searchInput || !dropdown) { return; }
             
             function navigateToAirport(airportId) {
                 var protocol = window.location.protocol;
@@ -499,7 +499,7 @@ $canonicalUrl = 'https://aviationwx.org/';
             }
             
             function searchAirports(query) {
-                if (!query || query.length < 2) return [];
+                if (!query || query.length < 2) { return []; }
                 
                 var queryLower = query.toLowerCase().trim();
                 var results = [];
@@ -525,8 +525,8 @@ $canonicalUrl = 'https://aviationwx.org/';
                                 (b.icao && b.icao.toLowerCase() === queryLower) ||
                                 (b.iata && b.iata.toLowerCase() === queryLower);
                     
-                    if (aExact && !bExact) return -1;
-                    if (!aExact && bExact) return 1;
+                    if (aExact && !bExact) { return -1; }
+                    if (!aExact && bExact) { return 1; }
                     return a.name.localeCompare(b.name);
                 });
                 
@@ -633,13 +633,13 @@ $canonicalUrl = 'https://aviationwx.org/';
                     }
                 } else if (e.key === 'Enter') {
                     e.preventDefault();
+                    var airportId = null;
                     if (selectedIndex >= 0 && selectedIndex < items.length) {
-                        var airportId = items[selectedIndex].dataset.airportId;
-                        if (airportId) navigateToAirport(airportId);
+                        airportId = items[selectedIndex].dataset.airportId;
                     } else if (items.length === 1) {
-                        var airportId = items[0].dataset.airportId;
-                        if (airportId) navigateToAirport(airportId);
+                        airportId = items[0].dataset.airportId;
                     }
+                    if (airportId) { navigateToAirport(airportId); }
                 } else if (e.key === 'Escape') {
                     dropdown.classList.remove('show');
                     searchInput.blur();

--- a/scripts/lint-javascript.js
+++ b/scripts/lint-javascript.js
@@ -58,31 +58,15 @@ function extractJavaScriptFromPHP(filePath) {
   let scriptIndex = 0;
   
   while ((match = scriptTagRegex.exec(content)) !== null) {
-    let jsCode = match[1];
+    const jsCode = match[1];
     const scriptTagStart = match.index;
     
-    // If JavaScript uses PHP output buffering (ob_start/ob_get_clean),
-    // the script tag might not have a proper closing tag in source.
-    // Check if jsCode contains PHP code that shouldn't be there
-    // (PHP code after JavaScript should be excluded)
-    if (jsCode.includes('<?php') || jsCode.includes('<?=')) {
-      // Find the last valid JavaScript line before PHP code
-      // Look for patterns that indicate end of JavaScript: });, });, etc.
-      // Split by PHP tags and take only the JavaScript parts
-      const parts = jsCode.split(/(<\?php|<\?=)/);
-      if (parts.length > 1) {
-        // Take only the JavaScript part before the first PHP tag
-        // This handles cases where PHP code appears after JavaScript
-        jsCode = parts[0].trim();
-        
-        // If the JavaScript part is too short, it might be a false positive
-        // (PHP tags might be inside JavaScript strings)
-        if (jsCode.length < 10) {
-          // Restore original - might be PHP in string literal
-          jsCode = match[1];
-        }
-      }
-    }
+    // Blocks containing PHP tags are linted whole: the placeholder
+    // substitution below rewrites <?= ?> and <?php ?> into valid JS.
+    // (An earlier version truncated such blocks at the first PHP tag to
+    // cope with pages/airport.php's output-buffer capture, which had no
+    // closing </script> in source. That capture pattern is gone, and the
+    // truncation hid most of each block from ESLint.)
     
     // Skip empty scripts
     if (!jsCode.trim()) {
@@ -153,12 +137,16 @@ function extractJavaScriptFromPHP(filePath) {
       return '0'; // Default placeholder (use number to avoid syntax issues)
     });
     
-    // First, handle ?> followed by semicolon (common pattern: const x = <?php ... ?>;)
-    // This must come BEFORE replacing <?php ... ?> blocks
-    cleanedCode = cleanedCode.replace(/\?>\s*;/g, '/* PHP close */');
+    // Replace <?php ... ?> blocks in expression position (const x = <?php ... ?>;)
+    // with a null placeholder so the statement stays valid JavaScript.
+    // Newlines are preserved so reported line numbers stay accurate.
+    cleanedCode = cleanedCode.replace(/(=\s*)<\?php([\s\S]*?)\?>/g, (match, prefix, phpCode) => {
+      const lines = (phpCode.match(/\n/g) || []).length;
+      return prefix + 'null' + '\n'.repeat(lines);
+    });
     
-    // Replace <?php ... ?> blocks with comments (preserve line count)
-    // Use non-greedy matching to handle nested cases
+    // Replace remaining (statement-position) <?php ... ?> blocks with comments
+    // (preserve line count). Use non-greedy matching to handle nested cases.
     cleanedCode = cleanedCode.replace(/<\?php[\s\S]*?\?>/gs, (phpCode) => {
       const lines = (phpCode.match(/\n/g) || []).length;
       // Replace with equivalent number of comment lines
@@ -328,7 +316,6 @@ async function lintJavaScript() {
       }
       
       // Count only real errors (not parsing errors)
-      errorCount += realErrors.length;
       errorCount += realErrors.length;
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #122, stacked on `refactor/dashboard-static-assets` (rebase onto main once #121/#122 merge). Small, two commits.

The JS lint extractor truncated any script block at its first PHP tag - a workaround for `pages/airport.php`'s old output-buffer capture, which had no closing `</script>` in source. #122 removed that capture pattern, so the workaround's reason to exist is gone, and it was actively hiding most inline JavaScript in the PHP pages from ESLint (the dashboard bootstrap was checked only up to its first declaration; the 404 and status page blocks were fragment-checked or skipped).

### Commit 1 - fix the findings the truncation was hiding (`6e4069d`)

Linting the full blocks surfaced 19 errors across `pages/airport.php`, `pages/error-404.php`, and `pages/error-404-airport.php`. All fixed with behavior preserved:

- `curly` violations: single-statement `if` bodies now use braces (pure formatting)
- Both 404 pages declared `var airportId` twice in sibling branches of the Enter-key search handler; restructured to a single declaration both branches assign. Verified in the browser: typing an identifier on the 404 page and pressing Enter still navigates to the airport subdomain

### Commit 2 - lint blocks in full (`0dc86ab`)

- Removed the truncation hack from `scripts/lint-javascript.js`
- Fixed the PHP substitution order: expression-position blocks (`const x = <?php ... ?>;`) now substitute to `null` so the statement parses; the old ordering ate the closing tag and broke parsing (this is why the bootstrap never linted)
- `eslint.config.js`: the airport.php bootstrap is the one place that *declares* the dashboard globals, so it gets `no-redeclare` with `builtinGlobals: false` (same-scope duplicate detection stays on) and `no-implicit-globals` off; added `AviationWX` to cross-file globals (created by `units.js` / `weather-timestamp-utils.js`)
- Removed a double-counting bug in the lint summary (every error was counted twice)

### Result

Every script block in every page now parses and lints - zero errors, zero parse-error fallbacks (the fallback path is kept as a safety net but no longer fires). Warnings rose from 94 to 209 because previously hidden blocks now contribute their non-failing style warnings; that debt is now at least visible.

## Test plan

- [x] `make test-ci` passes (full suite)
- [x] ESLint: 0 errors, no parse fallbacks across all linted files
- [x] Browser: 404 page search dropdown + Enter-key navigation verified working
- [x] `php -l` clean on all touched pages