### PR TITLE
Remove service worker transition code after fleet migration

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -62,9 +62,6 @@ Options -Indexes
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ready\.php$ health/ready.php [L]
 
-    # Return 404 for old service worker path (sw.js) - no longer used
-    RewriteRule ^sw\.js$ - [R=404,L]
-    
     # Route guides paths to index.php (for local dev/testing)
     # Must come before directory checks to prevent Apache from trying to access the guides/ directory
     # Match /guides, /guides/, and /guides/anything - force rewrite even if directory exists

--- a/lib/version.php
+++ b/lib/version.php
@@ -449,10 +449,6 @@ function renderClientVersionCheckScript(string $buildHash, int $buildTimestamp, 
                     return;
                 }
                 
-                // Drop the pre-simplification tracking key (was only updated
-                // by service worker controllerchange, which never fired)
-                try { localStorage.removeItem('aviationwx-last-sw-update'); } catch (e) { /* unavailable */ }
-                
                 // Check dead man's switch immediately
                 const deadManReason = checkDeadManSwitch();
                 if (deadManReason) {

--- a/pages/airport.php
+++ b/pages/airport.php
@@ -430,37 +430,6 @@ if ($themeCookie === 'dark') {
         : '/public/css/styles.css';
     ?>
     <link rel="stylesheet" href="<?= $cssHref ?>?v=<?= $buildHashShort ?>">
-    <script>
-        // The service worker was removed: it registered with /public/js/
-        // scope (no Service-Worker-Allowed header), so it never controlled
-        // the page and its offline/weather caching never ran. Unregister
-        // legacy registrations so existing clients drop them promptly;
-        // their update checks 404 and unregister as a fallback.
-        if ('serviceWorker' in navigator) {
-            window.addEventListener('load', () => {
-                navigator.serviceWorker.getRegistrations()
-                    .then((registrations) => Promise.allSettled(registrations.map((registration) => {
-                        console.log('[SW] Unregistering legacy service worker:', registration.scope);
-                        return registration.unregister();
-                    })))
-                    .then((results) => {
-                        results.forEach((result) => {
-                            // unregister() can reject or resolve false;
-                            // either way a legacy worker may remain on the
-                            // client, which is worth seeing in the console
-                            if (result.status === 'rejected') {
-                                console.warn('[SW] Legacy service worker unregister failed:', result.reason);
-                            } else if (result.value === false) {
-                                console.warn('[SW] Legacy service worker unregister returned false');
-                            }
-                        });
-                    })
-                    .catch((err) => {
-                        console.warn('[SW] Could not enumerate legacy service workers:', err);
-                    });
-            });
-        }
-    </script>
     <?php if ($injectStuckClientCleanup): ?>
     <!-- Stuck client cleanup - clears caches for clients on old code -->
     <script>

--- a/tests/Browser/tests/performance-optimizations.spec.js
+++ b/tests/Browser/tests/performance-optimizations.spec.js
@@ -49,23 +49,10 @@ test.describe('Performance Optimizations', () => {
     expect(scriptsExecuted).toBeTruthy();
   });
 
-  test('Legacy service workers should unregister without errors', async ({ page }) => {
-    const swErrors = [];
-    
-    // Listen for service worker related errors BEFORE navigation
-    page.on('pageerror', error => {
-      const errorText = error.message;
-      if (errorText.includes('service worker') || errorText.includes('ServiceWorker') || errorText.includes('sw.js')) {
-        swErrors.push(errorText);
-      }
-    });
-    
+  test('No service worker registrations exist after page load', async ({ page }) => {
     await page.goto(`${baseUrl}/?airport=${testAirport}`);
     await page.waitForLoadState('load');
-    await page.waitForTimeout(2000); // Allow the unregister pass to run
-    
-    // The page no longer registers a service worker; the inline cleanup
-    // script unregisters any legacy registrations from older builds
+
     const swState = await page.evaluate(async () => {
       if (!('serviceWorker' in navigator)) {
         return { supported: false, count: 0 };
@@ -73,8 +60,7 @@ test.describe('Performance Optimizations', () => {
       const registrations = await navigator.serviceWorker.getRegistrations();
       return { supported: true, count: registrations.length };
     });
-    
-    expect(swErrors).toHaveLength(0);
+
     if (swState.supported) {
       expect(swState.count).toBe(0);
     }

--- a/tests/Integration/HtmlOutputValidationTest.php
+++ b/tests/Integration/HtmlOutputValidationTest.php
@@ -593,14 +593,9 @@ class HtmlOutputValidationTest extends TestCase
     }
     
     /**
-     * The dashboard must ship the legacy service worker unregister pass.
-     *
-     * No service worker is registered anymore (removed as inert), but
-     * clients from older builds still carry registrations. Losing this
-     * inline cleanup would leave those workers in place with nothing to
-     * remove them except eventual 404-triggered unregistration.
+     * The dashboard must not register a service worker.
      */
-    public function testAirportPage_LegacyServiceWorkerCleanupPresent()
+    public function testAirportPage_DoesNotRegisterServiceWorker()
     {
         $html = $this->getCachedHtml('kspb');
         
@@ -609,11 +604,6 @@ class HtmlOutputValidationTest extends TestCase
             return;
         }
         
-        $this->assertStringContainsString(
-            'Unregistering legacy service worker',
-            $html,
-            'Dashboard should contain the legacy service worker unregister pass'
-        );
         $this->assertDoesNotMatchRegularExpression(
             '/serviceWorker\s*\.\s*register\s*\(/',
             $html,


### PR DESCRIPTION
## Summary

- Remove the legacy service worker unregister inline script from `pages/airport.php` now that post-#125 clients have cycled.
- Drop the obsolete `aviationwx-last-sw-update` localStorage cleanup from `lib/version.php`.
- Remove the `/sw.js` 404 rewrite from `.htaccess`.
- Update integration and browser tests to enforce no `serviceWorker.register()` and zero registrations after load (permanent invariants).

Closes #126

## Not changed (per issue)

- `performFullCleanup()` service worker unregistration in `lib/version.php`
- Stuck-client cleanup script in `pages/airport.php`

## Commits

1. Remove legacy unregister pass + test updates
2. Remove `aviationwx-last-sw-update` localStorage cleanup
3. Remove `.htaccess` `sw.js` rule

## Test plan

- [x] `make test-ci`
- [x] Zero grep hits for `Unregistering legacy service worker` and `aviationwx-last-sw-update`