### PR TITLE
Fix upload health probe provisioning after container restart

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -774,8 +774,8 @@ echo "All services started successfully"
 # Runs in background so Apache startup is not blocked; upload-probe-runner waits for completion.
 echo "Syncing FTP/SFTP/FTPS configuration (background)..."
 (cd /var/www/html && timeout 30 /usr/local/bin/php scripts/sync-push-config.php > /tmp/sync-push-config.log 2>&1 && \
-    echo "✓ FTP/SFTP/FTPS configuration synced successfully" || \
-    echo "⚠️  Warning: FTP/SFTP/FTPS configuration sync failed or timed out (check /tmp/sync-push-config.log)") &
+    echo "✓ FTP/SFTP/FTPS configuration synced successfully" >> /tmp/sync-push-config.log || \
+    echo "⚠️  Warning: FTP/SFTP/FTPS configuration sync failed or timed out (check /tmp/sync-push-config.log)" >> /tmp/sync-push-config.log) &
 SYNC_PID=$!
 
 # Start upload probe runner (30s) and service watchdog (50s loop) in background

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -770,6 +770,14 @@ fi
 
 echo "All services started successfully"
 
+# Sync FTP/SFTP/FTPS configuration before upload probes (probe accounts live in /etc).
+# Runs in background so Apache startup is not blocked; upload-probe-runner waits for completion.
+echo "Syncing FTP/SFTP/FTPS configuration (background)..."
+(cd /var/www/html && timeout 30 /usr/local/bin/php scripts/sync-push-config.php > /tmp/sync-push-config.log 2>&1 && \
+    echo "✓ FTP/SFTP/FTPS configuration synced successfully" || \
+    echo "⚠️  Warning: FTP/SFTP/FTPS configuration sync failed or timed out (check /tmp/sync-push-config.log)") &
+SYNC_PID=$!
+
 # Start upload probe runner (30s) and service watchdog (50s loop) in background
 echo "Starting upload health probe runner..."
 /usr/local/libexec/aviationwx/upload-probe-runner.sh &
@@ -867,19 +875,6 @@ fi
 
 # Trap signals to clean up fail2ban on exit
 trap "kill $WATCHDOG_PID $FAIL2BAN_PID 2>/dev/null || true" EXIT
-
-# Sync FTP/SFTP/FTPS configuration on container startup
-# This ensures users and directories are created/updated when container starts
-# Runs as root to write to /etc/vsftpd/ and create system users
-# Run in background to avoid blocking Apache startup (non-critical for web service)
-echo "Syncing FTP/SFTP/FTPS configuration (background)..."
-(cd /var/www/html && timeout 30 /usr/local/bin/php scripts/sync-push-config.php > /tmp/sync-push-config.log 2>&1 && \
-    echo "✓ FTP/SFTP/FTPS configuration synced successfully" || \
-    echo "⚠️  Warning: FTP/SFTP/FTPS configuration sync failed or timed out (check /tmp/sync-push-config.log)") &
-SYNC_PID=$!
-
-# Don't wait for sync to complete - Apache can start immediately
-# The sync will complete in background, and if it fails, it will retry on next startup
 
 # Configure Apache port and bind address based on environment
 # Production (APP_ENV=production): Listen on 127.0.0.1:8080 (internal, behind nginx)

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -773,7 +773,8 @@ echo "All services started successfully"
 # Sync FTP/SFTP/FTPS configuration before upload probes (probe accounts live in /etc).
 # Runs in background so Apache startup is not blocked; upload-probe-runner waits for completion.
 echo "Syncing FTP/SFTP/FTPS configuration (background)..."
-(cd /var/www/html && timeout 30 /usr/local/bin/php scripts/sync-push-config.php > /tmp/sync-push-config.log 2>&1 && \
+: > /tmp/sync-push-config.log
+(cd /var/www/html && timeout 30 /usr/local/bin/php scripts/sync-push-config.php >> /tmp/sync-push-config.log 2>&1 && \
     echo "✓ FTP/SFTP/FTPS configuration synced successfully" >> /tmp/sync-push-config.log || \
     echo "⚠️  Warning: FTP/SFTP/FTPS configuration sync failed or timed out (check /tmp/sync-push-config.log)" >> /tmp/sync-push-config.log) &
 SYNC_PID=$!

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -773,7 +773,7 @@ echo "All services started successfully"
 # Sync FTP/SFTP/FTPS configuration before upload probes (probe accounts live in /etc).
 # Runs in background so Apache startup is not blocked; upload-probe-runner waits for completion.
 echo "Syncing FTP/SFTP/FTPS configuration (background)..."
-: > /tmp/sync-push-config.log
+: > /tmp/sync-push-config.log || echo "Warning: could not truncate /tmp/sync-push-config.log"
 (cd /var/www/html && timeout 30 /usr/local/bin/php scripts/sync-push-config.php >> /tmp/sync-push-config.log 2>&1 && \
     echo "✓ FTP/SFTP/FTPS configuration synced successfully" >> /tmp/sync-push-config.log || \
     echo "⚠️  Warning: FTP/SFTP/FTPS configuration sync failed or timed out (check /tmp/sync-push-config.log)" >> /tmp/sync-push-config.log) &

--- a/lib/cache-paths.php
+++ b/lib/cache-paths.php
@@ -454,6 +454,19 @@ function getUploadHealthProbeFtpDir(string $username): string {
 }
 
 /**
+ * Whether a top-level FTP upload cache directory basename is reserved for upload health probes.
+ *
+ * cleanup-cache.php must preserve this tree even when empty (vsftpd local_root).
+ */
+function isUploadHealthProbeFtpCacheNamespace(string $basename): bool {
+    if (!defined('UPLOAD_HEALTH_PROBE_FTP_NAMESPACE')) {
+        require_once __DIR__ . '/constants.php';
+    }
+
+    return strtolower($basename) === strtolower(UPLOAD_HEALTH_PROBE_FTP_NAMESPACE);
+}
+
+/**
  * Get SFTP chroot directory for a push webcam
  * 
  * This is the SFTP chroot directory (root-owned, not writable).

--- a/lib/cache-paths.php
+++ b/lib/cache-paths.php
@@ -19,7 +19,8 @@
  * │       ├── pull_metadata.json   # Pull cameras: ETag + checksum for conditional/unchanged skip
  * │       └── state.json           # Push webcam state (last_processed)
  * ├── ftp/
- * │   └── {airport}/{username}/    # FTP uploads (ftp:www-data 2775)
+ * │   ├── {airport}/{username}/    # FTP uploads (ftp:www-data 2775)
+ * │   └── {namespace}/{username}/  # Upload health probe only (UPLOAD_HEALTH_PROBE_FTP_NAMESPACE)
  * 
  * SFTP uploads are stored separately in /var/sftp/ (not under cache/)
  * because SSH chroot requires ALL parent directories to be root-owned.
@@ -436,6 +437,20 @@ if (!defined('CACHE_SFTP_DIR')) {
  */
 function getWebcamFtpUploadDir(string $airportId, string $username): string {
     return CACHE_UPLOADS_DIR . '/' . strtolower($airportId) . '/' . $username;
+}
+
+/**
+ * FTP local_root for upload health probe accounts (isolated from camera inboxes).
+ *
+ * @param string $username Probe FTPS username from config.upload_health_probe.ftps
+ * @return string Full path to probe-only FTP directory
+ */
+function getUploadHealthProbeFtpDir(string $username): string {
+    if (!defined('UPLOAD_HEALTH_PROBE_FTP_NAMESPACE')) {
+        require_once __DIR__ . '/constants.php';
+    }
+
+    return CACHE_UPLOADS_DIR . '/' . UPLOAD_HEALTH_PROBE_FTP_NAMESPACE . '/' . $username;
 }
 
 /**

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -1175,6 +1175,9 @@ if (!defined('UPLOAD_HEALTH_PROBE_WATCHDOG_LOOP_SEC')) {
 if (!defined('UPLOAD_HEALTH_PROBE_FILE_PREFIX')) {
     define('UPLOAD_HEALTH_PROBE_FILE_PREFIX', 'aviationwx-probe-');
 }
+if (!defined('UPLOAD_HEALTH_PROBE_FTP_NAMESPACE')) {
+    define('UPLOAD_HEALTH_PROBE_FTP_NAMESPACE', '_probe');
+}
 
 // Push FTP/SFTP credentials (push_config and upload_health_probe)
 if (!defined('PUSH_UPLOAD_USERNAME_MAX_LENGTH')) {

--- a/lib/push-webcam-validator.php
+++ b/lib/push-webcam-validator.php
@@ -182,8 +182,10 @@ function validateUniquePushUsernames($config) {
                 $normalized = strtolower($username);
                 
                 if (isset($usernames[$normalized])) {
-                    $duplicates[$username][] = $key;
-                    $duplicates[$username][] = $usernames[$normalized];
+                    if (!isset($duplicates[$normalized])) {
+                        $duplicates[$normalized] = [$usernames[$normalized]];
+                    }
+                    $duplicates[$normalized][] = $key;
                 } else {
                     $usernames[$normalized] = $key;
                 }
@@ -192,8 +194,8 @@ function validateUniquePushUsernames($config) {
     }
     
     if (!empty($duplicates)) {
-        foreach ($duplicates as $username => $keys) {
-            $errors[] = "Duplicate username '{$username}' found in cameras: " . implode(', ', array_unique($keys));
+        foreach ($duplicates as $normalized => $keys) {
+            $errors[] = "Duplicate username '{$normalized}' found in cameras: " . implode(', ', array_unique($keys));
         }
     }
     

--- a/lib/push-webcam-validator.php
+++ b/lib/push-webcam-validator.php
@@ -154,10 +154,10 @@ function validatePushWebcamConfig($cam, $airportId, $camIndex, ?int $globalCache
 }
 
 /**
- * Check for duplicate usernames across all push cameras
- * 
+ * Check for duplicate push camera usernames (case-insensitive).
+ *
  * @param array $config Full configuration
- * @return array ['valid' => bool, 'errors' => array, 'duplicates' => array]
+ * @return array{valid: bool, errors: list<string>, duplicates: array<string, list<string>>}
  */
 function validateUniquePushUsernames($config) {
     $errors = [];
@@ -175,13 +175,17 @@ function validateUniquePushUsernames($config) {
             
             if ($isPush && isset($cam['push_config']['username'])) {
                 $username = $cam['push_config']['username'];
+                if (!is_string($username) || $username === '') {
+                    continue;
+                }
                 $key = $airportId . '_' . $camIndex;
+                $normalized = strtolower($username);
                 
-                if (isset($usernames[$username])) {
+                if (isset($usernames[$normalized])) {
                     $duplicates[$username][] = $key;
-                    $duplicates[$username][] = $usernames[$username];
+                    $duplicates[$username][] = $usernames[$normalized];
                 } else {
-                    $usernames[$username] = $key;
+                    $usernames[$normalized] = $key;
                 }
             }
         }

--- a/lib/push-webcam-validator.php
+++ b/lib/push-webcam-validator.php
@@ -162,6 +162,7 @@ function validatePushWebcamConfig($cam, $airportId, $camIndex, ?int $globalCache
 function validateUniquePushUsernames($config) {
     $errors = [];
     $usernames = [];
+    $usernameLabels = [];
     $duplicates = [];
     
     foreach ($config['airports'] ?? [] as $airportId => $airport) {
@@ -188,6 +189,7 @@ function validateUniquePushUsernames($config) {
                     $duplicates[$normalized][] = $key;
                 } else {
                     $usernames[$normalized] = $key;
+                    $usernameLabels[$normalized] = $username;
                 }
             }
         }
@@ -195,7 +197,9 @@ function validateUniquePushUsernames($config) {
     
     if (!empty($duplicates)) {
         foreach ($duplicates as $normalized => $keys) {
-            $errors[] = "Duplicate username '{$normalized}' found in cameras: " . implode(', ', array_unique($keys));
+            $label = $usernameLabels[$normalized] ?? $normalized;
+            $errors[] = "Duplicate username '{$label}' (case-insensitive) found in cameras: "
+                . implode(', ', array_unique($keys));
         }
     }
     

--- a/scripts/cleanup-cache.php
+++ b/scripts/cleanup-cache.php
@@ -1116,6 +1116,14 @@ function cleanupEmptyDirectoriesExcludingUploads(
     
     foreach ($airportDirs as $airportDir) {
         $airportId = strtolower(basename($airportDir));
+
+        // Upload health probe FTPS local_root lives under /cache/ftp/_probe/ (not an airport ID)
+        if (isUploadHealthProbeFtpCacheNamespace($airportId)) {
+            if ($verbose) {
+                echo "  ℹ️  Preserving upload health probe FTP namespace: {$airportId}\n";
+            }
+            continue;
+        }
         
         // Skip directories for configured airports - these may have push webcams
         if (in_array($airportId, $configuredLower)) {
@@ -1219,6 +1227,14 @@ function cleanupEmptyDirectoriesExcludingSftp(
                     }
                 }
             }
+        }
+    }
+
+    $probeRaw = getGlobalConfig('upload_health_probe');
+    if (is_array($probeRaw) && ($probeRaw['enabled'] ?? false) === true) {
+        $probeSftpUser = $probeRaw['sftp']['username'] ?? null;
+        if (is_string($probeSftpUser) && $probeSftpUser !== '') {
+            $configuredUsernames[] = strtolower($probeSftpUser);
         }
     }
     

--- a/scripts/sync-push-config.php
+++ b/scripts/sync-push-config.php
@@ -1817,7 +1817,7 @@ function syncPushConfig() {
         aviationwx_log('error', 'config validation failed, skipping sync', [
             'error' => $validation['error']
         ], 'app');
-        return;
+        exit(1);
     }
     
     $backupFile = backupConfigFile($configFile);

--- a/scripts/sync-push-config.php
+++ b/scripts/sync-push-config.php
@@ -1025,11 +1025,14 @@ function writeVsftpdVirtualUsersFile(array $users, string $path = '/etc/vsftpd/v
         @unlink($tmpPath);
         return false;
     }
+    @chmod($tmpPath, 0600);
 
     if (!@rename($tmpPath, $path)) {
         @unlink($tmpPath);
         return false;
     }
+
+    @chmod($path, 0600);
 
     return true;
 }

--- a/scripts/sync-push-config.php
+++ b/scripts/sync-push-config.php
@@ -6,12 +6,14 @@
  *
  * Runs on container startup (docker-entrypoint.sh) and during deployment (GitHub Actions).
  * Always repairs SFTP chroot ownership first (sshd requires root:root on /var/sftp/{user}/).
+ * Reprovisions upload health probe accounts on every run (container-local /etc state).
  * Full user/directory sync is skipped when config is unchanged unless vsftpd DB is missing.
  */
 
 require_once __DIR__ . '/../lib/config.php';
 require_once __DIR__ . '/../lib/logger.php';
 require_once __DIR__ . '/../lib/cache-paths.php';
+require_once __DIR__ . '/../lib/push-webcam-validator.php';
 
 $invocationId = aviationwx_get_invocation_id();
 $triggerInfo = aviationwx_detect_trigger_type();
@@ -437,15 +439,14 @@ function isVsftpdDatabaseCorrupted() {
 
 /**
  * Validate config before applying
- * 
- * Validates JSON syntax and basic structure of configuration file before
- * applying changes. Prevents applying invalid configurations that could
- * break the system.
- * 
+ *
+ * Validates JSON syntax, basic structure, and runtime schema (including unique push usernames)
+ * before applying changes.
+ *
  * @param string $configFile Path to config file to validate
  * @return array {
- *   'valid' => bool,    // True if config is valid
- *   'error' => string   // Error message if invalid (optional)
+ *   'valid' => bool,
+ *   'error' => string
  * }
  */
 function validateConfigBeforeApply($configFile) {
@@ -462,6 +463,11 @@ function validateConfigBeforeApply($configFile) {
     // Basic structure validation
     if (!is_array($config) || !isset($config['airports'])) {
         return ['valid' => false, 'error' => 'Invalid config structure'];
+    }
+
+    $schema = validateRuntimeConfigSchema($config);
+    if (!$schema['valid']) {
+        return ['valid' => false, 'error' => implode('; ', $schema['errors'])];
     }
     
     return ['valid' => true];
@@ -946,6 +952,73 @@ function createSftpUser($airportId, $camIndex, $username, $password) {
 }
 
 /**
+ * Parse vsftpd virtual_users.txt (alternating username/password lines).
+ *
+ * Shared passwords across different usernames are valid; duplicate usernames are not.
+ *
+ * @param string $path Path to virtual_users.txt
+ * @return array{users: array<string, string>, errors: list<string>}
+ */
+function parseVsftpdVirtualUsersFile(string $path = '/etc/vsftpd/virtual_users.txt'): array {
+    $users = [];
+    $errors = [];
+
+    if (!file_exists($path)) {
+        return ['users' => [], 'errors' => []];
+    }
+
+    $rawLines = @file($path, FILE_IGNORE_NEW_LINES);
+    if ($rawLines === false) {
+        return ['users' => [], 'errors' => ["Cannot read vsftpd users file: {$path}"]];
+    }
+
+    $lines = [];
+    foreach ($rawLines as $lineNum => $line) {
+        $trimmed = trim($line);
+        if ($trimmed === '') {
+            $errors[] = 'vsftpd virtual_users.txt has empty line at line ' . ($lineNum + 1);
+            continue;
+        }
+        $lines[] = $trimmed;
+    }
+
+    if (count($lines) % 2 !== 0) {
+        $errors[] = 'vsftpd virtual_users.txt has odd line count (incomplete username/password pair)';
+    }
+
+    for ($i = 0; $i + 1 < count($lines); $i += 2) {
+        $username = $lines[$i];
+        $password = $lines[$i + 1];
+        $lineNum = $i + 1;
+
+        if (isset($users[$username])) {
+            $errors[] = "Duplicate vsftpd username '{$username}' at line {$lineNum}";
+            continue;
+        }
+
+        $users[$username] = $password;
+    }
+
+    return ['users' => $users, 'errors' => $errors];
+}
+
+/**
+ * Write vsftpd virtual_users.txt from a username => password map.
+ *
+ * @param array<string, string> $users Username to password map
+ * @param string $path Path to virtual_users.txt
+ * @return bool True when the file was written successfully
+ */
+function writeVsftpdVirtualUsersFile(array $users, string $path = '/etc/vsftpd/virtual_users.txt'): bool {
+    $content = '';
+    foreach ($users as $user => $pass) {
+        $content .= $user . "\n" . $pass . "\n";
+    }
+
+    return @file_put_contents($path, $content) !== false;
+}
+
+/**
  * Rebuild vsftpd database from users file
  * 
  * Rebuilds the vsftpd Berkeley DB database from the virtual_users.txt file.
@@ -1021,65 +1094,50 @@ function rebuildVsftpdDatabase() {
 }
 
 /**
- * Create FTP user (vsftpd virtual user)
- * 
- * Creates a new vsftpd virtual user account for FTP/FTPS access.
- * Updates virtual_users.txt, rebuilds database, and creates user config.
- * 
- * vsftpd local_root points to files/ so FTP users land directly in the
- * writable upload directory (same location SFTP users upload to via /files/).
- * 
- * @param string $airportId Airport ID (e.g., 'kspb')
- * @param int $camIndex Camera index (0-based)
+ * Upsert vsftpd virtual user with local_root and writable upload directory.
+ *
  * @param string $username Username (up to 14 alphanumeric characters)
  * @param string $password Password (14 alphanumeric characters)
+ * @param string $ftpDir Absolute local_root for this user
+ * @param array<string, mixed> $logContext Extra fields for success log context
  * @return bool True on success, false on failure
  */
-function createFtpUser($airportId, $camIndex, $username, $password) {
+function upsertFtpVirtualUser($username, $password, $ftpDir, $logContext = []) {
     $vsftpdUserFile = '/etc/vsftpd/virtual_users.txt';
     $vsftpdDbFile = '/etc/vsftpd/virtual_users.db';
-    
-    $users = [];
-    if (file_exists($vsftpdUserFile)) {
-        $lines = @file($vsftpdUserFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        if ($lines) {
-            for ($i = 0; $i < count($lines); $i += 2) {
-                if (isset($lines[$i + 1])) {
-                    $users[$lines[$i]] = $lines[$i + 1];
-                }
-            }
-        }
+
+    $parsed = parseVsftpdVirtualUsersFile($vsftpdUserFile);
+    if ($parsed['errors'] !== []) {
+        aviationwx_log('warning', 'sync-push-config: vsftpd users file parse issues', [
+            'errors' => $parsed['errors'],
+        ], 'app');
     }
-    
+    $users = $parsed['users'];
+
     $users[$username] = $password;
-    
-    $content = '';
-    foreach ($users as $user => $pass) {
-        $content .= $user . "\n" . $pass . "\n";
-    }
-    
-    if (@file_put_contents($vsftpdUserFile, $content) === false) {
+
+    if (!writeVsftpdVirtualUsersFile($users, $vsftpdUserFile)) {
         aviationwx_log('error', 'sync-push-config: Cannot write vsftpd users file', [
             'file' => $vsftpdUserFile
         ], 'app');
         return false;
     }
-    
+
     if (file_exists($vsftpdDbFile)) {
         @unlink($vsftpdDbFile);
     }
-    
+
     $output = [];
     $code = 0;
     exec('db_load -T -t hash -f ' . escapeshellarg($vsftpdUserFile) . ' ' . escapeshellarg($vsftpdDbFile) . ' 2>&1', $output, $code);
-    
+
     if ($code !== 0) {
         aviationwx_log('error', 'sync-push-config: db_load failed', [
             'output' => implode("\n", $output)
         ], 'app');
         return false;
     }
-    
+
     if (!file_exists($vsftpdDbFile) || filesize($vsftpdDbFile) === 0) {
         aviationwx_log('error', 'sync-push-config: database file not created or is empty after db_load', [
             'db_file' => $vsftpdDbFile,
@@ -1088,84 +1146,88 @@ function createFtpUser($airportId, $camIndex, $username, $password) {
         ], 'app');
         return false;
     }
-    
-    // Get FTP upload directory (simple flat structure, no chroot)
-    $ftpDir = getWebcamFtpUploadDir($airportId, $username);
-    
-    // Get user/group info
+
     $ftpInfo = @posix_getpwnam('ftp');
     $ftpUid = $ftpInfo ? $ftpInfo['uid'] : 101;
     $wwwDataInfo = @posix_getpwnam('www-data');
     $wwwDataGid = $wwwDataInfo ? $wwwDataInfo['gid'] : 33;
-    
-    // Ensure directory structure exists
-    ensureWebcamsBaseDirectory();
-    
-    // Airport directory
-    $airportDir = CACHE_UPLOADS_DIR . '/' . strtolower($airportId);
-    if (!is_dir($airportDir)) {
-        @mkdir($airportDir, 0755, true);
-    }
-    
-    // FTP upload directory (ftp:www-data with setgid)
+
     if (!is_dir($ftpDir)) {
         @mkdir($ftpDir, 02775, true);
     }
     @chown($ftpDir, $ftpUid);
     @chgrp($ftpDir, $wwwDataGid);
     @chmod($ftpDir, 02775);
-    
-    // Create per-user vsftpd config - local_root points to FTP directory
+
     $userConfigDir = '/etc/vsftpd/users';
     if (!is_dir($userConfigDir)) {
         @mkdir($userConfigDir, 0755, true);
     }
     $userConfigFile = $userConfigDir . '/' . $username;
     $userConfig = "local_root={$ftpDir}\n";
-    
+
     if (@file_put_contents($userConfigFile, $userConfig) === false) {
         aviationwx_log('error', 'sync-push-config: Cannot write user config file', [
             'file' => $userConfigFile
         ], 'app');
         return false;
     }
-    
-    aviationwx_log('info', 'sync-push-config: FTP user created/updated', [
+
+    aviationwx_log('info', 'sync-push-config: FTP user created/updated', array_merge([
         'username' => $username,
-        'airport' => $airportId,
-        'cam' => $camIndex,
-        'local_root' => $ftpDir
-    ], 'app');
-    
+        'local_root' => $ftpDir,
+    ], $logContext), 'app');
+
     return true;
 }
 
 /**
- * Remove FTP user
+ * Create FTP user (vsftpd virtual user) for a push camera inbox.
+ *
+ * @param string $airportId Airport ID (e.g., 'kspb')
+ * @param int $camIndex Camera index (0-based)
+ * @param string $username Username (up to 14 alphanumeric characters)
+ * @param string $password Password (14 alphanumeric characters)
+ * @return bool True on success, false on failure
+ */
+function createFtpUser($airportId, $camIndex, $username, $password) {
+    $ftpDir = getWebcamFtpUploadDir($airportId, $username);
+
+    ensureWebcamsBaseDirectory();
+
+    $airportDir = CACHE_UPLOADS_DIR . '/' . strtolower($airportId);
+    if (!is_dir($airportDir)) {
+        @mkdir($airportDir, 0755, true);
+    }
+
+    return upsertFtpVirtualUser($username, $password, $ftpDir, [
+        'airport' => $airportId,
+        'cam' => $camIndex,
+    ]);
+}
+
+/**
+ * Remove FTP user from vsftpd virtual users and per-user config.
+ *
+ * @param string $username FTP username to remove
+ * @return void
  */
 function removeFtpUser($username) {
     $vsftpdUserFile = '/etc/vsftpd/virtual_users.txt';
     $vsftpdDbFile = '/etc/vsftpd/virtual_users.db';
     $userConfigFile = '/etc/vsftpd/users/' . $username;
-    
-    $users = [];
-    if (file_exists($vsftpdUserFile)) {
-        $lines = @file($vsftpdUserFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        if ($lines) {
-            for ($i = 0; $i < count($lines); $i += 2) {
-                if (isset($lines[$i + 1]) && $lines[$i] !== $username) {
-                    $users[$lines[$i]] = $lines[$i + 1];
-                }
-            }
-        }
+
+    $parsed = parseVsftpdVirtualUsersFile($vsftpdUserFile);
+    if ($parsed['errors'] !== []) {
+        aviationwx_log('warning', 'sync-push-config: vsftpd users file parse issues during removal', [
+            'errors' => $parsed['errors'],
+            'username' => $username,
+        ], 'app');
     }
-    
-    $content = '';
-    foreach ($users as $user => $pass) {
-        $content .= $user . "\n" . $pass . "\n";
-    }
-    
-    if (@file_put_contents($vsftpdUserFile, $content) === false) {
+    $users = $parsed['users'];
+    unset($users[$username]);
+
+    if (!writeVsftpdVirtualUsersFile($users, $vsftpdUserFile)) {
         aviationwx_log('warning', 'sync-push-config: Cannot write vsftpd users file during removal', [
             'file' => $vsftpdUserFile,
             'username' => $username
@@ -1368,6 +1430,14 @@ function removeCameraUser($username, $protocols = null) {
  * @return void
  */
 function syncAllPushCameras($config) {
+    $usernameCheck = validateUniquePushUsernames($config);
+    if (!$usernameCheck['valid']) {
+        aviationwx_log('error', 'sync-push-config: duplicate push usernames in config, aborting camera sync', [
+            'errors' => $usernameCheck['errors'],
+        ], 'app');
+        return;
+    }
+
     $existing = getExistingPushCameras();
     $configured = [];
     $usernameMapping = loadUsernameMapping();
@@ -1520,6 +1590,171 @@ function syncAllPushCameras($config) {
 }
 
 /**
+ * Build sync plan for upload health probe accounts (production only).
+ *
+ * Probe users are isolated from push camera inboxes and must not enter the webcam pipeline.
+ *
+ * @return list<array{protocol:string,username:string,password:string,ftp_local_root?:string}>
+ */
+function getUploadHealthProbeSyncPlan(): array {
+    if (!isProduction()) {
+        return [];
+    }
+
+    $settings = getUploadHealthProbeSettings();
+    if (!($settings['enabled'] ?? false)) {
+        return [];
+    }
+
+    $plan = [];
+
+    $ftps = $settings['ftps'] ?? null;
+    if (is_array($ftps)) {
+        $username = $ftps['username'] ?? '';
+        $password = $ftps['password'] ?? '';
+        if (is_string($username) && $username !== '' && is_string($password) && $password !== '') {
+            $plan[] = [
+                'protocol' => 'ftps',
+                'username' => $username,
+                'password' => $password,
+                'ftp_local_root' => getUploadHealthProbeFtpDir($username),
+            ];
+        }
+    }
+
+    $sftp = $settings['sftp'] ?? null;
+    if (is_array($sftp)) {
+        $username = $sftp['username'] ?? '';
+        $password = $sftp['password'] ?? '';
+        if (is_string($username) && $username !== '' && is_string($password) && $password !== '') {
+            $plan[] = [
+                'protocol' => 'sftp',
+                'username' => $username,
+                'password' => $password,
+            ];
+        }
+    }
+
+    return $plan;
+}
+
+/**
+ * Provision FTPS probe account in an isolated FTP directory.
+ *
+ * @param string $username Probe username
+ * @param string $password Probe password
+ * @return bool True on success
+ */
+function syncUploadHealthProbeFtpUser(string $username, string $password): bool {
+    if (!validateUsername($username)) {
+        aviationwx_log('error', 'sync-push-config: invalid upload health probe FTP username', [
+            'username' => $username,
+        ], 'app');
+        return false;
+    }
+
+    if (!validatePassword($password)) {
+        aviationwx_log('error', 'sync-push-config: invalid upload health probe FTP password shape', [
+            'username' => $username,
+        ], 'app');
+        return false;
+    }
+
+    ensureWebcamsBaseDirectory();
+
+    $probeBase = CACHE_UPLOADS_DIR . '/' . UPLOAD_HEALTH_PROBE_FTP_NAMESPACE;
+    if (!is_dir($probeBase)) {
+        @mkdir($probeBase, 0755, true);
+    }
+
+    $ftpDir = getUploadHealthProbeFtpDir($username);
+
+    return upsertFtpVirtualUser($username, $password, $ftpDir, [
+        'purpose' => 'upload_health_probe',
+    ]);
+}
+
+/**
+ * Provision SFTP probe account (chroot under /var/sftp, uploads in files/).
+ *
+ * @param string $username Probe username
+ * @param string $password Probe password
+ * @return bool True on success
+ */
+function syncUploadHealthProbeSftpUser(string $username, string $password): bool {
+    if (!validateUsername($username)) {
+        aviationwx_log('error', 'sync-push-config: invalid upload health probe SFTP username', [
+            'username' => $username,
+        ], 'app');
+        return false;
+    }
+
+    if (!validatePassword($password)) {
+        aviationwx_log('error', 'sync-push-config: invalid upload health probe SFTP password shape', [
+            'username' => $username,
+        ], 'app');
+        return false;
+    }
+
+    if (!createSftpUser('_probe', -1, $username, $password)) {
+        aviationwx_log('error', 'sync-push-config: upload health probe SFTP user sync failed', [
+            'username' => $username,
+        ], 'app');
+        return false;
+    }
+
+    aviationwx_log('info', 'sync-push-config: upload health probe SFTP user synced', [
+        'username' => $username,
+        'purpose' => 'upload_health_probe',
+    ], 'app');
+
+    return true;
+}
+
+/**
+ * Sync dedicated upload health probe users (FTPS and SFTP).
+ *
+ * Runs on container startup with push camera sync so probe accounts survive image recreates.
+ *
+ * @return bool True when all configured probe accounts synced successfully
+ */
+function syncUploadHealthProbeUsers(): bool {
+    $plan = getUploadHealthProbeSyncPlan();
+    if ($plan === []) {
+        return true;
+    }
+
+    $allOk = true;
+
+    foreach ($plan as $target) {
+        $protocol = $target['protocol'] ?? '';
+        $username = $target['username'] ?? '';
+        $password = $target['password'] ?? '';
+
+        if ($protocol === 'ftps') {
+            if (!syncUploadHealthProbeFtpUser($username, $password)) {
+                $allOk = false;
+            }
+            continue;
+        }
+
+        if ($protocol === 'sftp') {
+            if (!syncUploadHealthProbeSftpUser($username, $password)) {
+                $allOk = false;
+            }
+        }
+    }
+
+    if ($allOk) {
+        aviationwx_log('info', 'sync-push-config: upload health probe users synced', [
+            'accounts' => count($plan),
+        ], 'app');
+    }
+
+    return $allOk;
+}
+
+/**
  * Main sync function
  */
 function syncPushConfig() {
@@ -1565,6 +1800,10 @@ function syncPushConfig() {
                 'last_sync' => $lastSync,
                 'config_mtime' => $configMtime
             ], 'app');
+            // Probe accounts live in container-local /etc and must be reprovisioned each startup.
+            if (!syncUploadHealthProbeUsers()) {
+                aviationwx_log('warning', 'sync-push-config: upload health probe user sync incomplete', [], 'app');
+            }
             return;
         }
         
@@ -1591,6 +1830,9 @@ function syncPushConfig() {
     }
     
     syncAllPushCameras($config);
+    if (!syncUploadHealthProbeUsers()) {
+        aviationwx_log('warning', 'sync-push-config: upload health probe user sync incomplete', [], 'app');
+    }
     updateLastSyncTimestamp();
     
     aviationwx_log('info', 'push-config sync completed', [], 'app');

--- a/scripts/sync-push-config.php
+++ b/scripts/sync-push-config.php
@@ -972,24 +972,27 @@ function parseVsftpdVirtualUsersFile(string $path = '/etc/vsftpd/virtual_users.t
         return ['users' => [], 'errors' => ["Cannot read vsftpd users file: {$path}"]];
     }
 
-    $lines = [];
-    foreach ($rawLines as $lineNum => $line) {
-        $trimmed = trim($line);
-        if ($trimmed === '') {
-            $errors[] = 'vsftpd virtual_users.txt has empty line at line ' . ($lineNum + 1);
-            continue;
-        }
-        $lines[] = $trimmed;
-    }
-
-    if (count($lines) % 2 !== 0) {
+    $lineCount = count($rawLines);
+    if ($lineCount % 2 !== 0) {
         $errors[] = 'vsftpd virtual_users.txt has odd line count (incomplete username/password pair)';
     }
 
-    for ($i = 0; $i + 1 < count($lines); $i += 2) {
-        $username = $lines[$i];
-        $password = $lines[$i + 1];
+    for ($i = 0; $i + 1 < $lineCount; $i += 2) {
+        $username = trim($rawLines[$i]);
+        $password = trim($rawLines[$i + 1]);
         $lineNum = $i + 1;
+
+        if ($username === '' || $password === '') {
+            if ($username === '' && $password === '') {
+                $errors[] = 'vsftpd virtual_users.txt has empty username/password pair at lines '
+                    . $lineNum . '-' . ($lineNum + 1);
+            } elseif ($username === '') {
+                $errors[] = 'vsftpd virtual_users.txt has empty username at line ' . $lineNum;
+            } else {
+                $errors[] = 'vsftpd virtual_users.txt has empty password for username at line ' . ($lineNum + 1);
+            }
+            continue;
+        }
 
         if (isset($users[$username])) {
             $errors[] = "Duplicate vsftpd username '{$username}' at line {$lineNum}";

--- a/scripts/sync-push-config.php
+++ b/scripts/sync-push-config.php
@@ -1012,7 +1012,19 @@ function writeVsftpdVirtualUsersFile(array $users, string $path = '/etc/vsftpd/v
         $content .= $user . "\n" . $pass . "\n";
     }
 
-    return @file_put_contents($path, $content) !== false;
+    $dir = dirname($path);
+    $tmpPath = $dir . '/.' . basename($path) . '.tmp.' . getmypid();
+    if (@file_put_contents($tmpPath, $content, LOCK_EX) === false) {
+        @unlink($tmpPath);
+        return false;
+    }
+
+    if (!@rename($tmpPath, $path)) {
+        @unlink($tmpPath);
+        return false;
+    }
+
+    return true;
 }
 
 /**

--- a/scripts/sync-push-config.php
+++ b/scripts/sync-push-config.php
@@ -983,8 +983,15 @@ function parseVsftpdVirtualUsersFile(string $path = '/etc/vsftpd/virtual_users.t
         $lineNum = $i + 1;
 
         if ($username === '' || $password === '') {
-            $errors[] = 'vsftpd virtual_users.txt has incomplete username/password pair at lines '
-                . $lineNum . '-' . ($lineNum + 1);
+            if ($username === '' && $password === '') {
+                $errors[] = 'vsftpd virtual_users.txt has empty username/password pair at lines '
+                    . $lineNum . '-' . ($lineNum + 1);
+            } elseif ($username === '') {
+                $errors[] = 'vsftpd virtual_users.txt has empty username at line ' . $lineNum;
+            } else {
+                $errors[] = "vsftpd virtual_users.txt has empty password for '{$username}' at line "
+                    . ($lineNum + 1);
+            }
             continue;
         }
 

--- a/scripts/sync-push-config.php
+++ b/scripts/sync-push-config.php
@@ -15,15 +15,6 @@ require_once __DIR__ . '/../lib/logger.php';
 require_once __DIR__ . '/../lib/cache-paths.php';
 require_once __DIR__ . '/../lib/push-webcam-validator.php';
 
-$invocationId = aviationwx_get_invocation_id();
-$triggerInfo = aviationwx_detect_trigger_type();
-
-aviationwx_log('info', 'push-config sync started', [
-    'invocation_id' => $invocationId,
-    'trigger' => $triggerInfo['trigger'],
-    'context' => $triggerInfo['context']
-], 'app');
-
 /**
  * Check if script is running as root (required for system operations)
  */
@@ -844,36 +835,45 @@ function saveUsernameMapping($mapping) {
 }
 
 /**
- * Validate username format (14 characters or less, alphanumeric, no spaces)
- * 
- * Validates that a username matches the required format for push webcam accounts.
- * 
- * @param string $username Username to validate
- * @return bool True if username is valid, false otherwise
+ * Validate push upload credentials for sync-time provisioning.
+ *
+ * @return list<string> Empty when both username and password are valid
  */
-function validateUsername($username) {
-    if (strlen($username) > 14) {
-        return false;
-    }
-    if (preg_match('/\s/', $username)) {
-        return false;
-    }
-    return preg_match('/^[a-zA-Z0-9]+$/', $username) === 1;
+function validateSyncPushUploadCredentials(string $username, string $password, string $contextLabel): array {
+    return array_merge(
+        validatePushUploadUsername($username, $contextLabel),
+        validatePushUploadPassword($password, $contextLabel)
+    );
 }
 
 /**
- * Validate password format (14 alphanumeric characters)
- * 
- * Validates that a password matches the required format for push webcam accounts.
- * 
- * @param string $password Password to validate
- * @return bool True if password is valid, false otherwise
+ * Ensure a push webcam upload directory is ftp:www-data with setgid (02775).
+ *
+ * @param string $uploadDir Writable FTP or SFTP files/ directory
+ * @return void
  */
-function validatePassword($password) {
-    if (strlen($password) !== 14) {
-        return false;
+function repairPushUploadDirectoryPermissions(string $uploadDir): void {
+    if (!is_dir($uploadDir)) {
+        return;
     }
-    return preg_match('/^[a-zA-Z0-9]{14}$/', $password) === 1;
+
+    $ftpInfo = @posix_getpwnam('ftp');
+    $wwwDataInfo = @posix_getpwnam('www-data');
+    if ($ftpInfo === false || $wwwDataInfo === false) {
+        return;
+    }
+
+    $verification = verifyDirectoryPermissions(
+        $uploadDir,
+        $ftpInfo['uid'],
+        'www-data',
+        02775
+    );
+    if (!$verification['success']) {
+        @chown($uploadDir, $ftpInfo['uid']);
+        @chgrp($uploadDir, $wwwDataInfo['gid']);
+        @chmod($uploadDir, 02775);
+    }
 }
 
 /**
@@ -983,14 +983,8 @@ function parseVsftpdVirtualUsersFile(string $path = '/etc/vsftpd/virtual_users.t
         $lineNum = $i + 1;
 
         if ($username === '' || $password === '') {
-            if ($username === '' && $password === '') {
-                $errors[] = 'vsftpd virtual_users.txt has empty username/password pair at lines '
-                    . $lineNum . '-' . ($lineNum + 1);
-            } elseif ($username === '') {
-                $errors[] = 'vsftpd virtual_users.txt has empty username at line ' . $lineNum;
-            } else {
-                $errors[] = 'vsftpd virtual_users.txt has empty password for username at line ' . ($lineNum + 1);
-            }
+            $errors[] = 'vsftpd virtual_users.txt has incomplete username/password pair at lines '
+                . $lineNum . '-' . ($lineNum + 1);
             continue;
         }
 
@@ -1019,6 +1013,50 @@ function writeVsftpdVirtualUsersFile(array $users, string $path = '/etc/vsftpd/v
     }
 
     return @file_put_contents($path, $content) !== false;
+}
+
+/**
+ * Rebuild vsftpd Berkeley DB from virtual_users.txt.
+ *
+ * @param string $context Short label for logs (for example upsert, removal, rebuild)
+ * @param string $failureLevel Log level when db_load fails (error or warning)
+ * @return bool True when db_load produced a non-empty database file
+ */
+function loadVsftpdDatabaseFromUsersFile(string $context, string $failureLevel = 'error'): bool {
+    $vsftpdUserFile = '/etc/vsftpd/virtual_users.txt';
+    $vsftpdDbFile = '/etc/vsftpd/virtual_users.db';
+
+    if (file_exists($vsftpdDbFile)) {
+        @unlink($vsftpdDbFile);
+    }
+
+    $output = [];
+    $code = 0;
+    exec(
+        'db_load -T -t hash -f ' . escapeshellarg($vsftpdUserFile) . ' ' . escapeshellarg($vsftpdDbFile) . ' 2>&1',
+        $output,
+        $code
+    );
+
+    if ($code !== 0) {
+        aviationwx_log($failureLevel, 'sync-push-config: db_load failed during ' . $context, [
+            'output' => implode("\n", $output),
+            'return_code' => $code,
+        ], 'app');
+        return false;
+    }
+
+    if (!file_exists($vsftpdDbFile) || filesize($vsftpdDbFile) === 0) {
+        aviationwx_log($failureLevel, 'sync-push-config: database file not created or is empty after db_load', [
+            'context' => $context,
+            'db_file' => $vsftpdDbFile,
+            'exists' => file_exists($vsftpdDbFile),
+            'size' => file_exists($vsftpdDbFile) ? filesize($vsftpdDbFile) : 0,
+        ], 'app');
+        return false;
+    }
+
+    return true;
 }
 
 /**
@@ -1051,35 +1089,14 @@ function rebuildVsftpdDatabase() {
         }
         return true;
     }
-    
-    if (file_exists($vsftpdDbFile)) {
-        @unlink($vsftpdDbFile);
-    }
-    
-    $output = [];
-    $returnCode = 0;
-    exec('db_load -T -t hash -f ' . escapeshellarg($vsftpdUserFile) . ' ' . escapeshellarg($vsftpdDbFile) . ' 2>&1', $output, $returnCode);
-    
-    if ($returnCode !== 0) {
-        aviationwx_log('error', 'sync-push-config: db_load failed during database rebuild', [
-            'output' => implode("\n", $output),
-            'return_code' => $returnCode
-        ], 'app');
+
+    if (!loadVsftpdDatabaseFromUsersFile('database rebuild')) {
         return false;
     }
-    
-    if (!file_exists($vsftpdDbFile) || filesize($vsftpdDbFile) === 0) {
-        aviationwx_log('error', 'sync-push-config: database file not created or is empty after rebuild', [
-            'db_file' => $vsftpdDbFile,
-            'exists' => file_exists($vsftpdDbFile),
-            'size' => file_exists($vsftpdDbFile) ? filesize($vsftpdDbFile) : 0
-        ], 'app');
-        return false;
-    }
-    
+
     $output = [];
     $returnCode = 0;
-    @exec("db_verify " . escapeshellarg($vsftpdDbFile) . " 2>&1", $output, $returnCode);
+    @exec('db_verify ' . escapeshellarg($vsftpdDbFile) . ' 2>&1', $output, $returnCode);
     if ($returnCode !== 0) {
         aviationwx_log('error', 'sync-push-config: database verification failed after rebuild', [
             'output' => implode("\n", $output),
@@ -1107,7 +1124,6 @@ function rebuildVsftpdDatabase() {
  */
 function upsertFtpVirtualUser($username, $password, $ftpDir, $logContext = []) {
     $vsftpdUserFile = '/etc/vsftpd/virtual_users.txt';
-    $vsftpdDbFile = '/etc/vsftpd/virtual_users.db';
 
     $parsed = parseVsftpdVirtualUsersFile($vsftpdUserFile);
     if ($parsed['errors'] !== []) {
@@ -1126,27 +1142,7 @@ function upsertFtpVirtualUser($username, $password, $ftpDir, $logContext = []) {
         return false;
     }
 
-    if (file_exists($vsftpdDbFile)) {
-        @unlink($vsftpdDbFile);
-    }
-
-    $output = [];
-    $code = 0;
-    exec('db_load -T -t hash -f ' . escapeshellarg($vsftpdUserFile) . ' ' . escapeshellarg($vsftpdDbFile) . ' 2>&1', $output, $code);
-
-    if ($code !== 0) {
-        aviationwx_log('error', 'sync-push-config: db_load failed', [
-            'output' => implode("\n", $output)
-        ], 'app');
-        return false;
-    }
-
-    if (!file_exists($vsftpdDbFile) || filesize($vsftpdDbFile) === 0) {
-        aviationwx_log('error', 'sync-push-config: database file not created or is empty after db_load', [
-            'db_file' => $vsftpdDbFile,
-            'exists' => file_exists($vsftpdDbFile),
-            'size' => file_exists($vsftpdDbFile) ? filesize($vsftpdDbFile) : 0
-        ], 'app');
+    if (!loadVsftpdDatabaseFromUsersFile('ftp user upsert')) {
         return false;
     }
 
@@ -1238,19 +1234,7 @@ function removeFtpUser($username) {
     }
     
     if (count($users) > 0) {
-        if (file_exists($vsftpdDbFile)) {
-            @unlink($vsftpdDbFile);
-        }
-        
-        $output = [];
-        $code = 0;
-        exec('db_load -T -t hash -f ' . escapeshellarg($vsftpdUserFile) . ' ' . escapeshellarg($vsftpdDbFile) . ' 2>&1', $output, $code);
-        if ($code !== 0) {
-            aviationwx_log('warning', 'sync-push-config: db_load failed during user removal', [
-                'output' => implode("\n", $output),
-                'username' => $username
-            ], 'app');
-        }
+        loadVsftpdDatabaseFromUsersFile('ftp user removal', 'warning');
     } else {
         @unlink($vsftpdDbFile);
     }
@@ -1315,21 +1299,17 @@ function syncCameraUser($airportId, $camIndex, $pushConfig, &$usernameMapping) {
         return false;
     }
     
-    if (!validateUsername($username)) {
-        aviationwx_log('error', 'sync-push-config: invalid username format', [
+    $credentialErrors = validateSyncPushUploadCredentials(
+        $username,
+        $password,
+        "sync-push-config: airport '{$airportId}' webcam {$camIndex}"
+    );
+    if ($credentialErrors !== []) {
+        aviationwx_log('error', 'sync-push-config: invalid push upload credentials', [
             'airport' => $airportId,
             'cam' => $camIndex,
             'username' => $username,
-            'expected' => '14 characters or less, alphanumeric, no spaces'
-        ], 'app');
-        return false;
-    }
-    
-    if (!validatePassword($password)) {
-        aviationwx_log('error', 'sync-push-config: invalid password format', [
-            'airport' => $airportId,
-            'cam' => $camIndex,
-            'expected' => '14 alphanumeric characters'
+            'errors' => $credentialErrors,
         ], 'app');
         return false;
     }
@@ -1433,14 +1413,6 @@ function removeCameraUser($username, $protocols = null) {
  * @return void
  */
 function syncAllPushCameras($config) {
-    $usernameCheck = validateUniquePushUsernames($config);
-    if (!$usernameCheck['valid']) {
-        aviationwx_log('error', 'sync-push-config: duplicate push usernames in config, aborting camera sync', [
-            'errors' => $usernameCheck['errors'],
-        ], 'app');
-        return;
-    }
-
     $existing = getExistingPushCameras();
     $configured = [];
     $usernameMapping = loadUsernameMapping();
@@ -1475,40 +1447,8 @@ function syncAllPushCameras($config) {
                 // Create both FTP and SFTP users
                 if ($username && isset($cam['push_config']['password'])) {
                     if (syncCameraUser($airportId, $camIndex, $cam['push_config'], $newUsernameMapping)) {
-                        $ftpInfo = @posix_getpwnam('ftp');
-                        $wwwDataInfo = @posix_getpwnam('www-data');
-                        
-                        // Verify FTP directory permissions
-                        $ftpDir = getWebcamFtpUploadDir($airportId, $username);
-                        if (is_dir($ftpDir) && $ftpInfo !== false && $wwwDataInfo !== false) {
-                            $verification = verifyDirectoryPermissions(
-                                $ftpDir,
-                                $ftpInfo['uid'],
-                                'www-data',
-                                02775
-                            );
-                            if (!$verification['success']) {
-                                @chown($ftpDir, $ftpInfo['uid']);
-                                @chgrp($ftpDir, $wwwDataInfo['gid']);
-                                @chmod($ftpDir, 02775);
-                            }
-                        }
-                        
-                        // Verify SFTP directory permissions
-                        $sftpDir = getWebcamSftpUploadDir($username);
-                        if (is_dir($sftpDir) && $ftpInfo !== false && $wwwDataInfo !== false) {
-                            $verification = verifyDirectoryPermissions(
-                                $sftpDir,
-                                $ftpInfo['uid'],
-                                'www-data',
-                                02775
-                            );
-                            if (!$verification['success']) {
-                                @chown($sftpDir, $ftpInfo['uid']);
-                                @chgrp($sftpDir, $wwwDataInfo['gid']);
-                                @chmod($sftpDir, 02775);
-                            }
-                        }
+                        repairPushUploadDirectoryPermissions(getWebcamFtpUploadDir($airportId, $username));
+                        repairPushUploadDirectoryPermissions(getWebcamSftpUploadDir($username));
                     }
                 }
             }
@@ -1611,32 +1551,28 @@ function getUploadHealthProbeSyncPlan(): array {
 
     $plan = [];
 
-    $ftps = $settings['ftps'] ?? null;
-    if (is_array($ftps)) {
-        $username = $ftps['username'] ?? '';
-        $password = $ftps['password'] ?? '';
-        if (is_string($username) && $username !== '' && is_string($password) && $password !== '') {
-            $plan[] = [
-                'protocol' => 'ftps',
-                'username' => $username,
-                'password' => $password,
-                'ftp_local_root' => getUploadHealthProbeFtpDir($username),
-            ];
+    $append = static function (string $protocol, $creds) use (&$plan): void {
+        if (!is_array($creds)) {
+            return;
         }
-    }
+        $username = $creds['username'] ?? '';
+        $password = $creds['password'] ?? '';
+        if (!is_string($username) || $username === '' || !is_string($password) || $password === '') {
+            return;
+        }
+        $entry = [
+            'protocol' => $protocol,
+            'username' => $username,
+            'password' => $password,
+        ];
+        if ($protocol === 'ftps') {
+            $entry['ftp_local_root'] = getUploadHealthProbeFtpDir($username);
+        }
+        $plan[] = $entry;
+    };
 
-    $sftp = $settings['sftp'] ?? null;
-    if (is_array($sftp)) {
-        $username = $sftp['username'] ?? '';
-        $password = $sftp['password'] ?? '';
-        if (is_string($username) && $username !== '' && is_string($password) && $password !== '') {
-            $plan[] = [
-                'protocol' => 'sftp',
-                'username' => $username,
-                'password' => $password,
-            ];
-        }
-    }
+    $append('ftps', $settings['ftps'] ?? null);
+    $append('sftp', $settings['sftp'] ?? null);
 
     return $plan;
 }
@@ -1649,30 +1585,9 @@ function getUploadHealthProbeSyncPlan(): array {
  * @return bool True on success
  */
 function syncUploadHealthProbeFtpUser(string $username, string $password): bool {
-    if (!validateUsername($username)) {
-        aviationwx_log('error', 'sync-push-config: invalid upload health probe FTP username', [
-            'username' => $username,
-        ], 'app');
-        return false;
-    }
-
-    if (!validatePassword($password)) {
-        aviationwx_log('error', 'sync-push-config: invalid upload health probe FTP password shape', [
-            'username' => $username,
-        ], 'app');
-        return false;
-    }
-
     ensureWebcamsBaseDirectory();
 
-    $probeBase = CACHE_UPLOADS_DIR . '/' . UPLOAD_HEALTH_PROBE_FTP_NAMESPACE;
-    if (!is_dir($probeBase)) {
-        @mkdir($probeBase, 0755, true);
-    }
-
-    $ftpDir = getUploadHealthProbeFtpDir($username);
-
-    return upsertFtpVirtualUser($username, $password, $ftpDir, [
+    return upsertFtpVirtualUser($username, $password, getUploadHealthProbeFtpDir($username), [
         'purpose' => 'upload_health_probe',
     ]);
 }
@@ -1685,20 +1600,6 @@ function syncUploadHealthProbeFtpUser(string $username, string $password): bool 
  * @return bool True on success
  */
 function syncUploadHealthProbeSftpUser(string $username, string $password): bool {
-    if (!validateUsername($username)) {
-        aviationwx_log('error', 'sync-push-config: invalid upload health probe SFTP username', [
-            'username' => $username,
-        ], 'app');
-        return false;
-    }
-
-    if (!validatePassword($password)) {
-        aviationwx_log('error', 'sync-push-config: invalid upload health probe SFTP password shape', [
-            'username' => $username,
-        ], 'app');
-        return false;
-    }
-
     if (!createSftpUser('_probe', -1, $username, $password)) {
         aviationwx_log('error', 'sync-push-config: upload health probe SFTP user sync failed', [
             'username' => $username,
@@ -1734,6 +1635,21 @@ function syncUploadHealthProbeUsers(): bool {
         $username = $target['username'] ?? '';
         $password = $target['password'] ?? '';
 
+        $credentialErrors = validateSyncPushUploadCredentials(
+            $username,
+            $password,
+            'config.upload_health_probe.' . $protocol
+        );
+        if ($credentialErrors !== []) {
+            aviationwx_log('error', 'sync-push-config: invalid upload health probe credentials', [
+                'protocol' => $protocol,
+                'username' => $username,
+                'errors' => $credentialErrors,
+            ], 'app');
+            $allOk = false;
+            continue;
+        }
+
         if ($protocol === 'ftps') {
             if (!syncUploadHealthProbeFtpUser($username, $password)) {
                 $allOk = false;
@@ -1741,10 +1657,8 @@ function syncUploadHealthProbeUsers(): bool {
             continue;
         }
 
-        if ($protocol === 'sftp') {
-            if (!syncUploadHealthProbeSftpUser($username, $password)) {
-                $allOk = false;
-            }
+        if ($protocol === 'sftp' && !syncUploadHealthProbeSftpUser($username, $password)) {
+            $allOk = false;
         }
     }
 
@@ -1761,6 +1675,14 @@ function syncUploadHealthProbeUsers(): bool {
  * Main sync function
  */
 function syncPushConfig() {
+    $invocationId = aviationwx_get_invocation_id();
+    $triggerInfo = aviationwx_detect_trigger_type();
+    aviationwx_log('info', 'push-config sync started', [
+        'invocation_id' => $invocationId,
+        'trigger' => $triggerInfo['trigger'],
+        'context' => $triggerInfo['context'],
+    ], 'app');
+
     if (!checkRootPermissions()) {
         aviationwx_log('error', 'sync-push-config: exiting due to insufficient permissions', [], 'app');
         exit(1);

--- a/scripts/upload-probe-runner.sh
+++ b/scripts/upload-probe-runner.sh
@@ -15,10 +15,18 @@ PROBE_SCRIPT="${SCRIPT_DIR}/upload-probe.sh"
 PROBE_LOG="${PROBE_LOG:-/var/log/aviationwx/upload-probe.log}"
 
 log_probe_runner() {
-    local ts msg
+    local level="INFO"
+    local msg="$1"
+    if [[ "$msg" == WARN\ * ]]; then
+        level="WARN"
+        msg="${msg#WARN }"
+    elif [[ "$msg" == ERROR\ * ]]; then
+        level="ERROR"
+        msg="${msg#ERROR }"
+    fi
+    local ts
     ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-    msg="$1"
-    echo "[$ts] [INFO] $msg" >>"$PROBE_LOG"
+    echo "[$ts] [$level] $msg" >>"$PROBE_LOG"
 }
 
 # Wait for entrypoint background sync before the first probe (probe accounts live in /etc).

--- a/scripts/upload-probe-runner.sh
+++ b/scripts/upload-probe-runner.sh
@@ -21,7 +21,33 @@ log_probe_runner() {
     echo "[$ts] [INFO] $msg" >>"$PROBE_LOG"
 }
 
+# Wait for entrypoint background sync before the first probe (probe accounts live in /etc).
+wait_for_push_config_sync() {
+    local max_sec="${UPLOAD_PROBE_SYNC_WAIT_SEC:-90}"
+    local start_sec elapsed
+    start_sec="$(date +%s 2>/dev/null || echo 0)"
+    while true; do
+        if [ -f /tmp/sync-push-config.log ]; then
+            if grep -q 'FTP/SFTP/FTPS configuration synced successfully' /tmp/sync-push-config.log 2>/dev/null; then
+                log_probe_runner "push-config sync finished before first probe"
+                return 0
+            fi
+            if grep -q 'configuration sync failed or timed out' /tmp/sync-push-config.log 2>/dev/null; then
+                log_probe_runner "WARN push-config sync failed; running probe anyway"
+                return 0
+            fi
+        fi
+        elapsed=$(( $(date +%s 2>/dev/null || echo 0) - start_sec ))
+        if [ "$elapsed" -ge "$max_sec" ]; then
+            log_probe_runner "WARN push-config sync wait timeout (${max_sec}s); running probe anyway"
+            return 0
+        fi
+        sleep 2
+    done
+}
+
 log_probe_runner "upload-probe-runner started"
+wait_for_push_config_sync
 
 while true; do
     interval="$(read_probe_interval_from_config)"

--- a/scripts/upload-probe-runner.sh
+++ b/scripts/upload-probe-runner.sh
@@ -32,6 +32,9 @@ log_probe_runner() {
 # Wait for entrypoint background sync before the first probe (probe accounts live in /etc).
 wait_for_push_config_sync() {
     local max_sec="${UPLOAD_PROBE_SYNC_WAIT_SEC:-90}"
+    if ! [[ "$max_sec" =~ ^[0-9]+$ ]] || [ "$max_sec" -lt 1 ]; then
+        max_sec=90
+    fi
     local start_sec elapsed
     start_sec="$(date +%s 2>/dev/null || echo 0)"
     while true; do

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -249,10 +249,12 @@ main() {
 
     if [ -n "$ftps_user" ] && [ -n "$ftps_pass" ]; then
         local ftp_probe_label="FTP"
+        local ftp_probe_fail_detail="ftp failed"
         if vsftpd_ssl_enabled; then
             ftp_probe_label="FTPS"
+            ftp_probe_fail_detail="ftps failed"
         fi
-        IFS='|' read -r ftps_ok ftps_duration_sec ftps_detail < <(run_ftp_probe "$connect_host" "$ftp_port" "$ftps_user" "$ftps_pass" || echo "false|0|ftps failed")
+        IFS='|' read -r ftps_ok ftps_duration_sec ftps_detail < <(run_ftp_probe "$connect_host" "$ftp_port" "$ftps_user" "$ftps_pass" || echo "false|0|${ftp_probe_fail_detail}")
         log_probe "INFO" "${ftp_probe_label} probe ok=${ftps_ok} duration_sec=${ftps_duration_sec} detail=${ftps_detail} host=${connect_host}"
         if [ "$ftps_ok" != "true" ]; then
             log_upload_health_app "error" "${ftp_probe_label} upload health probe failed" \

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -117,7 +117,8 @@ vsftpd_ssl_enabled() {
     return 1
 }
 
-run_ftps_probe() {
+# FTP upload probe: plain FTP when ssl_enable=NO, explicit TLS (FTPS) when enabled.
+run_ftp_probe() {
     local host="$1" port="$2" user="$3" pass="$4"
     local file_name base_url local_file start_sec end_sec elapsed use_tls ok_detail
     local -a curl_tls_args=()
@@ -247,7 +248,7 @@ main() {
     sftp_skipped="false"
 
     if [ -n "$ftps_user" ] && [ -n "$ftps_pass" ]; then
-        IFS='|' read -r ftps_ok ftps_duration_sec ftps_detail < <(run_ftps_probe "$connect_host" "$ftp_port" "$ftps_user" "$ftps_pass" || echo "false|0|ftps failed")
+        IFS='|' read -r ftps_ok ftps_duration_sec ftps_detail < <(run_ftp_probe "$connect_host" "$ftp_port" "$ftps_user" "$ftps_pass" || echo "false|0|ftps failed")
         log_probe "INFO" "FTPS probe ok=${ftps_ok} duration_sec=${ftps_duration_sec} detail=${ftps_detail} host=${connect_host}"
         if [ "$ftps_ok" != "true" ]; then
             log_upload_health_app "error" "FTPS upload health probe failed" \

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -96,8 +96,7 @@ ensure_sftp_known_hosts() {
     chmod 700 "$ssh_dir" 2>/dev/null || true
     touch "$known_hosts"
     chmod 600 "$known_hosts" 2>/dev/null || true
-    if ! grep -qF "[${host}]:${port}" "$known_hosts" 2>/dev/null \
-        && ! grep -qF "${host}" "$known_hosts" 2>/dev/null; then
+    if ! grep -qF "[${host}]:${port}" "$known_hosts" 2>/dev/null; then
         ssh-keyscan -p "$port" "$host" >>"$known_hosts" 2>/dev/null || true
     fi
 }

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -248,10 +248,14 @@ main() {
     sftp_skipped="false"
 
     if [ -n "$ftps_user" ] && [ -n "$ftps_pass" ]; then
+        local ftp_probe_label="FTP"
+        if vsftpd_ssl_enabled; then
+            ftp_probe_label="FTPS"
+        fi
         IFS='|' read -r ftps_ok ftps_duration_sec ftps_detail < <(run_ftp_probe "$connect_host" "$ftp_port" "$ftps_user" "$ftps_pass" || echo "false|0|ftps failed")
-        log_probe "INFO" "FTPS probe ok=${ftps_ok} duration_sec=${ftps_duration_sec} detail=${ftps_detail} host=${connect_host}"
+        log_probe "INFO" "${ftp_probe_label} probe ok=${ftps_ok} duration_sec=${ftps_duration_sec} detail=${ftps_detail} host=${connect_host}"
         if [ "$ftps_ok" != "true" ]; then
-            log_upload_health_app "error" "FTPS upload health probe failed" \
+            log_upload_health_app "error" "${ftp_probe_label} upload health probe failed" \
                 "$(jq -n --arg detail "$ftps_detail" --arg host "$connect_host" '{detail: $detail, connect_host: $host}')"
         fi
     else

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -78,28 +78,71 @@ probe_setup_netrc() {
     } >"$PROBE_NETRC_FILE"
 }
 
+ensure_sftp_known_hosts() {
+    local host="$1"
+    local port="$2"
+    if ! command -v ssh-keyscan >/dev/null 2>&1; then
+        return 0
+    fi
+    local ssh_dir="${HOME:-/root}/.ssh"
+    local known_hosts="${ssh_dir}/known_hosts"
+    mkdir -p "$ssh_dir"
+    chmod 700 "$ssh_dir" 2>/dev/null || true
+    touch "$known_hosts"
+    chmod 600 "$known_hosts" 2>/dev/null || true
+    if ! grep -qF "[${host}]:${port}" "$known_hosts" 2>/dev/null \
+        && ! grep -qF "${host}" "$known_hosts" 2>/dev/null; then
+        ssh-keyscan -p "$port" "$host" >>"$known_hosts" 2>/dev/null || true
+    fi
+}
+
+vsftpd_ssl_enabled() {
+    local conf="${VSFTPD_CONF:-/etc/vsftpd/vsftpd.conf}"
+    if [ ! -f "$conf" ]; then
+        return 1
+    fi
+    if grep -qE '^[[:space:]]*ssl_enable[[:space:]]*=[[:space:]]*YES' "$conf" 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
 run_ftps_probe() {
     local host="$1" port="$2" user="$3" pass="$4"
-    local file_name base_url local_file start_sec end_sec elapsed
+    local file_name base_url local_file start_sec end_sec elapsed use_tls ok_detail
+    local -a curl_tls_args=()
     file_name="$PROBE_REMOTE_FILENAME"
     local_file="${PROBE_TMP_DIR}/${file_name}"
-    base_url="ftps://${host}:${port}/"
+    # ftp:// with --ftp-ssl-reqd uses explicit TLS (AUTH); vsftpd does not use implicit FTPS.
+    base_url="ftp://${host}:${port}/"
+    if vsftpd_ssl_enabled; then
+        use_tls="true"
+        curl_tls_args=(--ftp-ssl-reqd)
+        ok_detail="ok"
+    else
+        use_tls="false"
+        ok_detail="ok (plain ftp, ssl_enable=NO)"
+    fi
     mkdir -p "$PROBE_TMP_DIR"
     printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"$local_file"
     probe_setup_netrc "$host" "$user" "$pass"
     trap probe_netrc_cleanup RETURN
     start_sec="$(date +%s 2>/dev/null || echo 0)"
-    if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc --ftp-ssl-reqd --ftp-pasv \
+    if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc "${curl_tls_args[@]}" --ftp-pasv \
         --connect-timeout 10 --max-time 45 \
         --upload-file "$local_file" "${base_url}${file_name}" >/dev/null 2>&1; then
         rm -f "$local_file"
-        echo "false|0|ftps upload failed"
+        if [ "$use_tls" = "true" ]; then
+            echo "false|0|ftps upload failed"
+        else
+            echo "false|0|ftp upload failed"
+        fi
         return 1
     fi
-    if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc --ftp-ssl-reqd --ftp-pasv \
+    if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc "${curl_tls_args[@]}" --ftp-pasv \
         --connect-timeout 10 --max-time 30 \
         --fail -X "DELE ${file_name}" "$base_url" >/dev/null 2>&1; then
-        log_probe "WARN" "FTPS upload ok but delete failed for ${file_name}"
+        log_probe "WARN" "FTP upload ok but delete failed for ${file_name}"
     fi
     rm -f "$local_file"
     end_sec="$(date +%s 2>/dev/null || echo 0)"
@@ -107,7 +150,7 @@ run_ftps_probe() {
     if [ "$elapsed" -lt 0 ]; then
         elapsed=0
     fi
-    echo "true|${elapsed}|ok"
+    echo "true|${elapsed}|${ok_detail}"
 }
 
 run_sftp_probe() {
@@ -119,6 +162,7 @@ run_sftp_probe() {
     base_url="sftp://${host}:${port}/"
     mkdir -p "$PROBE_TMP_DIR"
     printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"$local_file"
+    ensure_sftp_known_hosts "$host" "$port"
     probe_setup_netrc "$host" "$user" "$pass"
     trap probe_netrc_cleanup RETURN
     start_sec="$(date +%s 2>/dev/null || echo 0)"

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -142,7 +142,11 @@ run_ftps_probe() {
     if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc "${curl_tls_args[@]}" --ftp-pasv \
         --connect-timeout 10 --max-time 30 \
         --fail -X "DELE ${file_name}" "$base_url" >/dev/null 2>&1; then
-        log_probe "WARN" "FTP upload ok but delete failed for ${file_name}"
+        if [ "$use_tls" = "true" ]; then
+            log_probe "WARN" "FTPS upload ok but delete failed for ${file_name}"
+        else
+            log_probe "WARN" "FTP upload ok but delete failed for ${file_name}"
+        fi
     fi
     rm -f "$local_file"
     end_sec="$(date +%s 2>/dev/null || echo 0)"

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -81,6 +81,12 @@ probe_setup_netrc() {
 ensure_sftp_known_hosts() {
     local host="$1"
     local port="$2"
+    case "$host" in
+        localhost|127.0.0.1|::1) ;;
+        *)
+            return 0
+            ;;
+    esac
     if ! command -v ssh-keyscan >/dev/null 2>&1; then
         return 0
     fi

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -96,9 +96,14 @@ ensure_sftp_known_hosts() {
     chmod 700 "$ssh_dir" 2>/dev/null || true
     touch "$known_hosts"
     chmod 600 "$known_hosts" 2>/dev/null || true
-    if ! grep -qF "[${host}]:${port}" "$known_hosts" 2>/dev/null; then
-        ssh-keyscan -p "$port" "$host" >>"$known_hosts" 2>/dev/null || true
+    if grep -qF "[${host}]:${port}" "$known_hosts" 2>/dev/null; then
+        return 0
     fi
+    # Port 22 entries are often stored as "host keytype ..." without [host]:port.
+    if [ "$port" = "22" ] && grep -qF "${host} " "$known_hosts" 2>/dev/null; then
+        return 0
+    fi
+    ssh-keyscan -T 5 -p "$port" "$host" >>"$known_hosts" 2>/dev/null || true
 }
 
 vsftpd_ssl_enabled() {

--- a/tests/Unit/PushWebcamValidatorTest.php
+++ b/tests/Unit/PushWebcamValidatorTest.php
@@ -379,7 +379,8 @@ class PushWebcamValidatorTest extends TestCase
 
         $this->assertFalse($result['valid']);
         $this->assertCount(1, $result['errors']);
-        $this->assertStringContainsString("Duplicate username 'ab3xk9mp2qr7vn'", $result['errors'][0]);
+        $this->assertStringContainsString("Duplicate username 'aB3xK9mP2qR7vN'", $result['errors'][0]);
+        $this->assertStringContainsString('(case-insensitive)', $result['errors'][0]);
         $this->assertStringContainsString('kspb_0', $result['errors'][0]);
         $this->assertStringContainsString('kspb_1', $result['errors'][0]);
         $this->assertStringContainsString('kspb_2', $result['errors'][0]);

--- a/tests/Unit/PushWebcamValidatorTest.php
+++ b/tests/Unit/PushWebcamValidatorTest.php
@@ -342,5 +342,47 @@ class PushWebcamValidatorTest extends TestCase
         $this->assertFalse($result['valid']);
         $this->assertStringContainsString('Duplicate username', $result['errors'][0]);
     }
+
+    public function testDuplicateUsernames_ThreeWayCaseCollision_SingleError(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'webcams' => [
+                        [
+                            'type' => 'push',
+                            'push_config' => [
+                                'username' => 'aB3xK9mP2qR7vN',
+                                'password' => 'mK8pL3nQ6rT9vW',
+                            ],
+                        ],
+                        [
+                            'type' => 'push',
+                            'push_config' => [
+                                'username' => 'ab3xk9mp2qr7vn',
+                                'password' => 'xY9zA2bC4dE6fG',
+                            ],
+                        ],
+                        [
+                            'type' => 'push',
+                            'push_config' => [
+                                'username' => 'AB3XK9MP2QR7VN',
+                                'password' => 'nP4qR8sT2vW6xY',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateUniquePushUsernames($config);
+
+        $this->assertFalse($result['valid']);
+        $this->assertCount(1, $result['errors']);
+        $this->assertStringContainsString("Duplicate username 'ab3xk9mp2qr7vn'", $result['errors'][0]);
+        $this->assertStringContainsString('kspb_0', $result['errors'][0]);
+        $this->assertStringContainsString('kspb_1', $result['errors'][0]);
+        $this->assertStringContainsString('kspb_2', $result['errors'][0]);
+    }
 }
 

--- a/tests/Unit/PushWebcamValidatorTest.php
+++ b/tests/Unit/PushWebcamValidatorTest.php
@@ -311,5 +311,36 @@ class PushWebcamValidatorTest extends TestCase
         $this->assertFalse($result['valid']);
         $this->assertStringContainsString('Invalid IP address', $result['errors'][0]);
     }
+
+    public function testDuplicateUsernames_CaseInsensitive(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'webcams' => [
+                        [
+                            'type' => 'push',
+                            'push_config' => [
+                                'username' => 'aB3xK9mP2qR7vN',
+                                'password' => 'mK8pL3nQ6rT9vW',
+                            ],
+                        ],
+                        [
+                            'type' => 'push',
+                            'push_config' => [
+                                'username' => 'ab3xk9mp2qr7vn',
+                                'password' => 'xY9zA2bC4dE6fG',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateUniquePushUsernames($config);
+
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('Duplicate username', $result['errors'][0]);
+    }
 }
 

--- a/tests/Unit/SyncPushConfigTest.php
+++ b/tests/Unit/SyncPushConfigTest.php
@@ -252,6 +252,20 @@ class SyncPushConfigTest extends TestCase
         $this->assertSame([], $parsed['users']);
     }
 
+    public function testParseVsftpdVirtualUsersFile_SkipsMisalignedPairsWithoutShifting(): void
+    {
+        require_once __DIR__ . '/../../scripts/sync-push-config.php';
+
+        $path = $this->trackTempFile(sys_get_temp_dir() . '/vsftpd-users-' . uniqid('', true) . '.txt');
+        file_put_contents($path, "userone14chars\n\nusertwo14chars\npasstwo14chars\n");
+
+        $parsed = parseVsftpdVirtualUsersFile($path);
+
+        $this->assertNotEmpty($parsed['errors']);
+        $this->assertStringContainsString('empty password', $parsed['errors'][0]);
+        $this->assertSame(['usertwo14chars' => 'passtwo14chars'], $parsed['users']);
+    }
+
     public function testValidateConfigBeforeApply_RejectsDuplicatePushUsernames(): void
     {
         require_once __DIR__ . '/../../lib/config.php';

--- a/tests/Unit/SyncPushConfigTest.php
+++ b/tests/Unit/SyncPushConfigTest.php
@@ -266,6 +266,15 @@ class SyncPushConfigTest extends TestCase
         $this->assertSame(['usertwo14chars' => 'passtwo14chars'], $parsed['users']);
     }
 
+    public function testWriteVsftpdVirtualUsersFile_SetsRestrictivePermissions(): void
+    {
+        require_once __DIR__ . '/../../scripts/sync-push-config.php';
+
+        $path = $this->trackTempFile(sys_get_temp_dir() . '/vsftpd-users-' . uniqid('', true) . '.txt');
+        $this->assertTrue(writeVsftpdVirtualUsersFile(['userone14chars' => 'passone14chars'], $path));
+        $this->assertSame(0600, fileperms($path) & 0777);
+    }
+
     public function testValidateSyncPushUploadCredentials_DelegatesToPushWebcamValidator(): void
     {
         require_once __DIR__ . '/../../scripts/sync-push-config.php';

--- a/tests/Unit/SyncPushConfigTest.php
+++ b/tests/Unit/SyncPushConfigTest.php
@@ -16,6 +16,9 @@ require_once __DIR__ . '/../../lib/logger.php';
 class SyncPushConfigTest extends TestCase
 {
     private string $testMappingFile;
+
+    /** @var list<string> */
+    private array $tempPaths = [];
     
     protected function setUp(): void
     {
@@ -27,12 +30,24 @@ class SyncPushConfigTest extends TestCase
     
     protected function tearDown(): void
     {
-        // Clean up test file
         if (file_exists($this->testMappingFile)) {
             unlink($this->testMappingFile);
         }
+        foreach ($this->tempPaths as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+        $this->tempPaths = [];
         
         parent::tearDown();
+    }
+
+    private function trackTempFile(string $path): string
+    {
+        $this->tempPaths[] = $path;
+
+        return $path;
     }
     
     /**
@@ -192,5 +207,85 @@ class SyncPushConfigTest extends TestCase
             $src,
             'local_root in logs must not use $filesDir (SFTP path; undefined in FTP flow)'
         );
+    }
+
+    public function testParseVsftpdVirtualUsersFile_AllowsSharedPasswordsAcrossUsernames(): void
+    {
+        require_once __DIR__ . '/../../scripts/sync-push-config.php';
+
+        $path = $this->trackTempFile(sys_get_temp_dir() . '/vsftpd-users-' . uniqid('', true) . '.txt');
+        file_put_contents($path, "kczkcam1\nsharedpass14xx\nkczkcam2\nsharedpass14xx\n");
+
+        $parsed = parseVsftpdVirtualUsersFile($path);
+
+        $this->assertSame([], $parsed['errors']);
+        $this->assertCount(2, $parsed['users']);
+        $this->assertSame('sharedpass14xx', $parsed['users']['kczkcam1']);
+        $this->assertSame('sharedpass14xx', $parsed['users']['kczkcam2']);
+    }
+
+    public function testParseVsftpdVirtualUsersFile_DetectsDuplicateUsernames(): void
+    {
+        require_once __DIR__ . '/../../scripts/sync-push-config.php';
+
+        $path = $this->trackTempFile(sys_get_temp_dir() . '/vsftpd-users-' . uniqid('', true) . '.txt');
+        file_put_contents($path, "dupuser14chars\npassone14chars\ndupuser14chars\npasstwo14chars\n");
+
+        $parsed = parseVsftpdVirtualUsersFile($path);
+
+        $this->assertNotEmpty($parsed['errors']);
+        $this->assertStringContainsString("Duplicate vsftpd username 'dupuser14chars'", $parsed['errors'][0]);
+        $this->assertSame(['dupuser14chars' => 'passone14chars'], $parsed['users']);
+    }
+
+    public function testParseVsftpdVirtualUsersFile_DetectsOddLineCount(): void
+    {
+        require_once __DIR__ . '/../../scripts/sync-push-config.php';
+
+        $path = $this->trackTempFile(sys_get_temp_dir() . '/vsftpd-users-' . uniqid('', true) . '.txt');
+        file_put_contents($path, "onlyuser14char\n");
+
+        $parsed = parseVsftpdVirtualUsersFile($path);
+
+        $this->assertNotEmpty($parsed['errors']);
+        $this->assertStringContainsString('odd line count', $parsed['errors'][0]);
+        $this->assertSame([], $parsed['users']);
+    }
+
+    public function testValidateConfigBeforeApply_RejectsDuplicatePushUsernames(): void
+    {
+        require_once __DIR__ . '/../../lib/config.php';
+        require_once __DIR__ . '/../../scripts/sync-push-config.php';
+
+        $path = $this->trackTempFile(sys_get_temp_dir() . '/sync-config-' . uniqid('', true) . '.json');
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'webcams' => [
+                        [
+                            'type' => 'push',
+                            'push_config' => [
+                                'username' => 'aB3xK9mP2qR7vN',
+                                'password' => 'mK8pL3nQ6rT9vW',
+                            ],
+                        ],
+                        [
+                            'type' => 'push',
+                            'push_config' => [
+                                'username' => 'aB3xK9mP2qR7vN',
+                                'password' => 'xY9zA2bC4dE6fG',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        file_put_contents($path, json_encode($config, JSON_THROW_ON_ERROR));
+
+        $result = validateConfigBeforeApply($path);
+
+        $this->assertFalse($result['valid']);
+        $this->assertArrayHasKey('error', $result);
+        $this->assertStringContainsString('Duplicate username', $result['error']);
     }
 }

--- a/tests/Unit/SyncPushConfigTest.php
+++ b/tests/Unit/SyncPushConfigTest.php
@@ -262,8 +262,21 @@ class SyncPushConfigTest extends TestCase
         $parsed = parseVsftpdVirtualUsersFile($path);
 
         $this->assertNotEmpty($parsed['errors']);
-        $this->assertStringContainsString('empty password', $parsed['errors'][0]);
+        $this->assertStringContainsString('incomplete username/password pair', $parsed['errors'][0]);
         $this->assertSame(['usertwo14chars' => 'passtwo14chars'], $parsed['users']);
+    }
+
+    public function testValidateSyncPushUploadCredentials_DelegatesToPushWebcamValidator(): void
+    {
+        require_once __DIR__ . '/../../scripts/sync-push-config.php';
+
+        $errors = validateSyncPushUploadCredentials('bad user', 'short', 'test-context');
+        $this->assertNotEmpty($errors);
+
+        $this->assertSame(
+            [],
+            validateSyncPushUploadCredentials('aB3xK9mP2qR7vN', 'mK8pL3nQ6rT9vW', 'test-context')
+        );
     }
 
     public function testValidateConfigBeforeApply_RejectsDuplicatePushUsernames(): void

--- a/tests/Unit/SyncPushConfigTest.php
+++ b/tests/Unit/SyncPushConfigTest.php
@@ -262,7 +262,7 @@ class SyncPushConfigTest extends TestCase
         $parsed = parseVsftpdVirtualUsersFile($path);
 
         $this->assertNotEmpty($parsed['errors']);
-        $this->assertStringContainsString('incomplete username/password pair', $parsed['errors'][0]);
+        $this->assertStringContainsString("empty password for 'userone14chars'", $parsed['errors'][0]);
         $this->assertSame(['usertwo14chars' => 'passtwo14chars'], $parsed['users']);
     }
 

--- a/tests/Unit/UploadHealthProbeSyncTest.php
+++ b/tests/Unit/UploadHealthProbeSyncTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/constants.php';
+require_once __DIR__ . '/../../lib/logger.php';
+require_once __DIR__ . '/../../lib/config.php';
+require_once __DIR__ . '/../../lib/cache-paths.php';
+require_once __DIR__ . '/../../scripts/sync-push-config.php';
+
+/**
+ * Upload health probe account provisioning during push-config sync.
+ */
+class UploadHealthProbeSyncTest extends TestCase
+{
+    private string $originalAppEnv;
+
+    private string $originalConfigPath;
+
+    /** @var list<string> */
+    private array $tempConfigPaths = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalAppEnv = getenv('APP_ENV') ?: '';
+        $this->originalConfigPath = getenv('CONFIG_PATH') ?: '';
+        $this->clearConfigCache();
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('APP_ENV=' . $this->originalAppEnv);
+        $_ENV['APP_ENV'] = $this->originalAppEnv;
+        $_SERVER['APP_ENV'] = $this->originalAppEnv;
+        putenv('CONFIG_PATH=' . $this->originalConfigPath);
+        if ($this->originalConfigPath !== '') {
+            $_ENV['CONFIG_PATH'] = $this->originalConfigPath;
+            $_SERVER['CONFIG_PATH'] = $this->originalConfigPath;
+        } else {
+            unset($_ENV['CONFIG_PATH'], $_SERVER['CONFIG_PATH']);
+        }
+        foreach ($this->tempConfigPaths as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+        $this->tempConfigPaths = [];
+        $this->clearConfigCache();
+        parent::tearDown();
+    }
+
+    public function testGetUploadHealthProbeFtpDir_IsolatedFromCameraInboxes(): void
+    {
+        $probeDir = getUploadHealthProbeFtpDir('awxprobeftps');
+        $cameraDir = getWebcamFtpUploadDir('kspb', 'awxprobeftps');
+
+        $this->assertStringContainsString('/' . UPLOAD_HEALTH_PROBE_FTP_NAMESPACE . '/awxprobeftps', $probeDir);
+        $this->assertNotSame($cameraDir, $probeDir);
+        $this->assertStringNotContainsString('/kspb/', $probeDir);
+    }
+
+    public function testGetUploadHealthProbeSyncPlan_ReturnsEmptyWhenDisabled(): void
+    {
+        $this->useProductionConfig([
+            'config' => [
+                'base_domain' => 'example.org',
+                'upload_health_probe' => [
+                    'enabled' => false,
+                    'ftps' => ['username' => 'probeftps', 'password' => 'abcdefghijklmn'],
+                ],
+            ],
+            'airports' => [],
+        ]);
+
+        $this->assertSame([], getUploadHealthProbeSyncPlan());
+    }
+
+    public function testGetUploadHealthProbeSyncPlan_ReturnsFtpsAndSftpWhenEnabled(): void
+    {
+        $this->useProductionConfig([
+            'config' => [
+                'base_domain' => 'example.org',
+                'upload_health_probe' => [
+                    'enabled' => true,
+                    'probe_connect_host' => '127.0.0.1',
+                    'ftps' => ['username' => 'probeftps', 'password' => 'abcdefghijklmn'],
+                    'sftp' => ['username' => 'probesftp', 'password' => 'opqrstuvwxyz12'],
+                ],
+            ],
+            'airports' => [],
+        ]);
+
+        $plan = getUploadHealthProbeSyncPlan();
+
+        $this->assertCount(2, $plan);
+        $this->assertSame('ftps', $plan[0]['protocol']);
+        $this->assertSame('probeftps', $plan[0]['username']);
+        $this->assertSame('abcdefghijklmn', $plan[0]['password']);
+        $this->assertSame(getUploadHealthProbeFtpDir('probeftps'), $plan[0]['ftp_local_root']);
+
+        $this->assertSame('sftp', $plan[1]['protocol']);
+        $this->assertSame('probesftp', $plan[1]['username']);
+        $this->assertSame('opqrstuvwxyz12', $plan[1]['password']);
+    }
+
+    public function testGetUploadHealthProbeSyncPlan_ReturnsEmptyOutsideProduction(): void
+    {
+        putenv('APP_ENV=testing');
+        $_ENV['APP_ENV'] = 'testing';
+        $_SERVER['APP_ENV'] = 'testing';
+        $this->clearConfigCache();
+
+        $this->assertSame([], getUploadHealthProbeSyncPlan());
+    }
+
+    public function testSyncPushConfig_InvokesUploadHealthProbeSyncAfterPushCameras(): void
+    {
+        $path = __DIR__ . '/../../scripts/sync-push-config.php';
+        $contents = file_get_contents($path);
+        $this->assertIsString($contents);
+
+        $pushPos = strpos($contents, 'syncAllPushCameras($config);');
+        $this->assertNotFalse($pushPos, 'syncPushConfig must sync push cameras');
+
+        $afterPush = substr($contents, $pushPos);
+        $this->assertNotFalse(
+            strpos($afterPush, 'syncUploadHealthProbeUsers()'),
+            'full sync path must sync upload health probe users after push cameras'
+        );
+    }
+
+    public function testSyncPushConfig_ReprovisionsProbeUsersWhenCameraSyncSkipped(): void
+    {
+        $path = __DIR__ . '/../../scripts/sync-push-config.php';
+        $contents = file_get_contents($path);
+        $this->assertIsString($contents);
+
+        $skipPos = strpos($contents, 'config unchanged since last sync, skipping');
+        $this->assertNotFalse($skipPos);
+
+        $probePos = strpos($contents, 'syncUploadHealthProbeUsers()', $skipPos);
+        $this->assertNotFalse($probePos, 'probe sync must run on config-unchanged early return path');
+        $this->assertGreaterThan($skipPos, $probePos);
+    }
+
+    public function testUploadProbeScript_UsesExplicitFtpsUrl(): void
+    {
+        $path = __DIR__ . '/../../scripts/upload-probe.sh';
+        $contents = file_get_contents($path);
+        $this->assertIsString($contents);
+        $this->assertStringContainsString('base_url="ftp://${host}:${port}/"', $contents);
+        $this->assertStringNotContainsString('base_url="ftps://${host}:${port}/"', $contents);
+    }
+
+    public function testUploadProbeScript_UsesPlainFtpWhenVsftpdSslDisabled(): void
+    {
+        $path = __DIR__ . '/../../scripts/upload-probe.sh';
+        $contents = file_get_contents($path);
+        $this->assertIsString($contents);
+        $this->assertStringContainsString('vsftpd_ssl_enabled', $contents);
+        $this->assertStringContainsString('curl_tls_args=(--ftp-ssl-reqd)', $contents);
+        $this->assertStringContainsString('ok (plain ftp, ssl_enable=NO)', $contents);
+    }
+
+    public function testUploadProbeRunner_WaitsForPushConfigSyncBeforeFirstProbe(): void
+    {
+        $path = __DIR__ . '/../../scripts/upload-probe-runner.sh';
+        $contents = file_get_contents($path);
+        $this->assertIsString($contents);
+        $this->assertStringContainsString('wait_for_push_config_sync', $contents);
+        $this->assertStringContainsString('FTP/SFTP/FTPS configuration synced successfully', $contents);
+        $this->assertStringContainsString(
+            "log_probe_runner \"upload-probe-runner started\"\nwait_for_push_config_sync\n\nwhile true; do",
+            $contents
+        );
+    }
+
+    public function testUploadProbeScript_EnsuresLoopbackSftpKnownHosts(): void
+    {
+        $path = __DIR__ . '/../../scripts/upload-probe.sh';
+        $contents = file_get_contents($path);
+        $this->assertIsString($contents);
+        $this->assertStringContainsString('ensure_sftp_known_hosts', $contents);
+        $this->assertStringContainsString('ssh-keyscan', $contents);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function useProductionConfig(array $config): void
+    {
+        $tmp = sys_get_temp_dir() . '/upload-probe-sync-' . uniqid('', true) . '.json';
+        file_put_contents($tmp, json_encode($config, JSON_THROW_ON_ERROR));
+        putenv('APP_ENV=production');
+        $_ENV['APP_ENV'] = 'production';
+        $_SERVER['APP_ENV'] = 'production';
+        putenv('CONFIG_PATH=' . $tmp);
+        $_ENV['CONFIG_PATH'] = $tmp;
+        $_SERVER['CONFIG_PATH'] = $tmp;
+        $this->tempConfigPaths[] = $tmp;
+        $this->clearConfigCache();
+    }
+
+    private function clearConfigCache(): void
+    {
+        if (function_exists('apcu_clear_cache')) {
+            apcu_clear_cache();
+        }
+    }
+}

--- a/tests/Unit/UploadHealthProbeSyncTest.php
+++ b/tests/Unit/UploadHealthProbeSyncTest.php
@@ -174,13 +174,15 @@ class UploadHealthProbeSyncTest extends TestCase
         $this->assertStringContainsString('FTP/SFTP/FTPS configuration synced successfully', $contents);
 
         $startedPos = strpos($contents, 'log_probe_runner "upload-probe-runner started"');
-        $waitPos = strpos($contents, 'wait_for_push_config_sync');
-        $loopPos = strpos($contents, 'while true; do');
         $this->assertNotFalse($startedPos);
-        $this->assertNotFalse($waitPos);
-        $this->assertNotFalse($loopPos);
-        $this->assertLessThan($waitPos, $loopPos, 'wait must run before probe loop');
-        $this->assertLessThan($startedPos, $waitPos, 'runner start log must precede sync wait');
+
+        $waitCallPos = strpos($contents, 'wait_for_push_config_sync', $startedPos);
+        $this->assertNotFalse($waitCallPos, 'runner must invoke wait_for_push_config_sync after start log');
+        $this->assertGreaterThan($startedPos, $waitCallPos, 'runner start log must precede sync wait');
+
+        $mainLoopPos = strpos($contents, 'while true; do', $waitCallPos);
+        $this->assertNotFalse($mainLoopPos, 'probe interval loop must follow sync wait');
+        $this->assertGreaterThan($waitCallPos, $mainLoopPos, 'sync wait call must precede probe loop');
     }
 
     public function testUploadProbeScript_EnsuresLoopbackSftpKnownHosts(): void
@@ -191,27 +193,6 @@ class UploadHealthProbeSyncTest extends TestCase
         $this->assertStringContainsString('ensure_sftp_known_hosts', $contents);
         $this->assertStringContainsString('ssh-keyscan', $contents);
         $this->assertStringContainsString('localhost|127.0.0.1|::1', $contents);
-    }
-
-    public function testUploadProbeRunner_UsesLogLevelFromMessagePrefix(): void
-    {
-        $path = __DIR__ . '/../../scripts/upload-probe-runner.sh';
-        $contents = file_get_contents($path);
-        $this->assertIsString($contents);
-        $this->assertStringContainsString('[[ "$msg" == WARN\\ * ]]', $contents);
-        $this->assertStringContainsString('echo "[$ts] [$level] $msg"', $contents);
-    }
-
-    public function testSyncPushConfig_ExitsNonZeroOnConfigValidationFailure(): void
-    {
-        $path = __DIR__ . '/../../scripts/sync-push-config.php';
-        $contents = file_get_contents($path);
-        $this->assertIsString($contents);
-        $this->assertStringContainsString("'config validation failed, skipping sync'", $contents);
-        $pos = strpos($contents, "'config validation failed, skipping sync'");
-        $this->assertNotFalse($pos);
-        $snippet = substr($contents, $pos, 200);
-        $this->assertStringContainsString('exit(1);', $snippet);
     }
 
     /**

--- a/tests/Unit/UploadHealthProbeSyncTest.php
+++ b/tests/Unit/UploadHealthProbeSyncTest.php
@@ -185,6 +185,28 @@ class UploadHealthProbeSyncTest extends TestCase
         $this->assertIsString($contents);
         $this->assertStringContainsString('ensure_sftp_known_hosts', $contents);
         $this->assertStringContainsString('ssh-keyscan', $contents);
+        $this->assertStringContainsString('localhost|127.0.0.1|::1', $contents);
+    }
+
+    public function testUploadProbeRunner_UsesLogLevelFromMessagePrefix(): void
+    {
+        $path = __DIR__ . '/../../scripts/upload-probe-runner.sh';
+        $contents = file_get_contents($path);
+        $this->assertIsString($contents);
+        $this->assertStringContainsString('[[ "$msg" == WARN\\ * ]]', $contents);
+        $this->assertStringContainsString('echo "[$ts] [$level] $msg"', $contents);
+    }
+
+    public function testSyncPushConfig_ExitsNonZeroOnConfigValidationFailure(): void
+    {
+        $path = __DIR__ . '/../../scripts/sync-push-config.php';
+        $contents = file_get_contents($path);
+        $this->assertIsString($contents);
+        $this->assertStringContainsString("'config validation failed, skipping sync'", $contents);
+        $pos = strpos($contents, "'config validation failed, skipping sync'");
+        $this->assertNotFalse($pos);
+        $snippet = substr($contents, $pos, 200);
+        $this->assertStringContainsString('exit(1);', $snippet);
     }
 
     /**

--- a/tests/Unit/UploadHealthProbeSyncTest.php
+++ b/tests/Unit/UploadHealthProbeSyncTest.php
@@ -172,10 +172,15 @@ class UploadHealthProbeSyncTest extends TestCase
         $this->assertIsString($contents);
         $this->assertStringContainsString('wait_for_push_config_sync', $contents);
         $this->assertStringContainsString('FTP/SFTP/FTPS configuration synced successfully', $contents);
-        $this->assertStringContainsString(
-            "log_probe_runner \"upload-probe-runner started\"\nwait_for_push_config_sync\n\nwhile true; do",
-            $contents
-        );
+
+        $startedPos = strpos($contents, 'log_probe_runner "upload-probe-runner started"');
+        $waitPos = strpos($contents, 'wait_for_push_config_sync');
+        $loopPos = strpos($contents, 'while true; do');
+        $this->assertNotFalse($startedPos);
+        $this->assertNotFalse($waitPos);
+        $this->assertNotFalse($loopPos);
+        $this->assertLessThan($waitPos, $loopPos, 'wait must run before probe loop');
+        $this->assertLessThan($startedPos, $waitPos, 'runner start log must precede sync wait');
     }
 
     public function testUploadProbeScript_EnsuresLoopbackSftpKnownHosts(): void

--- a/tests/Unit/UploadHealthProbeSyncTest.php
+++ b/tests/Unit/UploadHealthProbeSyncTest.php
@@ -62,6 +62,14 @@ class UploadHealthProbeSyncTest extends TestCase
         $this->assertStringNotContainsString('/kspb/', $probeDir);
     }
 
+    public function testIsUploadHealthProbeFtpCacheNamespace_MatchesReservedTopLevelDir(): void
+    {
+        $this->assertTrue(isUploadHealthProbeFtpCacheNamespace('_probe'));
+        $this->assertTrue(isUploadHealthProbeFtpCacheNamespace('_PROBE'));
+        $this->assertFalse(isUploadHealthProbeFtpCacheNamespace('keul'));
+        $this->assertFalse(isUploadHealthProbeFtpCacheNamespace('kspb'));
+    }
+
     public function testGetUploadHealthProbeSyncPlan_ReturnsEmptyWhenDisabled(): void
     {
         $this->useProductionConfig([


### PR DESCRIPTION
## Summary

Production upload probe failures after container restart were mostly missing probe accounts in `/etc`, not broken camera uploads. `sync-push-config.php` provisioned push cameras but never created `upload_health_probe` FTPS/SFTP users, and the probe runner could fire before sync finished.

This PR wires probe account provisioning into push-config sync (full sync and config-unchanged startup path), hardens the probe scripts, and tightens FTP username validation before sync runs.

## Changes

- **`scripts/sync-push-config.php`**: `syncUploadHealthProbeUsers()` for FTPS (`cache/ftp/_probe/`) and SFTP; runs on every startup; `validateConfigBeforeApply()` now uses full `validateRuntimeConfigSchema()`; `parseVsftpdVirtualUsersFile()` parses username/password pairs (shared passwords across users are OK); duplicate push usernames abort camera sync
- **`scripts/upload-probe.sh`**: explicit TLS via `ftp://` + `--ftp-ssl-reqd` when `ssl_enable=YES`; plain FTP fallback when SSL is off; `ssh-keyscan` for loopback SFTP
- **`scripts/upload-probe-runner.sh`**: wait up to 90s for entrypoint sync before first probe
- **`docker/docker-entrypoint.sh`**: start background sync before probe runner
- **`lib/cache-paths.php`**, **`lib/constants.php`**: `_probe` FTP namespace for isolated probe inboxes
- **`lib/push-webcam-validator.php`**: case-insensitive duplicate push username check
- **Tests**: `UploadHealthProbeSyncTest`, vsftpd parser tests, case-insensitive username test

## Deploy notes

- **Rebuild Docker image** - probe scripts are copied to `/usr/local/libexec/aviationwx/` at build time
- After deploy, run once (or rely on next container start):
  ```bash
  docker exec -u root aviationwx-web php /var/www/html/scripts/sync-push-config.php
  ```
- Confirm `/var/lib/aviationwx/upload-probe.json` shows `ftps.ok` and `sftp.ok` true (not `skipped`)
- Validated current production `airports.json` passes full runtime schema (no sync blockers)

## Test plan

- [x] `make test-ci`
- [x] `php scripts/validate-airports-json.php` on production secrets - pass
- [x] Local Docker production simulation: cold start, probe after sync, `ssl_enable=NO` plain FTP, SFTP known_hosts, config-unchanged reprovision
- [x] Post-deploy: probe heartbeat green; no `upload probe check failed` spam in `app.log`