### PR TITLE
NOTAM banner headlines with dedup and selection

### DIFF
--- a/api/notam.php
+++ b/api/notam.php
@@ -147,7 +147,7 @@ foreach ($notams as $notam) {
     }
     notamEnsureEffectiveSegments($notam);
     $currentStatus = revalidateNotamStatus($notam, $timezone);
-    if (!notamIsBannerRelevantStatus($currentStatus, $notam)) {
+    if (!notamIsBannerRelevantStatus($currentStatus, $notam, $nowUnix)) {
         continue;
     }
     $notam['status'] = $currentStatus;

--- a/api/notam.php
+++ b/api/notam.php
@@ -154,12 +154,12 @@ foreach ($notams as $notam) {
     $bannerCandidates[] = $notam;
 }
 
-$selectedForBanner = notamPrepareDashboardBannerRows($bannerCandidates, $airport, $timezone, $nowUnix);
+$bannerRows = notamPrepareDashboardBannerRows($bannerCandidates, $airport, $timezone, $nowUnix);
 
-// Format selected NOTAMs for frontend (add local times, official links, banner headlines)
+// Format deduplicated banner NOTAMs for frontend (add local times, official links, banner headlines)
 $formattedNotams = [];
 
-foreach ($selectedForBanner as $notam) {
+foreach ($bannerRows as $notam) {
     $currentStatus = (string) ($notam['status'] ?? revalidateNotamStatus($notam, $timezone));
     $startTimeUtc = $notam['start_time_utc'] ?? '';
     $endTimeUtc = $notam['end_time_utc'] ?? null;

--- a/api/notam.php
+++ b/api/notam.php
@@ -5,7 +5,8 @@
  * Serves NOTAM data to frontend with stale-while-revalidate caching.
  * Safety-critical: Re-validates NOTAM expiration at serve time and
  * implements failclosed when cache exceeds staleness threshold.
- * JSON NOTAM entries may include schedule_source, effective_segments, and current/next restriction window times.
+ * JSON NOTAM entries may include schedule_source, effective_segments, current/next restriction window times,
+ * and banner_headline / banner_schedule_line (visual cues; full message text remains authoritative).
  */
 
 require_once __DIR__ . '/../lib/config.php';
@@ -16,6 +17,7 @@ require_once __DIR__ . '/../lib/notam/fetcher.php';
 require_once __DIR__ . '/../lib/notam/filter.php';
 require_once __DIR__ . '/../lib/notam/schedule.php';
 require_once __DIR__ . '/../lib/notam/cache.php';
+require_once __DIR__ . '/../lib/notam/banner.php';
 
 // Start output buffering
 ob_start();
@@ -134,22 +136,31 @@ if ($isFailclosed) {
 // Use cached data if available, otherwise return empty
 $notams = $cachedData['notams'] ?? [];
 
-// Format NOTAMs for frontend (add local times, official links)
-// Re-validate status at serve time to catch NOTAMs that expired since caching
-$formattedNotams = [];
+// Re-validate and collect banner-eligible rows before selection
+$bannerCandidates = [];
 $timezone = getAirportTimezone($airportId, $airport);
+$nowUnix = time();
 
 foreach ($notams as $notam) {
+    if (!is_array($notam)) {
+        continue;
+    }
     notamEnsureEffectiveSegments($notam);
-    // Re-validate status at serve time using airport timezone (safety-critical)
     $currentStatus = revalidateNotamStatus($notam, $timezone);
-    
-    // Banner eligibility (status + 48h horizon) at serve time; cache may retain rows until next fetch
     if (!notamIsBannerRelevantStatus($currentStatus, $notam)) {
         continue;
     }
-    
-    // Format times
+    $notam['status'] = $currentStatus;
+    $bannerCandidates[] = $notam;
+}
+
+$selectedForBanner = notamPrepareDashboardBannerRows($bannerCandidates, $airport, $timezone, $nowUnix);
+
+// Format selected NOTAMs for frontend (add local times, official links, banner headlines)
+$formattedNotams = [];
+
+foreach ($selectedForBanner as $notam) {
+    $currentStatus = (string) ($notam['status'] ?? revalidateNotamStatus($notam, $timezone));
     $startTimeUtc = $notam['start_time_utc'] ?? '';
     $endTimeUtc = $notam['end_time_utc'] ?? null;
     
@@ -208,7 +219,6 @@ foreach ($notams as $notam) {
         ];
     }
     
-    $nowUnix = time();
     $currentWindowEndUtc = notamCurrentRestrictionEndUtc($notam, $nowUnix);
     $nextWindowStartUtc = notamNextRestrictionStartUtc($notam, $nowUnix);
     $currentWindowEndLocal = '';
@@ -243,6 +253,10 @@ foreach ($notams as $notam) {
         'id' => $notamId,
         'type' => $notam['notam_type'] ?? 'unknown',
         'status' => $currentStatus,
+        'banner_scope' => $notam['banner_scope'] ?? null,
+        'banner_category' => $notam['banner_category'] ?? null,
+        'banner_headline' => $notam['banner_headline'] ?? null,
+        'banner_schedule_line' => $notam['banner_schedule_line'] ?? null,
         'start_time_utc' => $startTimeUtc,
         'end_time_utc' => $endTimeUtc,
         'start_time_local' => $startTimeLocal,

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1548,7 +1548,7 @@ Each NOTAM is classified by temporal status (`classifyNotamDisplayStatusAt()` in
 
 **Cache filter** (`notamIsBannerRelevantStatus()`): retains `active`, `inactive_scheduled`, `upcoming_today`, and `upcoming_future` rows whose first window is within `NOTAM_BANNER_UPCOMING_FUTURE_HORIZON_SECONDS` (48 hours).
 
-**Serve filter** (`api/notam.php`): drops `expired` and `unknown`; returns the same banner-eligible statuses as the cache (re-validated at request time).
+**Serve filter** (`api/notam.php`): drops `expired` and `unknown`; returns the same banner-eligible statuses as the cache (re-validated at request time). Serve-time **event deduplication** (`deduplicateBannerNotams()` in `lib/notam/banner.php`) merges paired NOTAM rows for the same restriction (for example A-series and numeric ids for one fire TFR) before the API responds; there is no row cap after dedup.
 
 **Dashboard banners** (`pages/airport.php`): red **ACTIVE**, purple **SCHEDULED BREAK**, orange **UPCOMING** for `upcoming_today` and `upcoming_future`.
 
@@ -1716,7 +1716,8 @@ The `/api/notam.php` endpoint serves cached NOTAM data:
 #### NOTAM Content
 - **ID**: NOTAM identifier with link to official FAA source when `id` is present
 - **Status labels**: ACTIVE NOTAM, SCHEDULED BREAK, or UPCOMING NOTAM
-- **Message**: Full NOTAM text (all matching rows shown; no collapse)
+- **Headline**: Short parsed summary (`banner_headline`) plus schedule line; full NOTAM text remains below
+- **Message**: Full NOTAM text (all deduplicated matching rows shown; no collapse)
 - **Effective Times**: Envelope or segment window times in airport local timezone
 
 #### Visual Indicators

--- a/lib/notam/banner.php
+++ b/lib/notam/banner.php
@@ -230,13 +230,9 @@ function notamBannerEventFingerprint(array $notam, array $airport): string
         }
         $radiusKey = $radius !== null ? (string) round($radius, 2) : 'poly';
         $dailyKey = preg_match('/\bDLY\b/', strtoupper($text)) === 1 ? 'daily' : 'single';
-        $startKey = trim((string) ($notam['start_time_utc'] ?? ''));
-        if ($dailyKey === 'daily') {
-            $startKey = 'series';
-        }
 
-        return 'airspace|' . $category . '|' . $centerKey . '|' . $radiusKey . '|' . $vertical
-            . '|' . $dailyKey . '|' . $startKey;
+        return 'airspace|' . $airportKey . '|' . $category . '|' . $centerKey . '|' . $radiusKey . '|' . $vertical
+            . '|' . $dailyKey . '|' . $startKey . '|' . $endKey;
     }
 
     return 'unknown|' . trim((string) ($notam['id'] ?? '')) . '|' . substr(sha1($text), 0, 16);

--- a/lib/notam/banner.php
+++ b/lib/notam/banner.php
@@ -339,6 +339,19 @@ function notamBannerBuildAirspaceHeadline(string $category, string $text): strin
  */
 function notamBannerBuildScheduleLine(array &$notam, string $status, string $timezone, int $nowUnix): string
 {
+    if ($status === 'inactive_scheduled') {
+        $next = notamNextRestrictionStartUtc($notam, $nowUnix);
+        if ($next !== null && $next !== '') {
+            $ts = strtotime($next);
+            if ($ts !== false && $ts > $nowUnix) {
+                return 'Not active now - next window '
+                    . notamTfrMapLayerFormatLocalDateTimeForTooltip($ts, $timezone);
+            }
+        }
+
+        return 'Not active now - see NOTAM for schedule';
+    }
+
     $fromMap = notamTfrMapLayerTooltipStatusLine($notam, $status, $timezone, $nowUnix);
     if ($fromMap !== null && $fromMap !== '') {
         return $fromMap;
@@ -361,19 +374,6 @@ function notamBannerBuildScheduleLine(array &$notam, string $status, string $tim
         }
 
         return 'Active now';
-    }
-
-    if ($status === 'inactive_scheduled') {
-        $next = notamNextRestrictionStartUtc($notam, $nowUnix);
-        if ($next !== null && $next !== '') {
-            $ts = strtotime($next);
-            if ($ts !== false && $ts > $nowUnix) {
-                return 'Not active now - next window '
-                    . notamTfrMapLayerFormatLocalDateTimeForTooltip($ts, $timezone);
-            }
-        }
-
-        return 'Not active now - see NOTAM for schedule';
     }
 
     $start = notamFirstRestrictionStartUnix($notam);

--- a/lib/notam/banner.php
+++ b/lib/notam/banner.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Dashboard NOTAM banner taxonomy, headlines, deduplication, and selection.
+ * Dashboard NOTAM banner taxonomy, headlines, deduplication, and display ordering.
  *
  * Full NOTAM text is always retained for safety; headlines are visual cues only.
  */
@@ -487,16 +487,15 @@ function notamBannerSelectionSortKey(array $notam, int $nowUnix): array
 }
 
 /**
- * Select up to two NOTAM rows for the dashboard banner.
+ * Sort banner NOTAM rows for stable dashboard display (all deduplicated rows returned).
  *
- * Primary is the highest-priority current or next event. Secondary appears only when
- * scope differs from primary (e.g. runway closure plus nearby TFR).
+ * Order: status priority, then scope priority, then nearest restriction start.
  *
  * @param array<int, array<string, mixed>> $notams Deduplicated rows with banner fields
  * @param int $nowUnix Current Unix time
  * @return array<int, array<string, mixed>>
  */
-function selectNotamsForDashboardBanner(array $notams, int $nowUnix): array
+function sortBannerNotamsForDisplay(array $notams, int $nowUnix): array
 {
     if ($notams === []) {
         return [];
@@ -509,29 +508,19 @@ function selectNotamsForDashboardBanner(array $notams, int $nowUnix): array
         return $ka <=> $kb;
     });
 
-    $primary = $notams[0];
-    $selected = [$primary];
-    $primaryScope = (string) ($primary['banner_scope'] ?? '');
-
-    foreach (array_slice($notams, 1) as $candidate) {
-        $candidateScope = (string) ($candidate['banner_scope'] ?? '');
-        if ($candidateScope !== $primaryScope) {
-            $selected[] = $candidate;
-            break;
-        }
-    }
-
-    return $selected;
+    return $notams;
 }
 
 /**
- * Enrich, deduplicate, and select dashboard banner NOTAMs.
+ * Enrich, deduplicate, and sort dashboard banner NOTAMs.
+ *
+ * Returns every banner-eligible row after event deduplication (no row cap).
  *
  * @param array<int, array<string, mixed>> $notams Filtered cache rows (notam_type set)
  * @param array<string, mixed> $airport Airport configuration
  * @param string $timezone Airport IANA timezone
  * @param int $nowUnix Current Unix time
- * @return array<int, array<string, mixed>> Up to two rows for the banner API
+ * @return array<int, array<string, mixed>> Deduped rows for the banner API
  */
 function notamPrepareDashboardBannerRows(
     array $notams,
@@ -559,5 +548,5 @@ function notamPrepareDashboardBannerRows(
 
     $deduped = deduplicateBannerNotams($enriched);
 
-    return selectNotamsForDashboardBanner($deduped, $nowUnix);
+    return sortBannerNotamsForDisplay($deduped, $nowUnix);
 }

--- a/lib/notam/banner.php
+++ b/lib/notam/banner.php
@@ -1,0 +1,563 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Dashboard NOTAM banner taxonomy, headlines, deduplication, and selection.
+ *
+ * Full NOTAM text is always retained for safety; headlines are visual cues only.
+ */
+
+require_once __DIR__ . '/filter.php';
+require_once __DIR__ . '/schedule.php';
+require_once __DIR__ . '/map-layer.php';
+
+/** @var array<string, int> Lower sort value = higher banner priority */
+const NOTAM_BANNER_STATUS_PRIORITY = [
+    'active' => 0,
+    'inactive_scheduled' => 1,
+    'upcoming_today' => 2,
+    'upcoming_future' => 3,
+];
+
+/** @var array<string, int> Scope priority when status ties */
+const NOTAM_BANNER_SCOPE_PRIORITY = [
+    'aerodrome' => 0,
+    'runway' => 1,
+    'airspace' => 2,
+];
+
+/**
+ * Classify banner scope for a filtered NOTAM row.
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM with notam_type from {@see filterRelevantNotams()}
+ * @param array<string, mixed> $airport Airport configuration
+ * @return string|null aerodrome, runway, airspace, or null when not banner-eligible
+ */
+function notamBannerClassifyScope(array $notam, array $airport): ?string
+{
+    $notamType = (string) ($notam['notam_type'] ?? '');
+    if ($notamType === 'tfr') {
+        return 'airspace';
+    }
+    if ($notamType === 'aerodrome_closure' && isAerodromeClosure($notam, $airport)) {
+        return notamBannerClosureScopeFromNotam($notam);
+    }
+
+    return null;
+}
+
+/**
+ * Aerodrome-level vs runway-level closure scope.
+ *
+ * Aerodrome wins when both airport-wide and runway phrases appear.
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM row
+ * @return string aerodrome or runway
+ */
+function notamBannerClosureScopeFromNotam(array $notam): string
+{
+    $code = strtoupper((string) ($notam['code'] ?? ''));
+    if (str_starts_with($code, 'QFA')) {
+        return 'aerodrome';
+    }
+
+    $upper = strtoupper((string) ($notam['text'] ?? ''));
+    if (preg_match('/\bAD\s+AP\b.*\b(CLSD|CLOSED)\b/', $upper) === 1) {
+        return 'aerodrome';
+    }
+    if (preg_match('/\b(ARPT|AIRPORT)\b.*\b(CLSD|CLOSED)\b/', $upper) === 1) {
+        return 'aerodrome';
+    }
+
+    return 'runway';
+}
+
+/**
+ * Classify restriction category within a banner scope.
+ *
+ * @param string $scope From {@see notamBannerClassifyScope()}
+ * @param array<string, mixed> $notam Parsed NOTAM row
+ * @return string Category slug (full_closure, partial_restriction, fire, general, ...)
+ */
+function notamBannerClassifyCategory(string $scope, array $notam): string
+{
+    if ($scope === 'airspace') {
+        return notamBannerClassifyAirspaceCategory((string) ($notam['text'] ?? ''));
+    }
+
+    if ($scope === 'runway' && notamBannerTextIndicatesPartialRunwayRestriction((string) ($notam['text'] ?? ''))) {
+        return 'partial_restriction';
+    }
+
+    return 'full_closure';
+}
+
+/**
+ * Whether runway closure text includes partial aircraft limits.
+ *
+ * @param string $text NOTAM body
+ */
+function notamBannerTextIndicatesPartialRunwayRestriction(string $text): bool
+{
+    if ($text === '') {
+        return false;
+    }
+    $upper = strtoupper($text);
+    if (str_contains($upper, 'WINGSPAN')) {
+        return true;
+    }
+    if (preg_match('/\bCLSD\s+TO\b/', $upper) === 1) {
+        return true;
+    }
+    if (preg_match('/\bTO\s+ACFT\b/', $upper) === 1 && str_contains($upper, 'CLSD')) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Classify airspace TFR category from NOTAM prose (fail open to general).
+ *
+ * @param string $text NOTAM body
+ * @return string Category slug
+ */
+function notamBannerClassifyAirspaceCategory(string $text): string
+{
+    if ($text === '') {
+        return 'general';
+    }
+    $upper = strtoupper($text);
+
+    if (preg_match('/\b91\.137\s*\(\s*A\s*\)\s*\(\s*2\s*\)/', $upper) === 1
+        || str_contains($upper, 'FIRE FIGHTING')
+        || str_contains($upper, 'FIRE FIGHT')
+    ) {
+        return 'fire';
+    }
+    if (preg_match('/\b91\.137\s*\(\s*A\s*\)\s*\(\s*1\s*\)/', $upper) === 1) {
+        return 'hazard_surface';
+    }
+    if (preg_match('/\b91\.137\s*\(\s*A\s*\)\s*\(\s*3\s*\)/', $upper) === 1
+        || preg_match('/\bVIP\b/', $upper) === 1
+        || str_contains($upper, 'DISASTER')
+    ) {
+        return 'vip_disaster';
+    }
+    if (preg_match('/\b(ROCKET|SPACE\s+LAUNCH|LAUNCH\s+OPS)\b/', $upper) === 1
+        || str_contains($upper, 'GROUND BASED ROCKET')
+    ) {
+        return 'space_launch';
+    }
+    if (preg_match('/\b(UAS|DRONE)\b/', $upper) === 1) {
+        return 'uas';
+    }
+    if (preg_match('/\b(SPORTING|STADIUM)\b/', $upper) === 1) {
+        return 'sporting';
+    }
+
+    return 'general';
+}
+
+/**
+ * Extract a runway designator phrase for headlines and fingerprints.
+ *
+ * @param string $text NOTAM body
+ * @return string|null e.g. RWY 15/33 or RWY 13L/31R
+ */
+function notamBannerExtractRunwayDesignator(string $text): ?string
+{
+    if ($text === '') {
+        return null;
+    }
+    if (preg_match(
+        '/\bRWY\s+(\d{1,2}[LRC]?\s*\/\s*\d{1,2}[LRC]?|\d{1,2}[LRC]?)\b/i',
+        $text,
+        $matches
+    ) !== 1) {
+        return null;
+    }
+
+    $designator = strtoupper(preg_replace('/\s+/', '', $matches[1]) ?? $matches[1]);
+    if ($designator === '') {
+        return null;
+    }
+
+    if (str_contains($designator, '/')) {
+        return 'RWY ' . $designator;
+    }
+
+    return 'RWY ' . $designator;
+}
+
+/**
+ * Stable fingerprint for banner deduplication (paired A/numeric NOTAMs, same event).
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM row with banner_scope and banner_category
+ * @param array<string, mixed> $airport Airport configuration
+ */
+function notamBannerEventFingerprint(array $notam, array $airport): string
+{
+    $scope = (string) ($notam['banner_scope'] ?? '');
+    $category = (string) ($notam['banner_category'] ?? '');
+    $text = (string) ($notam['text'] ?? '');
+
+    $airportKey = strtolower((string) ($airport['icao'] ?? $airport['faa'] ?? $airport['iata'] ?? ''));
+
+    if ($scope === 'aerodrome') {
+        return 'aerodrome|' . $airportKey . '|' . $category;
+    }
+
+    if ($scope === 'runway') {
+        $rwy = notamBannerExtractRunwayDesignator($text) ?? 'unknown';
+        $partial = $category === 'partial_restriction'
+            ? substr(sha1(strtoupper($text)), 0, 12)
+            : 'full';
+
+        return 'runway|' . $airportKey . '|' . $rwy . '|' . $partial;
+    }
+
+    if ($scope === 'airspace') {
+        $coords = parseTfrCoordinates($text);
+        $radius = parseTfrRadiusNm($text);
+        $vertical = parseTfrVerticalLimitsSummary($text) ?? '';
+        $centerKey = 'none';
+        if ($coords !== null) {
+            $centerKey = sprintf('%.4f,%.4f', $coords['lat'], $coords['lon']);
+        }
+        $radiusKey = $radius !== null ? (string) round($radius, 2) : 'poly';
+        $dailyKey = preg_match('/\bDLY\b/', strtoupper($text)) === 1 ? 'daily' : 'single';
+        $startKey = trim((string) ($notam['start_time_utc'] ?? ''));
+        if ($dailyKey === 'daily') {
+            $startKey = 'series';
+        }
+
+        return 'airspace|' . $category . '|' . $centerKey . '|' . $radiusKey . '|' . $vertical
+            . '|' . $dailyKey . '|' . $startKey;
+    }
+
+    return 'unknown|' . trim((string) ($notam['id'] ?? '')) . '|' . substr(sha1($text), 0, 16);
+}
+
+/**
+ * Build a short dashboard headline (visual cue; full text remains authoritative).
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM row with banner_scope and banner_category
+ */
+function notamBannerBuildHeadline(array $notam): string
+{
+    $scope = (string) ($notam['banner_scope'] ?? '');
+    $category = (string) ($notam['banner_category'] ?? '');
+    $text = (string) ($notam['text'] ?? '');
+
+    if ($scope === 'aerodrome') {
+        return 'Airport closed';
+    }
+
+    if ($scope === 'runway') {
+        $rwy = notamBannerExtractRunwayDesignator($text) ?? 'Runway';
+        if ($category === 'partial_restriction') {
+            $detail = notamBannerPartialRunwayRestrictionPhrase($text);
+
+            return $detail !== null ? $rwy . ' restricted - ' . $detail : $rwy . ' restricted';
+        }
+
+        return $rwy . ' closed';
+    }
+
+    if ($scope === 'airspace') {
+        return notamBannerBuildAirspaceHeadline($category, $text);
+    }
+
+    return 'NOTAM restriction';
+}
+
+/**
+ * Partial runway restriction phrase for headlines.
+ *
+ * @param string $text NOTAM body
+ */
+function notamBannerPartialRunwayRestrictionPhrase(string $text): ?string
+{
+    $upper = strtoupper($text);
+    if (preg_match('/\bWINGSPAN\s+MORE\s+THAN\s+(\d+)\s*FT\b/', $upper, $m) === 1) {
+        return 'wingspan over ' . $m[1] . ' ft';
+    }
+    if (preg_match('/\bWEIGHT\s+MORE\s+THAN\s+(\d+)\s*(LB|LBS)\b/', $upper, $m) === 1) {
+        return 'weight over ' . $m[1] . ' lb';
+    }
+
+    return null;
+}
+
+/**
+ * Airspace TFR headline with geometry hints when parseable.
+ *
+ * @param string $category From {@see notamBannerClassifyAirspaceCategory()}
+ * @param string $text NOTAM body
+ */
+function notamBannerBuildAirspaceHeadline(string $category, string $text): string
+{
+    $upper = strtoupper($text);
+    $daily = preg_match('/\bDLY\b/', $upper) === 1;
+
+    $label = match ($category) {
+        'fire' => $daily ? 'Daily fire TFR' : 'Fire TFR',
+        'hazard_surface' => 'Hazard TFR',
+        'vip_disaster' => 'VIP TFR',
+        'space_launch' => 'Rocket test TFR',
+        'uas' => 'UAS TFR',
+        'sporting' => 'Sporting event TFR',
+        default => 'TFR',
+    };
+
+    $parts = [$label];
+    $radius = parseTfrRadiusNm($text);
+    if ($radius !== null) {
+        $nm = rtrim(rtrim(number_format($radius, 1, '.', ''), '0'), '.');
+        $parts[] = $nm . ' NM radius';
+    } elseif (count(parseTfrPolygonVertices($text)) >= 3) {
+        $parts[] = 'polygon area';
+    }
+
+    $vertical = parseTfrVerticalLimitsSummary($text);
+    if ($vertical !== null && $vertical !== '') {
+        $parts[] = $vertical;
+    }
+
+    return implode(' - ', $parts);
+}
+
+/**
+ * Human-readable schedule line for the banner headline block.
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM row
+ * @param string $status Display status from {@see revalidateNotamStatus()}
+ * @param string $timezone Airport IANA timezone
+ * @param int $nowUnix Current Unix time
+ */
+function notamBannerBuildScheduleLine(array &$notam, string $status, string $timezone, int $nowUnix): string
+{
+    $fromMap = notamTfrMapLayerTooltipStatusLine($notam, $status, $timezone, $nowUnix);
+    if ($fromMap !== null && $fromMap !== '') {
+        return $fromMap;
+    }
+
+    if ($status === 'active') {
+        $endUtc = notamCurrentRestrictionEndUtc($notam, $nowUnix);
+        if ($endUtc !== null && $endUtc !== '') {
+            $ts = strtotime($endUtc);
+            if ($ts !== false && $ts > $nowUnix) {
+                return 'Active until ' . notamTfrMapLayerFormatLocalDateTimeForTooltip($ts, $timezone);
+            }
+        }
+        $envEnd = trim((string) ($notam['end_time_utc'] ?? ''));
+        if ($envEnd !== '' && strtoupper($envEnd) !== 'PERM') {
+            $ts = strtotime($envEnd);
+            if ($ts !== false && $ts > $nowUnix) {
+                return 'Active until ' . notamTfrMapLayerFormatLocalDateTimeForTooltip($ts, $timezone);
+            }
+        }
+
+        return 'Active now';
+    }
+
+    if ($status === 'inactive_scheduled') {
+        $next = notamNextRestrictionStartUtc($notam, $nowUnix);
+        if ($next !== null && $next !== '') {
+            $ts = strtotime($next);
+            if ($ts !== false && $ts > $nowUnix) {
+                return 'Not active now - next window '
+                    . notamTfrMapLayerFormatLocalDateTimeForTooltip($ts, $timezone);
+            }
+        }
+
+        return 'Not active now - see NOTAM for schedule';
+    }
+
+    $start = notamFirstRestrictionStartUnix($notam);
+    if ($start !== null && $start > $nowUnix) {
+        return 'Upcoming from ' . notamTfrMapLayerFormatLocalDateTimeForTooltip($start, $timezone);
+    }
+
+    return 'See NOTAM for schedule';
+}
+
+/**
+ * Attach banner taxonomy and headline fields to a filtered NOTAM row.
+ *
+ * @param array<string, mixed> $notam Mutated in place
+ * @param array<string, mixed> $airport Airport configuration
+ * @param string $status Current display status
+ * @param string $timezone Airport IANA timezone
+ * @param int $nowUnix Current Unix time
+ */
+function notamEnrichBannerFields(
+    array &$notam,
+    array $airport,
+    string $status,
+    string $timezone,
+    int $nowUnix
+): void {
+    $scope = notamBannerClassifyScope($notam, $airport);
+    if ($scope === null) {
+        return;
+    }
+
+    $category = notamBannerClassifyCategory($scope, $notam);
+    $notam['banner_scope'] = $scope;
+    $notam['banner_category'] = $category;
+    $notam['banner_headline'] = notamBannerBuildHeadline($notam);
+    $notam['banner_schedule_line'] = notamBannerBuildScheduleLine($notam, $status, $timezone, $nowUnix);
+    $notam['banner_event_fingerprint'] = notamBannerEventFingerprint($notam, $airport);
+}
+
+/**
+ * Prefer ICAO A-series ids when merging duplicate banner events.
+ *
+ * @param array<string, mixed> $a Candidate NOTAM row
+ * @param array<string, mixed> $b Candidate NOTAM row
+ * @return int Negative if $a wins, positive if $b wins
+ */
+function notamBannerComparePreferredDuplicate(array $a, array $b): int
+{
+    $idA = trim((string) ($a['id'] ?? ''));
+    $idB = trim((string) ($b['id'] ?? ''));
+    $aSeries = preg_match('/^A\d+\//', $idA) === 1;
+    $bSeries = preg_match('/^A\d+\//', $idB) === 1;
+    if ($aSeries !== $bSeries) {
+        return $bSeries <=> $aSeries;
+    }
+
+    $lenA = strlen((string) ($a['text'] ?? ''));
+    $lenB = strlen((string) ($b['text'] ?? ''));
+
+    return $lenB <=> $lenA;
+}
+
+/**
+ * Deduplicate banner NOTAM rows by event fingerprint.
+ *
+ * @param array<int, array<string, mixed>> $notams Rows with banner_event_fingerprint set
+ * @return array<int, array<string, mixed>>
+ */
+function deduplicateBannerNotams(array $notams): array
+{
+    $byFingerprint = [];
+    $withoutFingerprint = [];
+    foreach ($notams as $notam) {
+        $fp = (string) ($notam['banner_event_fingerprint'] ?? '');
+        if ($fp === '') {
+            $withoutFingerprint[] = $notam;
+            continue;
+        }
+        if (!isset($byFingerprint[$fp])) {
+            $byFingerprint[$fp] = $notam;
+            continue;
+        }
+        if (notamBannerComparePreferredDuplicate($notam, $byFingerprint[$fp]) < 0) {
+            $byFingerprint[$fp] = $notam;
+        }
+    }
+
+    return array_merge(array_values($byFingerprint), $withoutFingerprint);
+}
+
+/**
+ * Sort key for banner selection (lower = higher priority).
+ *
+ * @param array<string, mixed> $notam Enriched NOTAM row
+ * @param int $nowUnix Current Unix time
+ * @return array{0: int, 1: int, 2: int} Tuple for spaceship operator
+ */
+function notamBannerSelectionSortKey(array $notam, int $nowUnix): array
+{
+    $status = (string) ($notam['status'] ?? 'upcoming_future');
+    $scope = (string) ($notam['banner_scope'] ?? 'airspace');
+    $statusPri = NOTAM_BANNER_STATUS_PRIORITY[$status] ?? 99;
+    $scopePri = NOTAM_BANNER_SCOPE_PRIORITY[$scope] ?? 99;
+
+    $nextStart = notamFirstRestrictionStartUnix($notam);
+    if ($nextStart === null || $nextStart <= $nowUnix) {
+        $nextStart = $nowUnix;
+    }
+
+    return [$statusPri, $scopePri, $nextStart];
+}
+
+/**
+ * Select up to two NOTAM rows for the dashboard banner.
+ *
+ * Primary is the highest-priority current or next event. Secondary appears only when
+ * scope differs from primary (e.g. runway closure plus nearby TFR).
+ *
+ * @param array<int, array<string, mixed>> $notams Deduplicated rows with banner fields
+ * @param int $nowUnix Current Unix time
+ * @return array<int, array<string, mixed>>
+ */
+function selectNotamsForDashboardBanner(array $notams, int $nowUnix): array
+{
+    if ($notams === []) {
+        return [];
+    }
+
+    usort($notams, static function (array $a, array $b) use ($nowUnix): int {
+        $ka = notamBannerSelectionSortKey($a, $nowUnix);
+        $kb = notamBannerSelectionSortKey($b, $nowUnix);
+
+        return $ka <=> $kb;
+    });
+
+    $primary = $notams[0];
+    $selected = [$primary];
+    $primaryScope = (string) ($primary['banner_scope'] ?? '');
+
+    foreach (array_slice($notams, 1) as $candidate) {
+        $candidateScope = (string) ($candidate['banner_scope'] ?? '');
+        if ($candidateScope !== $primaryScope) {
+            $selected[] = $candidate;
+            break;
+        }
+    }
+
+    return $selected;
+}
+
+/**
+ * Enrich, deduplicate, and select dashboard banner NOTAMs.
+ *
+ * @param array<int, array<string, mixed>> $notams Filtered cache rows (notam_type set)
+ * @param array<string, mixed> $airport Airport configuration
+ * @param string $timezone Airport IANA timezone
+ * @param int $nowUnix Current Unix time
+ * @return array<int, array<string, mixed>> Up to two rows for the banner API
+ */
+function notamPrepareDashboardBannerRows(
+    array $notams,
+    array $airport,
+    string $timezone,
+    int $nowUnix
+): array {
+    $enriched = [];
+    foreach ($notams as $notam) {
+        if (!is_array($notam)) {
+            continue;
+        }
+        $status = (string) ($notam['status'] ?? revalidateNotamStatus($notam, $timezone));
+        if (!notamIsBannerRelevantStatus($status, $notam)) {
+            continue;
+        }
+        $row = $notam;
+        notamEnrichBannerFields($row, $airport, $status, $timezone, $nowUnix);
+        if (!isset($row['banner_event_fingerprint'])) {
+            continue;
+        }
+        $row['status'] = $status;
+        $enriched[] = $row;
+    }
+
+    $deduped = deduplicateBannerNotams($enriched);
+
+    return selectNotamsForDashboardBanner($deduped, $nowUnix);
+}

--- a/lib/notam/banner.php
+++ b/lib/notam/banner.php
@@ -512,7 +512,7 @@ function notamBannerSortableRestrictionStartUnix(array &$notam, int $nowUnix): i
  *
  * @param array<string, mixed> $notam Enriched NOTAM row
  * @param int $nowUnix Current Unix time
- * @return array{0: int, 1: int, 2: int} Tuple for spaceship operator
+ * @return array{0: int, 1: int, 2: int, 3: string} Tuple for spaceship operator
  */
 function notamBannerSelectionSortKey(array $notam, int $nowUnix): array
 {
@@ -522,8 +522,9 @@ function notamBannerSelectionSortKey(array $notam, int $nowUnix): array
     $scopePri = NOTAM_BANNER_SCOPE_PRIORITY[$scope] ?? 99;
 
     $nextStart = notamBannerSortableRestrictionStartUnix($notam, $nowUnix);
+    $tieBreak = (string) ($notam['banner_event_fingerprint'] ?? $notam['id'] ?? '');
 
-    return [$statusPri, $scopePri, $nextStart];
+    return [$statusPri, $scopePri, $nextStart, $tieBreak];
 }
 
 /**

--- a/lib/notam/banner.php
+++ b/lib/notam/banner.php
@@ -204,9 +204,11 @@ function notamBannerEventFingerprint(array $notam, array $airport): string
     $text = (string) ($notam['text'] ?? '');
 
     $airportKey = strtolower((string) ($airport['icao'] ?? $airport['faa'] ?? $airport['iata'] ?? ''));
+    $startKey = trim((string) ($notam['start_time_utc'] ?? ''));
+    $endKey = trim((string) ($notam['end_time_utc'] ?? ''));
 
     if ($scope === 'aerodrome') {
-        return 'aerodrome|' . $airportKey . '|' . $category;
+        return 'aerodrome|' . $airportKey . '|' . $category . '|' . $startKey . '|' . $endKey;
     }
 
     if ($scope === 'runway') {
@@ -215,7 +217,7 @@ function notamBannerEventFingerprint(array $notam, array $airport): string
             ? substr(sha1(strtoupper($text)), 0, 12)
             : 'full';
 
-        return 'runway|' . $airportKey . '|' . $rwy . '|' . $partial;
+        return 'runway|' . $airportKey . '|' . $rwy . '|' . $partial . '|' . $startKey . '|' . $endKey;
     }
 
     if ($scope === 'airspace') {

--- a/lib/notam/banner.php
+++ b/lib/notam/banner.php
@@ -465,6 +465,47 @@ function deduplicateBannerNotams(array $notams): array
 }
 
 /**
+ * Restriction start used for banner display ordering at $nowUnix.
+ *
+ * Uses the next EFFECTIVE window for scheduled gaps; otherwise the earliest future start.
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM row
+ * @param int $nowUnix Current Unix time
+ */
+function notamBannerSortableRestrictionStartUnix(array &$notam, int $nowUnix): int
+{
+    $status = (string) ($notam['status'] ?? '');
+    if ($status === 'inactive_scheduled') {
+        $nextUtc = notamNextRestrictionStartUtc($notam, $nowUnix);
+        if ($nextUtc !== null && $nextUtc !== '') {
+            $nextTs = strtotime($nextUtc);
+            if ($nextTs !== false && $nextTs > 0) {
+                return $nextTs;
+            }
+        }
+    }
+
+    $firstStart = notamFirstRestrictionStartUnix($notam);
+    if ($firstStart !== null && $firstStart > $nowUnix) {
+        return $firstStart;
+    }
+
+    if ($status === 'active') {
+        return $nowUnix;
+    }
+
+    $nextUtc = notamNextRestrictionStartUtc($notam, $nowUnix);
+    if ($nextUtc !== null && $nextUtc !== '') {
+        $nextTs = strtotime($nextUtc);
+        if ($nextTs !== false && $nextTs > 0) {
+            return $nextTs;
+        }
+    }
+
+    return $firstStart ?? $nowUnix;
+}
+
+/**
  * Sort key for banner selection (lower = higher priority).
  *
  * @param array<string, mixed> $notam Enriched NOTAM row
@@ -478,10 +519,7 @@ function notamBannerSelectionSortKey(array $notam, int $nowUnix): array
     $statusPri = NOTAM_BANNER_STATUS_PRIORITY[$status] ?? 99;
     $scopePri = NOTAM_BANNER_SCOPE_PRIORITY[$scope] ?? 99;
 
-    $nextStart = notamFirstRestrictionStartUnix($notam);
-    if ($nextStart === null || $nextStart <= $nowUnix) {
-        $nextStart = $nowUnix;
-    }
+    $nextStart = notamBannerSortableRestrictionStartUnix($notam, $nowUnix);
 
     return [$statusPri, $scopePri, $nextStart];
 }
@@ -489,7 +527,7 @@ function notamBannerSelectionSortKey(array $notam, int $nowUnix): array
 /**
  * Sort banner NOTAM rows for stable dashboard display (all deduplicated rows returned).
  *
- * Order: status priority, then scope priority, then nearest restriction start.
+ * Order: status priority, then scope priority, then nearest upcoming restriction start.
  *
  * @param array<int, array<string, mixed>> $notams Deduplicated rows with banner fields
  * @param int $nowUnix Current Unix time

--- a/lib/notam/banner.php
+++ b/lib/notam/banner.php
@@ -534,7 +534,7 @@ function notamPrepareDashboardBannerRows(
             continue;
         }
         $status = (string) ($notam['status'] ?? revalidateNotamStatus($notam, $timezone));
-        if (!notamIsBannerRelevantStatus($status, $notam)) {
+        if (!notamIsBannerRelevantStatus($status, $notam, $nowUnix)) {
             continue;
         }
         $row = $notam;

--- a/lib/notam/filter.php
+++ b/lib/notam/filter.php
@@ -1165,10 +1165,11 @@ function filterRelevantNotams(array $notams, array $airport): array {
  *
  * @param string $status Status from {@see determineNotamStatus()}
  * @param array<string, mixed> $notam Parsed NOTAM; upcoming_future horizon uses {@see notamFirstRestrictionStartUnix()}
+ * @param int|null $nowUnix Reference time for horizon checks; null uses {@see time()}
  * @return bool True when the NOTAM should be retained in cache for this airport
  */
-function notamIsBannerRelevantStatus(string $status, array $notam): bool {
-    $now = time();
+function notamIsBannerRelevantStatus(string $status, array $notam, ?int $nowUnix = null): bool {
+    $now = $nowUnix ?? time();
     if (in_array($status, ['active', 'upcoming_today', 'inactive_scheduled'], true)) {
         return true;
     }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -315,11 +315,35 @@ body {
 .notam-line {
     padding: 10px 20px;
     display: flex;
+    flex-direction: column;
+    gap: 8px;
+    line-height: 1.5;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.notam-headline-row {
+    display: flex;
     flex-wrap: wrap;
     align-items: baseline;
     gap: 6px;
-    line-height: 1.5;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.notam-headline {
+    font-weight: 700;
+    font-size: 15px;
+    flex: 1 1 auto;
+    min-width: 150px;
+}
+
+.notam-full-text {
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 1.45;
+    opacity: 0.95;
+    overflow-wrap: break-word;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    padding-top: 8px;
+    width: 100%;
 }
 
 .notam-line:last-child {
@@ -367,8 +391,12 @@ body {
         padding: 12px 15px;
     }
 
-    .notam-message {
+    .notam-headline {
         min-width: 0;
+    }
+
+    .notam-full-text {
+        font-size: 11px;
     }
 
     .notam-time-range {

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -5347,15 +5347,24 @@ function createNotamLine(notam, mode) {
         statusText = 'SCHEDULED BREAK';
     }
     const notamId = notam.id ? `[${escapeHtml(notam.id)}]` : '';
-    const timeRange = formatNotamTimeRange(notam, mode);
+    const headline = notam.banner_headline
+        ? escapeHtml(notam.banner_headline)
+        : escapeHtml(notam.message);
+    const scheduleLine = notam.banner_schedule_line
+        ? escapeHtml(notam.banner_schedule_line)
+        : escapeHtml(formatNotamTimeRange(notam, mode));
+    const fullText = escapeHtml(notam.message || '');
     
     return `
         <div class="notam-line">
-            <span class="notam-icon">${icon}</span>
-            <span class="notam-status">${statusText}</span>
-            <span class="notam-id">${notamId}</span>
-            <span class="notam-message">${escapeHtml(notam.message)}</span>
-            <span class="notam-time-range">${timeRange}</span>
+            <div class="notam-headline-row">
+                <span class="notam-icon">${icon}</span>
+                <span class="notam-status">${statusText}</span>
+                <span class="notam-id">${notamId}</span>
+                <span class="notam-headline">${headline}</span>
+                <span class="notam-time-range">${scheduleLine}</span>
+            </div>
+            <div class="notam-full-text">${fullText}</div>
         </div>
     `;
 }

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -5349,7 +5349,7 @@ function createNotamLine(notam, mode) {
     const notamId = notam.id ? `[${escapeHtml(notam.id)}]` : '';
     const headline = notam.banner_headline
         ? escapeHtml(notam.banner_headline)
-        : escapeHtml(notam.message);
+        : escapeHtml(notam.message || '');
     const scheduleLine = notam.banner_schedule_line
         ? escapeHtml(notam.banner_schedule_line)
         : escapeHtml(formatNotamTimeRange(notam, mode));

--- a/tests/Unit/NotamBannerTest.php
+++ b/tests/Unit/NotamBannerTest.php
@@ -227,34 +227,35 @@ final class NotamBannerTest extends TestCase
         $text = 'ID..AIRSPACE 34NM SE COEUR D\'ALENE, ID..TEMPORARY FLIGHT RESTRICTIONS. '
             . 'PURSUANT TO 14 CFR SECTION 91.137(A)(2) WI AN AREA DEFINED AS 7NM RADIUS OF '
             . '473130N1160445W (MLP268018.0) SFC-7500FT';
+        $now = strtotime('2026-06-17T12:00:00Z');
         $notams = [
             [
                 'id' => 'A3389/2026',
                 'notam_type' => 'tfr',
                 'text' => $text,
-                'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 7200),
-                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 36000),
+                'start_time_utc' => '2026-06-17T14:00:00Z',
+                'end_time_utc' => '2026-06-18T05:00:00Z',
                 'status' => 'upcoming_today',
             ],
             [
                 'id' => '8838/2026',
                 'notam_type' => 'tfr',
                 'text' => $text,
-                'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 7200),
-                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 36000),
+                'start_time_utc' => '2026-06-17T14:00:00Z',
+                'end_time_utc' => '2026-06-18T05:00:00Z',
                 'status' => 'upcoming_today',
             ],
             [
                 'id' => '8821/2026',
                 'notam_type' => 'tfr',
                 'text' => $text . ' DLY 1400-0500',
-                'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 90000),
-                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 1200000),
+                'start_time_utc' => '2026-06-18T14:00:00Z',
+                'end_time_utc' => '2026-07-02T05:00:00Z',
                 'status' => 'upcoming_future',
             ],
         ];
 
-        $rows = notamPrepareDashboardBannerRows($notams, $airport, 'America/Los_Angeles', time());
+        $rows = notamPrepareDashboardBannerRows($notams, $airport, 'America/Los_Angeles', $now);
 
         $this->assertCount(2, $rows);
         $this->assertSame('upcoming_today', $rows[0]['status']);

--- a/tests/Unit/NotamBannerTest.php
+++ b/tests/Unit/NotamBannerTest.php
@@ -119,6 +119,31 @@ final class NotamBannerTest extends TestCase
         $this->assertSame('A3389/2026', $deduped[0]['id']);
     }
 
+    public function testNotamBannerBuildScheduleLine_InactiveScheduled_UsesNextWindowPhrasing(): void
+    {
+        $notam = [
+            'effective_segments' => [
+                [
+                    'start_time_utc' => '2026-06-17T10:00:00Z',
+                    'end_time_utc' => '2026-06-17T14:00:00Z',
+                ],
+                [
+                    'start_time_utc' => '2026-06-17T20:00:00Z',
+                    'end_time_utc' => '2026-06-18T05:00:00Z',
+                ],
+            ],
+        ];
+        $line = notamBannerBuildScheduleLine(
+            $notam,
+            'inactive_scheduled',
+            'America/Los_Angeles',
+            strtotime('2026-06-17T16:00:00Z')
+        );
+
+        $this->assertStringStartsWith('Not active now - next window', $line);
+        $this->assertStringNotContainsString('Upcoming from', $line);
+    }
+
     public function testSortBannerNotamsForDisplay_TodayBeforeFuture_OrdersByStatus(): void
     {
         $now = strtotime('2026-06-17T12:00:00Z');

--- a/tests/Unit/NotamBannerTest.php
+++ b/tests/Unit/NotamBannerTest.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../../lib/notam/filter.php';
 require_once __DIR__ . '/../../lib/notam/banner.php';
 
 /**
- * Dashboard NOTAM banner taxonomy, deduplication, and selection.
+ * Dashboard NOTAM banner taxonomy, deduplication, and display ordering.
  */
 final class NotamBannerTest extends TestCase
 {
@@ -119,7 +119,7 @@ final class NotamBannerTest extends TestCase
         $this->assertSame('A3389/2026', $deduped[0]['id']);
     }
 
-    public function testSelectNotamsForDashboardBanner_PrefersUpcomingTodayOverFutureSeries(): void
+    public function testSortBannerNotamsForDisplay_OrdersByStatusThenScope(): void
     {
         $now = strtotime('2026-06-17T12:00:00Z');
         $today = [
@@ -141,13 +141,14 @@ final class NotamBannerTest extends TestCase
             'banner_event_fingerprint' => 'fp-future',
         ];
 
-        $selected = selectNotamsForDashboardBanner([$future, $today], $now);
+        $sorted = sortBannerNotamsForDisplay([$future, $today], $now);
 
-        $this->assertCount(1, $selected);
-        $this->assertSame('fp-today', $selected[0]['banner_event_fingerprint']);
+        $this->assertCount(2, $sorted);
+        $this->assertSame('fp-today', $sorted[0]['banner_event_fingerprint']);
+        $this->assertSame('fp-future', $sorted[1]['banner_event_fingerprint']);
     }
 
-    public function testSelectNotamsForDashboardBanner_AllowsSecondRowWhenScopeDiffers(): void
+    public function testSortBannerNotamsForDisplay_ReturnsAllDistinctDedupedRows(): void
     {
         $now = time();
         $runway = [
@@ -169,14 +170,14 @@ final class NotamBannerTest extends TestCase
             'banner_event_fingerprint' => 'tfr-fp',
         ];
 
-        $selected = selectNotamsForDashboardBanner([$tfr, $runway], $now);
+        $sorted = sortBannerNotamsForDisplay([$tfr, $runway], $now);
 
-        $this->assertCount(2, $selected);
-        $this->assertSame('runway', $selected[0]['banner_scope']);
-        $this->assertSame('airspace', $selected[1]['banner_scope']);
+        $this->assertCount(2, $sorted);
+        $this->assertSame('runway', $sorted[0]['banner_scope']);
+        $this->assertSame('airspace', $sorted[1]['banner_scope']);
     }
 
-    public function testPrepareDashboardBannerRows_S83LikePairCollapsesToOne(): void
+    public function testPrepareDashboardBannerRows_S83LikeDedupesPairsKeepsDistinctEvents(): void
     {
         $airport = ['icao' => 'KS83', 'faa' => 'S83', 'name' => 'Shoshone County', 'lat' => 47.49, 'lon' => -115.87];
         $text = 'ID..AIRSPACE 34NM SE COEUR D\'ALENE, ID..TEMPORARY FLIGHT RESTRICTIONS. '
@@ -209,11 +210,13 @@ final class NotamBannerTest extends TestCase
             ],
         ];
 
-        $selected = notamPrepareDashboardBannerRows($notams, $airport, 'America/Los_Angeles', time());
+        $rows = notamPrepareDashboardBannerRows($notams, $airport, 'America/Los_Angeles', time());
 
-        $this->assertCount(1, $selected);
-        $this->assertSame('airspace', $selected[0]['banner_scope']);
-        $this->assertStringContainsString('Fire TFR', $selected[0]['banner_headline']);
-        $this->assertNotEmpty($selected[0]['banner_schedule_line']);
+        $this->assertCount(2, $rows);
+        $this->assertSame('upcoming_today', $rows[0]['status']);
+        $this->assertStringContainsString('Fire TFR', $rows[0]['banner_headline']);
+        $this->assertSame('upcoming_future', $rows[1]['status']);
+        $this->assertStringContainsString('Daily fire TFR', $rows[1]['banner_headline']);
+        $this->assertNotEmpty($rows[0]['banner_schedule_line']);
     }
 }

--- a/tests/Unit/NotamBannerTest.php
+++ b/tests/Unit/NotamBannerTest.php
@@ -119,6 +119,48 @@ final class NotamBannerTest extends TestCase
         $this->assertSame('A3389/2026', $deduped[0]['id']);
     }
 
+    public function testDeduplicateBannerNotams_DifferentAirspaceWindowsSameGeometry_KeepsBothRows(): void
+    {
+        $airport = ['icao' => 'KS83', 'faa' => 'S83', 'name' => 'Shoshone County'];
+        $text = 'ID..AIRSPACE 34NM SE COEUR D\'ALENE, ID..TEMPORARY FLIGHT RESTRICTIONS. '
+            . 'PURSUANT TO 14 CFR SECTION 91.137(A)(2) WI AN AREA DEFINED AS 7NM RADIUS OF '
+            . '473130N1160445W SFC-7500FT';
+        $base = [
+            'notam_type' => 'tfr',
+            'text' => $text,
+            'banner_scope' => 'airspace',
+            'banner_category' => 'fire',
+        ];
+        $first = $base + [
+            'id' => 'A2001/2026',
+            'start_time_utc' => '2026-06-17T14:00:00Z',
+            'end_time_utc' => '2026-06-18T05:00:00Z',
+            'banner_event_fingerprint' => notamBannerEventFingerprint(
+                $base + [
+                    'start_time_utc' => '2026-06-17T14:00:00Z',
+                    'end_time_utc' => '2026-06-18T05:00:00Z',
+                ],
+                $airport
+            ),
+        ];
+        $second = $base + [
+            'id' => 'A2002/2026',
+            'start_time_utc' => '2026-06-20T14:00:00Z',
+            'end_time_utc' => '2026-06-21T05:00:00Z',
+            'banner_event_fingerprint' => notamBannerEventFingerprint(
+                $base + [
+                    'start_time_utc' => '2026-06-20T14:00:00Z',
+                    'end_time_utc' => '2026-06-21T05:00:00Z',
+                ],
+                $airport
+            ),
+        ];
+
+        $deduped = deduplicateBannerNotams([$first, $second]);
+
+        $this->assertCount(2, $deduped);
+    }
+
     public function testDeduplicateBannerNotams_DifferentRunwayClosureWindows_KeepsBothRows(): void
     {
         $airport = $this->kspbAirport();

--- a/tests/Unit/NotamBannerTest.php
+++ b/tests/Unit/NotamBannerTest.php
@@ -119,6 +119,45 @@ final class NotamBannerTest extends TestCase
         $this->assertSame('A3389/2026', $deduped[0]['id']);
     }
 
+    public function testDeduplicateBannerNotams_DifferentRunwayClosureWindows_KeepsBothRows(): void
+    {
+        $airport = $this->kspbAirport();
+        $base = [
+            'notam_type' => 'aerodrome_closure',
+            'text' => 'RWY 15/33 CLSD',
+            'banner_scope' => 'runway',
+            'banner_category' => 'full_closure',
+        ];
+        $first = $base + [
+            'id' => 'A1001/2026',
+            'start_time_utc' => '2026-06-17T14:00:00Z',
+            'end_time_utc' => '2026-06-18T05:00:00Z',
+            'banner_event_fingerprint' => notamBannerEventFingerprint(
+                $base + [
+                    'start_time_utc' => '2026-06-17T14:00:00Z',
+                    'end_time_utc' => '2026-06-18T05:00:00Z',
+                ],
+                $airport
+            ),
+        ];
+        $second = $base + [
+            'id' => 'A1002/2026',
+            'start_time_utc' => '2026-06-20T14:00:00Z',
+            'end_time_utc' => '2026-06-21T05:00:00Z',
+            'banner_event_fingerprint' => notamBannerEventFingerprint(
+                $base + [
+                    'start_time_utc' => '2026-06-20T14:00:00Z',
+                    'end_time_utc' => '2026-06-21T05:00:00Z',
+                ],
+                $airport
+            ),
+        ];
+
+        $deduped = deduplicateBannerNotams([$first, $second]);
+
+        $this->assertCount(2, $deduped);
+    }
+
     public function testNotamBannerBuildScheduleLine_InactiveScheduled_UsesNextWindowPhrasing(): void
     {
         $notam = [

--- a/tests/Unit/NotamBannerTest.php
+++ b/tests/Unit/NotamBannerTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/notam/filter.php';
+require_once __DIR__ . '/../../lib/notam/banner.php';
+
+/**
+ * Dashboard NOTAM banner taxonomy, deduplication, and selection.
+ */
+final class NotamBannerTest extends TestCase
+{
+    private function kspbAirport(): array
+    {
+        return [
+            'icao' => 'KSPB',
+            'faa' => 'SPB',
+            'name' => 'Scappoose Industrial Airpark',
+            'timezone' => 'America/Los_Angeles',
+        ];
+    }
+
+    public function testClassifyScope_RunwayClosure(): void
+    {
+        $airport = $this->kspbAirport();
+        $notam = [
+            'notam_type' => 'aerodrome_closure',
+            'code' => '',
+            'text' => 'RWY 15/33 CLSD',
+            'location' => 'KSPB',
+            'scenario' => '86',
+            'aixm_runway_event' => true,
+        ];
+
+        $this->assertSame('runway', notamBannerClassifyScope($notam, $airport));
+        $this->assertSame('full_closure', notamBannerClassifyCategory('runway', $notam));
+        $this->assertSame('RWY 15/33 closed', notamBannerBuildHeadline([
+            'banner_scope' => 'runway',
+            'banner_category' => 'full_closure',
+            'text' => $notam['text'],
+        ]));
+    }
+
+    public function testClassifyScope_AerodromeClosure(): void
+    {
+        $airport = $this->kspbAirport();
+        $notam = [
+            'notam_type' => 'aerodrome_closure',
+            'code' => 'QFALC',
+            'text' => 'AD AP CLSD',
+            'location' => 'KSPB',
+        ];
+
+        $this->assertSame('aerodrome', notamBannerClassifyScope($notam, $airport));
+        $this->assertSame('Airport closed', notamBannerBuildHeadline([
+            'banner_scope' => 'aerodrome',
+            'banner_category' => 'full_closure',
+            'text' => $notam['text'],
+        ]));
+    }
+
+    public function testClassifyScope_PartialRunwayRestrictionHeadline(): void
+    {
+        $text = 'DFW RWY 13L/31R CLSD TO ACFT WINGSPAN MORE THAN 214FT';
+        $this->assertTrue(notamBannerTextIndicatesPartialRunwayRestriction($text));
+        $this->assertSame('partial_restriction', notamBannerClassifyCategory('runway', ['text' => $text]));
+        $this->assertSame(
+            'RWY 13L/31R restricted - wingspan over 214 ft',
+            notamBannerBuildHeadline([
+                'banner_scope' => 'runway',
+                'banner_category' => 'partial_restriction',
+                'text' => $text,
+            ])
+        );
+    }
+
+    public function testClassifyAirspace_FireTfrHeadline(): void
+    {
+        $text = 'ID..AIRSPACE 34NM SE COEUR D\'ALENE, ID..TEMPORARY FLIGHT RESTRICTIONS. '
+            . 'PURSUANT TO 14 CFR SECTION 91.137(A)(2) WI AN AREA DEFINED AS 7NM RADIUS OF '
+            . '473130N1160445W SFC-7500FT GOLD RUN FIRE';
+        $this->assertSame('fire', notamBannerClassifyAirspaceCategory($text));
+        $headline = notamBannerBuildAirspaceHeadline('fire', $text);
+        $this->assertStringContainsString('Fire TFR', $headline);
+        $this->assertStringContainsString('7 NM radius', $headline);
+    }
+
+    public function testClassifyAirspace_RocketTestCategory(): void
+    {
+        $text = 'ZLC UT..AIRSPACE OGDEN, UT..TEMPORARY FLIGHT RESTRICTIONS WITHIN AN AREA '
+            . 'DEFINED AS 5NM RADIUS OF 413900N1122300W STATIC GROUND BASED ROCKET ENGINE TEST.';
+        $this->assertSame('space_launch', notamBannerClassifyAirspaceCategory($text));
+        $this->assertStringContainsString('Rocket test TFR', notamBannerBuildAirspaceHeadline('space_launch', $text));
+    }
+
+    public function testDeduplicateBannerNotams_MergesPairedFireTfrIds(): void
+    {
+        $airport = ['icao' => 'KS83', 'faa' => 'S83', 'name' => 'Shoshone County'];
+        $text = 'ID..AIRSPACE 34NM SE COEUR D\'ALENE, ID..TEMPORARY FLIGHT RESTRICTIONS. '
+            . 'PURSUANT TO 14 CFR SECTION 91.137(A)(2) WI AN AREA DEFINED AS 7NM RADIUS OF '
+            . '473130N1160445W SFC-7500FT';
+        $base = [
+            'notam_type' => 'tfr',
+            'text' => $text,
+            'start_time_utc' => '2026-06-17T14:00:00Z',
+            'end_time_utc' => '2026-06-18T05:00:00Z',
+            'status' => 'upcoming_today',
+            'banner_scope' => 'airspace',
+            'banner_category' => 'fire',
+        ];
+        $a = $base + ['id' => 'A3389/2026', 'banner_event_fingerprint' => notamBannerEventFingerprint($base + ['id' => 'A3389/2026'], $airport)];
+        $b = $base + ['id' => '8838/2026', 'banner_event_fingerprint' => $a['banner_event_fingerprint']];
+
+        $deduped = deduplicateBannerNotams([$b, $a]);
+
+        $this->assertCount(1, $deduped);
+        $this->assertSame('A3389/2026', $deduped[0]['id']);
+    }
+
+    public function testSelectNotamsForDashboardBanner_PrefersUpcomingTodayOverFutureSeries(): void
+    {
+        $now = strtotime('2026-06-17T12:00:00Z');
+        $today = [
+            'status' => 'upcoming_today',
+            'banner_scope' => 'airspace',
+            'banner_category' => 'fire',
+            'start_time_utc' => '2026-06-17T14:00:00Z',
+            'end_time_utc' => '2026-06-18T05:00:00Z',
+            'text' => 'TFR today',
+            'banner_event_fingerprint' => 'fp-today',
+        ];
+        $future = [
+            'status' => 'upcoming_future',
+            'banner_scope' => 'airspace',
+            'banner_category' => 'fire',
+            'start_time_utc' => '2026-06-18T14:00:00Z',
+            'end_time_utc' => '2026-07-02T05:00:00Z',
+            'text' => 'TFR DLY 1400-0500',
+            'banner_event_fingerprint' => 'fp-future',
+        ];
+
+        $selected = selectNotamsForDashboardBanner([$future, $today], $now);
+
+        $this->assertCount(1, $selected);
+        $this->assertSame('fp-today', $selected[0]['banner_event_fingerprint']);
+    }
+
+    public function testSelectNotamsForDashboardBanner_AllowsSecondRowWhenScopeDiffers(): void
+    {
+        $now = time();
+        $runway = [
+            'status' => 'active',
+            'banner_scope' => 'runway',
+            'banner_category' => 'full_closure',
+            'text' => 'RWY 15/33 CLSD',
+            'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $now - 3600),
+            'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $now + 3600),
+            'banner_event_fingerprint' => 'runway-fp',
+        ];
+        $tfr = [
+            'status' => 'active',
+            'banner_scope' => 'airspace',
+            'banner_category' => 'fire',
+            'text' => 'TEMPORARY FLIGHT RESTRICTIONS 5NM RADIUS',
+            'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $now - 3600),
+            'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $now + 3600),
+            'banner_event_fingerprint' => 'tfr-fp',
+        ];
+
+        $selected = selectNotamsForDashboardBanner([$tfr, $runway], $now);
+
+        $this->assertCount(2, $selected);
+        $this->assertSame('runway', $selected[0]['banner_scope']);
+        $this->assertSame('airspace', $selected[1]['banner_scope']);
+    }
+
+    public function testPrepareDashboardBannerRows_S83LikePairCollapsesToOne(): void
+    {
+        $airport = ['icao' => 'KS83', 'faa' => 'S83', 'name' => 'Shoshone County', 'lat' => 47.49, 'lon' => -115.87];
+        $text = 'ID..AIRSPACE 34NM SE COEUR D\'ALENE, ID..TEMPORARY FLIGHT RESTRICTIONS. '
+            . 'PURSUANT TO 14 CFR SECTION 91.137(A)(2) WI AN AREA DEFINED AS 7NM RADIUS OF '
+            . '473130N1160445W (MLP268018.0) SFC-7500FT';
+        $notams = [
+            [
+                'id' => 'A3389/2026',
+                'notam_type' => 'tfr',
+                'text' => $text,
+                'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 7200),
+                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 36000),
+                'status' => 'upcoming_today',
+            ],
+            [
+                'id' => '8838/2026',
+                'notam_type' => 'tfr',
+                'text' => $text,
+                'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 7200),
+                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 36000),
+                'status' => 'upcoming_today',
+            ],
+            [
+                'id' => '8821/2026',
+                'notam_type' => 'tfr',
+                'text' => $text . ' DLY 1400-0500',
+                'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 90000),
+                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 1200000),
+                'status' => 'upcoming_future',
+            ],
+        ];
+
+        $selected = notamPrepareDashboardBannerRows($notams, $airport, 'America/Los_Angeles', time());
+
+        $this->assertCount(1, $selected);
+        $this->assertSame('airspace', $selected[0]['banner_scope']);
+        $this->assertStringContainsString('Fire TFR', $selected[0]['banner_headline']);
+        $this->assertNotEmpty($selected[0]['banner_schedule_line']);
+    }
+}

--- a/tests/Unit/NotamBannerTest.php
+++ b/tests/Unit/NotamBannerTest.php
@@ -22,7 +22,7 @@ final class NotamBannerTest extends TestCase
         ];
     }
 
-    public function testClassifyScope_RunwayClosure(): void
+    public function testNotamBannerClassifyScope_RunwayClosureText_ReturnsRunwayScope(): void
     {
         $airport = $this->kspbAirport();
         $notam = [
@@ -43,7 +43,7 @@ final class NotamBannerTest extends TestCase
         ]));
     }
 
-    public function testClassifyScope_AerodromeClosure(): void
+    public function testNotamBannerClassifyScope_AerodromeClosureText_ReturnsAerodromeScope(): void
     {
         $airport = $this->kspbAirport();
         $notam = [
@@ -61,7 +61,7 @@ final class NotamBannerTest extends TestCase
         ]));
     }
 
-    public function testClassifyScope_PartialRunwayRestrictionHeadline(): void
+    public function testNotamBannerClassifyCategory_PartialRunwayRestriction_ReturnsWingspanHeadline(): void
     {
         $text = 'DFW RWY 13L/31R CLSD TO ACFT WINGSPAN MORE THAN 214FT';
         $this->assertTrue(notamBannerTextIndicatesPartialRunwayRestriction($text));
@@ -76,7 +76,7 @@ final class NotamBannerTest extends TestCase
         );
     }
 
-    public function testClassifyAirspace_FireTfrHeadline(): void
+    public function testNotamBannerClassifyAirspace_FireTfrText_ReturnsFireHeadline(): void
     {
         $text = 'ID..AIRSPACE 34NM SE COEUR D\'ALENE, ID..TEMPORARY FLIGHT RESTRICTIONS. '
             . 'PURSUANT TO 14 CFR SECTION 91.137(A)(2) WI AN AREA DEFINED AS 7NM RADIUS OF '
@@ -87,7 +87,7 @@ final class NotamBannerTest extends TestCase
         $this->assertStringContainsString('7 NM radius', $headline);
     }
 
-    public function testClassifyAirspace_RocketTestCategory(): void
+    public function testNotamBannerClassifyAirspace_RocketTestText_ReturnsSpaceLaunchCategory(): void
     {
         $text = 'ZLC UT..AIRSPACE OGDEN, UT..TEMPORARY FLIGHT RESTRICTIONS WITHIN AN AREA '
             . 'DEFINED AS 5NM RADIUS OF 413900N1122300W STATIC GROUND BASED ROCKET ENGINE TEST.';
@@ -95,7 +95,7 @@ final class NotamBannerTest extends TestCase
         $this->assertStringContainsString('Rocket test TFR', notamBannerBuildAirspaceHeadline('space_launch', $text));
     }
 
-    public function testDeduplicateBannerNotams_MergesPairedFireTfrIds(): void
+    public function testDeduplicateBannerNotams_MatchingFingerprints_MergesToSingleRow(): void
     {
         $airport = ['icao' => 'KS83', 'faa' => 'S83', 'name' => 'Shoshone County'];
         $text = 'ID..AIRSPACE 34NM SE COEUR D\'ALENE, ID..TEMPORARY FLIGHT RESTRICTIONS. '
@@ -119,7 +119,7 @@ final class NotamBannerTest extends TestCase
         $this->assertSame('A3389/2026', $deduped[0]['id']);
     }
 
-    public function testSortBannerNotamsForDisplay_OrdersByStatusThenScope(): void
+    public function testSortBannerNotamsForDisplay_TodayBeforeFuture_OrdersByStatus(): void
     {
         $now = strtotime('2026-06-17T12:00:00Z');
         $today = [
@@ -148,7 +148,7 @@ final class NotamBannerTest extends TestCase
         $this->assertSame('fp-future', $sorted[1]['banner_event_fingerprint']);
     }
 
-    public function testSortBannerNotamsForDisplay_OrdersInactiveScheduledByNextWindow(): void
+    public function testSortBannerNotamsForDisplay_InactiveScheduled_OrdersByNextWindowStart(): void
     {
         $now = strtotime('2026-06-17T16:00:00Z');
         $soonerGap = [
@@ -192,7 +192,7 @@ final class NotamBannerTest extends TestCase
         $this->assertSame('fp-later', $sorted[1]['banner_event_fingerprint']);
     }
 
-    public function testSortBannerNotamsForDisplay_ReturnsAllDistinctDedupedRows(): void
+    public function testSortBannerNotamsForDisplay_ActiveRunwayAndTfr_ReturnsBothRowsRunwayFirst(): void
     {
         $now = time();
         $runway = [
@@ -221,7 +221,7 @@ final class NotamBannerTest extends TestCase
         $this->assertSame('airspace', $sorted[1]['banner_scope']);
     }
 
-    public function testPrepareDashboardBannerRows_S83LikeDedupesPairsKeepsDistinctEvents(): void
+    public function testNotamPrepareDashboardBannerRows_S83LikePairs_DedupesToTwoDistinctEvents(): void
     {
         $airport = ['icao' => 'KS83', 'faa' => 'S83', 'name' => 'Shoshone County', 'lat' => 47.49, 'lon' => -115.87];
         $text = 'ID..AIRSPACE 34NM SE COEUR D\'ALENE, ID..TEMPORARY FLIGHT RESTRICTIONS. '

--- a/tests/Unit/NotamBannerTest.php
+++ b/tests/Unit/NotamBannerTest.php
@@ -148,6 +148,50 @@ final class NotamBannerTest extends TestCase
         $this->assertSame('fp-future', $sorted[1]['banner_event_fingerprint']);
     }
 
+    public function testSortBannerNotamsForDisplay_OrdersInactiveScheduledByNextWindow(): void
+    {
+        $now = strtotime('2026-06-17T16:00:00Z');
+        $soonerGap = [
+            'status' => 'inactive_scheduled',
+            'banner_scope' => 'runway',
+            'banner_category' => 'full_closure',
+            'text' => 'RWY 15/33 CLSD',
+            'effective_segments' => [
+                [
+                    'start_time_utc' => '2026-06-17T10:00:00Z',
+                    'end_time_utc' => '2026-06-17T14:00:00Z',
+                ],
+                [
+                    'start_time_utc' => '2026-06-17T20:00:00Z',
+                    'end_time_utc' => '2026-06-18T05:00:00Z',
+                ],
+            ],
+            'banner_event_fingerprint' => 'fp-sooner',
+        ];
+        $laterGap = [
+            'status' => 'inactive_scheduled',
+            'banner_scope' => 'runway',
+            'banner_category' => 'full_closure',
+            'text' => 'RWY 15/33 CLSD',
+            'effective_segments' => [
+                [
+                    'start_time_utc' => '2026-06-17T08:00:00Z',
+                    'end_time_utc' => '2026-06-17T12:00:00Z',
+                ],
+                [
+                    'start_time_utc' => '2026-06-18T14:00:00Z',
+                    'end_time_utc' => '2026-06-19T05:00:00Z',
+                ],
+            ],
+            'banner_event_fingerprint' => 'fp-later',
+        ];
+
+        $sorted = sortBannerNotamsForDisplay([$laterGap, $soonerGap], $now);
+
+        $this->assertSame('fp-sooner', $sorted[0]['banner_event_fingerprint']);
+        $this->assertSame('fp-later', $sorted[1]['banner_event_fingerprint']);
+    }
+
     public function testSortBannerNotamsForDisplay_ReturnsAllDistinctDedupedRows(): void
     {
         $now = time();

--- a/tests/Unit/NotamBannerTest.php
+++ b/tests/Unit/NotamBannerTest.php
@@ -183,6 +183,34 @@ final class NotamBannerTest extends TestCase
         $this->assertStringNotContainsString('Upcoming from', $line);
     }
 
+    public function testSortBannerNotamsForDisplay_TiedActiveRunwayClosures_OrdersByFingerprint(): void
+    {
+        $now = strtotime('2026-06-17T12:00:00Z');
+        $alpha = [
+            'status' => 'active',
+            'banner_scope' => 'runway',
+            'banner_category' => 'full_closure',
+            'text' => 'RWY 15/33 CLSD',
+            'start_time_utc' => '2026-06-17T10:00:00Z',
+            'end_time_utc' => '2026-06-18T05:00:00Z',
+            'banner_event_fingerprint' => 'alpha-fp',
+        ];
+        $beta = [
+            'status' => 'active',
+            'banner_scope' => 'runway',
+            'banner_category' => 'full_closure',
+            'text' => 'RWY 03/21 CLSD',
+            'start_time_utc' => '2026-06-17T10:00:00Z',
+            'end_time_utc' => '2026-06-18T05:00:00Z',
+            'banner_event_fingerprint' => 'beta-fp',
+        ];
+
+        $sorted = sortBannerNotamsForDisplay([$beta, $alpha], $now);
+
+        $this->assertSame('alpha-fp', $sorted[0]['banner_event_fingerprint']);
+        $this->assertSame('beta-fp', $sorted[1]['banner_event_fingerprint']);
+    }
+
     public function testSortBannerNotamsForDisplay_TodayBeforeFuture_OrdersByStatus(): void
     {
         $now = strtotime('2026-06-17T12:00:00Z');


### PR DESCRIPTION
## Summary

- Adds server-side NOTAM banner taxonomy, headline generation, event deduplication, and display ordering so dashboards show scannable headlines instead of duplicate paired rows (e.g. S83 fire TFR A/numeric pairs).
- API returns all deduplicated, filter-eligible banner rows with `banner_headline` and `banner_schedule_line`; full `message` text is always included for safety.
- Dashboard UI renders a scannable headline row plus full FAA NOTAM body below.

## Changes

- **`lib/notam/banner.php`**: scope/category classification (aerodrome, runway, airspace), headline builders, fingerprint dedup, stable display ordering
- **`api/notam.php`**: `notamPrepareDashboardBannerRows()` at serve time; new JSON fields for banner metadata
- **`public/js/airport-dashboard.js`**, **`public/css/styles.css`**: headline + full-text two-tier banner layout
- **`tests/Unit/NotamBannerTest.php`**: runway/aerodrome/TFR headlines, S83-like dedup, inactive-scheduled ordering

## Safety notes

- Full NOTAM text is never hidden or truncated; headlines are visual cues only
- Serve-time status revalidation and failclosed staleness behavior unchanged

## Test plan

- [x] `make test-ci`
- [x] `tests/Unit/NotamBannerTest.php`
- [x] Verify S83 (or similar) shows deduplicated fire TFR banners with headline + full text
- [x] Verify active runway closure headline (`RWY 15/33 closed`) with full text below
- [x] Verify mixed active runway + TFR shows both banners when scopes differ