### PR TITLE
Prioritize active TFRs on airports directory map

### DIFF
--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1600,6 +1600,33 @@ The `/api/notam.php` endpoint serves cached NOTAM data:
 - Adds official FAA NOTAM links for each NOTAM
 - Returns JSON array of formatted NOTAMs
 
+### Airports directory TFR map layer
+
+The airports network map (`pages/airports.php`, served at `airports.aviationwx.org`) draws geo-relevant TFRs from an aggregated GeoJSON layer. This path is separate from per-airport dashboard banners: banners list every deduplicated event row; the map shows one drawable shape per geometry.
+
+**Build** (`notamTfrMapLayerBuildPayload()` in `lib/notam/map-layer.php`):
+
+1. Read each listed airport NOTAM cache (`cache/notam/{airport_id}.json`).
+2. Keep TFR rows where `classifyNotamDisplayStatusAt()` is not `expired` or `unknown`.
+3. Skip duplicate global NOTAM `id` values while scanning caches.
+4. Emit a GeoJSON Feature per row: polygon outer ring from decoded vertices, or a Point + `radius_nm` for circle TFRs (client draws `L.circle` in meters).
+5. **Geometry deduplication** (`notamTfrMapLayerDeduplicateFeaturesByGeometry()`): features that share the same drawable geometry key collapse to one feature. When keys collide, keep the highest-priority status:
+
+   | Priority | Status |
+   |----------|--------|
+   | 1 (wins) | `active` |
+   | 2 | `inactive_scheduled` |
+   | 3 | `upcoming_today` |
+   | 4 | `upcoming_future` |
+
+   Equal-priority ties break on lower `notam_id` (lexicographic). This is **not** the dashboard banner event fingerprint (`notamBannerEventFingerprint()`): map keys use rounded circle center + radius, or polygon ring vertices in ring order, so paired A/numeric NOTAMs and same-shape upcoming series merge for display only.
+
+**Style bucket** (`notamTfrMapLayerStyleBucket()`): `active` (red stroke/fill) only when status is `active`; all other retained statuses map to `upcoming` (amber), including `inactive_scheduled`.
+
+**Serve**: `GET /api/notam-map.php` returns cached GeoJSON when younger than `getNotamCacheTtlSeconds()`; otherwise rebuilds and writes the aggregate cache file. Production access is browser-only (`lib/notam/map-api-access.php`).
+
+**Safety**: Geometry dedup prefers the currently active restriction so an overlapping upcoming NOTAM cannot mask an active TFR on the directory map.
+
 ---
 
 ## Data Display on Dashboard
@@ -1723,6 +1750,14 @@ The `/api/notam.php` endpoint serves cached NOTAM data:
 #### Visual Indicators
 - **Icons**: 🚨 active, ⏸️ scheduled gap, ⚠️ upcoming
 - **Color Coding**: Red active, purple scheduled, orange upcoming (see `.notam-banner-*` in `public/css/styles.css`)
+
+#### Airports directory map (TFR layer)
+
+- **Location**: Leaflet map on `pages/airports.php` (`airports.aviationwx.org`)
+- **Data**: `GET /api/notam-map.php` (aggregated GeoJSON; see [Airports directory TFR map layer](#airports-directory-tfr-map-layer))
+- **Geometry**: Polygons or true-radius circles (`L.circle`); tap/click opens popup with NOTAM id, schedule line, vertical limits, FAA link
+- **Styling**: Red active, amber upcoming (includes scheduled gaps between EFFECTIVE windows)
+- **Refresh**: Client polls on the same cadence as NOTAM cache TTL
 
 ### Data Refresh Behavior
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1612,12 +1612,14 @@ The airports network map (`pages/airports.php`, served at `airports.aviationwx.o
 4. Emit a GeoJSON Feature per row: polygon outer ring from decoded vertices, or a Point + `radius_nm` for circle TFRs (client draws `L.circle` in meters).
 5. **Geometry deduplication** (`notamTfrMapLayerDeduplicateFeaturesByGeometry()`): features that share the same drawable geometry key collapse to one feature. When keys collide, keep the highest-priority status:
 
-   | Priority | Status |
-   |----------|--------|
-   | 1 (wins) | `active` |
-   | 2 | `inactive_scheduled` |
-   | 3 | `upcoming_today` |
-   | 4 | `upcoming_future` |
+   | Rank (`NOTAM_TFR_MAP_STATUS_PRIORITY`) | Status |
+   |----------------------------------------|--------|
+   | 0 (wins) | `active` |
+   | 1 | `inactive_scheduled` |
+   | 2 | `upcoming_today` |
+   | 3 | `upcoming_future` |
+
+   Lower rank wins (`notamTfrMapLayerStatusPriority()`).
 
    Equal-priority ties break on lower `notam_id` (lexicographic). This is **not** the dashboard banner event fingerprint (`notamBannerEventFingerprint()`): map keys use rounded circle center + radius, or polygon ring vertices in ring order, so paired A/numeric NOTAMs and same-shape upcoming series merge for display only.
 

--- a/lib/notam/map-layer.php
+++ b/lib/notam/map-layer.php
@@ -18,6 +18,14 @@ require_once __DIR__ . '/schedule.php';
 /** Segments on approximate circle rings (visual only, not for navigation). */
 const NOTAM_TFR_MAP_CIRCLE_SEGMENTS = 64;
 
+/** @var array<string, int> Lower value = higher priority when geometry overlaps */
+const NOTAM_TFR_MAP_STATUS_PRIORITY = [
+    'active' => 0,
+    'inactive_scheduled' => 1,
+    'upcoming_today' => 2,
+    'upcoming_future' => 3,
+];
+
 /**
  * Build one closed GeoJSON outer ring [lon, lat] from decoded TFR vertices.
  *
@@ -82,6 +90,145 @@ function notamTfrMapLayerGeoJsonRingFromCircle(float $centerLat, float $centerLo
  */
 function notamTfrMapLayerStyleBucket(string $status): string {
     return $status === 'active' ? 'active' : 'upcoming';
+}
+
+/**
+ * Sortable priority for overlapping map features (lower = wins).
+ *
+ * Aligns with dashboard banner status ordering; kept local so the map layer
+ * does not depend on banner headline/dedup code.
+ *
+ * @param string $status From {@see classifyNotamDisplayStatusAt()}
+ * @return int Priority rank (lower = higher priority)
+ */
+function notamTfrMapLayerStatusPriority(string $status): int {
+    return NOTAM_TFR_MAP_STATUS_PRIORITY[$status] ?? 99;
+}
+
+/**
+ * Stable geometry key for deduplicating overlapping TFR map features.
+ *
+ * @param array<string, mixed> $feature GeoJSON Feature with geometry and properties
+ * @return string|null Null when geometry cannot be keyed
+ */
+function notamTfrMapLayerFeatureGeometryKey(array $feature): ?string {
+    $geometry = $feature['geometry'] ?? null;
+    if (!is_array($geometry)) {
+        return null;
+    }
+    $type = (string) ($geometry['type'] ?? '');
+    $props = is_array($feature['properties'] ?? null) ? $feature['properties'] : [];
+
+    if ($type === 'Point' && ($props['geometry_kind'] ?? '') === 'circle') {
+        $coords = $geometry['coordinates'] ?? null;
+        if (!is_array($coords) || count($coords) < 2) {
+            return null;
+        }
+        $radiusNm = isset($props['radius_nm']) ? (float) $props['radius_nm'] : 0.0;
+        if ($radiusNm <= 0) {
+            return null;
+        }
+
+        return sprintf(
+            'circle|%.4f|%.4f|%.2f',
+            round((float) $coords[1], 4),
+            round((float) $coords[0], 4),
+            round($radiusNm, 2)
+        );
+    }
+
+    if ($type === 'Polygon') {
+        $rings = $geometry['coordinates'] ?? null;
+        if (!is_array($rings) || !isset($rings[0]) || !is_array($rings[0])) {
+            return null;
+        }
+        $parts = [];
+        $ring = $rings[0];
+        $count = count($ring);
+        for ($i = 0; $i < $count; $i++) {
+            if ($i === $count - 1 && $count > 1) {
+                $first = $ring[0];
+                $last = $ring[$i];
+                if (is_array($first) && is_array($last)
+                    && abs((float) $first[0] - (float) $last[0]) < 1e-9
+                    && abs((float) $first[1] - (float) $last[1]) < 1e-9
+                ) {
+                    continue;
+                }
+            }
+            if (!is_array($ring[$i]) || count($ring[$i]) < 2) {
+                continue;
+            }
+            $parts[] = sprintf('%.4f,%.4f', round((float) $ring[$i][0], 4), round((float) $ring[$i][1], 4));
+        }
+        if ($parts === []) {
+            return null;
+        }
+
+        return 'poly|' . implode(';', $parts);
+    }
+
+    return null;
+}
+
+/**
+ * Pick the higher-priority feature when two share the same geometry key.
+ *
+ * @param array<string, mixed> $candidate New feature
+ * @param array<string, mixed> $incumbent Existing feature for the geometry key
+ * @return array<string, mixed>
+ */
+function notamTfrMapLayerPreferFeature(array $candidate, array $incumbent): array {
+    $candidateStatus = (string) (($candidate['properties'] ?? [])['status'] ?? '');
+    $incumbentStatus = (string) (($incumbent['properties'] ?? [])['status'] ?? '');
+    $candidatePri = notamTfrMapLayerStatusPriority($candidateStatus);
+    $incumbentPri = notamTfrMapLayerStatusPriority($incumbentStatus);
+    if ($candidatePri < $incumbentPri) {
+        return $candidate;
+    }
+    if ($candidatePri > $incumbentPri) {
+        return $incumbent;
+    }
+
+    $candidateId = (string) (($candidate['properties'] ?? [])['notam_id'] ?? '');
+    $incumbentId = (string) (($incumbent['properties'] ?? [])['notam_id'] ?? '');
+
+    return strcmp($candidateId, $incumbentId) < 0 ? $candidate : $incumbent;
+}
+
+/**
+ * Collapse overlapping TFR features so the highest-priority status wins.
+ *
+ * Map-only dedup: distinct drawable geometry (not dashboard event fingerprints).
+ * Active restrictions must not be masked by overlapping upcoming NOTAMs.
+ *
+ * @param array<int, array<string, mixed>> $features GeoJSON features
+ * @return array<int, array<string, mixed>>
+ */
+function notamTfrMapLayerDeduplicateFeaturesByGeometry(array $features): array {
+    if ($features === []) {
+        return [];
+    }
+
+    $byGeometry = [];
+    $ungrouped = [];
+    foreach ($features as $feature) {
+        if (!is_array($feature)) {
+            continue;
+        }
+        $key = notamTfrMapLayerFeatureGeometryKey($feature);
+        if ($key === null || $key === '') {
+            $ungrouped[] = $feature;
+            continue;
+        }
+        if (!isset($byGeometry[$key])) {
+            $byGeometry[$key] = $feature;
+            continue;
+        }
+        $byGeometry[$key] = notamTfrMapLayerPreferFeature($feature, $byGeometry[$key]);
+    }
+
+    return array_merge(array_values($byGeometry), $ungrouped);
 }
 
 /**
@@ -318,6 +465,8 @@ function notamTfrMapLayerBuildPayload(array $config): array {
             ];
         }
     }
+
+    $features = notamTfrMapLayerDeduplicateFeaturesByGeometry($features);
 
     return [
         'type' => 'FeatureCollection',

--- a/tests/Unit/NotamMapLayerTest.php
+++ b/tests/Unit/NotamMapLayerTest.php
@@ -1,14 +1,18 @@
 <?php
-/**
- * NOTAM TFR map layer (GeoJSON aggregation) unit tests.
- */
+
+declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../lib/notam/map-layer.php';
 
-class NotamMapLayerTest extends TestCase {
-    public function testGeoJsonRingFromVertices_ClosedSquare(): void {
+/**
+ * NOTAM TFR map layer (GeoJSON aggregation) unit tests.
+ */
+final class NotamMapLayerTest extends TestCase
+{
+    public function testNotamTfrMapLayerGeoJsonRingFromVertices_ClosedSquare_ReturnsClosedRing(): void
+    {
         $vertices = [
             ['lat' => 45.0, 'lon' => -122.0],
             ['lat' => 45.0, 'lon' => -123.0],
@@ -24,20 +28,23 @@ class NotamMapLayerTest extends TestCase {
         $this->assertEqualsWithDelta($first[1], $last[1], 1e-9);
     }
 
-    public function testGeoJsonRingFromCircle_Closed(): void {
+    public function testNotamTfrMapLayerGeoJsonRingFromCircle_DefaultSegments_ReturnsClosedRing(): void
+    {
         $ring = notamTfrMapLayerGeoJsonRingFromCircle(45.0, -122.0, 5.0);
         $this->assertCount(NOTAM_TFR_MAP_CIRCLE_SEGMENTS + 1, $ring);
         $this->assertEqualsWithDelta($ring[0][0], $ring[count($ring) - 1][0], 1e-9);
         $this->assertEqualsWithDelta($ring[0][1], $ring[count($ring) - 1][1], 1e-9);
     }
 
-    public function testMapLayerStyleBucket(): void {
+    public function testNotamTfrMapLayerStyleBucket_VariousStatuses_MapsToActiveOrUpcoming(): void
+    {
         $this->assertSame('active', notamTfrMapLayerStyleBucket('active'));
         $this->assertSame('upcoming', notamTfrMapLayerStyleBucket('inactive_scheduled'));
         $this->assertSame('upcoming', notamTfrMapLayerStyleBucket('upcoming_today'));
     }
 
-    public function testTooltipStatusLine_ActiveUntilSegmentEnd(): void {
+    public function testNotamTfrMapLayerTooltipStatusLine_ActiveSegment_ReturnsActiveUntilLine(): void
+    {
         $notam = [
             'id' => 'T1',
             'text' => '',
@@ -53,7 +60,8 @@ class NotamMapLayerTest extends TestCase {
         $this->assertStringContainsString('May 15, 2026', $line);
     }
 
-    public function testTooltipStatusLine_UpcomingFirstWindow(): void {
+    public function testNotamTfrMapLayerTooltipStatusLine_UpcomingFirstWindow_ReturnsUpcomingFromLine(): void
+    {
         $notam = [
             'id' => 'T1',
             'text' => '',
@@ -68,7 +76,8 @@ class NotamMapLayerTest extends TestCase {
         $this->assertStringContainsString(' to ', $line);
     }
 
-    public function testTooltipStatusLine_InactiveScheduledNextWindow(): void {
+    public function testNotamTfrMapLayerTooltipStatusLine_InactiveScheduledGap_ReturnsUpcomingFromLine(): void
+    {
         $notam = [
             'id' => 'T1',
             'text' => '',
@@ -84,7 +93,8 @@ class NotamMapLayerTest extends TestCase {
         $this->assertStringContainsString('10:00 PM', $line);
     }
 
-    public function testTooltipStatusLine_EnvelopeOnlyActive(): void {
+    public function testNotamTfrMapLayerTooltipStatusLine_EnvelopeOnlyActive_ReturnsActiveUntilLine(): void
+    {
         $notam = [
             'id' => 'T2',
             'text' => '',
@@ -95,5 +105,94 @@ class NotamMapLayerTest extends TestCase {
         $line = notamTfrMapLayerTooltipStatusLine($notam, 'active', 'UTC', $now);
         $this->assertNotNull($line);
         $this->assertStringStartsWith('Active now until', $line);
+    }
+
+    public function testNotamTfrMapLayerDeduplicateFeaturesByGeometry_ActiveAndUpcomingCircle_KeepsActive(): void
+    {
+        $active = [
+            'type' => 'Feature',
+            'geometry' => ['type' => 'Point', 'coordinates' => [-116.08, 47.52]],
+            'properties' => [
+                'geometry_kind' => 'circle',
+                'radius_nm' => 7.0,
+                'status' => 'active',
+                'map_layer_style' => 'active',
+                'notam_id' => 'A3389/2026',
+            ],
+        ];
+        $upcoming = [
+            'type' => 'Feature',
+            'geometry' => ['type' => 'Point', 'coordinates' => [-116.08, 47.52]],
+            'properties' => [
+                'geometry_kind' => 'circle',
+                'radius_nm' => 7.0,
+                'status' => 'upcoming_future',
+                'map_layer_style' => 'upcoming',
+                'notam_id' => '8821/2026',
+            ],
+        ];
+
+        $deduped = notamTfrMapLayerDeduplicateFeaturesByGeometry([$upcoming, $active]);
+
+        $this->assertCount(1, $deduped);
+        $this->assertSame('active', $deduped[0]['properties']['status']);
+        $this->assertSame('A3389/2026', $deduped[0]['properties']['notam_id']);
+    }
+
+    public function testNotamTfrMapLayerDeduplicateFeaturesByGeometry_ScheduledGapAndUpcomingCircle_KeepsScheduledGap(): void
+    {
+        $scheduled = [
+            'type' => 'Feature',
+            'geometry' => ['type' => 'Point', 'coordinates' => [-116.08, 47.52]],
+            'properties' => [
+                'geometry_kind' => 'circle',
+                'radius_nm' => 7.0,
+                'status' => 'inactive_scheduled',
+                'notam_id' => 'A1001/2026',
+            ],
+        ];
+        $upcoming = [
+            'type' => 'Feature',
+            'geometry' => ['type' => 'Point', 'coordinates' => [-116.08, 47.52]],
+            'properties' => [
+                'geometry_kind' => 'circle',
+                'radius_nm' => 7.0,
+                'status' => 'upcoming_future',
+                'notam_id' => 'A1002/2026',
+            ],
+        ];
+
+        $deduped = notamTfrMapLayerDeduplicateFeaturesByGeometry([$upcoming, $scheduled]);
+
+        $this->assertCount(1, $deduped);
+        $this->assertSame('inactive_scheduled', $deduped[0]['properties']['status']);
+    }
+
+    public function testNotamTfrMapLayerDeduplicateFeaturesByGeometry_DistinctCircles_KeepsBoth(): void
+    {
+        $a = [
+            'type' => 'Feature',
+            'geometry' => ['type' => 'Point', 'coordinates' => [-116.08, 47.52]],
+            'properties' => [
+                'geometry_kind' => 'circle',
+                'radius_nm' => 7.0,
+                'status' => 'upcoming_today',
+                'notam_id' => 'A1',
+            ],
+        ];
+        $b = [
+            'type' => 'Feature',
+            'geometry' => ['type' => 'Point', 'coordinates' => [-117.08, 48.52]],
+            'properties' => [
+                'geometry_kind' => 'circle',
+                'radius_nm' => 7.0,
+                'status' => 'upcoming_today',
+                'notam_id' => 'A2',
+            ],
+        ];
+
+        $deduped = notamTfrMapLayerDeduplicateFeaturesByGeometry([$a, $b]);
+
+        $this->assertCount(2, $deduped);
     }
 }


### PR DESCRIPTION
## Summary

- Fixes overlapping TFR circles on the airports directory map showing as upcoming (amber) when an active restriction exists at the same geometry.
- Collapses GeoJSON features that share drawable geometry and keeps the highest-priority status (`active` over scheduled gaps and upcoming windows).
- Documents the map-layer build and dedup rules in `docs/DATA_FLOW.md`.

## Changes

- **`lib/notam/map-layer.php`**: geometry keys for circles and polygons, `notamTfrMapLayerDeduplicateFeaturesByGeometry()`, status priority aligned with banner ordering
- **`tests/Unit/NotamMapLayerTest.php`**: dedup cases (active beats upcoming, scheduled gap beats upcoming, distinct circles kept), test naming aligned with `CODE_STYLE.md`
- **`docs/DATA_FLOW.md`**: processing and display sections for the airports TFR map layer

## Behavior

- Map dedup is geometry-based (center + radius or polygon ring), separate from dashboard banner event fingerprints.
- Dashboard banners still return every deduplicated event row; the map shows one shape per drawable geometry.
- Style bucket stays red only for `active`; other retained statuses render amber.

## Test plan

- [x] `make test-ci`
- [x] `tests/Unit/NotamMapLayerTest.php` (10 tests)
- [x] Verify an airport with paired + daily fire TFRs (e.g. S83) shows a red active circle when today's window is active