### PR TITLE
WMM phase 2: wire magnetic declination cascade to offline WMM

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -1055,10 +1055,10 @@ function getStalenessThresholds(?array $airport = null): array {
  *
  * Safety-critical: Aligns runway wind diagram with magnetic north.
  * Positive = East (magnetic north is East of true north), negative = West.
- * Cascade: airport override → global override → NOAA API (when geomag_api_key set) → 0.
- * Values clamped to -180..180 (invalid config/API data must not mislead).
+ * Cascade: airport override → global override → offline WMM → 0.
+ * Values clamped to -180..180 (invalid override or computed data must not mislead).
  *
- * @param array|null $airport Airport config (with lat, lon for API lookup)
+ * @param array|null $airport Airport config (with lat, lon for WMM lookup)
  * @return float Declination in degrees (-180 to 180)
  */
 function getMagneticDeclination(?array $airport = null): float
@@ -1069,17 +1069,14 @@ function getMagneticDeclination(?array $airport = null): float
         $decl = (float) $airport['magnetic_declination'];
     } elseif (($global = getGlobalConfig('magnetic_declination')) !== null) {
         $decl = (float) $global;
-    } else {
-        $apiKey = getGlobalConfig('geomag_api_key');
-        if (is_string($apiKey) && $apiKey !== '' && $airport !== null) {
-            $lat = isset($airport['lat']) ? (float) $airport['lat'] : null;
-            $lon = isset($airport['lon']) ? (float) $airport['lon'] : null;
-            if ($lat !== null && $lon !== null) {
-                require_once __DIR__ . '/magnetic-declination.php';
-                $apiDecl = fetchMagneticDeclinationFromApi($lat, $lon, $apiKey);
-                if ($apiDecl !== null) {
-                    $decl = $apiDecl;
-                }
+    } elseif ($airport !== null) {
+        $lat = isset($airport['lat']) ? (float) $airport['lat'] : null;
+        $lon = isset($airport['lon']) ? (float) $airport['lon'] : null;
+        if ($lat !== null && $lon !== null) {
+            require_once __DIR__ . '/magnetic-declination.php';
+            $wmmDecl = fetchMagneticDeclinationFromWmm($lat, $lon);
+            if ($wmmDecl !== null) {
+                $decl = $wmmDecl;
             }
         }
     }

--- a/lib/config.php
+++ b/lib/config.php
@@ -1070,9 +1070,13 @@ function getMagneticDeclination(?array $airport = null): float
     } elseif (($global = getGlobalConfig('magnetic_declination')) !== null) {
         $decl = (float) $global;
     } elseif ($airport !== null) {
-        $lat = isset($airport['lat']) ? (float) $airport['lat'] : null;
-        $lon = isset($airport['lon']) ? (float) $airport['lon'] : null;
-        if ($lat !== null && $lon !== null) {
+        if (
+            isset($airport['lat'], $airport['lon'])
+            && is_numeric($airport['lat'])
+            && is_numeric($airport['lon'])
+        ) {
+            $lat = (float) $airport['lat'];
+            $lon = (float) $airport['lon'];
             require_once __DIR__ . '/magnetic-declination.php';
             $wmmDecl = fetchMagneticDeclinationFromWmm($lat, $lon);
             if ($wmmDecl !== null) {

--- a/lib/config.php
+++ b/lib/config.php
@@ -1065,9 +1065,9 @@ function getMagneticDeclination(?array $airport = null): float
 {
     $decl = 0.0;
 
-    if ($airport !== null && isset($airport['magnetic_declination'])) {
+    if ($airport !== null && isset($airport['magnetic_declination']) && is_numeric($airport['magnetic_declination'])) {
         $decl = (float) $airport['magnetic_declination'];
-    } elseif (($global = getGlobalConfig('magnetic_declination')) !== null) {
+    } elseif (($global = getGlobalConfig('magnetic_declination')) !== null && is_numeric($global)) {
         $decl = (float) $global;
     } elseif ($airport !== null) {
         if (

--- a/lib/magnetic-declination.php
+++ b/lib/magnetic-declination.php
@@ -15,9 +15,7 @@
  * Registration: https://www.ngdc.noaa.gov/geomag/CalcSurvey.shtml
  */
 
-require_once __DIR__ . '/cache-paths.php';
 require_once __DIR__ . '/logger.php';
-require_once __DIR__ . '/circuit-breaker.php';
 require_once __DIR__ . '/wmm/WmmCoefficients.php';
 require_once __DIR__ . '/wmm/WmmCalculator.php';
 
@@ -168,6 +166,9 @@ function fetchMagneticDeclinationFromWmm(float $lat, float $lon, ?int $timestamp
  */
 function fetchMagneticDeclinationFromApi(float $lat, float $lon, string $apiKey): ?float
 {
+    require_once __DIR__ . '/cache-paths.php';
+    require_once __DIR__ . '/circuit-breaker.php';
+
     if ($apiKey === '' || $lat < -90 || $lat > 90 || $lon < -180 || $lon > 180) {
         return null;
     }

--- a/lib/magnetic-declination.php
+++ b/lib/magnetic-declination.php
@@ -43,13 +43,13 @@ function getWmmManifest(): ?array
     $loaded = true;
     $manifestPath = WmmCoefficients::getBundledManifestPath();
     if (!is_readable($manifestPath)) {
-        aviationwx_log('error', 'wmm: manifest file is not readable', ['path' => $manifestPath], 'app');
+        aviationwx_log('error', 'wmm: manifest file is not readable', ['path' => $manifestPath], 'app', true);
         return null;
     }
 
     $manifestJson = file_get_contents($manifestPath);
     if ($manifestJson === false) {
-        aviationwx_log('error', 'wmm: failed to read manifest file', ['path' => $manifestPath], 'app');
+        aviationwx_log('error', 'wmm: failed to read manifest file', ['path' => $manifestPath], 'app', true);
         return null;
     }
 
@@ -58,7 +58,7 @@ function getWmmManifest(): ?array
         aviationwx_log('error', 'wmm: invalid manifest JSON', [
             'path' => $manifestPath,
             'json_error' => json_last_error_msg(),
-        ], 'app');
+        ], 'app', true);
         return null;
     }
 
@@ -122,21 +122,28 @@ function fetchMagneticDeclinationFromWmm(float $lat, float $lon, ?int $timestamp
     }
 
     if (!isWmmValidForTimestamp($timestamp)) {
-        $context = [
-            'lat' => $lat,
-            'lon' => $lon,
-            'timestamp' => $timestamp,
-        ];
-        $manifest = getWmmManifest();
-        if ($manifest === null) {
-            aviationwx_log('error', 'wmm: manifest unavailable', $context, 'app');
-        } elseif (!isset($manifest['valid_through_epoch'], $manifest['epoch'])) {
-            aviationwx_log('error', 'wmm: manifest missing epoch or valid_through_epoch', $context, 'app');
-        } else {
-            $context['decimal_year'] = WmmCalculator::timestampToDecimalYear($timestamp);
-            $context['epoch'] = (float) $manifest['epoch'];
-            $context['valid_through_epoch'] = (float) $manifest['valid_through_epoch'];
-            aviationwx_log('warning', 'wmm: timestamp outside coefficient validity window', $context, 'app');
+        static $loggedWmmValidityFailure = false;
+        if (!$loggedWmmValidityFailure) {
+            $loggedWmmValidityFailure = true;
+            $manifest = getWmmManifest();
+            if ($manifest === null) {
+                // getWmmManifest() already logged unreadable/invalid manifest details once.
+            } elseif (
+                !isset($manifest['valid_through_epoch'], $manifest['epoch'])
+                || !is_numeric($manifest['epoch'])
+                || !is_numeric($manifest['valid_through_epoch'])
+            ) {
+                aviationwx_log('error', 'wmm: manifest missing or non-numeric epoch bounds', [
+                    'path' => WmmCoefficients::getBundledManifestPath(),
+                ], 'app', true);
+            } else {
+                aviationwx_log('warning', 'wmm: timestamp outside coefficient validity window', [
+                    'timestamp' => $timestamp,
+                    'decimal_year' => WmmCalculator::timestampToDecimalYear($timestamp),
+                    'epoch' => (float) $manifest['epoch'],
+                    'valid_through_epoch' => (float) $manifest['valid_through_epoch'],
+                ], 'app', true);
+            }
         }
         return null;
     }

--- a/lib/magnetic-declination.php
+++ b/lib/magnetic-declination.php
@@ -154,8 +154,10 @@ function fetchMagneticDeclinationFromWmm(float $lat, float $lon, ?int $timestamp
         aviationwx_log('warning', 'wmm: declination calculation failed', [
             'lat' => $lat,
             'lon' => $lon,
+            'timestamp' => $timestamp,
+            'decimal_year' => WmmCalculator::timestampToDecimalYear($timestamp),
             'error' => $e->getMessage(),
-        ], 'app');
+        ], 'app', true);
         return null;
     }
 

--- a/lib/magnetic-declination.php
+++ b/lib/magnetic-declination.php
@@ -166,7 +166,7 @@ function fetchMagneticDeclinationFromWmm(float $lat, float $lon, ?int $timestamp
             'lat' => $lat,
             'lon' => $lon,
             'declination' => $declination,
-        ], 'app');
+        ], 'app', true);
         return null;
     }
 

--- a/lib/magnetic-declination.php
+++ b/lib/magnetic-declination.php
@@ -112,6 +112,10 @@ function fetchMagneticDeclinationFromWmm(float $lat, float $lon, ?int $timestamp
         return null;
     }
 
+    if ($timestamp < 0) {
+        return null;
+    }
+
     if (!isWmmValidForTimestamp($timestamp)) {
         $context = [
             'lat' => $lat,

--- a/lib/magnetic-declination.php
+++ b/lib/magnetic-declination.php
@@ -86,6 +86,10 @@ function isWmmValidForTimestamp(int $timestamp): bool
         return false;
     }
 
+    if (!is_numeric($manifest['epoch']) || !is_numeric($manifest['valid_through_epoch'])) {
+        return false;
+    }
+
     $epochDecimalYear = (float) $manifest['epoch'];
     $validThroughDecimalYear = (float) $manifest['valid_through_epoch'];
     $decimalYear = WmmCalculator::timestampToDecimalYear($timestamp);

--- a/lib/magnetic-declination.php
+++ b/lib/magnetic-declination.php
@@ -70,10 +70,10 @@ function getWmmManifest(): ?array
 /**
  * Whether bundled WMM coefficients are valid for the given timestamp.
  *
- * Manifest valid_through_epoch is a WMM decimal year (e.g. 2030.0), not a Unix timestamp.
+ * Manifest epoch and valid_through_epoch are WMM decimal years (e.g. 2025.0..2030.0), not Unix timestamps.
  *
  * @param int $timestamp Unix timestamp (UTC)
- * @return bool True when the timestamp's decimal year is within valid_through_epoch
+ * @return bool True when the timestamp's decimal year is within the manifest validity window
  */
 function isWmmValidForTimestamp(int $timestamp): bool
 {
@@ -82,21 +82,22 @@ function isWmmValidForTimestamp(int $timestamp): bool
     }
 
     $manifest = getWmmManifest();
-    if ($manifest === null || !isset($manifest['valid_through_epoch'])) {
+    if ($manifest === null || !isset($manifest['valid_through_epoch'], $manifest['epoch'])) {
         return false;
     }
 
+    $epochDecimalYear = (float) $manifest['epoch'];
     $validThroughDecimalYear = (float) $manifest['valid_through_epoch'];
     $decimalYear = WmmCalculator::timestampToDecimalYear($timestamp);
 
-    return $decimalYear <= $validThroughDecimalYear;
+    return $decimalYear >= $epochDecimalYear && $decimalYear <= $validThroughDecimalYear;
 }
 
 /**
  * Fetch magnetic declination from bundled WMM coefficients.
  *
- * Returns null when coordinates are invalid, the timestamp's decimal year exceeds the
- * manifest valid_through_epoch (WMM decimal year, not Unix time), or calculation fails.
+ * Returns null when coordinates are invalid, the timestamp's decimal year is outside the
+ * manifest validity window (epoch..valid_through_epoch, WMM decimal years), or calculation fails.
  * Caller must fall back to 0.
  *
  * @param float $lat       Latitude (-90 to 90)
@@ -125,12 +126,13 @@ function fetchMagneticDeclinationFromWmm(float $lat, float $lon, ?int $timestamp
         $manifest = getWmmManifest();
         if ($manifest === null) {
             aviationwx_log('error', 'wmm: manifest unavailable', $context, 'app');
-        } elseif (!isset($manifest['valid_through_epoch'])) {
-            aviationwx_log('error', 'wmm: manifest missing valid_through_epoch', $context, 'app');
+        } elseif (!isset($manifest['valid_through_epoch'], $manifest['epoch'])) {
+            aviationwx_log('error', 'wmm: manifest missing epoch or valid_through_epoch', $context, 'app');
         } else {
             $context['decimal_year'] = WmmCalculator::timestampToDecimalYear($timestamp);
+            $context['epoch'] = (float) $manifest['epoch'];
             $context['valid_through_epoch'] = (float) $manifest['valid_through_epoch'];
-            aviationwx_log('warning', 'wmm: decimal year past valid_through_epoch', $context, 'app');
+            aviationwx_log('warning', 'wmm: timestamp outside coefficient validity window', $context, 'app');
         }
         return null;
     }

--- a/lib/magnetic-declination.php
+++ b/lib/magnetic-declination.php
@@ -72,8 +72,10 @@ function getWmmManifest(): ?array
 /**
  * Whether bundled WMM coefficients are valid for the given timestamp.
  *
+ * Manifest valid_through_epoch is a WMM decimal year (e.g. 2030.0), not a Unix timestamp.
+ *
  * @param int $timestamp Unix timestamp (UTC)
- * @return bool True when the timestamp is within manifest valid_through_epoch
+ * @return bool True when the timestamp's decimal year is within valid_through_epoch
  */
 function isWmmValidForTimestamp(int $timestamp): bool
 {
@@ -86,17 +88,18 @@ function isWmmValidForTimestamp(int $timestamp): bool
         return false;
     }
 
-    $validThrough = (float) $manifest['valid_through_epoch'];
+    $validThroughDecimalYear = (float) $manifest['valid_through_epoch'];
     $decimalYear = WmmCalculator::timestampToDecimalYear($timestamp);
 
-    return $decimalYear <= $validThrough;
+    return $decimalYear <= $validThroughDecimalYear;
 }
 
 /**
  * Fetch magnetic declination from bundled WMM coefficients.
  *
- * Returns null when coordinates are invalid, coefficients are past valid_through_epoch,
- * or calculation fails. Caller must fall back to 0.
+ * Returns null when coordinates are invalid, the timestamp's decimal year exceeds the
+ * manifest valid_through_epoch (WMM decimal year, not Unix time), or calculation fails.
+ * Caller must fall back to 0.
  *
  * @param float $lat       Latitude (-90 to 90)
  * @param float $lon       Longitude (-180 to 180)
@@ -125,7 +128,7 @@ function fetchMagneticDeclinationFromWmm(float $lat, float $lon, ?int $timestamp
         } else {
             $context['decimal_year'] = WmmCalculator::timestampToDecimalYear($timestamp);
             $context['valid_through_epoch'] = (float) $manifest['valid_through_epoch'];
-            aviationwx_log('warning', 'wmm: timestamp past valid_through_epoch', $context, 'app');
+            aviationwx_log('warning', 'wmm: decimal year past valid_through_epoch', $context, 'app');
         }
         return null;
     }

--- a/lib/magnetic-declination.php
+++ b/lib/magnetic-declination.php
@@ -1,13 +1,15 @@
 <?php
 
 /**
- * Magnetic Declination Lookup (NOAA NCEI Geomagnetic API)
+ * Magnetic Declination Lookup
  *
  * Safety-critical: Declination aligns runway wind diagram with magnetic north.
  * Incorrect values could mislead pilots interpreting wind vs runway orientation.
  *
- * Fetches from NOAA NCEI when geomag_api_key is configured. Falls back to config
- * override or 0. Results cached 7 days (declination ~0.1°/year).
+ * Production cascade (via getMagneticDeclination in config.php):
+ * airport override → global override → offline WMM → 0.
+ *
+ * Also provides NOAA NCEI geomag-web API helpers (deprecated in cascade; removed in phase 3).
  *
  * API: https://www.ngdc.noaa.gov/geomag-web/calculators/calculateDeclination
  * Registration: https://www.ngdc.noaa.gov/geomag/CalcSurvey.shtml
@@ -16,6 +18,8 @@
 require_once __DIR__ . '/cache-paths.php';
 require_once __DIR__ . '/logger.php';
 require_once __DIR__ . '/circuit-breaker.php';
+require_once __DIR__ . '/wmm/WmmCoefficients.php';
+require_once __DIR__ . '/wmm/WmmCalculator.php';
 
 /** NOAA NCEI geomag-web API base URL */
 const GEOMAG_API_BASE = 'https://www.ngdc.noaa.gov/geomag-web/calculators/calculateDeclination';
@@ -23,6 +27,131 @@ const GEOMAG_API_BASE = 'https://www.ngdc.noaa.gov/geomag-web/calculators/calcul
 /** Valid declination range (degrees). Values outside indicate bad data. */
 const GEOMAG_DECLINATION_MIN = -180.0;
 const GEOMAG_DECLINATION_MAX = 180.0;
+
+/**
+ * Load bundled WMM manifest metadata (cached for the request).
+ *
+ * @return array<string, mixed>|null Parsed manifest, or null when unreadable or invalid
+ */
+function getWmmManifest(): ?array
+{
+    static $manifest = null;
+    static $loaded = false;
+
+    if ($loaded) {
+        return $manifest;
+    }
+
+    $loaded = true;
+    $manifestPath = WmmCoefficients::getBundledManifestPath();
+    if (!is_readable($manifestPath)) {
+        aviationwx_log('error', 'wmm: manifest file is not readable', ['path' => $manifestPath], 'app');
+        return null;
+    }
+
+    $manifestJson = file_get_contents($manifestPath);
+    if ($manifestJson === false) {
+        aviationwx_log('error', 'wmm: failed to read manifest file', ['path' => $manifestPath], 'app');
+        return null;
+    }
+
+    $parsed = json_decode($manifestJson, true);
+    if (!is_array($parsed) || json_last_error() !== JSON_ERROR_NONE) {
+        aviationwx_log('error', 'wmm: invalid manifest JSON', [
+            'path' => $manifestPath,
+            'json_error' => json_last_error_msg(),
+        ], 'app');
+        return null;
+    }
+
+    $manifest = $parsed;
+
+    return $manifest;
+}
+
+/**
+ * Whether bundled WMM coefficients are valid for the given timestamp.
+ *
+ * @param int $timestamp Unix timestamp (UTC)
+ * @return bool True when the timestamp is within manifest valid_through_epoch
+ */
+function isWmmValidForTimestamp(int $timestamp): bool
+{
+    if ($timestamp < 0) {
+        return false;
+    }
+
+    $manifest = getWmmManifest();
+    if ($manifest === null || !isset($manifest['valid_through_epoch'])) {
+        return false;
+    }
+
+    $validThrough = (float) $manifest['valid_through_epoch'];
+    $decimalYear = WmmCalculator::timestampToDecimalYear($timestamp);
+
+    return $decimalYear <= $validThrough;
+}
+
+/**
+ * Fetch magnetic declination from bundled WMM coefficients.
+ *
+ * Returns null when coordinates are invalid, coefficients are past valid_through_epoch,
+ * or calculation fails. Caller must fall back to 0.
+ *
+ * @param float $lat       Latitude (-90 to 90)
+ * @param float $lon       Longitude (-180 to 180)
+ * @param int|null $timestamp Unix timestamp (UTC); defaults to now
+ * @return float|null Declination in degrees, or null on failure
+ */
+function fetchMagneticDeclinationFromWmm(float $lat, float $lon, ?int $timestamp = null): ?float
+{
+    $timestamp ??= time();
+
+    if ($lat < -90 || $lat > 90 || $lon < -180 || $lon > 180) {
+        return null;
+    }
+
+    if (!isWmmValidForTimestamp($timestamp)) {
+        $context = [
+            'lat' => $lat,
+            'lon' => $lon,
+            'timestamp' => $timestamp,
+        ];
+        $manifest = getWmmManifest();
+        if ($manifest === null) {
+            aviationwx_log('error', 'wmm: manifest unavailable', $context, 'app');
+        } elseif (!isset($manifest['valid_through_epoch'])) {
+            aviationwx_log('error', 'wmm: manifest missing valid_through_epoch', $context, 'app');
+        } else {
+            $context['decimal_year'] = WmmCalculator::timestampToDecimalYear($timestamp);
+            $context['valid_through_epoch'] = (float) $manifest['valid_through_epoch'];
+            aviationwx_log('warning', 'wmm: timestamp past valid_through_epoch', $context, 'app');
+        }
+        return null;
+    }
+
+    try {
+        $declination = WmmCalculator::getDeclination($timestamp, $lat, $lon);
+    } catch (\InvalidArgumentException $e) {
+        aviationwx_log('warning', 'wmm: declination calculation failed', [
+            'lat' => $lat,
+            'lon' => $lon,
+            'error' => $e->getMessage(),
+        ], 'app');
+        return null;
+    }
+
+    if ($declination < GEOMAG_DECLINATION_MIN || $declination > GEOMAG_DECLINATION_MAX) {
+        aviationwx_log('warning', 'wmm: declination out of bounds', [
+            'lat' => $lat,
+            'lon' => $lon,
+            'declination' => $declination,
+        ], 'app');
+        return null;
+    }
+
+    return $declination;
+}
 
 /**
  * Fetch magnetic declination from NOAA NCEI API (with cache)

--- a/tests/Integration/PublicApiIntegrationTest.php
+++ b/tests/Integration/PublicApiIntegrationTest.php
@@ -252,10 +252,15 @@ class PublicApiIntegrationTest extends TestCase
         $this->assertNotNull($airport, 'Response should include airport');
         $this->assertArrayHasKey('magnetic_declination', $airport);
         $this->assertIsFloat($airport['magnetic_declination']);
+        $this->assertArrayHasKey('lat', $airport, 'Airport response must include lat for WMM validation');
+        $this->assertArrayHasKey('lon', $airport, 'Airport response must include lon for WMM validation');
+        $this->assertTrue(is_numeric($airport['lat']), 'lat must be numeric');
+        $this->assertTrue(is_numeric($airport['lon']), 'lon must be numeric');
 
+        require_once dirname(__DIR__, 2) . '/lib/wmm/WmmCoefficients.php';
         require_once dirname(__DIR__, 2) . '/lib/wmm/WmmCalculator.php';
-        $lat = (float) ($airport['lat'] ?? 0);
-        $lon = (float) ($airport['lon'] ?? 0);
+        $lat = (float) $airport['lat'];
+        $lon = (float) $airport['lon'];
         $expected = WmmCalculator::getDeclination(time(), $lat, $lon);
         $this->assertEqualsWithDelta($expected, $airport['magnetic_declination'], 0.05);
     }

--- a/tests/Integration/PublicApiIntegrationTest.php
+++ b/tests/Integration/PublicApiIntegrationTest.php
@@ -251,7 +251,7 @@ class PublicApiIntegrationTest extends TestCase
         $airport = $response['json']['airport'] ?? null;
         $this->assertNotNull($airport, 'Response should include airport');
         $this->assertArrayHasKey('magnetic_declination', $airport);
-        $this->assertIsFloat($airport['magnetic_declination']);
+        $this->assertTrue(is_numeric($airport['magnetic_declination']), 'magnetic_declination must be numeric degrees');
         $this->assertArrayHasKey('lat', $airport, 'Airport response must include lat for WMM validation');
         $this->assertArrayHasKey('lon', $airport, 'Airport response must include lon for WMM validation');
         $this->assertTrue(is_numeric($airport['lat']), 'lat must be numeric');

--- a/tests/Integration/PublicApiIntegrationTest.php
+++ b/tests/Integration/PublicApiIntegrationTest.php
@@ -235,6 +235,32 @@ class PublicApiIntegrationTest extends TestCase
     }
 
     /**
+     * GET /v1/airports/{id} returns offline WMM magnetic declination when no override is set.
+     */
+    public function testGetAirport_MagneticDeclination_FromOfflineWmm(): void
+    {
+        $this->skipIfApiDisabled();
+
+        $response = $this->apiRequest('/airports/kspb');
+
+        if ($response['code'] !== 200) {
+            $this->markTestSkipped('Airport kspb not available (got ' . $response['code'] . ')');
+            return;
+        }
+
+        $airport = $response['json']['airport'] ?? null;
+        $this->assertNotNull($airport, 'Response should include airport');
+        $this->assertArrayHasKey('magnetic_declination', $airport);
+        $this->assertIsFloat($airport['magnetic_declination']);
+
+        require_once dirname(__DIR__, 2) . '/lib/wmm/WmmCalculator.php';
+        $lat = (float) ($airport['lat'] ?? 0);
+        $lon = (float) ($airport['lon'] ?? 0);
+        $expected = WmmCalculator::getDeclination(time(), $lat, $lon);
+        $this->assertEqualsWithDelta($expected, $airport['magnetic_declination'], 0.05);
+    }
+
+    /**
      * GET /v1/airports/{id} exposes custom_links and external_links; legacy top-level links key is absent.
      */
     public function testGetAirport_CustomLinksAndExternalLinksKeys(): void

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -614,6 +614,7 @@ class ConfigTest extends TestCase {
      * Test getMagneticDeclination() returns offline WMM when no override is set
      */
     public function testGetMagneticDeclination_NoOverride_ReturnsWmmValue(): void {
+        require_once __DIR__ . '/../../lib/wmm/WmmCoefficients.php';
         require_once __DIR__ . '/../../lib/wmm/WmmCalculator.php';
         $airport = ['lat' => 45.54, 'lon' => -122.95];
         $expected = WmmCalculator::getDeclination(time(), 45.54, -122.95);

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -611,13 +611,14 @@ class ConfigTest extends TestCase {
     }
 
     /**
-     * Test getMagneticDeclination() returns 0 when no override and no API key
+     * Test getMagneticDeclination() returns offline WMM when no override is set
      */
-    public function testGetMagneticDeclination_NoOverride_ReturnsZero(): void {
+    public function testGetMagneticDeclination_NoOverride_ReturnsWmmValue(): void {
+        require_once __DIR__ . '/../../lib/wmm/WmmCalculator.php';
         $airport = ['lat' => 45.54, 'lon' => -122.95];
+        $expected = WmmCalculator::getDeclination(time(), 45.54, -122.95);
         $result = getMagneticDeclination($airport);
-        $this->assertIsFloat($result);
-        $this->assertSame(0.0, $result, 'Should return 0 when no override (API not called in test mode)');
+        $this->assertEqualsWithDelta($expected, $result, 0.05);
     }
 
     /**

--- a/tests/Unit/JavaScriptStaticAnalysisTest.php
+++ b/tests/Unit/JavaScriptStaticAnalysisTest.php
@@ -65,11 +65,9 @@ class JavaScriptStaticAnalysisTest extends TestCase
             }
             
             $content = file_get_contents($file);
-            
-            // Extract JavaScript code blocks
-            preg_match_all('/<script[^>]*>(.*?)<\/script>/is', $content, $matches);
-            
-            foreach ($matches[1] as $index => $jsCode) {
+            $jsBlocks = $this->extractJavaScriptBlocks($file, $content);
+
+            foreach ($jsBlocks as $index => $jsCode) {
                 // Skip empty scripts
                 if (trim($jsCode) === '') {
                     continue;
@@ -154,11 +152,9 @@ class JavaScriptStaticAnalysisTest extends TestCase
             }
             
             $content = file_get_contents($file);
-            
-            // Extract JavaScript code blocks
-            preg_match_all('/<script[^>]*>(.*?)<\/script>/is', $content, $matches);
-            
-            foreach ($matches[1] as $index => $jsCode) {
+            $jsBlocks = $this->extractJavaScriptBlocks($file, $content);
+
+            foreach ($jsBlocks as $index => $jsCode) {
                 // Check for incorrect weather.php calls
                 // Should use /api/weather.php, not /weather.php
                 $incorrectPatterns = [
@@ -231,6 +227,10 @@ class JavaScriptStaticAnalysisTest extends TestCase
             
             $content = file_get_contents($file);
             $filename = basename($file);
+
+            if ($this->isStandaloneJavaScriptFile($file)) {
+                continue;
+            }
             
             // Check if file uses output buffering for script handling
             // These files dynamically generate </script> tags via PHP, so simple
@@ -320,11 +320,9 @@ class JavaScriptStaticAnalysisTest extends TestCase
             }
             
             $content = file_get_contents($file);
-            
-            // Extract JavaScript code blocks
-            preg_match_all('/<script[^>]*>(.*?)<\/script>/is', $content, $matches);
-            
-            foreach ($matches[1] as $index => $jsCode) {
+            $jsBlocks = $this->extractJavaScriptBlocks($file, $content);
+
+            foreach ($jsBlocks as $index => $jsCode) {
                 // Remove PHP code blocks from JavaScript code for analysis
                 // PHP blocks should be excluded from JavaScript analysis
                 $jsCodeWithoutPhp = preg_replace('/<\?php.*?\?>/is', '', $jsCode);
@@ -403,5 +401,26 @@ class JavaScriptStaticAnalysisTest extends TestCase
         }
         
         $this->assertTrue(true);
+    }
+
+    /**
+     * Standalone .js bundles are analyzed as one source unit; PHP pages use inline script blocks.
+     *
+     * @return list<string>
+     */
+    private function extractJavaScriptBlocks(string $file, string $content): array
+    {
+        if ($this->isStandaloneJavaScriptFile($file)) {
+            return $content === '' ? [] : [$content];
+        }
+
+        preg_match_all('/<script[^>]*>(.*?)<\/script>/is', $content, $matches);
+
+        return $matches[1];
+    }
+
+    private function isStandaloneJavaScriptFile(string $file): bool
+    {
+        return str_ends_with(strtolower($file), '.js');
     }
 }

--- a/tests/Unit/JavaScriptStaticAnalysisTest.php
+++ b/tests/Unit/JavaScriptStaticAnalysisTest.php
@@ -416,7 +416,7 @@ class JavaScriptStaticAnalysisTest extends TestCase
 
         preg_match_all('/<script[^>]*>(.*?)<\/script>/is', $content, $matches);
 
-        return $matches[1];
+        return $matches[1] ?? [];
     }
 
     private function isStandaloneJavaScriptFile(string $file): bool

--- a/tests/Unit/JavaScriptStaticAnalysisTest.php
+++ b/tests/Unit/JavaScriptStaticAnalysisTest.php
@@ -18,11 +18,12 @@ class JavaScriptStaticAnalysisTest extends TestCase
     {
         parent::setUp();
         
-        // Files that contain JavaScript code
+        // Files that contain JavaScript code (inline in PHP pages and extracted dashboard JS)
         $this->testFiles = [
             __DIR__ . '/../../pages/airport.php',
             __DIR__ . '/../../pages/homepage.php',
             __DIR__ . '/../../pages/error-404-airport.php',
+            __DIR__ . '/../../public/js/airport-dashboard.js',
         ];
     }
     

--- a/tests/Unit/JavaScriptStaticAnalysisTest.php
+++ b/tests/Unit/JavaScriptStaticAnalysisTest.php
@@ -64,7 +64,7 @@ class JavaScriptStaticAnalysisTest extends TestCase
                 continue;
             }
             
-            $content = file_get_contents($file);
+            $content = $this->readTestFileContent($file);
             $jsBlocks = $this->extractJavaScriptBlocks($file, $content);
 
             foreach ($jsBlocks as $index => $jsCode) {
@@ -151,7 +151,7 @@ class JavaScriptStaticAnalysisTest extends TestCase
                 continue;
             }
             
-            $content = file_get_contents($file);
+            $content = $this->readTestFileContent($file);
             $jsBlocks = $this->extractJavaScriptBlocks($file, $content);
 
             foreach ($jsBlocks as $index => $jsCode) {
@@ -197,8 +197,8 @@ class JavaScriptStaticAnalysisTest extends TestCase
                 continue;
             }
             
-            $content = file_get_contents($file);
-            if (strpos($content, '/api/weather.php') !== false || 
+            $content = $this->readTestFileContent($file);
+            if (strpos($content, '/api/weather.php') !== false ||
                 strpos($content, 'api/weather.php') !== false) {
                 $foundCorrectEndpoint = true;
                 break;
@@ -225,7 +225,7 @@ class JavaScriptStaticAnalysisTest extends TestCase
                 continue;
             }
             
-            $content = file_get_contents($file);
+            $content = $this->readTestFileContent($file);
             $filename = basename($file);
 
             if ($this->isStandaloneJavaScriptFile($file)) {
@@ -319,7 +319,7 @@ class JavaScriptStaticAnalysisTest extends TestCase
                 continue;
             }
             
-            $content = file_get_contents($file);
+            $content = $this->readTestFileContent($file);
             $jsBlocks = $this->extractJavaScriptBlocks($file, $content);
 
             foreach ($jsBlocks as $index => $jsCode) {
@@ -422,5 +422,15 @@ class JavaScriptStaticAnalysisTest extends TestCase
     private function isStandaloneJavaScriptFile(string $file): bool
     {
         return str_ends_with(strtolower($file), '.js');
+    }
+
+    private function readTestFileContent(string $file): string
+    {
+        $content = file_get_contents($file);
+        if ($content === false) {
+            $this->fail(sprintf('Failed to read test file: %s', $file));
+        }
+
+        return $content;
     }
 }

--- a/tests/Unit/MagneticDeclinationSafetyTest.php
+++ b/tests/Unit/MagneticDeclinationSafetyTest.php
@@ -7,10 +7,11 @@
  * Incorrect values could mislead pilots interpreting wind vs runway orientation.
  *
  * Tests verify:
- * - Cascade: airport override → global override → API → 0 (fail-safe)
+ * - Cascade: airport override → global override → offline WMM → 0 (fail-safe)
  * - Bounds: declination must be -180° to 180°
- * - API response parsing handles multiple formats
- * - Fallback to 0 when API unavailable (never expose stale/wrong data)
+ * - WMM staleness refusal past manifest valid_through_epoch
+ * - Legacy geomag API response parsing (removed from cascade in phase 3)
+ * - Fallback to 0 when WMM is unavailable (never expose stale/wrong data)
  *
  * Reference: NOAA WMM, Natural Resources Canada (Canadian airports)
  */
@@ -19,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../lib/config.php';
 require_once __DIR__ . '/../../lib/magnetic-declination.php';
+require_once __DIR__ . '/../../lib/wmm/WmmCalculator.php';
 
 class MagneticDeclinationSafetyTest extends TestCase
 {
@@ -52,13 +54,122 @@ class MagneticDeclinationSafetyTest extends TestCase
     }
 
     /**
-     * SAFETY: No override and no API key must return 0 (fail-safe)
+     * SAFETY: No override must use offline WMM when coordinates are available
      */
-    public function testGetMagneticDeclination_NoOverride_ReturnsZero(): void
+    public function testGetMagneticDeclination_NoOverride_ReturnsWmmValue(): void
     {
         $airport = ['lat' => 45.54, 'lon' => -122.95];
+        $expected = WmmCalculator::getDeclination(time(), 45.54, -122.95);
         $result = getMagneticDeclination($airport);
-        $this->assertSame(0.0, $result, 'Must return 0 when no override (API mocked in test mode)');
+        $this->assertEqualsWithDelta($expected, $result, 0.05);
+    }
+
+    /**
+     * SAFETY: Airport override must beat offline WMM
+     */
+    public function testGetMagneticDeclination_Cascade_AirportOverrideBeatsWmm(): void
+    {
+        $airport = ['magnetic_declination' => 7.5, 'lat' => 45.54, 'lon' => -122.95];
+        $this->assertSame(7.5, getMagneticDeclination($airport));
+    }
+
+    /**
+     * SAFETY: Global override must beat offline WMM
+     */
+    public function testGetMagneticDeclination_Cascade_GlobalOverrideBeatsWmm(): void
+    {
+        $originalConfigPath = getenv('CONFIG_PATH');
+        $tmpConfig = tempnam(sys_get_temp_dir(), 'awx-mag-decl-');
+        $this->assertNotFalse($tmpConfig);
+
+        $fixture = json_decode(
+            (string) file_get_contents(__DIR__ . '/../Fixtures/airports.json.test'),
+            true
+        );
+        $this->assertIsArray($fixture);
+        $fixture['config']['magnetic_declination'] = 9.25;
+
+        file_put_contents($tmpConfig, json_encode($fixture, JSON_THROW_ON_ERROR));
+        putenv('CONFIG_PATH=' . $tmpConfig);
+        clearConfigCache();
+
+        try {
+            $airport = ['lat' => 45.54, 'lon' => -122.95];
+            $this->assertSame(9.25, getMagneticDeclination($airport));
+        } finally {
+            if ($originalConfigPath !== false) {
+                putenv('CONFIG_PATH=' . $originalConfigPath);
+            } else {
+                putenv('CONFIG_PATH');
+            }
+            clearConfigCache();
+            @unlink($tmpConfig);
+        }
+    }
+
+    /**
+     * SAFETY: WMM valid_through_epoch boundary accepts the last published NOAA test year
+     */
+    public function testIsWmmValidForTimestamp_LastNoaaFixtureYear_ReturnsTrue(): void
+    {
+        $timestamp = WmmCalculator::decimalYearToTimestamp(2029.5);
+        $this->assertTrue(isWmmValidForTimestamp($timestamp));
+    }
+
+    /**
+     * SAFETY: WMM must refuse timestamps clearly past valid_through_epoch
+     */
+    public function testIsWmmValidForTimestamp_AfterValidThroughEpoch_ReturnsFalse(): void
+    {
+        $timestamp = gmmktime(0, 0, 0, 1, 1, 2031);
+        $this->assertNotFalse($timestamp);
+        $this->assertFalse(isWmmValidForTimestamp($timestamp));
+    }
+
+    /**
+     * SAFETY: WMM must refuse coefficients past valid_through_epoch
+     */
+    public function testFetchMagneticDeclinationFromWmm_PastValidThroughEpoch_ReturnsNull(): void
+    {
+        $timestamp = gmmktime(0, 0, 0, 1, 1, 2031);
+        $this->assertNotFalse($timestamp);
+        $result = fetchMagneticDeclinationFromWmm(45.54, -122.95, $timestamp);
+        $this->assertNull($result);
+    }
+
+    /**
+     * SAFETY: Missing coordinates must fall through to 0
+     */
+    public function testGetMagneticDeclination_MissingCoordinates_ReturnsZero(): void
+    {
+        $airport = ['icao' => 'KPDX'];
+        $this->assertSame(0.0, getMagneticDeclination($airport));
+    }
+
+    /**
+     * SAFETY: fetchMagneticDeclinationFromWmm - invalid lat returns null
+     */
+    public function testFetchMagneticDeclinationFromWmm_InvalidLat_ReturnsNull(): void
+    {
+        $result = fetchMagneticDeclinationFromWmm(95.0, -122.95);
+        $this->assertNull($result);
+    }
+
+    /**
+     * SAFETY: fetchMagneticDeclinationFromWmm - invalid lon returns null
+     */
+    public function testFetchMagneticDeclinationFromWmm_InvalidLon_ReturnsNull(): void
+    {
+        $result = fetchMagneticDeclinationFromWmm(45.54, -200.0);
+        $this->assertNull($result);
+    }
+
+    /**
+     * SAFETY: isWmmValidForTimestamp accepts current time within model epoch
+     */
+    public function testIsWmmValidForTimestamp_CurrentTime_ReturnsTrue(): void
+    {
+        $this->assertTrue(isWmmValidForTimestamp(time()));
     }
 
     /**

--- a/tests/Unit/MagneticDeclinationSafetyTest.php
+++ b/tests/Unit/MagneticDeclinationSafetyTest.php
@@ -82,14 +82,14 @@ class MagneticDeclinationSafetyTest extends TestCase
         $tmpConfig = tempnam(sys_get_temp_dir(), 'awx-mag-decl-');
         $this->assertNotFalse($tmpConfig);
 
-        $fixture = json_decode(
-            (string) file_get_contents(__DIR__ . '/../Fixtures/airports.json.test'),
-            true
-        );
+        $fixtureContents = file_get_contents(__DIR__ . '/../Fixtures/airports.json.test');
+        $this->assertNotFalse($fixtureContents, 'Fixture file must be readable');
+        $fixture = json_decode($fixtureContents, true, 512, JSON_THROW_ON_ERROR);
         $this->assertIsArray($fixture);
         $fixture['config']['magnetic_declination'] = 9.25;
 
-        file_put_contents($tmpConfig, json_encode($fixture, JSON_THROW_ON_ERROR));
+        $written = file_put_contents($tmpConfig, json_encode($fixture, JSON_THROW_ON_ERROR));
+        $this->assertNotFalse($written, 'Temp config must be writable');
         putenv('CONFIG_PATH=' . $tmpConfig);
         clearConfigCache();
 

--- a/tests/Unit/MagneticDeclinationSafetyTest.php
+++ b/tests/Unit/MagneticDeclinationSafetyTest.php
@@ -147,6 +147,15 @@ class MagneticDeclinationSafetyTest extends TestCase
     }
 
     /**
+     * SAFETY: Non-numeric coordinates must fall through to 0 (not cast to 0.0, 0.0)
+     */
+    public function testGetMagneticDeclination_NonNumericCoordinates_ReturnsZero(): void
+    {
+        $airport = ['lat' => '', 'lon' => '-122.95'];
+        $this->assertSame(0.0, getMagneticDeclination($airport));
+    }
+
+    /**
      * SAFETY: fetchMagneticDeclinationFromWmm - invalid lat returns null
      */
     public function testFetchMagneticDeclinationFromWmm_InvalidLat_ReturnsNull(): void

--- a/tests/Unit/MagneticDeclinationSafetyTest.php
+++ b/tests/Unit/MagneticDeclinationSafetyTest.php
@@ -127,6 +127,15 @@ class MagneticDeclinationSafetyTest extends TestCase
     }
 
     /**
+     * SAFETY: WMM must refuse timestamps before the manifest epoch
+     */
+    public function testIsWmmValidForTimestamp_BeforeEpoch_ReturnsFalse(): void
+    {
+        $timestamp = WmmCalculator::decimalYearToTimestamp(2024.5);
+        $this->assertFalse(isWmmValidForTimestamp($timestamp));
+    }
+
+    /**
      * SAFETY: WMM must refuse coefficients past valid_through_epoch
      */
     public function testFetchMagneticDeclinationFromWmm_PastValidThroughEpoch_ReturnsNull(): void

--- a/tests/Unit/MagneticDeclinationSafetyTest.php
+++ b/tests/Unit/MagneticDeclinationSafetyTest.php
@@ -74,6 +74,16 @@ class MagneticDeclinationSafetyTest extends TestCase
     }
 
     /**
+     * SAFETY: Non-numeric airport override must fall through to offline WMM
+     */
+    public function testGetMagneticDeclination_NonNumericAirportOverride_UsesWmm(): void
+    {
+        $airport = ['magnetic_declination' => '', 'lat' => 45.54, 'lon' => -122.95];
+        $expected = WmmCalculator::getDeclination(time(), 45.54, -122.95);
+        $this->assertEqualsWithDelta($expected, getMagneticDeclination($airport), 0.05);
+    }
+
+    /**
      * SAFETY: Global override must beat offline WMM
      */
     public function testGetMagneticDeclination_Cascade_GlobalOverrideBeatsWmm(): void

--- a/tests/Unit/MagneticDeclinationSafetyTest.php
+++ b/tests/Unit/MagneticDeclinationSafetyTest.php
@@ -10,7 +10,7 @@
  * - Cascade: airport override → global override → offline WMM → 0 (fail-safe)
  * - Bounds: declination must be -180° to 180°
  * - WMM staleness refusal past manifest valid_through_epoch
- * - Legacy geomag API response parsing (removed from cascade in phase 3)
+ * - Legacy geomag API response parsing helpers (removed in phase 3; no longer in cascade)
  * - Fallback to 0 when WMM is unavailable (never expose stale/wrong data)
  *
  * Reference: NOAA WMM, Natural Resources Canada (Canadian airports)

--- a/tests/Unit/SafeStorageTest.php
+++ b/tests/Unit/SafeStorageTest.php
@@ -5,7 +5,9 @@
  * Verifies that pages using localStorage include the safeStorageGet/safeStorageSet
  * pattern to handle SecurityError in iOS Private Browsing and disabled storage.
  *
- * @see pages/airports.php
+ * @see pages/airports.php (inline preferences script)
+ * @see public/js/airport-dashboard.js (airport dashboard preferences; extracted from pages/airport.php)
+ * @see lib/version.php (version-check IIFE embedded in pages/airport.php)
  * @see pages/airport.php
  */
 
@@ -23,13 +25,20 @@ class SafeStorageTest extends TestCase
         $this->projectRoot = dirname(__DIR__, 2);
     }
 
+    private function readProjectFile(string $relativePath): string
+    {
+        $content = file_get_contents($this->projectRoot . '/' . $relativePath);
+        $this->assertNotFalse($content, $relativePath . ' should be readable');
+
+        return $content;
+    }
+
     /**
      * safeStorageGet pattern: try/catch around localStorage.getItem returning null on error
      */
     public function testAirportsPage_ContainsSafeStorageGetPattern(): void
     {
-        $content = file_get_contents($this->projectRoot . '/pages/airports.php');
-        $this->assertNotEmpty($content, 'airports.php should be readable');
+        $content = $this->readProjectFile('pages/airports.php');
 
         $this->assertStringContainsString('safeStorageGet', $content, 'Should define safeStorageGet');
         $this->assertStringContainsString('localStorage.getItem', $content, 'Should use localStorage');
@@ -45,7 +54,7 @@ class SafeStorageTest extends TestCase
      */
     public function testAirportsPage_ContainsSafeStorageSetPattern(): void
     {
-        $content = file_get_contents($this->projectRoot . '/pages/airports.php');
+        $content = $this->readProjectFile('pages/airports.php');
         $this->assertStringContainsString('safeStorageSet', $content, 'Should define safeStorageSet');
         $this->assertMatchesRegularExpression(
             '/try\s*\{\s*localStorage\.setItem\([^)]+\)\s*;\s*\}\s*catch/',
@@ -55,12 +64,11 @@ class SafeStorageTest extends TestCase
     }
 
     /**
-     * Airport page preferences block contains safe storage helpers
+     * Airport dashboard preferences live in the extracted JS bundle.
      */
     public function testAirportPage_ContainsSafeStorageHelpers(): void
     {
-        $content = file_get_contents($this->projectRoot . '/pages/airport.php');
-        $this->assertNotEmpty($content, 'airport.php should be readable');
+        $content = $this->readProjectFile('public/js/airport-dashboard.js');
 
         $this->assertStringContainsString('safeStorageGet', $content, 'Should define safeStorageGet');
         $this->assertStringContainsString('safeStorageSet', $content, 'Should define safeStorageSet');
@@ -68,11 +76,11 @@ class SafeStorageTest extends TestCase
     }
 
     /**
-     * Airport page uses safeStorageGet for preference reads (not raw localStorage.getItem)
+     * Airport dashboard preference getters use safeStorageGet (not raw localStorage.getItem).
      */
     public function testAirportPage_PreferenceGettersUseSafeStorage(): void
     {
-        $content = file_get_contents($this->projectRoot . '/pages/airport.php');
+        $content = $this->readProjectFile('public/js/airport-dashboard.js');
 
         $this->assertStringContainsString(
             'safeStorageGet(\'aviationwx_time_format\')',
@@ -87,11 +95,11 @@ class SafeStorageTest extends TestCase
     }
 
     /**
-     * Airport page version check block has its own safe storage helpers (IIFE scope)
+     * Version-check IIFE (rendered from lib/version.php) documents Private Browsing handling.
      */
     public function testAirportPage_VersionBlockHasSafeStorage(): void
     {
-        $content = file_get_contents($this->projectRoot . '/pages/airport.php');
+        $content = $this->readProjectFile('lib/version.php');
 
         $this->assertMatchesRegularExpression(
             '/SecurityError.*Private Browsing/',

--- a/tests/Unit/SafeStorageTest.php
+++ b/tests/Unit/SafeStorageTest.php
@@ -8,7 +8,6 @@
  * @see pages/airports.php (inline preferences script)
  * @see public/js/airport-dashboard.js (airport dashboard preferences; extracted from pages/airport.php)
  * @see lib/version.php (version-check IIFE embedded in pages/airport.php)
- * @see pages/airport.php
  */
 
 namespace AviationWX\Tests;

--- a/tests/Unit/SafeStorageTest.php
+++ b/tests/Unit/SafeStorageTest.php
@@ -66,7 +66,7 @@ class SafeStorageTest extends TestCase
     /**
      * Airport dashboard preferences live in the extracted JS bundle.
      */
-    public function testAirportPage_ContainsSafeStorageHelpers(): void
+    public function testAirportDashboardJs_ContainsSafeStorageHelpers(): void
     {
         $content = $this->readProjectFile('public/js/airport-dashboard.js');
 
@@ -78,7 +78,7 @@ class SafeStorageTest extends TestCase
     /**
      * Airport dashboard preference getters use safeStorageGet (not raw localStorage.getItem).
      */
-    public function testAirportPage_PreferenceGettersUseSafeStorage(): void
+    public function testAirportDashboardJs_PreferenceGettersUseSafeStorage(): void
     {
         $content = $this->readProjectFile('public/js/airport-dashboard.js');
 
@@ -97,7 +97,7 @@ class SafeStorageTest extends TestCase
     /**
      * Version-check IIFE (rendered from lib/version.php) documents Private Browsing handling.
      */
-    public function testAirportPage_VersionBlockHasSafeStorage(): void
+    public function testVersionPhp_VersionBlockHasSafeStorage(): void
     {
         $content = $this->readProjectFile('lib/version.php');
 


### PR DESCRIPTION
## Summary

- Connect `getMagneticDeclination()` to bundled WMM2025: cascade is airport override → global override → offline WMM → `0`.
- Add `fetchMagneticDeclinationFromWmm()`, manifest loading, and fail-closed `valid_through_epoch` checks with structured logging.
- Expand safety, config, and Public API integration tests for cascade order and staleness refusal.
- Fix stale unit tests (`JavaScriptStaticAnalysisTest`, `SafeStorageTest`) that still scanned inline `pages/airport.php` after dashboard JS moved to `public/js/airport-dashboard.js`.

Closes #153

## Breaking changes

- `geomag_api_key` is no longer used in the production declination cascade (geomag helpers remain until phase 3 / #154). Airports without manual overrides now receive offline WMM values instead of `0` when geomag was not configured.

## Files

- `lib/config.php` - WMM cascade in `getMagneticDeclination()`
- `lib/magnetic-declination.php` - WMM manifest, validity, and lookup helpers
- `tests/Unit/MagneticDeclinationSafetyTest.php` - cascade, staleness, boundary tests
- `tests/Integration/PublicApiIntegrationTest.php` - `/v1/airports/kspb` magnetic_declination contract
- `tests/Unit/ConfigTest.php`, `JavaScriptStaticAnalysisTest.php`, `SafeStorageTest.php` - updated expectations

## Test plan

- [x] `APP_ENV=testing vendor/bin/phpunit tests/Unit/MagneticDeclinationSafetyTest.php`
- [x] `APP_ENV=testing vendor/bin/phpunit --testsuite Unit` (2568 tests, 0 failures)
- [x] `make test-ci` (Docker CI parity)
- [x] Confirm `/api/v1/airports/kspb` returns WMM `magnetic_declination` on local dev