### PR TITLE
Harden NOTAM map layer cache for deploy safety and maintainability

### DIFF
--- a/api/notam-map.php
+++ b/api/notam-map.php
@@ -2,9 +2,11 @@
 /**
  * Internal NOTAM TFR map layer API (airports directory map only).
  *
- * Serves a GeoJSON FeatureCollection built from per-airport NOTAM caches.
- * Cache TTL matches {@see getNotamCacheTtlSeconds()} (same as per-airport NOTAM JSON).
- * In production, access is limited to browser use from the airport map UI; see
+ * Drawable geometry is cached on disk; status and map colors are revalidated
+ * at serve time from per-airport NOTAM caches. HTTP Cache-Control uses
+ * {@see NOTAM_API_CACHE_TTL_SECONDS} (shared with api/notam.php); JSON
+ * cache_ttl_seconds reflects {@see getNotamCacheTtlSeconds()} for client poll.
+ * Production access is limited to browser use from the airport map UI; see
  * {@see notamMapLayerApiRequestIsAllowed()}.
  */
 
@@ -12,6 +14,7 @@ require_once __DIR__ . '/../lib/config.php';
 require_once __DIR__ . '/../lib/logger.php';
 require_once __DIR__ . '/../lib/constants.php';
 require_once __DIR__ . '/../lib/notam/map-api-access.php';
+require_once __DIR__ . '/../lib/notam/http-cache-headers.php';
 require_once __DIR__ . '/../lib/notam/map-layer.php';
 
 ob_start();
@@ -36,6 +39,7 @@ if (!notamMapLayerApiRequestIsAllowed()) {
 
 try {
     $payload = notamTfrMapLayerServeOrRebuild();
+    notamInternalApiSendSharedCacheHeaders();
     echo json_encode($payload, JSON_UNESCAPED_SLASHES);
 } catch (Throwable $e) {
     ob_clean();

--- a/api/notam.php
+++ b/api/notam.php
@@ -18,34 +18,13 @@ require_once __DIR__ . '/../lib/notam/filter.php';
 require_once __DIR__ . '/../lib/notam/schedule.php';
 require_once __DIR__ . '/../lib/notam/cache.php';
 require_once __DIR__ . '/../lib/notam/banner.php';
+require_once __DIR__ . '/../lib/notam/http-cache-headers.php';
 
 // Start output buffering
 ob_start();
 
 // Set JSON header
 header('Content-Type: application/json');
-
-/**
- * Send cache headers for successful NOTAM responses
- *
- * Browsers and the CDN may share a response for NOTAM_API_CACHE_TTL_SECONDS,
- * with stale-while-revalidate letting the edge refresh in the background.
- * The window is small against the hourly upstream NMS refresh and the
- * 3 minute dashboard poll, so a new restriction is never delayed
- * meaningfully by the cache. Error responses carry no cache headers and
- * stay uncached at the edge.
- *
- * @return void
- */
-function notamApiSendCacheHeaders(): void
-{
-    header(
-        'Cache-Control: public'
-        . ', max-age=' . NOTAM_API_CACHE_TTL_SECONDS
-        . ', s-maxage=' . NOTAM_API_CACHE_TTL_SECONDS
-        . ', stale-while-revalidate=' . NOTAM_API_CACHE_SWR_SECONDS
-    );
-}
 
 // Get airport ID
 $airportId = isset($_GET['airport']) ? trim($_GET['airport']) : '';

--- a/docs/API.md
+++ b/docs/API.md
@@ -140,7 +140,7 @@ Returns filtered NOTAM rows (closures and relevant TFRs) as JSON for the per-air
 
 #### `GET /api/notam-map.php`
 
-Returns a GeoJSON `FeatureCollection` of TFR geometries for the **airports directory map** (`pages/airports.php`). Features include properties such as `notam_id`, `status`, `status_line`, `vertical_limits`, `geometry_kind` (`polygon` or `circle`), `official_link`, and style hints. The payload is cached on disk with the same TTL as per-airport NOTAM JSON (`getNotamCacheTtlSeconds()`).
+Returns a GeoJSON `FeatureCollection` of TFR geometries for the **airports directory map** (`pages/airports.php`). Features include properties such as `notam_id`, `status`, `status_line`, `vertical_limits`, `geometry_kind` (`polygon` or `circle`), `official_link`, and style hints. Drawable geometry is cached on disk (`cache/notam/tfr-map-layer.json`) with a `map_layer_build_token` for deploy invalidation; status and map colors are revalidated at serve time using the same `revalidateNotamStatus()` / `isTfr()` checks as `api/notam.php`. Successful responses use the short shared HTTP cache window (`NOTAM_API_CACHE_TTL_SECONDS`); JSON `cache_ttl_seconds` reflects the disk/client poll interval (`getNotamCacheTtlSeconds()`).
 
 **Access:** In production, callers must satisfy map-only browser rules (`lib/notam/map-api-access.php`); nginx also rejects `Sec-Fetch-Site: cross-site` for this path (`docker/nginx.conf`). Non-production and test mode allow open access for local development and CI.
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1625,7 +1625,14 @@ The airports network map (`pages/airports.php`, served at `airports.aviationwx.o
 
 **Style bucket** (`notamTfrMapLayerStyleBucket()`): `active` (red stroke/fill) only when status is `active`; all other retained statuses map to `upcoming` (amber), including `inactive_scheduled`.
 
-**Serve**: `GET /api/notam-map.php` returns cached GeoJSON when younger than `getNotamCacheTtlSeconds()`; otherwise rebuilds and writes the aggregate cache file. Production access is browser-only (`lib/notam/map-api-access.php`).
+**Serve** (`notamTfrMapLayerServeOrRebuild()`):
+
+1. **Shared disk cache** (`cache/notam/tfr-map-layer.json`) stores drawable geometry and `map_layer_build_token` ({@see getGitSha()} or {@see NOTAM_TFR_MAP_LAYER_LOGIC_VERSION} when SHA is unset). Rebuild when the aggregate file is missing or invalid, older than `getNotamCacheTtlSeconds()`, any listed per-airport NOTAM cache file is newer than the aggregate, or the build token no longer matches (code deploy).
+2. **Single-flight rebuild**: `flock()` on `tfr-map-layer.rebuild.lock` so concurrent requests do not all parse geometry; waiters serve the existing aggregate when present.
+3. **Serve-time status revalidation** (`notamTfrMapLayerRevalidatePayload()`): one pass over listed airport caches, then `revalidateNotamStatus()` and `isTfr()` parity with `api/notam.php`, refresh `map_layer_style` / `status_line`, drop expired rows, and re-apply geometry dedup.
+4. **HTTP cache**: `GET /api/notam-map.php` sends `Cache-Control` with `NOTAM_API_CACHE_TTL_SECONDS` / `NOTAM_API_CACHE_SWR_SECONDS` (same as `api/notam.php`). JSON `cache_ttl_seconds` is the disk/client poll TTL (`getNotamCacheTtlSeconds()`), not the HTTP window.
+
+Production access is browser-only (`lib/notam/map-api-access.php`).
 
 **Safety**: Geometry dedup prefers the currently active restriction so an overlapping upcoming NOTAM cannot mask an active TFR on the directory map.
 

--- a/lib/cache-paths.php
+++ b/lib/cache-paths.php
@@ -597,10 +597,26 @@ function getNotamCachePath(string $airportId): string {
 /**
  * Aggregated TFR GeoJSON for the airports directory map (internal use).
  *
+ * Uses {@see notamCacheDirectory()} when available so test overrides align
+ * with per-airport NOTAM cache paths.
+ *
  * @return string Full path to JSON cache file
  */
 function getNotamTfrMapLayerCachePath(): string {
-    return CACHE_NOTAM_DIR . '/tfr-map-layer.json';
+    require_once __DIR__ . '/notam/cache.php';
+
+    return notamCacheDirectory() . '/tfr-map-layer.json';
+}
+
+/**
+ * Exclusive flock target for single-flight NOTAM map layer rebuilds.
+ *
+ * @return string Full path to lock file (created on demand)
+ */
+function getNotamTfrMapLayerRebuildLockPath(): string {
+    require_once __DIR__ . '/notam/cache.php';
+
+    return notamCacheDirectory() . '/tfr-map-layer.rebuild.lock';
 }
 
 /**

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -135,6 +135,7 @@ if (!defined('STALE_WHILE_REVALIDATE_SECONDS')) {
 // NMS refresh is hourly (NOTAM_CACHE_TTL_DEFAULT) and power samples drift
 // over hours, so a one-minute shared window adds nothing meaningful to the
 // pipeline latency that the upstream refresh and dashboard polls dominate.
+// GET /api/notam-map.php uses the same NOTAM_* values for the airports map.
 if (!defined('NOTAM_API_CACHE_TTL_SECONDS')) {
     define('NOTAM_API_CACHE_TTL_SECONDS', 60);
 }

--- a/lib/notam/filter.php
+++ b/lib/notam/filter.php
@@ -1084,10 +1084,11 @@ function notamUpcomingBucketForStartAt(int $startUnix, string $timezone, int $no
  * 
  * @param array<string, mixed> $notam Cached NOTAM row: start_time_utc, optional effective_segments, optional status
  * @param string $timezone Airport timezone (e.g., 'America/Denver'), defaults to UTC
+ * @param int|null $nowUnix Optional fixed clock for tests; defaults to {@see time()}
  * @return string When start_time_utc is valid: 'active', 'inactive_scheduled', 'upcoming_today', 'upcoming_future', or 'expired'. When start is missing or invalid: cached status or 'unknown'
  */
-function revalidateNotamStatus(array $notam, string $timezone = 'UTC'): string {
-    $now = time();
+function revalidateNotamStatus(array $notam, string $timezone = 'UTC', ?int $nowUnix = null): string {
+    $now = $nowUnix ?? time();
     $startTimeRaw = !empty($notam['start_time_utc']) ? strtotime($notam['start_time_utc']) : false;
     $startTime = ($startTimeRaw !== false && $startTimeRaw > 0) ? $startTimeRaw : null;
     if ($startTime === null) {

--- a/lib/notam/http-cache-headers.php
+++ b/lib/notam/http-cache-headers.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Shared HTTP cache headers for slow-changing NOTAM internal API responses.
+ */
+
+require_once __DIR__ . '/../constants.php';
+
+/**
+ * Send Cache-Control for NOTAM JSON endpoints (dashboard and map layer).
+ *
+ * Browsers and the CDN may share a response for NOTAM_API_CACHE_TTL_SECONDS,
+ * with stale-while-revalidate letting the edge refresh in the background.
+ *
+ * @return void
+ */
+function notamInternalApiSendSharedCacheHeaders(): void
+{
+    header(
+        'Cache-Control: public'
+        . ', max-age=' . NOTAM_API_CACHE_TTL_SECONDS
+        . ', s-maxage=' . NOTAM_API_CACHE_TTL_SECONDS
+        . ', stale-while-revalidate=' . NOTAM_API_CACHE_SWR_SECONDS
+    );
+}
+
+/**
+ * Send Cache-Control for successful NOTAM dashboard responses.
+ *
+ * @return void
+ */
+function notamApiSendCacheHeaders(): void
+{
+    notamInternalApiSendSharedCacheHeaders();
+}

--- a/lib/notam/map-layer.php
+++ b/lib/notam/map-layer.php
@@ -2,8 +2,10 @@
 /**
  * Aggregated TFR GeoJSON for the airports directory map (internal API only).
  *
- * Rebuilds from per-airport NOTAM cache files using the same TTL as
- * {@see getNotamCacheTtlSeconds()} so map geometry tracks NOTAM fetch cadence.
+ * Geometry is cached on disk and rebuilt when per-airport NOTAM sources change,
+ * aggregate age exceeds {@see getNotamCacheTtlSeconds()}, or the cache is missing.
+ * Status, style, and tooltip lines are revalidated at serve time from per-airport
+ * caches so restriction colors track wall-clock windows without rebuilding geometry.
  */
 
 require_once __DIR__ . '/../logger.php';
@@ -12,6 +14,7 @@ require_once __DIR__ . '/../constants.php';
 require_once __DIR__ . '/../cache-paths.php';
 require_once __DIR__ . '/../units.php';
 require_once __DIR__ . '/../weather/utils.php';
+require_once __DIR__ . '/cache.php';
 require_once __DIR__ . '/filter.php';
 require_once __DIR__ . '/schedule.php';
 
@@ -25,6 +28,12 @@ const NOTAM_TFR_MAP_STATUS_PRIORITY = [
     'upcoming_today' => 2,
     'upcoming_future' => 3,
 ];
+
+/**
+ * Bump when map build, dedup, or serve-time revalidation logic changes and
+ * {@see getGitSha()} is empty (local dev, some CI jobs).
+ */
+const NOTAM_TFR_MAP_LAYER_LOGIC_VERSION = 1;
 
 /**
  * Build one closed GeoJSON outer ring [lon, lat] from decoded TFR vertices.
@@ -344,40 +353,140 @@ function notamTfrMapLayerTooltipStatusLine(array &$notam, string $status, string
 }
 
 /**
- * Build GeoJSON FeatureCollection payload from listed airport NOTAM caches.
+ * Build token stored in aggregate cache so code deploys invalidate stale geometry.
+ *
+ * @return string Short deploy SHA or a logic-version fallback
+ */
+function notamTfrMapLayerCurrentBuildToken(): string {
+    $sha = getGitSha();
+    if ($sha !== '') {
+        return $sha;
+    }
+
+    return 'logic-v' . NOTAM_TFR_MAP_LAYER_LOGIC_VERSION;
+}
+
+/**
+ * True when decoded aggregate JSON has the expected FeatureCollection shape.
+ *
+ * @param array<string, mixed>|null $decoded Decoded aggregate cache payload
+ * @return bool
+ */
+function notamTfrMapLayerAggregateFileIsValid(?array $decoded): bool {
+    return is_array($decoded)
+        && ($decoded['type'] ?? '') === 'FeatureCollection'
+        && isset($decoded['features'])
+        && is_array($decoded['features']);
+}
+
+/**
+ * True when cached aggregate was built by the current deploy or logic version.
+ *
+ * @param array<string, mixed>|null $cachedPayload Decoded aggregate cache
+ * @return bool
+ */
+function notamTfrMapLayerAggregateBuildTokenMatches(?array $cachedPayload): bool {
+    if ($cachedPayload === null) {
+        return false;
+    }
+    $stored = trim((string)($cachedPayload['map_layer_build_token'] ?? ''));
+    if ($stored === '') {
+        return false;
+    }
+
+    return $stored === notamTfrMapLayerCurrentBuildToken();
+}
+
+/**
+ * Load listed airport NOTAM caches in one pass for build and serve-time revalidation.
  *
  * @param array<string, mixed> $config Full config from {@see loadConfig()}
- * @return array{type: string, features: array<int, array<string, mixed>>, generated_at: int, cache_ttl_seconds: int}
+ * @return array{
+ *     newest_mtime: int,
+ *     by_id: array<string, array{notam: array<string, mixed>, timezone: string, airport_id: string}>,
+ *     airports: array<string, array{airport: array<string, mixed>, timezone: string, notams: array<int, mixed>, cache_mtime: int}>
+ * }
  */
-function notamTfrMapLayerBuildPayload(array $config): array {
-    $ttl = getNotamCacheTtlSeconds();
-    $features = [];
-    $seenIds = [];
+function notamTfrMapLayerLoadListedAirportCaches(array $config): array {
+    $result = [
+        'newest_mtime' => 0,
+        'by_id' => [],
+        'airports' => [],
+    ];
+    if (!isset($config['airports']) || !is_array($config['airports'])) {
+        return $result;
+    }
 
     $listed = getListedAirports($config);
     foreach ($listed as $airportId => $airport) {
         if (!is_array($airport) || !isAirportEnabled($airport)) {
             continue;
         }
-        if (!isset($airport['lat'], $airport['lon'])) {
-            continue;
+        $cachePath = notamCacheFilePath((string)$airportId);
+        $cache = notamReadCachePayload($cachePath);
+        $cacheMtime = is_readable($cachePath) ? (int)@filemtime($cachePath) : 0;
+        if ($cacheMtime > $result['newest_mtime']) {
+            $result['newest_mtime'] = $cacheMtime;
         }
-        $cachePath = getNotamCachePath((string)$airportId);
-        if (!is_readable($cachePath)) {
-            continue;
-        }
-        $raw = @file_get_contents($cachePath);
-        if ($raw === false || $raw === '') {
-            continue;
-        }
-        $cache = json_decode($raw, true);
-        if (!is_array($cache) || !isset($cache['notams']) || !is_array($cache['notams'])) {
-            continue;
+        $notams = [];
+        if ($cache !== null && isset($cache['notams']) && is_array($cache['notams'])) {
+            $notams = $cache['notams'];
         }
         $timezone = getAirportTimezone($airport);
+        $result['airports'][(string)$airportId] = [
+            'airport' => $airport,
+            'timezone' => $timezone,
+            'notams' => $notams,
+            'cache_mtime' => $cacheMtime,
+        ];
+        foreach ($notams as $notam) {
+            if (!is_array($notam)) {
+                continue;
+            }
+            $id = trim((string)($notam['id'] ?? ''));
+            if ($id === '') {
+                continue;
+            }
+            $result['by_id'][$id] = [
+                'notam' => $notam,
+                'timezone' => $timezone,
+                'airport_id' => (string)$airportId,
+            ];
+        }
+    }
+
+    return $result;
+}
+
+/**
+ * Build GeoJSON FeatureCollection payload from listed airport NOTAM caches.
+ *
+ * @param array<string, mixed> $config Full config from {@see loadConfig()}
+ * @param array{
+ *     newest_mtime: int,
+ *     by_id: array<string, array{notam: array<string, mixed>, timezone: string, airport_id: string}>,
+ *     airports: array<string, array{airport: array<string, mixed>, timezone: string, notams: array<int, mixed>, cache_mtime: int}>
+ * }|null $listedCaches Optional preload from {@see notamTfrMapLayerLoadListedAirportCaches()}
+ * @return array{type: string, features: array<int, array<string, mixed>>, generated_at: int, cache_ttl_seconds: int, map_layer_build_token: string}
+ */
+function notamTfrMapLayerBuildPayload(array $config, ?array $listedCaches = null): array {
+    $ttl = getNotamCacheTtlSeconds();
+    $features = [];
+    $seenIds = [];
+
+    if ($listedCaches === null) {
+        $listedCaches = notamTfrMapLayerLoadListedAirportCaches($config);
+    }
+
+    foreach ($listedCaches['airports'] as $airportId => $entry) {
+        $airport = $entry['airport'];
+        if (!is_array($airport) || !isset($airport['lat'], $airport['lon'])) {
+            continue;
+        }
+        $timezone = $entry['timezone'];
         $now = time();
 
-        foreach ($cache['notams'] as $notam) {
+        foreach ($entry['notams'] as $notam) {
             if (!is_array($notam)) {
                 continue;
             }
@@ -473,7 +582,366 @@ function notamTfrMapLayerBuildPayload(array $config): array {
         'features' => $features,
         'generated_at' => time(),
         'cache_ttl_seconds' => $ttl,
+        'map_layer_build_token' => notamTfrMapLayerCurrentBuildToken(),
     ];
+}
+
+/**
+ * Latest modification time among listed airport NOTAM cache files.
+ *
+ * @param array<string, mixed> $config Full config from {@see loadConfig()}
+ * @return int Unix mtime, or 0 when no readable per-airport cache exists
+ */
+function notamTfrMapLayerNewestPerAirportCacheMtime(array $config): int {
+    return notamTfrMapLayerLoadListedAirportCaches($config)['newest_mtime'];
+}
+
+/**
+ * Whether the on-disk aggregate map layer should be rebuilt from source caches.
+ *
+ * Pure predicate: pass a decoded aggregate payload when already loaded to avoid
+ * extra disk reads. Does not read the aggregate file itself.
+ *
+ * @param int $mapMtime {@see filemtime()} of aggregate cache, or 0 when missing
+ * @param array<string, mixed> $config Full config from {@see loadConfig()}
+ * @param int $ttl Aggregate max age from {@see getNotamCacheTtlSeconds()}
+ * @param array<string, mixed>|null $cachedPayload Decoded aggregate JSON, if available
+ * @param int|null $newestSourceMtime Optional preload from {@see notamTfrMapLayerLoadListedAirportCaches()}
+ * @return bool True when geometry rebuild is required
+ */
+function notamTfrMapLayerAggregateNeedsRebuild(
+    int $mapMtime,
+    array $config,
+    int $ttl,
+    ?array $cachedPayload = null,
+    ?int $newestSourceMtime = null
+): bool {
+    if ($mapMtime <= 0) {
+        return true;
+    }
+
+    $age = time() - $mapMtime;
+    if ($age < 0 || $age >= $ttl) {
+        return true;
+    }
+
+    $sourceMtime = $newestSourceMtime ?? notamTfrMapLayerNewestPerAirportCacheMtime($config);
+    if ($sourceMtime > $mapMtime) {
+        return true;
+    }
+
+    if ($cachedPayload === null || !notamTfrMapLayerAggregateFileIsValid($cachedPayload)) {
+        return true;
+    }
+
+    return !notamTfrMapLayerAggregateBuildTokenMatches($cachedPayload);
+}
+
+/**
+ * Read decoded aggregate map layer JSON from disk.
+ *
+ * @return array<string, mixed>|null FeatureCollection payload or null when missing/invalid
+ */
+function notamTfrMapLayerReadAggregateCache(): ?array {
+    $path = getNotamTfrMapLayerCachePath();
+    if (!is_readable($path)) {
+        return null;
+    }
+
+    $decoded = json_decode((string)@file_get_contents($path), true);
+    if (!notamTfrMapLayerAggregateFileIsValid(is_array($decoded) ? $decoded : null)) {
+        return null;
+    }
+
+    return $decoded;
+}
+
+/**
+ * Recompute status, map style, and tooltip lines from per-airport NOTAM caches.
+ *
+ * Cached geometry is retained; deduplication runs again so active restrictions
+ * win when wall-clock status changes without a geometry rebuild. Uses the same
+ * TFR filter and status helper as {@see api/notam.php}.
+ *
+ * @param array<string, mixed> $payload GeoJSON FeatureCollection from disk or build
+ * @param array<string, mixed> $config Full config from {@see loadConfig()}
+ * @param int|null $nowUnix Current Unix time (UTC instants); defaults to {@see time()}
+ * @param array{
+ *     newest_mtime: int,
+ *     by_id: array<string, array{notam: array<string, mixed>, timezone: string, airport_id: string}>,
+ *     airports: array<string, array{airport: array<string, mixed>, timezone: string, notams: array<int, mixed>, cache_mtime: int}>
+ * }|null $listedCaches Optional preload from {@see notamTfrMapLayerLoadListedAirportCaches()}
+ * @return array<string, mixed> Payload with fresh status fields and {@see time()} as generated_at
+ */
+function notamTfrMapLayerRevalidatePayload(
+    array $payload,
+    array $config,
+    ?int $nowUnix = null,
+    ?array $listedCaches = null
+): array {
+    $nowUnix = $nowUnix ?? time();
+    $ttl = getNotamCacheTtlSeconds();
+    $features = $payload['features'] ?? [];
+    if (!is_array($features) || $features === []) {
+        return [
+            'type' => 'FeatureCollection',
+            'features' => [],
+            'generated_at' => $nowUnix,
+            'cache_ttl_seconds' => $ttl,
+        ];
+    }
+
+    if ($listedCaches === null) {
+        $listedCaches = notamTfrMapLayerLoadListedAirportCaches($config);
+    }
+    $lookup = $listedCaches['by_id'];
+    $revalidated = [];
+    foreach ($features as $feature) {
+        if (!is_array($feature)) {
+            continue;
+        }
+        $props = is_array($feature['properties'] ?? null) ? $feature['properties'] : [];
+        $notamId = trim((string)($props['notam_id'] ?? ''));
+        if ($notamId === '' || !isset($lookup[$notamId])) {
+            continue;
+        }
+
+        $entry = $lookup[$notamId];
+        $notam = $entry['notam'];
+        if (!isTfr($notam)) {
+            continue;
+        }
+        notamEnsureEffectiveSegments($notam);
+        $status = revalidateNotamStatus($notam, $entry['timezone'], $nowUnix);
+        if ($status === 'expired' || $status === 'unknown') {
+            continue;
+        }
+
+        $props['status'] = $status;
+        $props['map_layer_style'] = notamTfrMapLayerStyleBucket($status);
+        $props['airport_id'] = $entry['airport_id'];
+        $statusLine = notamTfrMapLayerTooltipStatusLine($notam, $status, $entry['timezone'], $nowUnix);
+        if ($statusLine !== null && $statusLine !== '') {
+            $props['status_line'] = $statusLine;
+        } else {
+            unset($props['status_line']);
+        }
+        $feature['properties'] = $props;
+        $revalidated[] = $feature;
+    }
+
+    $revalidated = notamTfrMapLayerDeduplicateFeaturesByGeometry($revalidated);
+
+    return [
+        'type' => 'FeatureCollection',
+        'features' => $revalidated,
+        'generated_at' => $nowUnix,
+        'cache_ttl_seconds' => $ttl,
+    ];
+}
+
+/**
+ * Rebuild aggregate geometry under an exclusive flock (single-flight, non-blocking).
+ *
+ * @param array<string, mixed> $config Full config from {@see loadConfig()}
+ * @param int $mapMtime Known aggregate mtime before lock attempt
+ * @param int $ttl Aggregate max age from {@see getNotamCacheTtlSeconds()}
+ * @param array{
+ *     newest_mtime: int,
+ *     by_id: array<string, array{notam: array<string, mixed>, timezone: string, airport_id: string}>,
+ *     airports: array<string, array{airport: array<string, mixed>, timezone: string, notams: array<int, mixed>, cache_mtime: int}>
+ * } $listedCaches Preloaded per-airport caches
+ * @param array<string, mixed>|null $cachedPayload Decoded aggregate JSON, if already read
+ * @return array<string, mixed>|null Fresh or existing payload; null when a waiter should retry read
+ */
+function notamTfrMapLayerRebuildAggregateLocked(
+    array $config,
+    int $mapMtime,
+    int $ttl,
+    array $listedCaches,
+    ?array $cachedPayload = null
+): ?array {
+    $lockPath = getNotamTfrMapLayerRebuildLockPath();
+    $lockDir = dirname($lockPath);
+    if (!is_dir($lockDir)) {
+        if (!@mkdir($lockDir, 0755, true) && !is_dir($lockDir)) {
+            return notamTfrMapLayerBuildPayload($config, $listedCaches);
+        }
+    }
+
+    $fp = @fopen($lockPath, 'c+');
+    if ($fp === false) {
+        return notamTfrMapLayerBuildPayload($config, $listedCaches);
+    }
+
+    if (!@flock($fp, LOCK_EX | LOCK_NB)) {
+        fclose($fp);
+
+        return null;
+    }
+
+    try {
+        $path = getNotamTfrMapLayerCachePath();
+        $currentMtime = is_file($path) ? (int)@filemtime($path) : 0;
+        $currentCached = $currentMtime !== $mapMtime
+            ? notamTfrMapLayerReadAggregateCache()
+            : $cachedPayload;
+
+        if (!notamTfrMapLayerAggregateNeedsRebuild(
+            $currentMtime,
+            $config,
+            $ttl,
+            $currentCached,
+            $listedCaches['newest_mtime']
+        )) {
+            return $currentCached ?? notamTfrMapLayerReadAggregateCache();
+        }
+
+        $payload = notamTfrMapLayerBuildPayload($config, $listedCaches);
+        if (!notamTfrMapLayerWriteCache($payload)) {
+            aviationwx_log('warning', 'notam map layer: failed to write cache', [
+                'path' => $path,
+                'feature_count' => count($payload['features'] ?? []),
+            ], 'app');
+        } else {
+            aviationwx_log('info', 'notam map layer: cache rebuilt', [
+                'feature_count' => count($payload['features'] ?? []),
+                'ttl_seconds' => $ttl,
+            ], 'app');
+        }
+
+        return $payload;
+    } finally {
+        @flock($fp, LOCK_UN);
+        fclose($fp);
+    }
+}
+
+/**
+ * Rebuild aggregate geometry under a blocking flock (cold start).
+ *
+ * @param array<string, mixed> $config Full config from {@see loadConfig()}
+ * @param int $ttl Aggregate max age from {@see getNotamCacheTtlSeconds()}
+ * @param array{
+ *     newest_mtime: int,
+ *     by_id: array<string, array{notam: array<string, mixed>, timezone: string, airport_id: string}>,
+ *     airports: array<string, array{airport: array<string, mixed>, timezone: string, notams: array<int, mixed>, cache_mtime: int}>
+ * } $listedCaches Preloaded per-airport caches
+ * @return array<string, mixed>|null Fresh or existing payload
+ */
+function notamTfrMapLayerRebuildAggregateBlocking(array $config, int $ttl, array $listedCaches): ?array {
+    $lockPath = getNotamTfrMapLayerRebuildLockPath();
+    $lockDir = dirname($lockPath);
+    if (!is_dir($lockDir)) {
+        if (!@mkdir($lockDir, 0755, true) && !is_dir($lockDir)) {
+            return notamTfrMapLayerBuildPayload($config, $listedCaches);
+        }
+    }
+
+    $fp = @fopen($lockPath, 'c+');
+    if ($fp === false) {
+        return notamTfrMapLayerBuildPayload($config, $listedCaches);
+    }
+
+    if (!@flock($fp, LOCK_EX)) {
+        fclose($fp);
+
+        return notamTfrMapLayerReadAggregateCache();
+    }
+
+    try {
+        $path = getNotamTfrMapLayerCachePath();
+        $currentMtime = is_file($path) ? (int)@filemtime($path) : 0;
+        $currentCached = notamTfrMapLayerReadAggregateCache();
+        if (!notamTfrMapLayerAggregateNeedsRebuild(
+            $currentMtime,
+            $config,
+            $ttl,
+            $currentCached,
+            $listedCaches['newest_mtime']
+        )) {
+            return $currentCached;
+        }
+
+        $payload = notamTfrMapLayerBuildPayload($config, $listedCaches);
+        if (!notamTfrMapLayerWriteCache($payload)) {
+            aviationwx_log('warning', 'notam map layer: failed to write cache', [
+                'path' => $path,
+                'feature_count' => count($payload['features'] ?? []),
+            ], 'app');
+        }
+
+        return $payload;
+    } finally {
+        @flock($fp, LOCK_UN);
+        fclose($fp);
+    }
+}
+
+/**
+ * Load or rebuild cached geometry (disk aggregate) for the map layer.
+ *
+ * Serve path cases:
+ * 1. Fresh aggregate on disk - return as-is.
+ * 2. Stale aggregate - non-blocking flock rebuild.
+ * 3. Lock held - return existing aggregate if another worker rebuilt.
+ * 4. Cold start - blocking flock rebuild.
+ * 5. Lock unavailable - build in-process without persisting coordination.
+ *
+ * @param array<string, mixed> $config Full config from {@see loadConfig()}
+ * @param int $ttl Aggregate max age from {@see getNotamCacheTtlSeconds()}
+ * @param array{
+ *     newest_mtime: int,
+ *     by_id: array<string, array{notam: array<string, mixed>, timezone: string, airport_id: string}>,
+ *     airports: array<string, array{airport: array<string, mixed>, timezone: string, notams: array<int, mixed>, cache_mtime: int}>
+ * } $listedCaches Preloaded per-airport caches
+ * @return array<string, mixed> GeoJSON FeatureCollection with geometry metadata
+ */
+function notamTfrMapLayerResolveCachedGeometry(array $config, int $ttl, array $listedCaches): array {
+    $path = getNotamTfrMapLayerCachePath();
+    $mapMtime = is_file($path) ? (int)@filemtime($path) : 0;
+    $cached = notamTfrMapLayerReadAggregateCache();
+
+    if (!notamTfrMapLayerAggregateNeedsRebuild(
+        $mapMtime,
+        $config,
+        $ttl,
+        $cached,
+        $listedCaches['newest_mtime']
+    )) {
+        return $cached ?? [
+            'type' => 'FeatureCollection',
+            'features' => [],
+            'generated_at' => time(),
+            'cache_ttl_seconds' => $ttl,
+            'map_layer_build_token' => notamTfrMapLayerCurrentBuildToken(),
+        ];
+    }
+
+    $rebuilt = notamTfrMapLayerRebuildAggregateLocked($config, $mapMtime, $ttl, $listedCaches, $cached);
+    if ($rebuilt !== null) {
+        return $rebuilt;
+    }
+
+    $cached = notamTfrMapLayerReadAggregateCache();
+    if ($cached !== null) {
+        return $cached;
+    }
+
+    $rebuilt = notamTfrMapLayerRebuildAggregateBlocking($config, $ttl, $listedCaches);
+    if ($rebuilt !== null) {
+        return $rebuilt;
+    }
+
+    $payload = notamTfrMapLayerBuildPayload($config, $listedCaches);
+    if (!notamTfrMapLayerWriteCache($payload)) {
+        aviationwx_log('warning', 'notam map layer: failed to write cache after lock miss', [
+            'path' => $path,
+            'feature_count' => count($payload['features'] ?? []),
+        ], 'app');
+    }
+
+    return $payload;
 }
 
 /**
@@ -507,48 +975,36 @@ function notamTfrMapLayerWriteCache(array $payload): bool {
 }
 
 /**
- * Return cached GeoJSON if fresh; otherwise rebuild from NOTAM caches and write.
+ * Return map GeoJSON: shared disk cache for geometry, serve-time status refresh.
+ *
+ * Three TTL concepts apply to this endpoint:
+ * - {@see getNotamCacheTtlSeconds()} on disk aggregate and in JSON cache_ttl_seconds
+ *   (client poll interval on airports.php).
+ * - {@see NOTAM_API_CACHE_TTL_SECONDS} on HTTP Cache-Control (browser/CDN sharing).
+ * - Serve-time revalidation uses wall clock on every origin request.
  *
  * @return array<string, mixed> GeoJSON FeatureCollection plus generated_at and cache_ttl_seconds
  */
 function notamTfrMapLayerServeOrRebuild(): array {
-    $path = getNotamTfrMapLayerCachePath();
     $ttl = getNotamCacheTtlSeconds();
-    if (is_readable($path)) {
-        $age = time() - (int)@filemtime($path);
-        if ($age >= 0 && $age < $ttl) {
-            $decoded = json_decode((string)@file_get_contents($path), true);
-            if (is_array($decoded) && ($decoded['type'] ?? '') === 'FeatureCollection'
-                && isset($decoded['features']) && is_array($decoded['features'])) {
-                return $decoded;
-            }
-        }
-    }
-
+    $now = time();
     $config = loadConfig();
+    $emptyConfig = ['airports' => []];
+
     if ($config === null || !isset($config['airports'])) {
         $empty = [
             'type' => 'FeatureCollection',
             'features' => [],
-            'generated_at' => time(),
+            'generated_at' => $now,
             'cache_ttl_seconds' => $ttl,
         ];
-        notamTfrMapLayerWriteCache($empty);
-        return $empty;
+        $listedCaches = notamTfrMapLayerLoadListedAirportCaches($emptyConfig);
+
+        return notamTfrMapLayerRevalidatePayload($empty, $emptyConfig, $now, $listedCaches);
     }
 
-    $payload = notamTfrMapLayerBuildPayload($config);
-    if (!notamTfrMapLayerWriteCache($payload)) {
-        aviationwx_log('warning', 'notam map layer: failed to write cache', [
-            'path' => $path,
-            'feature_count' => count($payload['features'] ?? []),
-        ], 'app');
-    } else {
-        aviationwx_log('info', 'notam map layer: cache rebuilt', [
-            'feature_count' => count($payload['features'] ?? []),
-            'ttl_seconds' => $ttl,
-        ], 'app');
-    }
+    $listedCaches = notamTfrMapLayerLoadListedAirportCaches($config);
+    $geometry = notamTfrMapLayerResolveCachedGeometry($config, $ttl, $listedCaches);
 
-    return $payload;
+    return notamTfrMapLayerRevalidatePayload($geometry, $config, $now, $listedCaches);
 }

--- a/lib/notam/map-layer.php
+++ b/lib/notam/map-layer.php
@@ -447,6 +447,9 @@ function notamTfrMapLayerLoadListedAirportCaches(array $config): array {
             if ($id === '') {
                 continue;
             }
+            if (isset($result['by_id'][$id])) {
+                continue;
+            }
             $result['by_id'][$id] = [
                 'notam' => $notam,
                 'timezone' => $timezone,

--- a/lib/notam/map-layer.php
+++ b/lib/notam/map-layer.php
@@ -398,6 +398,18 @@ function notamTfrMapLayerAggregateBuildTokenMatches(?array $cachedPayload): bool
 }
 
 /**
+ * Aggregate map layer file mtime after clearing PHP's per-request stat cache.
+ *
+ * @return int Unix mtime, or 0 when the file is missing
+ */
+function notamTfrMapLayerAggregateCacheMtime(): int {
+    $path = getNotamTfrMapLayerCachePath();
+    clearstatcache(true, $path);
+
+    return is_file($path) ? (int)@filemtime($path) : 0;
+}
+
+/**
  * Load listed airport NOTAM caches in one pass for build and serve-time revalidation.
  *
  * @param array<string, mixed> $config Full config from {@see loadConfig()}
@@ -647,6 +659,7 @@ function notamTfrMapLayerAggregateNeedsRebuild(
  */
 function notamTfrMapLayerReadAggregateCache(): ?array {
     $path = getNotamTfrMapLayerCachePath();
+    clearstatcache(true, $path);
     if (!is_readable($path)) {
         return null;
     }
@@ -808,7 +821,7 @@ function notamTfrMapLayerRebuildAggregateLocked(
 
     try {
         $path = getNotamTfrMapLayerCachePath();
-        $currentMtime = is_file($path) ? (int)@filemtime($path) : 0;
+        $currentMtime = notamTfrMapLayerAggregateCacheMtime();
         $currentCached = $currentMtime !== $mapMtime
             ? notamTfrMapLayerReadAggregateCache()
             : $cachedPayload;
@@ -877,7 +890,7 @@ function notamTfrMapLayerRebuildAggregateBlocking(array $config, int $ttl, array
 
     try {
         $path = getNotamTfrMapLayerCachePath();
-        $currentMtime = is_file($path) ? (int)@filemtime($path) : 0;
+        $currentMtime = notamTfrMapLayerAggregateCacheMtime();
         $currentCached = notamTfrMapLayerReadAggregateCache();
         if (!notamTfrMapLayerAggregateNeedsRebuild(
             $currentMtime,
@@ -925,7 +938,7 @@ function notamTfrMapLayerRebuildAggregateBlocking(array $config, int $ttl, array
  */
 function notamTfrMapLayerResolveCachedGeometry(array $config, int $ttl, array $listedCaches): array {
     $path = getNotamTfrMapLayerCachePath();
-    $mapMtime = is_file($path) ? (int)@filemtime($path) : 0;
+    $mapMtime = notamTfrMapLayerAggregateCacheMtime();
     $cached = notamTfrMapLayerReadAggregateCache();
 
     if (!notamTfrMapLayerAggregateNeedsRebuild(

--- a/lib/notam/map-layer.php
+++ b/lib/notam/map-layer.php
@@ -648,8 +648,31 @@ function notamTfrMapLayerReadAggregateCache(): ?array {
         return null;
     }
 
-    $decoded = json_decode((string)@file_get_contents($path), true);
+    $raw = @file_get_contents($path);
+    if ($raw === false || $raw === '') {
+        aviationwx_log('warning', 'notam map layer: unreadable aggregate cache', [
+            'path' => $path,
+        ], 'app');
+
+        return null;
+    }
+
+    try {
+        $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+    } catch (JsonException $e) {
+        aviationwx_log('warning', 'notam map layer: invalid aggregate cache JSON', [
+            'path' => $path,
+            'error' => $e->getMessage(),
+        ], 'app');
+
+        return null;
+    }
+
     if (!notamTfrMapLayerAggregateFileIsValid(is_array($decoded) ? $decoded : null)) {
+        aviationwx_log('warning', 'notam map layer: aggregate cache has unexpected shape', [
+            'path' => $path,
+        ], 'app');
+
         return null;
     }
 

--- a/tests/Integration/InternalApiCacheHeadersTest.php
+++ b/tests/Integration/InternalApiCacheHeadersTest.php
@@ -54,6 +54,21 @@ class InternalApiCacheHeadersTest extends TestCase
         );
     }
 
+    public function testNotamMapApi_Success_SendsSharedCacheHeaders(): void
+    {
+        $response = $this->makeRequest('api/notam-map.php');
+
+        if ($response['http_code'] === 0) {
+            $this->markTestSkipped('Endpoint not available');
+        }
+
+        $this->assertSame(200, $response['http_code']);
+        $cacheControl = $response['headers']['cache-control'] ?? '';
+        $this->assertStringContainsString('public', $cacheControl);
+        $this->assertStringContainsString('s-maxage=' . NOTAM_API_CACHE_TTL_SECONDS, $cacheControl);
+        $this->assertStringContainsString('stale-while-revalidate=', $cacheControl);
+    }
+
     public function testStationPowerApi_Success_SendsSharedCacheHeaders(): void
     {
         // spfx carries station_power in the test fixture; a 200 needs no

--- a/tests/Unit/NotamMapLayerTest.php
+++ b/tests/Unit/NotamMapLayerTest.php
@@ -17,7 +17,9 @@ final class NotamMapLayerTest extends TestCase
     protected function setUp(): void
     {
         $this->cacheDir = sys_get_temp_dir() . '/aviationwx-notam-map-' . bin2hex(random_bytes(4));
-        mkdir($this->cacheDir, 0755, true);
+        if (!mkdir($this->cacheDir, 0755, true) && !is_dir($this->cacheDir)) {
+            self::fail('Could not create NOTAM map test cache directory: ' . $this->cacheDir);
+        }
         $GLOBALS['notamCacheTestDirectory'] = $this->cacheDir;
     }
 

--- a/tests/Unit/NotamMapLayerTest.php
+++ b/tests/Unit/NotamMapLayerTest.php
@@ -46,14 +46,22 @@ final class NotamMapLayerTest extends TestCase
     private function writeAggregateCache(array $features, int $mtime, ?string $buildToken = null): void
     {
         $mapPath = getNotamTfrMapLayerCachePath();
-        file_put_contents($mapPath, json_encode([
+        $json = json_encode([
             'type' => 'FeatureCollection',
             'features' => $features,
             'generated_at' => $mtime,
             'cache_ttl_seconds' => 3600,
             'map_layer_build_token' => $buildToken ?? notamTfrMapLayerCurrentBuildToken(),
-        ], JSON_UNESCAPED_SLASHES));
-        touch($mapPath, $mtime);
+        ], JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            self::fail('Could not encode NOTAM map aggregate test cache JSON');
+        }
+        if (file_put_contents($mapPath, $json) === false) {
+            self::fail('Could not write NOTAM map aggregate test cache: ' . $mapPath);
+        }
+        if (!touch($mapPath, $mtime)) {
+            self::fail('Could not set mtime on NOTAM map aggregate test cache: ' . $mapPath);
+        }
     }
 
     /**
@@ -62,12 +70,21 @@ final class NotamMapLayerTest extends TestCase
     private function writePerAirportNotamCache(string $airportId, array $notams): void
     {
         $path = notamCacheFilePath($airportId);
+        $fetchedAt = time();
         $payload = [
             'notams' => $notams,
-            'fetched_at' => time(),
+            'fetched_at' => $fetchedAt,
         ];
-        file_put_contents($path, json_encode($payload, JSON_UNESCAPED_SLASHES));
-        touch($path, time());
+        $json = json_encode($payload, JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            self::fail('Could not encode per-airport NOTAM test cache JSON for ' . $airportId);
+        }
+        if (file_put_contents($path, $json) === false) {
+            self::fail('Could not write per-airport NOTAM test cache: ' . $path);
+        }
+        if (!touch($path, $fetchedAt)) {
+            self::fail('Could not set mtime on per-airport NOTAM test cache: ' . $path);
+        }
     }
 
     /**

--- a/tests/Unit/NotamMapLayerTest.php
+++ b/tests/Unit/NotamMapLayerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../../lib/notam/cache.php';
 require_once __DIR__ . '/../../lib/notam/map-layer.php';
 
 /**
@@ -11,6 +12,352 @@ require_once __DIR__ . '/../../lib/notam/map-layer.php';
  */
 final class NotamMapLayerTest extends TestCase
 {
+    private string $cacheDir = '';
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir() . '/aviationwx-notam-map-' . bin2hex(random_bytes(4));
+        mkdir($this->cacheDir, 0755, true);
+        $GLOBALS['notamCacheTestDirectory'] = $this->cacheDir;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['notamCacheTestDirectory']);
+        if ($this->cacheDir === '' || !is_dir($this->cacheDir)) {
+            return;
+        }
+
+        foreach (scandir($this->cacheDir) ?: [] as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $this->cacheDir . '/' . $item;
+            is_dir($path) ? self::removeTree($path) : @unlink($path);
+        }
+        @rmdir($this->cacheDir);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $features
+     */
+    private function writeAggregateCache(array $features, int $mtime, ?string $buildToken = null): void
+    {
+        $mapPath = getNotamTfrMapLayerCachePath();
+        file_put_contents($mapPath, json_encode([
+            'type' => 'FeatureCollection',
+            'features' => $features,
+            'generated_at' => $mtime,
+            'cache_ttl_seconds' => 3600,
+            'map_layer_build_token' => $buildToken ?? notamTfrMapLayerCurrentBuildToken(),
+        ], JSON_UNESCAPED_SLASHES));
+        touch($mapPath, $mtime);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function writePerAirportNotamCache(string $airportId, array $notams): void
+    {
+        $path = notamCacheFilePath($airportId);
+        $payload = [
+            'notams' => $notams,
+            'fetched_at' => time(),
+        ];
+        file_put_contents($path, json_encode($payload, JSON_UNESCAPED_SLASHES));
+        touch($path, time());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function minimalListedAirportConfig(string $airportId = 's83'): array
+    {
+        return [
+            'airports' => [
+                $airportId => [
+                    'enabled' => true,
+                    'listed' => true,
+                    'lat' => 47.52,
+                    'lon' => -116.08,
+                    'timezone' => 'UTC',
+                ],
+            ],
+        ];
+    }
+
+    private static function removeTree(string $dir): void
+    {
+        foreach (scandir($dir) ?: [] as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? self::removeTree($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+
+    public function testNotamTfrMapLayerAggregateNeedsRebuild_MissingMap_ReturnsTrue(): void
+    {
+        $config = $this->minimalListedAirportConfig();
+        $this->assertTrue(notamTfrMapLayerAggregateNeedsRebuild(0, $config, 3600));
+    }
+
+    public function testNotamTfrMapLayerAggregateNeedsRebuild_FreshMapAndSources_ReturnsFalse(): void
+    {
+        $config = $this->minimalListedAirportConfig();
+        $now = time();
+        $this->writePerAirportNotamCache('s83', []);
+        $this->writeAggregateCache([], $now);
+
+        $this->assertFalse(notamTfrMapLayerAggregateNeedsRebuild(
+            $now,
+            $config,
+            3600,
+            notamTfrMapLayerReadAggregateCache(),
+            $now
+        ));
+    }
+
+    public function testNotamTfrMapLayerAggregateNeedsRebuild_StaleBuildToken_ReturnsTrue(): void
+    {
+        $config = $this->minimalListedAirportConfig();
+        $now = time();
+        $this->writePerAirportNotamCache('s83', []);
+        $this->writeAggregateCache([], $now, 'stale-token');
+
+        $this->assertTrue(notamTfrMapLayerAggregateNeedsRebuild(
+            $now,
+            $config,
+            3600,
+            notamTfrMapLayerReadAggregateCache(),
+            $now
+        ));
+    }
+
+    public function testNotamTfrMapLayerAggregateNeedsRebuild_NewerSource_ReturnsTrue(): void
+    {
+        $config = $this->minimalListedAirportConfig();
+        $mapTime = time() - 100;
+        $this->writeAggregateCache([], $mapTime);
+
+        $this->writePerAirportNotamCache('s83', []);
+        touch(notamCacheFilePath('s83'), time());
+
+        $this->assertTrue(notamTfrMapLayerAggregateNeedsRebuild(
+            $mapTime,
+            $config,
+            3600,
+            notamTfrMapLayerReadAggregateCache(),
+            time()
+        ));
+    }
+
+    public function testNotamTfrMapLayerAggregateNeedsRebuild_ExpiredTtl_ReturnsTrue(): void
+    {
+        $config = $this->minimalListedAirportConfig();
+        $mapTime = time() - 4000;
+        $this->writeAggregateCache([], $mapTime);
+        $this->writePerAirportNotamCache('s83', []);
+        touch(notamCacheFilePath('s83'), $mapTime);
+
+        $this->assertTrue(notamTfrMapLayerAggregateNeedsRebuild(
+            $mapTime,
+            $config,
+            3600,
+            notamTfrMapLayerReadAggregateCache(),
+            $mapTime
+        ));
+    }
+
+    private function sampleTfrText(): string
+    {
+        return 'ZLC UT..AIRSPACE OGDEN, UT..TEMPORARY FLIGHT RESTRICTIONS '
+            . 'WITHIN AN AREA DEFINED AS 5NM RADIUS OF 413900N1122300W (OGD319029) STATIC GROUND BASED ROCKET ENGINE TEST.';
+    }
+
+    public function testNotamTfrMapLayerRevalidatePayload_UpdatesStatusAndPromotesActiveOnDedup(): void
+    {
+        $config = $this->minimalListedAirportConfig();
+        $now = strtotime('2026-05-15T20:00:00Z');
+        $tfrText = $this->sampleTfrText();
+        $segment = [
+            'start_time_utc' => '2026-05-15T18:00:00Z',
+            'end_time_utc' => '2026-05-15T22:00:00Z',
+        ];
+        $this->writePerAirportNotamCache('s83', [
+            [
+                'id' => 'A3389/2026',
+                'text' => $tfrText,
+                'start_time_utc' => '2026-05-15T18:00:00Z',
+                'end_time_utc' => '2026-05-15T22:00:00Z',
+                'effective_segments' => [$segment],
+            ],
+            [
+                'id' => '8821/2026',
+                'text' => $tfrText,
+                'start_time_utc' => '2026-05-16T18:00:00Z',
+                'end_time_utc' => '2026-05-16T22:00:00Z',
+                'effective_segments' => [
+                    [
+                        'start_time_utc' => '2026-05-16T18:00:00Z',
+                        'end_time_utc' => '2026-05-16T22:00:00Z',
+                    ],
+                ],
+            ],
+        ]);
+
+        $cached = [
+            'type' => 'FeatureCollection',
+            'features' => [
+                [
+                    'type' => 'Feature',
+                    'geometry' => ['type' => 'Point', 'coordinates' => [-116.08, 47.52]],
+                    'properties' => [
+                        'geometry_kind' => 'circle',
+                        'radius_nm' => 7.0,
+                        'status' => 'upcoming_future',
+                        'map_layer_style' => 'upcoming',
+                        'notam_id' => '8821/2026',
+                        'airport_id' => 's83',
+                    ],
+                ],
+                [
+                    'type' => 'Feature',
+                    'geometry' => ['type' => 'Point', 'coordinates' => [-116.08, 47.52]],
+                    'properties' => [
+                        'geometry_kind' => 'circle',
+                        'radius_nm' => 7.0,
+                        'status' => 'upcoming_future',
+                        'map_layer_style' => 'upcoming',
+                        'notam_id' => 'A3389/2026',
+                        'airport_id' => 's83',
+                    ],
+                ],
+            ],
+            'generated_at' => $now - 500,
+            'cache_ttl_seconds' => 3600,
+        ];
+
+        $out = notamTfrMapLayerRevalidatePayload($cached, $config, $now);
+
+        $this->assertCount(1, $out['features']);
+        $this->assertSame('active', $out['features'][0]['properties']['status']);
+        $this->assertSame('active', $out['features'][0]['properties']['map_layer_style']);
+        $this->assertSame('A3389/2026', $out['features'][0]['properties']['notam_id']);
+        $this->assertSame($now, $out['generated_at']);
+    }
+
+    public function testNotamTfrMapLayerRevalidatePayload_DropsExpiredFeature(): void
+    {
+        $config = $this->minimalListedAirportConfig();
+        $now = strtotime('2026-05-16T10:00:00Z');
+        $this->writePerAirportNotamCache('s83', [
+            [
+                'id' => 'T1/2026',
+                'text' => $this->sampleTfrText(),
+                'start_time_utc' => '2026-05-15T18:00:00Z',
+                'end_time_utc' => '2026-05-15T22:00:00Z',
+                'effective_segments' => [
+                    [
+                        'start_time_utc' => '2026-05-15T18:00:00Z',
+                        'end_time_utc' => '2026-05-15T22:00:00Z',
+                    ],
+                ],
+            ],
+        ]);
+
+        $cached = [
+            'type' => 'FeatureCollection',
+            'features' => [
+                [
+                    'type' => 'Feature',
+                    'geometry' => ['type' => 'Point', 'coordinates' => [-116.08, 47.52]],
+                    'properties' => [
+                        'geometry_kind' => 'circle',
+                        'radius_nm' => 7.0,
+                        'status' => 'active',
+                        'map_layer_style' => 'active',
+                        'notam_id' => 'T1/2026',
+                        'airport_id' => 's83',
+                    ],
+                ],
+            ],
+            'generated_at' => $now - 500,
+            'cache_ttl_seconds' => 3600,
+        ];
+
+        $out = notamTfrMapLayerRevalidatePayload($cached, $config, $now);
+
+        $this->assertSame([], $out['features']);
+    }
+
+    public function testNotamTfrMapLayerRevalidatePayload_DropsNonTfrRow(): void
+    {
+        $config = $this->minimalListedAirportConfig();
+        $now = time();
+        $this->writePerAirportNotamCache('s83', [
+            [
+                'id' => 'RWY1/2026',
+                'text' => 'RWY 17 CLSD',
+                'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $now - 3600),
+                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $now + 3600),
+            ],
+        ]);
+
+        $cached = [
+            'type' => 'FeatureCollection',
+            'features' => [
+                [
+                    'type' => 'Feature',
+                    'geometry' => ['type' => 'Point', 'coordinates' => [-116.08, 47.52]],
+                    'properties' => [
+                        'geometry_kind' => 'circle',
+                        'radius_nm' => 7.0,
+                        'status' => 'active',
+                        'map_layer_style' => 'active',
+                        'notam_id' => 'RWY1/2026',
+                        'airport_id' => 's83',
+                    ],
+                ],
+            ],
+            'generated_at' => $now - 500,
+            'cache_ttl_seconds' => 3600,
+        ];
+
+        $out = notamTfrMapLayerRevalidatePayload($cached, $config, $now);
+
+        $this->assertSame([], $out['features']);
+    }
+
+    public function testNotamTfrMapLayerServeOrRebuild_BuildsFeatureFromListedAirportCache(): void
+    {
+        $config = loadConfig();
+        if ($config === null || !isset($config['airports']['kspb'])) {
+            $this->markTestSkipped('Fixture config missing kspb');
+        }
+
+        $now = time();
+        $tfrText = $this->sampleTfrText();
+        $this->writePerAirportNotamCache('kspb', [
+            [
+                'id' => 'TFR1/2026',
+                'text' => $tfrText,
+                'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $now - 3600),
+                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', $now + 7200),
+            ],
+        ]);
+
+        $payload = notamTfrMapLayerServeOrRebuild();
+
+        $this->assertNotEmpty($payload['features']);
+        $this->assertSame('TFR1/2026', $payload['features'][0]['properties']['notam_id'] ?? null);
+        $aggregate = notamTfrMapLayerReadAggregateCache();
+        $this->assertNotNull($aggregate);
+        $this->assertSame(notamTfrMapLayerCurrentBuildToken(), $aggregate['map_layer_build_token'] ?? null);
+    }
+
     public function testNotamTfrMapLayerGeoJsonRingFromVertices_ClosedSquare_ReturnsClosedRing(): void
     {
         $vertices = [

--- a/tests/Unit/NotamMapLayerTest.php
+++ b/tests/Unit/NotamMapLayerTest.php
@@ -55,7 +55,7 @@ final class NotamMapLayerTest extends TestCase
     }
 
     /**
-     * @param array<string, mixed> $config
+     * @param array<int, array<string, mixed>> $notams
      */
     private function writePerAirportNotamCache(string $airportId, array $notams): void
     {


### PR DESCRIPTION
## Summary
- Adds layered map cache strategy: shared disk geometry cache, invalidation when per-airport sources change or `map_layer_build_token` (deploy SHA / logic version) drifts, `flock` single-flight rebuilds, 60s HTTP cache for many users, and serve-time status revalidation.
- Refactors `notamTfrMapLayerServeOrRebuild()` into clearer resolve/revalidate steps with one-pass `notamTfrMapLayerLoadListedAirportCaches()` and pure `notamTfrMapLayerAggregateNeedsRebuild()` (no disk read side effects).
- Aligns map revalidation with `api/notam.php` via `revalidateNotamStatus()` + `isTfr()`; extracts shared `notamInternalApiSendSharedCacheHeaders()` for dashboard and map APIs.

## Test plan
- [x] `make test-ci`
- [x] Unit: rebuild predicates, stale build token, revalidation/dedup, non-TFR drop, full `notamTfrMapLayerServeOrRebuild()` path
- [x] Integration: `testNotamMapApi_Success_SendsSharedCacheHeaders`
- [x] Manual: load `airports.aviationwx.org`, confirm TFR colors update across an active window; deploy and confirm map geometry picks up new dedup logic without waiting full TTL