### PR TITLE
Add webcam approximate_heading to config and Public API

### DIFF
--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -1363,8 +1363,7 @@
                 "image_url",
                 "history_enabled",
                 "refresh_seconds",
-                "approximate_heading",
-                "approximate_heading_reference"
+                "approximate_heading"
               ],
               "properties": {
                 "index": {
@@ -1392,13 +1391,7 @@
                   "nullable": true,
                   "minimum": 0,
                   "maximum": 360,
-                  "description": "Direction the camera lens points, in true-north degrees (0-360). Non-null on active non-maintenance airports. Null when the airport is in maintenance or heading is not yet commissioned."
-                },
-                "approximate_heading_reference": {
-                  "type": "string",
-                  "nullable": true,
-                  "enum": ["true_north"],
-                  "description": "Reference frame for approximate_heading. true_north when approximate_heading is set; null otherwise."
+                  "description": "Direction the camera lens points, in true-north degrees clockwise from north (0-360). Non-null on active non-maintenance airports. Null when the airport is in maintenance or heading is not yet commissioned."
                 }
               }
             }

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -1357,6 +1357,15 @@
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "index",
+                "name",
+                "image_url",
+                "history_enabled",
+                "refresh_seconds",
+                "approximate_heading",
+                "approximate_heading_reference"
+              ],
               "properties": {
                 "index": {
                   "type": "integer"
@@ -1377,6 +1386,19 @@
                 },
                 "refresh_seconds": {
                   "type": "integer"
+                },
+                "approximate_heading": {
+                  "type": "integer",
+                  "nullable": true,
+                  "minimum": 0,
+                  "maximum": 360,
+                  "description": "Direction the camera lens points, in true-north degrees (0-360). Non-null on active non-maintenance airports. Null when the airport is in maintenance or heading is not yet commissioned."
+                },
+                "approximate_heading_reference": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": ["true_north"],
+                  "description": "Reference frame for approximate_heading. true_north when approximate_heading is set; null otherwise."
                 }
               }
             }

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -1362,6 +1362,7 @@
                 "name",
                 "image_url",
                 "history_enabled",
+                "history_url",
                 "refresh_seconds",
                 "approximate_heading"
               ],

--- a/api/v1/webcams.php
+++ b/api/v1/webcams.php
@@ -95,6 +95,12 @@ function formatWebcamMetadata(string $airportId, int $index, array $webcam, arra
             ? '/v1/airports/' . $airportId . '/webcams/' . $index . '/history'
             : null,
         'refresh_seconds' => $refreshSeconds,
+        'approximate_heading' => isset($webcam['approximate_heading'])
+            ? (int) $webcam['approximate_heading']
+            : null,
+        'approximate_heading_reference' => isset($webcam['approximate_heading'])
+            ? 'true_north'
+            : null,
     ];
 }
 

--- a/api/v1/webcams.php
+++ b/api/v1/webcams.php
@@ -98,9 +98,6 @@ function formatWebcamMetadata(string $airportId, int $index, array $webcam, arra
         'approximate_heading' => isset($webcam['approximate_heading'])
             ? (int) $webcam['approximate_heading']
             : null,
-        'approximate_heading_reference' => isset($webcam['approximate_heading'])
-            ? 'true_north'
-            : null,
     ];
 }
 

--- a/api/v1/webcams.php
+++ b/api/v1/webcams.php
@@ -95,9 +95,30 @@ function formatWebcamMetadata(string $airportId, int $index, array $webcam, arra
             ? '/v1/airports/' . $airportId . '/webcams/' . $index . '/history'
             : null,
         'refresh_seconds' => $refreshSeconds,
-        'approximate_heading' => isset($webcam['approximate_heading'])
-            ? (int) $webcam['approximate_heading']
-            : null,
+        'approximate_heading' => formatWebcamApproximateHeadingForApi($webcam),
     ];
+}
+
+/**
+ * Resolve approximate_heading for Public API output without unsafe coercion.
+ *
+ * Config validation requires integer 0-360, but runtime config may be stale or
+ * hand-edited. Reject non-integers and out-of-range values rather than casting.
+ *
+ * @param array $webcam Webcam configuration
+ * @return int|null Heading degrees, or null when omitted or invalid
+ */
+function formatWebcamApproximateHeadingForApi(array $webcam): ?int
+{
+    if (!array_key_exists('approximate_heading', $webcam)) {
+        return null;
+    }
+
+    $heading = $webcam['approximate_heading'];
+    if (!is_int($heading) || $heading < 0 || $heading > 360) {
+        return null;
+    }
+
+    return $heading;
 }
 

--- a/config/airports.json.example
+++ b/config/airports.json.example
@@ -213,45 +213,52 @@
         {
           "name": "North Runway Camera (MJPEG)",
           "url": "https://example.com/video.mjpg",
-          "refresh_seconds": 60
+          "refresh_seconds": 60,
+          "approximate_heading": 318
         },
         {
           "name": "South Runway Camera (MJPEG Auth)",
           "url": "https://example.com/mjpg/stream",
           "type": "mjpeg",
-          "refresh_seconds": 60
+          "refresh_seconds": 60,
+          "approximate_heading": 210
         },
         {
           "name": "West Camera (Static JPEG)",
           "url": "https://example.com/webcam.jpg",
           "type": "static_jpeg",
-          "refresh_seconds": 120
+          "refresh_seconds": 120,
+          "approximate_heading": 270
         },
         {
           "name": "East Camera (Static JPEG Auth)",
           "url": "https://example.com/webcam.jpg",
           "type": "static_jpeg",
-          "refresh_seconds": 60
+          "refresh_seconds": 60,
+          "approximate_heading": 90
         },
         {
           "name": "North-East Camera (Static PNG)",
           "url": "https://example.com/webcam.png",
           "type": "static_png",
-          "refresh_seconds": 60
+          "refresh_seconds": 60,
+          "approximate_heading": 45
         },
         {
           "name": "Runway Camera (RTSP Basic)",
           "url": "rtsp://camera.example.com:554/stream1",
           "type": "rtsp",
           "rtsp_transport": "tcp",
-          "refresh_seconds": 60
+          "refresh_seconds": 60,
+          "approximate_heading": 152
         },
         {
           "name": "Tower Camera (RTSP Auth)",
           "url": "rtsp://camera.example.com:554/stream1",
           "type": "rtsp",
           "rtsp_transport": "tcp",
-          "refresh_seconds": 60
+          "refresh_seconds": 60,
+          "approximate_heading": 180
         },
         {
           "name": "Hangar Camera (RTSP Advanced)",
@@ -261,21 +268,24 @@
           "rtsp_fetch_timeout": 10,
           "rtsp_max_runtime": 6,
           "transcode_timeout": 8,
-          "refresh_seconds": 30
+          "refresh_seconds": 30,
+          "approximate_heading": 270
         },
         {
           "name": "Field Camera (RTSP UDP)",
           "url": "rtsp://camera.example.com:554/stream1",
           "type": "rtsp",
           "rtsp_transport": "udp",
-          "refresh_seconds": 60
+          "refresh_seconds": 60,
+          "approximate_heading": 90
         },
         {
           "name": "UniFi Protect Camera (Local RTSP)",
           "url": "rtsp://192.168.1.1:7447/FKEFbCxO0CiAF3TH",
           "type": "rtsp",
           "rtsp_transport": "tcp",
-          "refresh_seconds": 60
+          "refresh_seconds": 60,
+          "approximate_heading": 315
         },
         {
           "name": "UniFi Protect Camera (Shared RTSPS)",
@@ -285,19 +295,22 @@
           "rtsp_fetch_timeout": 10,
           "rtsp_max_runtime": 6,
           "transcode_timeout": 8,
-          "refresh_seconds": 30
+          "refresh_seconds": 30,
+          "approximate_heading": 135
         },
         {
           "name": "Private Network Camera (RTSP)",
           "url": "rtsp://192.168.1.100:554/stream1",
           "type": "rtsp",
           "rtsp_transport": "tcp",
-          "refresh_seconds": 60
+          "refresh_seconds": 60,
+          "approximate_heading": 225
         },
         {
           "name": "Push Camera (Basic)",
           "type": "push",
           "refresh_seconds": 60,
+          "approximate_heading": 0,
           "push_config": {
             "username": "kspbCam0Push01",
             "password": "SecurePass1234",
@@ -309,6 +322,7 @@
           "name": "Push Camera (Full Config)",
           "type": "push",
           "refresh_seconds": 60,
+          "approximate_heading": 180,
           "push_config": {
             "username": "kspbCam1Push02",
             "password": "AnotherPass5678",
@@ -320,6 +334,7 @@
           "name": "Push Camera (Large Files)",
           "type": "push",
           "refresh_seconds": 120,
+          "approximate_heading": 90,
           "push_config": {
             "username": "kspbCam2Push03",
             "password": "SecurePass9012",
@@ -474,8 +489,8 @@
       "frequencies": {"ctaf": "122.9"},
       "services": {"repairs_available": false},
       "webcams": [
-        {"name": "North - POE", "url": "https://example.com/north.jpg"},
-        {"name": "South - POE", "url": "https://example.com/south.jpg"}
+        {"name": "North - POE", "url": "https://example.com/north.jpg", "approximate_heading": 0},
+        {"name": "South - POE", "url": "https://example.com/south.jpg", "approximate_heading": 180}
       ],
       "partners": [],
       "weather_sources": [],

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -155,6 +155,7 @@ Values are strings in MHz (e.g. `"122.8"`, `"123.05"`).
 |--------|---------|-------------|
 | **Common** |||
 | `name` | - | Display name |
+| `approximate_heading` | - | **Required** when the airport is `enabled: true` and not in `maintenance`. Integer **0**-**360**: direction the camera lens points, in **true north** degrees. Optional on maintenance or disabled airports until commissioned. Aim within ±10° when measuring (operational target, not validated). See [Guide 02](../guides/02-location-and-siting.md) (how to measure) and [Guide 08](../guides/08-camera-configuration.md) (installer checklist). |
 | `enabled` | `true` | When `false`, the slot stays in config/UI but acquisition fields such as `url`, `push_config`, and `base_url` are not required and workers do not run for this camera |
 | **Conditional** |||
 | `url` | - | Stream/image URL for pull types (`http` / `mjpeg` / `static_jpeg` / `static_png` / `rtsp`). Not used for `push` (credentials live under `push_config`) or for `aviationwx_api` (use `base_url`). Omit for `enabled: false` placeholders. |

--- a/guides/02-location-and-siting.md
+++ b/guides/02-location-and-siting.md
@@ -50,6 +50,18 @@ If you have multiple cameras, a simple, pilot-friendly recipe is:
 
 Windsock visibility is **not a priority** (wind is better captured by a local weather station).
 
+### Camera look direction (`approximate_heading`)
+AviationWX records **which way each camera points** in config as `approximate_heading`: an integer **0-360** in **true north** degrees (0 = north, 90 = east, 180 = south, 270 = west).
+
+**Naming tip:** when a camera name ends with a cardinal direction (for example `North`, `East`, `NW Facing`), that usually means **look direction** from the mount, not where the camera is mounted. `02ID - North` looks north (~0°), not "mounted on the north side."
+
+**How to measure:**
+- Stand at the camera mount (or use Google Earth from the mount point toward a landmark in the frame).
+- Record the bearing in **true north** degrees.
+- Aim within about **±10°** when you can (operational target; exact survey is not required for every field).
+
+You will enter this value in the final airport config (see Guide 08 and `docs/CONFIGURATION.md`).
+
 ### Weather station
 Place it where it reflects **field conditions** (not sheltered, not heat-soaked), while staying safe and permitted.
 

--- a/guides/08-camera-configuration.md
+++ b/guides/08-camera-configuration.md
@@ -562,6 +562,15 @@ Use this checklist when evaluating any camera for AviationWX.
 
 ---
 
+## Approximate heading (required in final config)
+Each camera needs `approximate_heading` in the airport config when the airport is **enabled** and **not in maintenance**: true-north degrees **0-360** for the direction the lens points.
+
+- Use **true north**, not magnetic (runway numbers on charts are magnetic; this field is not).
+- Measure after the mount is aimed (see Guide 02).
+- Aim within about **±10°** when possible.
+
+Full schema details: `docs/CONFIGURATION.md`.
+
 ## Decision (write it down)
 
 After configuring your camera, document these details:
@@ -571,6 +580,7 @@ After configuring your camera, document these details:
 | Item | Your Answer |
 |------|-------------|
 | Camera model(s) | |
+| Approximate heading per camera (true north, 0-360) | CAM1: ___ / CAM2: ___ / … |
 | Integration method | FTPS / SFTP / FTP / RTSP / Bridge |
 | Capture/upload interval | |
 | Resolution | |

--- a/guides/11-installation-planning-and-handoff.md
+++ b/guides/11-installation-planning-and-handoff.md
@@ -125,6 +125,7 @@ Recommended spares:
 - ☐ Identify the primary local maintainer and a backup contact
 - ☐ Document how to access equipment (keys, escort rules, contact numbers)
 - ☐ Document how to verify the system is healthy (simple "green checks")
+- ☐ Record **approximate heading** per camera after mount (true north, 0-360; Guide 02)
 - ☐ Document how to reboot safely (what to power-cycle first)
 - ☐ Document who pays for ongoing costs (LTE plan, Starlink, etc.)
 - ☐ Store credentials and configuration in a shared, controlled location
@@ -133,7 +134,7 @@ Recommended spares:
 ### Minimal documentation template (copy/paste)
 - **Airport:** ________
 - **Location(s):** ________
-- **Cameras:** CAM1 (model) ________ / CAM2 ________ / …
+- **Cameras:** CAM1 (model) ________ heading: ___ / CAM2 ________ heading: ___ / …
 - **Weather station:** ________
 - **Power:** ________
 - **Internet:** ________

--- a/guides/12-submit-an-airport-to-aviationwx.md
+++ b/guides/12-submit-an-airport-to-aviationwx.md
@@ -154,6 +154,7 @@ This is the simplest and usually produces the best still-image quality.
 - Camera brand + model (example: Reolink RLC‑810WA)
 - "I want scheduled JPEG uploads" (FTP/FTPs/SFTP)
 - Desired upload interval (start at 5 minutes unless you have a reason not to)
+- **Approximate look direction per camera** (true north degrees 0-360; see Guide 02)
 
 **What happens next**
 - AviationWX will reply with the **upload destination details** (server/port/username/path), so you can configure the camera.
@@ -169,11 +170,13 @@ https://support.reolink.com/hc/en-us/articles/360020081034-How-to-Set-up-FTP-for
 - Camera brand + model
 - RTSP URL (or enough info for us to derive it)
 - A dedicated camera user + password (ideally a **view-only** account created specifically for AviationWX)
+- **Approximate look direction** (true north degrees 0-360; see Guide 02)
 
 ### Option C - Snapshot URL (HTTP/HTTPS)
 **What to send**
 - Snapshot URL
 - Any credentials required (again: a dedicated "AviationWX" view-only account is ideal)
+- **Approximate look direction** (true north degrees 0-360; see Guide 02)
 
 > Security note: please do **not** send your personal admin login if you can avoid it. When possible, create a dedicated read-only account for the camera/stream and share that instead.
 
@@ -184,6 +187,7 @@ After you email us, we'll validate:
 
 ### Camera validation
 - The view is useful for pilots (see Guide 02: horizon + runway/approach context)
+- **Approximate heading** is recorded per camera in config (required before go-live)
 - Image is readable in common conditions (overcast, rain, fog, sunrise/sunset)
 - Updates arrive reliably (and recover after outages)
 - The install respects permission + privacy expectations (Guide 01)
@@ -224,6 +228,7 @@ Body:
 - Number of cameras:
 - Method: FTP/FTPs/SFTP (preferred) / RTSP / Snapshot URL
 - Camera models:
+- Approximate heading per camera (true north, 0-360):
 - Details (RTSP URL, snapshot URL, or request for FTP destination):
 
 Attachments:

--- a/guides/14-self-hosting-and-federation.md
+++ b/guides/14-self-hosting-and-federation.md
@@ -346,7 +346,8 @@ Example single-airport config:
           "name": "Runway 27",
           "url": "rtsp://camera.local/stream1",
           "type": "rtsp",
-          "refresh_seconds": 60
+          "refresh_seconds": 60,
+          "approximate_heading": 270
         }
       ]
     }

--- a/lib/config.php
+++ b/lib/config.php
@@ -2954,11 +2954,11 @@ function validateWebcamApproximateHeading(
     $label = "Airport '{$airportCode}' webcam[{$idx}]";
 
     if ($requiresHeading) {
-        if (!isset($webcam['approximate_heading'])) {
+        if (!array_key_exists('approximate_heading', $webcam)) {
             $errors[] = "{$label} missing required 'approximate_heading' (airport is enabled and not in maintenance)";
             return $errors;
         }
-    } elseif (!isset($webcam['approximate_heading'])) {
+    } elseif (!array_key_exists('approximate_heading', $webcam)) {
         return $errors;
     }
 

--- a/lib/config.php
+++ b/lib/config.php
@@ -2932,6 +2932,45 @@ function isAirportInMaintenance(array $airport): bool {
 }
 
 /**
+ * Validate approximate_heading on a webcam when present or required by airport state.
+ *
+ * Required when the airport is enabled and not in maintenance. Optional on disabled or
+ * maintenance airports; when present, range and type are still validated.
+ *
+ * @param array $webcam Webcam configuration
+ * @param array $airport Parent airport configuration
+ * @param string $airportCode Airport identifier for error messages
+ * @param int $idx Webcam index for error messages
+ * @return array Validation error strings
+ */
+function validateWebcamApproximateHeading(
+    array $webcam,
+    array $airport,
+    string $airportCode,
+    int $idx
+): array {
+    $errors = [];
+    $requiresHeading = isAirportEnabled($airport) && !isAirportInMaintenance($airport);
+    $label = "Airport '{$airportCode}' webcam[{$idx}]";
+
+    if ($requiresHeading) {
+        if (!isset($webcam['approximate_heading'])) {
+            $errors[] = "{$label} missing required 'approximate_heading' (airport is enabled and not in maintenance)";
+            return $errors;
+        }
+    } elseif (!isset($webcam['approximate_heading'])) {
+        return $errors;
+    }
+
+    $heading = $webcam['approximate_heading'];
+    if (!is_int($heading) || $heading < 0 || $heading > 360) {
+        $errors[] = "{$label} has invalid approximate_heading: must be integer 0-360";
+    }
+
+    return $errors;
+}
+
+/**
  * Check if an airport is unlisted (hidden from discovery)
  * 
  * Returns true only if `unlisted` is explicitly set to true.
@@ -4804,10 +4843,10 @@ function validateAirportsJsonStructure(array $config): array {
                         // Still reject unknown top-level keys so typos cannot slip through (e.g. refesh_seconds)
                         if ($skipAcquisitionValidation) {
                             $allowedDisabledWebcamFields = [
-                                'api_key', 'base_url', 'camera_index', 'crop_margins', 'enabled', 'name',
-                                'push_config', 'refresh_seconds', 'rtsp_fetch_timeout', 'rtsp_max_runtime',
-                                'rtsp_transport', 'timeout_seconds', 'transcode_timeout', 'type', 'url',
-                                'variant_heights',
+                                'api_key', 'approximate_heading', 'base_url', 'camera_index', 'crop_margins',
+                                'enabled', 'name', 'push_config', 'refresh_seconds', 'rtsp_fetch_timeout',
+                                'rtsp_max_runtime', 'rtsp_transport', 'timeout_seconds', 'transcode_timeout',
+                                'type', 'url', 'variant_heights',
                             ];
                             foreach ($webcam as $key => $_val) {
                                 if (!in_array($key, $allowedDisabledWebcamFields, true)) {
@@ -4822,7 +4861,10 @@ function validateAirportsJsonStructure(array $config): array {
                         
                         if ($webcamType === 'push') {
                             // Define allowed fields for push cameras
-                            $allowedPushWebcamFields = ['name', 'type', 'push_config', 'refresh_seconds', 'variant_heights', 'crop_margins', 'enabled'];
+                            $allowedPushWebcamFields = [
+                                'name', 'type', 'push_config', 'refresh_seconds', 'variant_heights',
+                                'crop_margins', 'enabled', 'approximate_heading',
+                            ];
                             
                             // Check for unknown fields in push webcam
                             foreach ($webcam as $key => $value) {
@@ -4880,7 +4922,11 @@ function validateAirportsJsonStructure(array $config): array {
                             }
                         } elseif ($webcamType === 'rtsp') {
                             // Define allowed fields for RTSP cameras
-                            $allowedRtspWebcamFields = ['name', 'type', 'url', 'rtsp_transport', 'refresh_seconds', 'rtsp_fetch_timeout', 'rtsp_max_runtime', 'transcode_timeout', 'variant_heights', 'crop_margins', 'enabled'];
+                            $allowedRtspWebcamFields = [
+                                'name', 'type', 'url', 'rtsp_transport', 'refresh_seconds',
+                                'rtsp_fetch_timeout', 'rtsp_max_runtime', 'transcode_timeout',
+                                'variant_heights', 'crop_margins', 'enabled', 'approximate_heading',
+                            ];
                             
                             // Check for unknown fields in RTSP webcam
                             foreach ($webcam as $key => $value) {
@@ -4898,7 +4944,8 @@ function validateAirportsJsonStructure(array $config): array {
                         } elseif ($webcamType === 'aviationwx_api') {
                             $allowedFederatedWebcamFields = [
                                 'name', 'type', 'base_url', 'api_key', 'timeout_seconds',
-                                'camera_index', 'refresh_seconds', 'variant_heights', 'crop_margins', 'enabled',
+                                'camera_index', 'refresh_seconds', 'variant_heights', 'crop_margins',
+                                'enabled', 'approximate_heading',
                             ];
                             foreach ($webcam as $key => $value) {
                                 if (!in_array($key, $allowedFederatedWebcamFields, true)) {
@@ -4924,7 +4971,10 @@ function validateAirportsJsonStructure(array $config): array {
                             }
                         } else {
                             // Define allowed fields for pull cameras (http/mjpeg/static_jpeg/static_png)
-                            $allowedPullWebcamFields = ['name', 'type', 'url', 'refresh_seconds', 'variant_heights', 'crop_margins', 'enabled'];
+                            $allowedPullWebcamFields = [
+                                'name', 'type', 'url', 'refresh_seconds', 'variant_heights',
+                                'crop_margins', 'enabled', 'approximate_heading',
+                            ];
                             
                             // Check for unknown fields in pull webcam
                             foreach ($webcam as $key => $value) {
@@ -4973,6 +5023,14 @@ function validateAirportsJsonStructure(array $config): array {
                             );
                             $errors = array_merge($errors, $marginErrors);
                         }
+
+                        $headingErrors = validateWebcamApproximateHeading(
+                            $webcam,
+                            $airport,
+                            $airportCode,
+                            $idx
+                        );
+                        $errors = array_merge($errors, $headingErrors);
                     }
                 }
             }

--- a/tests/Fixtures/airports.json.test
+++ b/tests/Fixtures/airports.json.test
@@ -74,7 +74,8 @@
       "webcams": [
         {
           "name": "Test Camera 1",
-          "url": "https://example.com/cam1.jpg"
+          "url": "https://example.com/cam1.jpg",
+          "approximate_heading": 318
         }
       ],
       "runways": [

--- a/tests/Integration/PublicApiWebcamTest.php
+++ b/tests/Integration/PublicApiWebcamTest.php
@@ -498,9 +498,8 @@ class PublicApiWebcamTest extends TestCase
 
         foreach ($webcams as $webcam) {
             $this->assertArrayHasKey('approximate_heading', $webcam);
-            $this->assertArrayHasKey('approximate_heading_reference', $webcam);
+            $this->assertArrayNotHasKey('approximate_heading_reference', $webcam);
             $this->assertIsInt($webcam['approximate_heading']);
-            $this->assertSame('true_north', $webcam['approximate_heading_reference']);
             $this->assertArrayHasKey('image_url', $webcam);
         }
     }
@@ -527,9 +526,8 @@ class PublicApiWebcamTest extends TestCase
 
         foreach ($webcams as $webcam) {
             $this->assertArrayHasKey('approximate_heading', $webcam);
-            $this->assertArrayHasKey('approximate_heading_reference', $webcam);
+            $this->assertArrayNotHasKey('approximate_heading_reference', $webcam);
             $this->assertNull($webcam['approximate_heading']);
-            $this->assertNull($webcam['approximate_heading_reference']);
         }
     }
 

--- a/tests/Integration/PublicApiWebcamTest.php
+++ b/tests/Integration/PublicApiWebcamTest.php
@@ -473,4 +473,81 @@ class PublicApiWebcamTest extends TestCase
         $this->assertEquals(count($frames), $frameCount,
             'Frame count in meta should match actual frames array length');
     }
+
+    /**
+     * GET /v1/airports/{id}/webcams returns approximate_heading on active airports.
+     */
+    public function testListWebcams_IncludesApproximateHeadingOnActiveAirport(): void
+    {
+        $response = $this->apiRequest('/airports/' . self::$testAirport . '/webcams');
+
+        if ($response['status'] === 0) {
+            $this->markTestSkipped('Web server not available at ' . self::$apiBaseUrl);
+        }
+
+        if ($response['status'] === 429) {
+            $this->markTestSkipped('Rate limited - test requires API key');
+        }
+
+        $this->assertEquals(200, $response['status'], 'Webcam list should return 200');
+
+        $data = $response['json'];
+        $this->assertTrue($data['success'] ?? false);
+        $webcams = $data['webcams'] ?? [];
+        $this->assertNotEmpty($webcams, 'kspb fixture should have webcams');
+
+        foreach ($webcams as $webcam) {
+            $this->assertArrayHasKey('approximate_heading', $webcam);
+            $this->assertArrayHasKey('approximate_heading_reference', $webcam);
+            $this->assertIsInt($webcam['approximate_heading']);
+            $this->assertSame('true_north', $webcam['approximate_heading_reference']);
+            $this->assertArrayHasKey('image_url', $webcam);
+        }
+    }
+
+    /**
+     * Maintenance airports may return null approximate_heading when not configured.
+     */
+    public function testListWebcams_NullHeadingOnMaintenanceAirport(): void
+    {
+        $response = $this->apiRequest('/airports/pdx/webcams');
+
+        if ($response['status'] === 0) {
+            $this->markTestSkipped('Web server not available at ' . self::$apiBaseUrl);
+        }
+
+        if ($response['status'] === 429) {
+            $this->markTestSkipped('Rate limited - test requires API key');
+        }
+
+        $this->assertEquals(200, $response['status']);
+
+        $webcams = $response['json']['webcams'] ?? [];
+        $this->assertNotEmpty($webcams);
+
+        foreach ($webcams as $webcam) {
+            $this->assertArrayHasKey('approximate_heading', $webcam);
+            $this->assertArrayHasKey('approximate_heading_reference', $webcam);
+            $this->assertNull($webcam['approximate_heading']);
+            $this->assertNull($webcam['approximate_heading_reference']);
+        }
+    }
+
+    /**
+     * Disabled airports are not served by the Public API.
+     */
+    public function testListWebcams_DisabledAirportReturns404(): void
+    {
+        $response = $this->apiRequest('/airports/ksea/webcams');
+
+        if ($response['status'] === 0) {
+            $this->markTestSkipped('Web server not available at ' . self::$apiBaseUrl);
+        }
+
+        if ($response['status'] === 429) {
+            $this->markTestSkipped('Rate limited - test requires API key');
+        }
+
+        $this->assertEquals(404, $response['status']);
+    }
 }

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -1627,6 +1627,224 @@ class ConfigValidationTest extends TestCase
     }
 
     /**
+     * approximate_heading is required on enabled, non-maintenance airports.
+     */
+    public function testWebcam_ApproximateHeading_RequiredOnEnabledAirport(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'enabled' => true,
+                    'maintenance' => false,
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Test Camera',
+                            'url' => 'https://example.com/cam.jpg',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString("missing required 'approximate_heading'", implode(' ', $result['errors']));
+    }
+
+    public function testWebcam_ApproximateHeading_ValidOnEnabledAirport(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'enabled' => true,
+                    'maintenance' => false,
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Test Camera',
+                            'url' => 'https://example.com/cam.jpg',
+                            'approximate_heading' => 90,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], implode(' ', $result['errors'] ?? []));
+    }
+
+    public function testWebcam_ApproximateHeading_OptionalOnMaintenanceAirport(): void
+    {
+        $config = [
+            'airports' => [
+                'pdx' => [
+                    'name' => 'Maintenance Airport',
+                    'enabled' => true,
+                    'maintenance' => true,
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Test Camera',
+                            'url' => 'https://example.com/cam.jpg',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], implode(' ', $result['errors'] ?? []));
+    }
+
+    public function testWebcam_ApproximateHeading_OptionalOnDisabledAirport(): void
+    {
+        $config = [
+            'airports' => [
+                'ksea' => [
+                    'name' => 'Disabled Airport',
+                    'enabled' => false,
+                    'lat' => 47.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Test Camera',
+                            'url' => 'https://example.com/cam.jpg',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], implode(' ', $result['errors'] ?? []));
+    }
+
+    public function testWebcam_ApproximateHeading_InvalidRange(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'enabled' => true,
+                    'maintenance' => false,
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Test Camera',
+                            'url' => 'https://example.com/cam.jpg',
+                            'approximate_heading' => 361,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('invalid approximate_heading', implode(' ', $result['errors']));
+    }
+
+    public function testWebcam_ApproximateHeading_RejectsStringValue(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'enabled' => true,
+                    'maintenance' => false,
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Test Camera',
+                            'url' => 'https://example.com/cam.jpg',
+                            'approximate_heading' => '180',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('invalid approximate_heading', implode(' ', $result['errors']));
+    }
+
+    public function testWebcam_ApproximateHeading_RequiredOnDisabledPlaceholderSlot(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'enabled' => true,
+                    'maintenance' => false,
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Reserved slot',
+                            'enabled' => false,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString("missing required 'approximate_heading'", implode(' ', $result['errors']));
+    }
+
+    public function testWebcam_ApproximateHeading_ValidOnDisabledPlaceholderSlotWhenSet(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'enabled' => true,
+                    'maintenance' => false,
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Reserved slot',
+                            'enabled' => false,
+                            'approximate_heading' => 270,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], implode(' ', $result['errors'] ?? []));
+    }
+
+    /**
      * Test weather source validation - Valid configurations
      */
     public function testWeatherSource_ValidTempest()

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -1734,6 +1734,34 @@ class ConfigValidationTest extends TestCase
         $this->assertTrue($result['valid'], implode(' ', $result['errors'] ?? []));
     }
 
+    public function testWebcam_ApproximateHeading_RejectsExplicitNullOnMaintenanceAirport(): void
+    {
+        $config = [
+            'airports' => [
+                'pdx' => [
+                    'name' => 'Maintenance Airport',
+                    'enabled' => true,
+                    'maintenance' => true,
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Test Camera',
+                            'url' => 'https://example.com/cam.jpg',
+                            'approximate_heading' => null,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('invalid approximate_heading', implode(' ', $result['errors']));
+    }
+
     public function testWebcam_ApproximateHeading_InvalidRange(): void
     {
         $config = [

--- a/tests/Unit/PublicApiWebcamMetadataTest.php
+++ b/tests/Unit/PublicApiWebcamMetadataTest.php
@@ -33,9 +33,8 @@ class PublicApiWebcamMetadataTest extends TestCase
         $formatted = formatWebcamMetadata('kspb', 0, $webcam, $airport);
 
         $this->assertArrayHasKey('approximate_heading', $formatted);
-        $this->assertArrayHasKey('approximate_heading_reference', $formatted);
+        $this->assertArrayNotHasKey('approximate_heading_reference', $formatted);
         $this->assertSame(90, $formatted['approximate_heading']);
-        $this->assertSame('true_north', $formatted['approximate_heading_reference']);
     }
 
     public function testFormatWebcamMetadata_NullHeadingWhenOmitted(): void
@@ -54,12 +53,11 @@ class PublicApiWebcamMetadataTest extends TestCase
         $formatted = formatWebcamMetadata('pdx', 0, $webcam, $airport);
 
         $this->assertArrayHasKey('approximate_heading', $formatted);
-        $this->assertArrayHasKey('approximate_heading_reference', $formatted);
+        $this->assertArrayNotHasKey('approximate_heading_reference', $formatted);
         $this->assertNull($formatted['approximate_heading']);
-        $this->assertNull($formatted['approximate_heading_reference']);
     }
 
-    public function testFormatWebcamMetadata_AlwaysIncludesHeadingKeys(): void
+    public function testFormatWebcamMetadata_AlwaysIncludesHeadingKey(): void
     {
         self::loadFormatWebcamMetadata();
 
@@ -69,7 +67,7 @@ class PublicApiWebcamMetadataTest extends TestCase
         $formatted = formatWebcamMetadata('kspb', 0, $webcam, $airport);
 
         $this->assertArrayHasKey('approximate_heading', $formatted);
-        $this->assertArrayHasKey('approximate_heading_reference', $formatted);
+        $this->assertArrayNotHasKey('approximate_heading_reference', $formatted);
         $this->assertArrayHasKey('image_url', $formatted);
         $this->assertSame('/v1/airports/kspb/webcams/0/image', $formatted['image_url']);
     }

--- a/tests/Unit/PublicApiWebcamMetadataTest.php
+++ b/tests/Unit/PublicApiWebcamMetadataTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Unit tests for Public API webcam list metadata formatting.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class PublicApiWebcamMetadataTest extends TestCase
+{
+    private static function loadFormatWebcamMetadata(): void
+    {
+        static $loaded = false;
+        if (!$loaded) {
+            require_once __DIR__ . '/../../lib/config.php';
+            require_once __DIR__ . '/../../api/v1/webcams.php';
+            $loaded = true;
+        }
+    }
+
+    public function testFormatWebcamMetadata_IncludesHeadingWhenConfigured(): void
+    {
+        self::loadFormatWebcamMetadata();
+
+        $airport = [
+            'enabled' => true,
+            'maintenance' => false,
+        ];
+        $webcam = [
+            'name' => 'East Camera',
+            'approximate_heading' => 90,
+        ];
+
+        $formatted = formatWebcamMetadata('kspb', 0, $webcam, $airport);
+
+        $this->assertArrayHasKey('approximate_heading', $formatted);
+        $this->assertArrayHasKey('approximate_heading_reference', $formatted);
+        $this->assertSame(90, $formatted['approximate_heading']);
+        $this->assertSame('true_north', $formatted['approximate_heading_reference']);
+    }
+
+    public function testFormatWebcamMetadata_NullHeadingWhenOmitted(): void
+    {
+        self::loadFormatWebcamMetadata();
+
+        $airport = [
+            'enabled' => true,
+            'maintenance' => true,
+        ];
+        $webcam = [
+            'name' => 'Maintenance Camera',
+            'url' => 'https://example.com/cam.jpg',
+        ];
+
+        $formatted = formatWebcamMetadata('pdx', 0, $webcam, $airport);
+
+        $this->assertArrayHasKey('approximate_heading', $formatted);
+        $this->assertArrayHasKey('approximate_heading_reference', $formatted);
+        $this->assertNull($formatted['approximate_heading']);
+        $this->assertNull($formatted['approximate_heading_reference']);
+    }
+
+    public function testFormatWebcamMetadata_AlwaysIncludesHeadingKeys(): void
+    {
+        self::loadFormatWebcamMetadata();
+
+        $airport = ['enabled' => true, 'maintenance' => false];
+        $webcam = ['name' => 'Camera'];
+
+        $formatted = formatWebcamMetadata('kspb', 0, $webcam, $airport);
+
+        $this->assertArrayHasKey('approximate_heading', $formatted);
+        $this->assertArrayHasKey('approximate_heading_reference', $formatted);
+        $this->assertArrayHasKey('image_url', $formatted);
+        $this->assertSame('/v1/airports/kspb/webcams/0/image', $formatted['image_url']);
+    }
+}

--- a/tests/Unit/PublicApiWebcamMetadataTest.php
+++ b/tests/Unit/PublicApiWebcamMetadataTest.php
@@ -75,4 +75,36 @@ class PublicApiWebcamMetadataTest extends TestCase
         $this->assertArrayHasKey('image_url', $formatted);
         $this->assertSame('/v1/airports/kspb/webcams/0/image', $formatted['image_url']);
     }
+
+    public function testFormatWebcamMetadata_NullHeadingForNonIntegerValue(): void
+    {
+        self::loadFormatWebcamMetadata();
+
+        $airport = ['enabled' => true, 'maintenance' => false];
+        $webcam = [
+            'name' => 'Camera',
+            'approximate_heading' => 90.5,
+        ];
+
+        $formatted = formatWebcamMetadata('kspb', 0, $webcam, $airport);
+
+        $this->assertArrayHasKey('approximate_heading', $formatted);
+        $this->assertNull($formatted['approximate_heading']);
+    }
+
+    public function testFormatWebcamMetadata_NullHeadingForNumericString(): void
+    {
+        self::loadFormatWebcamMetadata();
+
+        $airport = ['enabled' => true, 'maintenance' => false];
+        $webcam = [
+            'name' => 'Camera',
+            'approximate_heading' => '180',
+        ];
+
+        $formatted = formatWebcamMetadata('kspb', 0, $webcam, $airport);
+
+        $this->assertArrayHasKey('approximate_heading', $formatted);
+        $this->assertNull($formatted['approximate_heading']);
+    }
 }

--- a/tests/Unit/PublicApiWebcamMetadataTest.php
+++ b/tests/Unit/PublicApiWebcamMetadataTest.php
@@ -62,12 +62,16 @@ class PublicApiWebcamMetadataTest extends TestCase
         self::loadFormatWebcamMetadata();
 
         $airport = ['enabled' => true, 'maintenance' => false];
-        $webcam = ['name' => 'Camera'];
+        $webcam = [
+            'name' => 'Camera',
+            'approximate_heading' => 318,
+        ];
 
         $formatted = formatWebcamMetadata('kspb', 0, $webcam, $airport);
 
         $this->assertArrayHasKey('approximate_heading', $formatted);
         $this->assertArrayNotHasKey('approximate_heading_reference', $formatted);
+        $this->assertSame(318, $formatted['approximate_heading']);
         $this->assertArrayHasKey('image_url', $formatted);
         $this->assertSame('/v1/airports/kspb/webcams/0/image', $formatted['image_url']);
     }

--- a/tests/Unit/PublicApiWebcamMetadataTest.php
+++ b/tests/Unit/PublicApiWebcamMetadataTest.php
@@ -72,6 +72,7 @@ class PublicApiWebcamMetadataTest extends TestCase
         $this->assertArrayHasKey('approximate_heading', $formatted);
         $this->assertArrayNotHasKey('approximate_heading_reference', $formatted);
         $this->assertSame(318, $formatted['approximate_heading']);
+        $this->assertArrayHasKey('history_url', $formatted);
         $this->assertArrayHasKey('image_url', $formatted);
         $this->assertSame('/v1/airports/kspb/webcams/0/image', $formatted['image_url']);
     }


### PR DESCRIPTION
## Summary

I need each webcam to record which way it points so third-party clients can sync our catalog (`GET /v1/airports` → `GET /v1/airports/{id}/webcams`) and orient images on their maps. This PR adds `approximate_heading` end to end:

- **Config:** required integer 0-360 (true north) when an airport is `enabled: true` and not in `maintenance`; optional on disabled or maintenance airports until commissioned.
- **Public API:** `GET /v1/airports/{id}/webcams` always returns the `approximate_heading` key on each list item (integer on active airports, `null` on maintenance when omitted). Values are true-north degrees only - no separate reference field.
- **Docs:** CONFIGURATION.md, OpenAPI, and installer guides (02, 08, 11, 12, 14).

Not on `?metadata=1` image responses - heading stays on the list metadata endpoint with `image_url`.

## Breaking change (scoped)

Taking an airport out of maintenance or enabling it requires every `webcams[]` entry (including `enabled: false` placeholder slots) to have a valid `approximate_heading`.

## Production deploy order

1. Merge and deploy **aviationwx-secrets** PR (headings for 61 active webcams) first.
2. Then merge this PR.

## Related

- Secrets PR: `aviationwx-secrets` branch `feature/webcam-approximate-heading` (merge before this for production)
- Config generator removal is a **separate PR** on `remove-config-generator` (no dependency)

## Code changes

| Area | Files |
|------|-------|
| Validation | `lib/config.php` - `validateWebcamApproximateHeading()`, all webcam allowlists |
| Public API | `api/v1/webcams.php` - `formatWebcamMetadata()` |
| OpenAPI | `api/docs/openapi.json` - required nullable contract on list items |
| Fixtures / example | `tests/Fixtures/airports.json.test`, `config/airports.json.example` |
| Tests | `ConfigValidationTest`, `PublicApiWebcamMetadataTest`, integration list tests |

## Test plan

- [x] `make test-ci`
- [x] After secrets deploy: smoke `GET /v1/airports/kspb/webcams` - non-null heading on each camera
- [x] `GET /v1/airports/pdx/webcams` - `approximate_heading` key present, null values (maintenance fixture)