### PR TITLE
NOTAM map layer: use revalidateNotamStatus in geometry build path

### DIFF
--- a/lib/notam/map-layer.php
+++ b/lib/notam/map-layer.php
@@ -5,7 +5,8 @@
  * Geometry is cached on disk and rebuilt when per-airport NOTAM sources change,
  * aggregate age exceeds {@see getNotamCacheTtlSeconds()}, or the cache is missing.
  * Status, style, and tooltip lines are revalidated at serve time from per-airport
- * caches so restriction colors track wall-clock windows without rebuilding geometry.
+ * caches using {@see revalidateNotamStatus()} so restriction colors track wall-clock
+ * windows without rebuilding geometry. Geometry build uses the same helper.
  */
 
 require_once __DIR__ . '/../logger.php';
@@ -521,7 +522,7 @@ function notamTfrMapLayerBuildPayload(array $config, ?array $listedCaches = null
             }
 
             notamEnsureEffectiveSegments($notam);
-            $status = classifyNotamDisplayStatusAt($notam, $timezone, $now);
+            $status = revalidateNotamStatus($notam, $timezone, $now);
             if ($status === 'expired' || $status === 'unknown') {
                 continue;
             }

--- a/tests/Unit/NotamMapLayerTest.php
+++ b/tests/Unit/NotamMapLayerTest.php
@@ -263,6 +263,46 @@ final class NotamMapLayerTest extends TestCase
             . 'WITHIN AN AREA DEFINED AS 5NM RADIUS OF 413900N1122300W (OGD319029) STATIC GROUND BASED ROCKET ENGINE TEST.';
     }
 
+    public function testNotamTfrMapLayerBuildPayload_UsesCachedStatusWhenStartTimeMissing(): void
+    {
+        $config = $this->minimalListedAirportConfig();
+        $tfrText = $this->sampleTfrText();
+        $this->writePerAirportNotamCache('s83', [
+            [
+                'id' => 'CACHE1/2026',
+                'text' => $tfrText,
+                'start_time_utc' => '',
+                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 7200),
+                'status' => 'active',
+            ],
+        ]);
+
+        $payload = notamTfrMapLayerBuildPayload($config);
+
+        $this->assertCount(1, $payload['features']);
+        $this->assertSame('active', $payload['features'][0]['properties']['status'] ?? null);
+        $this->assertSame('active', $payload['features'][0]['properties']['map_layer_style'] ?? null);
+    }
+
+    public function testNotamTfrMapLayerBuildPayload_SkipsUnknownCachedStatusWhenStartTimeMissing(): void
+    {
+        $config = $this->minimalListedAirportConfig();
+        $tfrText = $this->sampleTfrText();
+        $this->writePerAirportNotamCache('s83', [
+            [
+                'id' => 'CACHE2/2026',
+                'text' => $tfrText,
+                'start_time_utc' => '',
+                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 7200),
+                'status' => 'unknown',
+            ],
+        ]);
+
+        $payload = notamTfrMapLayerBuildPayload($config);
+
+        $this->assertSame([], $payload['features']);
+    }
+
     public function testNotamTfrMapLayerRevalidatePayload_UpdatesStatusAndPromotesActiveOnDedup(): void
     {
         $config = $this->minimalListedAirportConfig();


### PR DESCRIPTION
## Summary

- `notamTfrMapLayerBuildPayload()` now classifies TFR status with `revalidateNotamStatus()`, matching serve-time revalidation and `api/notam.php`.
- Fixes divergence when `start_time_utc` is missing or invalid: build path now honors cached `status` instead of always returning `unknown` via `classifyNotamDisplayStatusAt()`.
- Adds unit tests for cached-status inclusion and unknown exclusion on geometry build.

Closes #140

## Breaking changes

None. Map features for NOTAMs with missing start times may now appear when cached status is `active` (parity with API/revalidate). Previously they were omitted on first build.

## Files changed

- `lib/notam/map-layer.php` - build path uses `revalidateNotamStatus()`
- `tests/Unit/NotamMapLayerTest.php` - build-path status parity tests

## Test plan

- [x] `make test-ci`
- [x] Unit: missing `start_time_utc` + cached `active` produces map feature
- [x] Unit: missing `start_time_utc` + cached `unknown` still excluded