### PR TITLE
Bucket rate limits by CF-Connecting-IP first

### DIFF
--- a/api/map-tiles.php
+++ b/api/map-tiles.php
@@ -73,7 +73,8 @@ if (!checkRateLimit('map_tiles', 300, 60)) {
         'retry_after' => 60
     ]);
     aviationwx_log('warning', 'map tiles rate limit exceeded', [
-        'ip' => $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? 'unknown',
+        // Log the same identity the limiter bucketed by
+        'ip' => getRateLimitClientIp(),
         'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? 'unknown'
     ], 'api');
     exit;

--- a/lib/rate-limit.php
+++ b/lib/rate-limit.php
@@ -8,10 +8,35 @@ require_once __DIR__ . '/config.php';
  */
 
 /**
+ * Get the client IP used for rate limit bucketing
+ *
+ * Prefers CF-Connecting-IP: Cloudflare overwrites it on every proxied
+ * request, so clients cannot forge it through the CDN. X-Forwarded-For
+ * comes second because its first entry is client-supplied - Cloudflare
+ * appends the real address to whatever arrived, so trusting XFF alone
+ * lets an abuser rotate buckets with a spoofed header. Matches the
+ * Public API's getPublicApiClientIp() ordering.
+ *
+ * Bucketing identity only. NOT for security decisions like first-party
+ * detection; those must use REMOTE_ADDR (see isFirstPartyRequest()).
+ *
+ * @return string Client IP, or 'unknown' when none is available
+ */
+function getRateLimitClientIp(): string {
+    if (!empty($_SERVER['HTTP_CF_CONNECTING_IP'])) {
+        return trim($_SERVER['HTTP_CF_CONNECTING_IP']);
+    }
+
+    $ip = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+    // X-Forwarded-For can contain a comma-separated chain; first is the client
+    return trim(explode(',', $ip)[0]);
+}
+
+/**
  * Check if request should be rate limited
  * 
  * Implements IP-based rate limiting using APCu (preferred) or file-based fallback.
- * Extracts client IP from X-Forwarded-For header or REMOTE_ADDR.
+ * Buckets by client IP via getRateLimitClientIp().
  * 
  * @param string $key Unique key for this rate limit (e.g., 'weather_api', 'webcam_api')
  * @param int $maxRequests Maximum requests allowed in the time window (default: RATE_LIMIT_WEATHER_MAX)
@@ -19,10 +44,7 @@ require_once __DIR__ . '/config.php';
  * @return bool True if allowed, false if rate limited
  */
 function checkRateLimit($key, $maxRequests = RATE_LIMIT_WEATHER_MAX, $windowSeconds = RATE_LIMIT_WEATHER_WINDOW) {
-    // Get client IP (respect proxy headers)
-    $ip = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? 'unknown';
-    // Handle comma-separated IPs (X-Forwarded-For can contain multiple IPs)
-    $ip = trim(explode(',', $ip)[0]);
+    $ip = getRateLimitClientIp();
     
     // Use APCu if available for rate limiting
     if (function_exists('apcu_fetch') && function_exists('apcu_store')) {
@@ -238,8 +260,9 @@ function checkRateLimitFileBasedFallback($key, $maxRequests, $windowSeconds, $ip
  * @return array Returns array with 'remaining' (int) and 'reset' (int timestamp) keys
  */
 function getRateLimitRemaining(string $key, int $maxRequests = RATE_LIMIT_WEATHER_MAX, int $windowSeconds = RATE_LIMIT_WEATHER_WINDOW): array {
-    $ip = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? 'unknown';
-    $ip = trim(explode(',', $ip)[0]);
+    // Must derive the same identity as checkRateLimit, or the
+    // X-RateLimit-* headers describe a different client's bucket
+    $ip = getRateLimitClientIp();
     
     if (!function_exists('apcu_fetch')) {
         require_once __DIR__ . '/cache-paths.php';

--- a/lib/rate-limit.php
+++ b/lib/rate-limit.php
@@ -23,13 +23,21 @@ require_once __DIR__ . '/config.php';
  * @return string Client IP, or 'unknown' when none is available
  */
 function getRateLimitClientIp(): string {
-    if (!empty($_SERVER['HTTP_CF_CONNECTING_IP'])) {
-        return trim($_SERVER['HTTP_CF_CONNECTING_IP']);
+    // Trim before testing: a whitespace-only header passes empty() and
+    // would collapse all such clients onto the md5('') bucket
+    $cfIp = trim($_SERVER['HTTP_CF_CONNECTING_IP'] ?? '');
+    if ($cfIp !== '') {
+        return $cfIp;
     }
 
-    $ip = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? 'unknown';
     // X-Forwarded-For can contain a comma-separated chain; first is the client
-    return trim(explode(',', $ip)[0]);
+    $xff = trim(explode(',', $_SERVER['HTTP_X_FORWARDED_FOR'] ?? '')[0]);
+    if ($xff !== '') {
+        return $xff;
+    }
+
+    $remoteAddr = trim($_SERVER['REMOTE_ADDR'] ?? '');
+    return $remoteAddr !== '' ? $remoteAddr : 'unknown';
 }
 
 /**

--- a/tests/Unit/RateLimitTest.php
+++ b/tests/Unit/RateLimitTest.php
@@ -37,6 +37,110 @@ class RateLimitTest extends TestCase
     }
 
     /**
+     * Restore $_SERVER IP-related keys after a test mutates them
+     */
+    private function withServerVars(array $vars, callable $fn): void
+    {
+        $keys = ['HTTP_CF_CONNECTING_IP', 'HTTP_X_FORWARDED_FOR', 'REMOTE_ADDR'];
+        $saved = [];
+        foreach ($keys as $key) {
+            $saved[$key] = $_SERVER[$key] ?? null;
+            unset($_SERVER[$key]);
+        }
+        foreach ($vars as $key => $value) {
+            $_SERVER[$key] = $value;
+        }
+
+        try {
+            $fn();
+        } finally {
+            foreach ($keys as $key) {
+                if ($saved[$key] === null) {
+                    unset($_SERVER[$key]);
+                } else {
+                    $_SERVER[$key] = $saved[$key];
+                }
+            }
+        }
+    }
+
+    /**
+     * Cloudflare's header wins even when a client supplies a spoofed
+     * X-Forwarded-For, so abusers cannot rotate rate limit buckets
+     */
+    public function testGetRateLimitClientIp_CfConnectingIpBeatsSpoofedXff()
+    {
+        $this->withServerVars([
+            'HTTP_CF_CONNECTING_IP' => '203.0.113.7',
+            'HTTP_X_FORWARDED_FOR' => '198.51.100.99, 203.0.113.7',
+            'REMOTE_ADDR' => '172.68.1.1',
+        ], function () {
+            $this->assertSame('203.0.113.7', getRateLimitClientIp());
+        });
+    }
+
+    /**
+     * Without Cloudflare the first X-Forwarded-For entry is the client
+     */
+    public function testGetRateLimitClientIp_XffFirstEntryWhenNoCfHeader()
+    {
+        $this->withServerVars([
+            'HTTP_X_FORWARDED_FOR' => ' 198.51.100.20 , 10.0.0.1',
+            'REMOTE_ADDR' => '10.0.0.1',
+        ], function () {
+            $this->assertSame('198.51.100.20', getRateLimitClientIp());
+        });
+    }
+
+    /**
+     * Direct connections fall back to the TCP source address
+     */
+    public function testGetRateLimitClientIp_RemoteAddrFallback()
+    {
+        $this->withServerVars([
+            'REMOTE_ADDR' => '192.0.2.33',
+        ], function () {
+            $this->assertSame('192.0.2.33', getRateLimitClientIp());
+        });
+    }
+
+    /**
+     * CLI and malformed requests must not fail the limiter
+     */
+    public function testGetRateLimitClientIp_UnknownWhenNothingAvailable()
+    {
+        $this->withServerVars([], function () {
+            $this->assertSame('unknown', getRateLimitClientIp());
+        });
+    }
+
+    /**
+     * checkRateLimit and getRateLimitRemaining must bucket by the same
+     * identity or the X-RateLimit-* headers describe the wrong client
+     */
+    public function testRateLimit_BucketsByCfConnectingIp()
+    {
+        $this->withServerVars([
+            'HTTP_CF_CONNECTING_IP' => '203.0.113.50',
+            'HTTP_X_FORWARDED_FOR' => '198.51.100.1',
+            'REMOTE_ADDR' => '172.68.2.2',
+        ], function () {
+            $key = 'test_cf_bucket_' . uniqid();
+            $max = 5;
+            checkRateLimit($key, $max, 60);
+            $afterFirst = getRateLimitRemaining($key, $max, 60)['remaining'];
+
+            // A different spoofed XFF must not move the client to a new bucket
+            $_SERVER['HTTP_X_FORWARDED_FOR'] = '198.51.100.2';
+            checkRateLimit($key, $max, 60);
+            $afterSecond = getRateLimitRemaining($key, $max, 60)['remaining'];
+
+            $this->assertSame($afterFirst - 1, $afterSecond,
+                'Spoofed XFF rotated the bucket despite CF-Connecting-IP being present');
+        });
+    }
+
+    /**
      * Ensures first request is allowed, establishing baseline rate limit behavior
      */
     public function testCheckRateLimit_FirstRequest()

--- a/tests/Unit/RateLimitTest.php
+++ b/tests/Unit/RateLimitTest.php
@@ -115,6 +115,27 @@ class RateLimitTest extends TestCase
     }
 
     /**
+     * Whitespace-only headers must fall through instead of bucketing
+     * every such client together on an empty identity
+     */
+    public function testGetRateLimitClientIp_WhitespaceHeadersFallThrough()
+    {
+        $this->withServerVars([
+            'HTTP_CF_CONNECTING_IP' => '   ',
+            'HTTP_X_FORWARDED_FOR' => ' , 10.0.0.1',
+            'REMOTE_ADDR' => '192.0.2.44',
+        ], function () {
+            $this->assertSame('192.0.2.44', getRateLimitClientIp());
+        });
+
+        $this->withServerVars([
+            'HTTP_X_FORWARDED_FOR' => '  ',
+        ], function () {
+            $this->assertSame('unknown', getRateLimitClientIp());
+        });
+    }
+
+    /**
      * checkRateLimit and getRateLimitRemaining must bucket by the same
      * identity or the X-RateLimit-* headers describe the wrong client
      */


### PR DESCRIPTION
## Summary

Follow-up hardening from today's map-tiles 429 investigation. The internal rate limiter (`lib/rate-limit.php`) derived its bucketing identity from the first `X-Forwarded-For` entry, which is client-supplied: Cloudflare appends the real connecting address to whatever XFF chain arrives, so the first entry is whatever the client claims. An abuser could rotate buckets indefinitely with a spoofed header, making the per-IP limit ineffective against exactly the traffic it exists for. Normal browsers were bucketed correctly, which is why today's 429s were honest (two of us testing tiles from one egress IP).

## Changes

- New `getRateLimitClientIp()` in `lib/rate-limit.php`: prefers `CF-Connecting-IP` (Cloudflare overwrites it on every proxied request, unforgeable through the CDN), then the first XFF entry, then `REMOTE_ADDR`. Same ordering the Public API's `getPublicApiClientIp()` and the embed helpers have used all along - this brings the internal limiter in line with the established pattern.
- `checkRateLimit()` and `getRateLimitRemaining()` both use the helper, guaranteeing the `X-RateLimit-*` headers describe the same bucket the limiter applied.
- The map-tiles abuse log now records the same identity the limiter bucketed by, instead of re-deriving XFF-first.
- The helper docblock carries the same warning as the Public API version: bucketing identity only, never for security decisions like first-party detection (those stay on `REMOTE_ADDR`).

## Scope check

Swept the codebase for other XFF-first usage: `lib/public-api/middleware.php` and `lib/embed-helpers.php` already prefer `CF-Connecting-IP`; the only remaining sites were the two in `lib/rate-limit.php` plus the map-tiles log line, all covered here.

## Test plan

- [x] Five new unit tests pin the precedence: CF header beats spoofed XFF, XFF first-entry parsing with whitespace, REMOTE_ADDR fallback, 'unknown' for CLI, and an end-to-end check that a spoofed XFF cannot rotate a Cloudflare-fronted client to a fresh bucket
- [x] Full `make test-ci` passes (18 tests, 57 assertions in the rate limit suite)
- [x] Local Docker smoke: map-tiles and weather endpoints serve 200 with CF and spoofed-XFF headers present