### PR TITLE
WMM phase 4: NOAA coefficient verify CI and maintainer update script

### DIFF
--- a/.github/workflows/weekly-wmm-coefficients.yml
+++ b/.github/workflows/weekly-wmm-coefficients.yml
@@ -1,0 +1,45 @@
+name: Weekly WMM coefficient verify
+run-name: "WMM coefficient verify (${{ github.event_name }})"
+
+on:
+  schedule:
+    # Wednesday 10:30 UTC (staggered from upstream probes Tuesday 10:15 UTC)
+    - cron: '30 10 * * 3'
+  workflow_dispatch: {}
+
+concurrency:
+  group: weekly-wmm-coefficients
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify-wmm:
+    name: Verify vendored WMM vs NOAA
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: curl, json, mbstring, zip
+          coverage: none
+
+      - name: Verify WMM coefficients against NOAA
+        run: php scripts/verify-wmm-coefficients.php
+
+      - name: Summary
+        if: success()
+        run: |
+          {
+            echo "## WMM coefficient verify"
+            echo ""
+            echo "Vendored \`data/wmm/WMM.COF\` matches NOAA's published coefficient zip."
+            echo "When this job fails, run \`scripts/update-wmm-coefficients.php\` locally and open a reviewed PR."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #
 # See docs/LOCAL_SETUP.md and docs/TESTING.md for complete documentation.
 
-.PHONY: help init build build-force up down down-prod restart logs shell test test-unit test-integration test-external-apis test-browser test-local test-error-detector metrics-test smoke clean config config-check dev update-leaflet test-up test-down test-shell test-logs test-e2e test-clean smoke-test station-power-fetch check-builtin-aviation-links
+.PHONY: help init build build-force up down down-prod restart logs shell test test-unit test-integration test-external-apis test-browser test-local test-error-detector metrics-test smoke clean config config-check dev update-leaflet test-up test-down test-shell test-logs test-e2e test-clean smoke-test station-power-fetch check-builtin-aviation-links verify-wmm-coefficients update-wmm-coefficients
 
 help: ## Show this help message
 	@echo ''
@@ -19,7 +19,7 @@ help: ## Show this help message
 	@grep -E '^(dev|up|down|down-prod|restart|logs|shell|station-power-fetch):.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
 	@echo ''
 	@echo '\033[1;33mTesting:\033[0m'
-	@grep -E '^(test|test-ci|test-unit|test-integration|test-external-apis|test-e2e|test-browser|test-local|metrics-test|smoke|smoke-test|check-builtin-aviation-links):.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^(test|test-ci|test-unit|test-integration|test-external-apis|test-e2e|test-browser|test-local|metrics-test|smoke|smoke-test|check-builtin-aviation-links|verify-wmm-coefficients|update-wmm-coefficients):.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 	@echo ''
 	@echo '\033[1;33mTest Environment (Isolated):\033[0m'
 	@grep -E '^(test-up|test-down|test-shell|test-logs|test-clean):.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -221,6 +221,12 @@ test-ci: ## Run all tests that GitHub CI runs (comprehensive)
 
 check-builtin-aviation-links: ## HEAD-probe built-in aviation HTTPS URLs (networked; same as scheduled CI)
 	@php scripts/check-builtin-aviation-links.php
+
+verify-wmm-coefficients: ## Compare vendored WMM.COF to NOAA coefficient zip (networked; same as weekly CI)
+	@php scripts/verify-wmm-coefficients.php
+
+update-wmm-coefficients: ## Maintainer: refresh WMM.COF, manifest, and golden fixtures from NOAA (networked)
+	@php scripts/update-wmm-coefficients.php
 
 # Optional: PHPUNIT_ARGS='--filter NotamScheduleTest' (do not use `make test-unit -- --filter ...`; Make treats --filter as a target)
 test-unit: ## Run unit tests only (fast; optional PHPUNIT_ARGS for PHPUnit)

--- a/data/wmm/README.md
+++ b/data/wmm/README.md
@@ -6,4 +6,18 @@
 - **Manifest:** `manifest.json` records model metadata and SHA-256 for verification
 - **Source:** [WMM coefficients](https://www.ncei.noaa.gov/products/world-magnetic-model/wmm-coefficients)
 
-Update only when NOAA releases a new WMM model; refresh `manifest.json` and golden tests in the same change.
+## Maintainer updates
+
+When NOAA publishes a new WMM model (or the weekly verify CI job reports drift):
+
+```bash
+php scripts/update-wmm-coefficients.php   # refresh WMM.COF, manifest.json, golden fixtures
+make test-unit                            # WmmCalculatorTest + WmmCoefficientsTest
+make verify-wmm-coefficients            # confirm alignment with NOAA (optional dry-run check)
+```
+
+Use `--dry-run` on the update script to preview metadata without writing files. Commit all three paths above in one reviewed PR - production never downloads coefficients at runtime.
+
+## Weekly CI
+
+`.github/workflows/weekly-wmm-coefficients.yml` runs `scripts/verify-wmm-coefficients.php` every Wednesday. It discovers the current WMM*COF.zip from NOAA's coefficients page and compares header fields and SHA-256 to `manifest.json`. Failures mean NOAA has published new coefficients that are not yet vendored in the repo.

--- a/data/wmm/README.md
+++ b/data/wmm/README.md
@@ -12,8 +12,8 @@ When NOAA publishes a new WMM model (or the weekly verify CI job reports drift):
 
 ```bash
 php scripts/update-wmm-coefficients.php   # refresh WMM.COF, manifest.json, golden fixtures
-make test-unit                            # WmmCalculatorTest + WmmCoefficientsTest
-make verify-wmm-coefficients            # confirm alignment with NOAA (optional dry-run check)
+make test-unit                            # full unit test suite (includes WmmCalculatorTest)
+make verify-wmm-coefficients            # networked NOAA verify (same as weekly CI)
 ```
 
 Use `--dry-run` on the update script to preview metadata without writing files. Commit all three paths above in one reviewed PR - production never downloads coefficients at runtime.

--- a/data/wmm/README.md
+++ b/data/wmm/README.md
@@ -12,7 +12,7 @@ When NOAA publishes a new WMM model (or the weekly verify CI job reports drift):
 
 ```bash
 php scripts/update-wmm-coefficients.php   # refresh WMM.COF, manifest.json, golden fixtures
-make test-unit                            # full unit test suite (includes WmmCalculatorTest)
+make test-ci                            # full CI validation (required before commit/push)
 make verify-wmm-coefficients            # networked NOAA verify (same as weekly CI)
 ```
 

--- a/lib/wmm/WmmNoaaSync.php
+++ b/lib/wmm/WmmNoaaSync.php
@@ -429,6 +429,8 @@ final class WmmNoaaSync
 
         $body = curl_exec($ch);
         $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
         if ($body === false || $code < 200 || $code >= 400) {
             return null;
         }

--- a/lib/wmm/WmmNoaaSync.php
+++ b/lib/wmm/WmmNoaaSync.php
@@ -395,6 +395,17 @@ final class WmmNoaaSync
                 continue;
             }
 
+            if (
+                !is_numeric($parts[0])
+                || !is_numeric($parts[1])
+                || !is_numeric($parts[2])
+                || !is_numeric($parts[3])
+                || !is_numeric($parts[4])
+                || !is_numeric($parts[5])
+            ) {
+                continue;
+            }
+
             $key = self::fixtureMatchKey(
                 (float) $parts[0],
                 (float) $parts[1],

--- a/lib/wmm/WmmNoaaSync.php
+++ b/lib/wmm/WmmNoaaSync.php
@@ -54,13 +54,7 @@ final class WmmNoaaSync
      */
     public static function fetchSourcePageHtml(?string $sourcePage = null): string
     {
-        $url = $sourcePage ?? self::SOURCE_PAGE;
-        $html = self::httpGet($url);
-        if ($html === null) {
-            throw new \RuntimeException('Failed to fetch NOAA WMM coefficients page: ' . $url);
-        }
-
-        return $html;
+        return self::httpGet($sourcePage ?? self::SOURCE_PAGE);
     }
 
     /**
@@ -73,8 +67,8 @@ final class WmmNoaaSync
     public static function downloadZipToTempFile(string $zipUrl): string
     {
         $body = self::httpGet($zipUrl);
-        if ($body === null || $body === '') {
-            throw new \RuntimeException('Failed to download WMM coefficient zip: ' . $zipUrl);
+        if ($body === '') {
+            throw new \RuntimeException('Downloaded WMM coefficient zip is empty: ' . $zipUrl);
         }
 
         $tempPath = tempnam(sys_get_temp_dir(), 'wmm-cof-');
@@ -423,7 +417,10 @@ final class WmmNoaaSync
         return sprintf('%.1f|%d|%.0f|%.0f', $decimalYear, (int) round($altKm), $lat, $lon);
     }
 
-    private static function httpGet(string $url): ?string
+    /**
+     * @throws \RuntimeException When cURL is unavailable or the request fails
+     */
+    private static function httpGet(string $url): string
     {
         if (!function_exists('curl_init')) {
             throw new \RuntimeException('PHP curl extension is required for NOAA WMM sync');
@@ -431,7 +428,7 @@ final class WmmNoaaSync
 
         $ch = curl_init($url);
         if ($ch === false) {
-            return null;
+            throw new \RuntimeException('Failed to initialize cURL for: ' . $url);
         }
 
         curl_setopt_array($ch, [
@@ -442,14 +439,34 @@ final class WmmNoaaSync
             CURLOPT_TIMEOUT => 120,
             CURLOPT_SSL_VERIFYPEER => true,
             CURLOPT_USERAGENT => self::USER_AGENT,
+            CURLOPT_PROTOCOLS => CURLPROTO_HTTPS,
+            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTPS,
         ]);
 
         $body = curl_exec($ch);
         $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $effectiveUrl = (string) curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+        $curlError = curl_error($ch);
         // CurlHandle frees at scope exit; curl_close() is a no-op since PHP 8.0 (deprecated 8.5).
 
         if ($body === false || $code < 200 || $code >= 400) {
-            return null;
+            $details = [];
+            if ($curlError !== '') {
+                $details[] = 'cURL error: ' . $curlError;
+            }
+            if ($code > 0) {
+                $details[] = 'HTTP status: ' . $code;
+            }
+            if ($effectiveUrl !== '' && $effectiveUrl !== $url) {
+                $details[] = 'effective URL: ' . $effectiveUrl;
+            }
+
+            $message = 'HTTP GET failed for ' . $url;
+            if ($details !== []) {
+                $message .= ' (' . implode('; ', $details) . ')';
+            }
+
+            throw new \RuntimeException($message);
         }
 
         return $body;

--- a/lib/wmm/WmmNoaaSync.php
+++ b/lib/wmm/WmmNoaaSync.php
@@ -29,7 +29,12 @@ final class WmmNoaaSync
      */
     public static function discoverCoefficientZipUrl(string $html): ?string
     {
-        if (!preg_match_all('#https://[^"\s<>]+WMM(\d+)COF\.zip#i', $html, $matches, PREG_SET_ORDER)) {
+        if (!preg_match_all(
+            '#https://(?:www\.)?ncei\.noaa\.gov/[^"\s<>]+WMM(\d+)COF\.zip#i',
+            $html,
+            $matches,
+            PREG_SET_ORDER
+        )) {
             return null;
         }
 

--- a/lib/wmm/WmmNoaaSync.php
+++ b/lib/wmm/WmmNoaaSync.php
@@ -1,0 +1,438 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOAA WMM coefficient discovery, download, and vendored manifest alignment.
+ *
+ * Used by maintainer scripts and weekly CI verify (no runtime production fetch).
+ *
+ * @see https://www.ncei.noaa.gov/products/world-magnetic-model/wmm-coefficients
+ */
+final class WmmNoaaSync
+{
+    public const SOURCE_PAGE = 'https://www.ncei.noaa.gov/products/world-magnetic-model/wmm-coefficients';
+
+    /** WMM models are published with a five-year validity window (decimal years). */
+    public const VALIDITY_SPAN_DECIMAL_YEARS = 5.0;
+
+    private const USER_AGENT = 'AviationWX-wmm-sync/1.0 (+https://aviationwx.org)';
+
+    /**
+     * Discover the coefficient zip URL from NOAA WMM coefficients page HTML.
+     *
+     * When multiple COF archives are linked, selects the highest model year
+     * (for example WMM2025COF.zip over WMM2020COF.zip).
+     *
+     * @param string $html Page HTML from {@see SOURCE_PAGE}
+     * @return string|null Absolute HTTPS zip URL, or null when none found
+     */
+    public static function discoverCoefficientZipUrl(string $html): ?string
+    {
+        if (!preg_match_all('#https://[^"\s<>]+WMM(\d+)COF\.zip#i', $html, $matches, PREG_SET_ORDER)) {
+            return null;
+        }
+
+        usort($matches, static function (array $a, array $b): int {
+            return (int) $b[1] <=> (int) $a[1];
+        });
+
+        return $matches[0][0];
+    }
+
+    /**
+     * Fetch NOAA WMM coefficients page HTML.
+     *
+     * @param string|null $sourcePage Override page URL (defaults to {@see SOURCE_PAGE})
+     * @return string Raw HTML body
+     * @throws \RuntimeException When the page cannot be fetched
+     */
+    public static function fetchSourcePageHtml(?string $sourcePage = null): string
+    {
+        $url = $sourcePage ?? self::SOURCE_PAGE;
+        $html = self::httpGet($url);
+        if ($html === null) {
+            throw new \RuntimeException('Failed to fetch NOAA WMM coefficients page: ' . $url);
+        }
+
+        return $html;
+    }
+
+    /**
+     * Download a coefficient zip archive to a temporary file.
+     *
+     * @param string $zipUrl HTTPS URL to WMM*COF.zip
+     * @return string Absolute path to the downloaded temp file (caller should unlink)
+     * @throws \RuntimeException When download fails
+     */
+    public static function downloadZipToTempFile(string $zipUrl): string
+    {
+        $body = self::httpGet($zipUrl);
+        if ($body === null || $body === '') {
+            throw new \RuntimeException('Failed to download WMM coefficient zip: ' . $zipUrl);
+        }
+
+        $tempPath = tempnam(sys_get_temp_dir(), 'wmm-cof-');
+        if ($tempPath === false) {
+            throw new \RuntimeException('Failed to allocate temp file for WMM zip download');
+        }
+
+        if (file_put_contents($tempPath, $body) === false) {
+            @unlink($tempPath);
+            throw new \RuntimeException('Failed to write WMM zip to temp file: ' . $tempPath);
+        }
+
+        return $tempPath;
+    }
+
+    /**
+     * Extract WMM.COF and optional NOAA test vectors from a coefficient zip.
+     *
+     * @param string $zipPath Absolute path to WMM*COF.zip
+     * @return array{
+     *     cof: string,
+     *     test_values: string|null,
+     *     cof_entry: string,
+     *     test_values_entry: string|null
+     * }
+     * @throws \RuntimeException When the archive is invalid or WMM.COF is missing
+     */
+    public static function extractZipContents(string $zipPath): array
+    {
+        if (!class_exists(\ZipArchive::class)) {
+            throw new \RuntimeException('PHP zip extension (ZipArchive) is required');
+        }
+
+        $zip = new \ZipArchive();
+        if ($zip->open($zipPath) !== true) {
+            throw new \RuntimeException('Failed to open WMM coefficient zip: ' . $zipPath);
+        }
+
+        $cofEntry = null;
+        $testValuesEntry = null;
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $name = $zip->getNameIndex($i);
+            if (!is_string($name) || str_ends_with($name, '/')) {
+                continue;
+            }
+            $basename = basename($name);
+            if ($basename === 'WMM.COF') {
+                $cofEntry = $name;
+            } elseif (preg_match('/TestValues\.txt$/i', $basename)) {
+                $testValuesEntry = $name;
+            }
+        }
+
+        if ($cofEntry === null) {
+            $zip->close();
+            throw new \RuntimeException('WMM.COF not found inside coefficient zip: ' . $zipPath);
+        }
+
+        $cofContent = $zip->getFromName($cofEntry);
+        if ($cofContent === false) {
+            $zip->close();
+            throw new \RuntimeException('Failed to read WMM.COF from zip entry: ' . $cofEntry);
+        }
+
+        $testValuesContent = null;
+        if ($testValuesEntry !== null) {
+            $raw = $zip->getFromName($testValuesEntry);
+            if ($raw !== false) {
+                $testValuesContent = $raw;
+            }
+        }
+
+        $zip->close();
+
+        return [
+            'cof' => $cofContent,
+            'test_values' => $testValuesContent,
+            'cof_entry' => $cofEntry,
+            'test_values_entry' => $testValuesEntry,
+        ];
+    }
+
+    /**
+     * Parse epoch, model name, and release date from WMM.COF header line.
+     *
+     * @param string $cofContent Raw WMM.COF file contents
+     * @return array{epoch: float, model: string, release_date: string}
+     * @throws \InvalidArgumentException When header is missing or malformed
+     */
+    public static function parseCofHeaderFromContent(string $cofContent): array
+    {
+        foreach (preg_split('/\R/', $cofContent) ?: [] as $line) {
+            $line = trim($line);
+            if ($line === '' || str_starts_with($line, '9999')) {
+                continue;
+            }
+
+            $parts = preg_split('/\s+/', $line);
+            if ($parts === false || $parts === []) {
+                continue;
+            }
+
+            if (!is_numeric($parts[0]) || !isset($parts[1]) || !preg_match('/^WMM-/', $parts[1])) {
+                throw new \InvalidArgumentException('WMM coefficient file has invalid or missing header');
+            }
+
+            return [
+                'epoch' => (float) $parts[0],
+                'model' => $parts[1],
+                'release_date' => $parts[2] ?? '',
+            ];
+        }
+
+        throw new \InvalidArgumentException('WMM coefficient file missing header line');
+    }
+
+    /**
+     * Build manifest metadata for a NOAA coefficient release.
+     *
+     * @param array{epoch: float, model: string, release_date: string} $header Parsed COF header
+     * @param string $cofSha256 Lowercase hex SHA-256 of WMM.COF bytes
+     * @param string $zipUrl NOAA coefficient zip URL used for this release
+     * @return array<string, mixed> Manifest fields for data/wmm/manifest.json
+     */
+    public static function buildManifest(array $header, string $cofSha256, string $zipUrl): array
+    {
+        return [
+            'model' => $header['model'],
+            'epoch' => $header['epoch'],
+            'release_date' => $header['release_date'],
+            'valid_through_epoch' => $header['epoch'] + self::VALIDITY_SPAN_DECIMAL_YEARS,
+            'source_page' => self::SOURCE_PAGE,
+            'source_zip_url' => $zipUrl,
+            'cof_file' => 'WMM.COF',
+            'cof_sha256' => strtolower($cofSha256),
+        ];
+    }
+
+    /**
+     * Compare NOAA WMM.COF bytes against vendored manifest expectations.
+     *
+     * @param array<string, mixed> $manifest Parsed manifest.json
+     * @param string $noaaCofContent Raw WMM.COF from NOAA zip
+     * @return array{
+     *     ok: bool,
+     *     errors: list<string>,
+     *     noaa: array{epoch: float, model: string, release_date: string, cof_sha256: string}
+     * }
+     */
+    public static function compareNoaaCofToManifest(array $manifest, string $noaaCofContent): array
+    {
+        $errors = [];
+
+        try {
+            $header = self::parseCofHeaderFromContent($noaaCofContent);
+        } catch (\InvalidArgumentException $e) {
+            return [
+                'ok' => false,
+                'errors' => ['NOAA WMM.COF header parse failed: ' . $e->getMessage()],
+                'noaa' => [
+                    'epoch' => 0.0,
+                    'model' => '',
+                    'release_date' => '',
+                    'cof_sha256' => hash('sha256', $noaaCofContent),
+                ],
+            ];
+        }
+
+        $noaaSha256 = hash('sha256', $noaaCofContent);
+        $noaaSummary = [
+            'epoch' => $header['epoch'],
+            'model' => $header['model'],
+            'release_date' => $header['release_date'],
+            'cof_sha256' => $noaaSha256,
+        ];
+
+        foreach (['model', 'epoch', 'release_date', 'cof_sha256'] as $key) {
+            if (!array_key_exists($key, $manifest)) {
+                $errors[] = "Vendored manifest missing required key: {$key}";
+                continue;
+            }
+        }
+
+        if ($errors !== []) {
+            return ['ok' => false, 'errors' => $errors, 'noaa' => $noaaSummary];
+        }
+
+        if ((string) $manifest['model'] !== $header['model']) {
+            $errors[] = sprintf(
+                'Model mismatch: vendored=%s NOAA=%s',
+                (string) $manifest['model'],
+                $header['model']
+            );
+        }
+
+        if (!is_numeric($manifest['epoch']) || abs((float) $manifest['epoch'] - $header['epoch']) > 0.0001) {
+            $errors[] = sprintf(
+                'Epoch mismatch: vendored=%s NOAA=%s',
+                (string) $manifest['epoch'],
+                (string) $header['epoch']
+            );
+        }
+
+        if ((string) $manifest['release_date'] !== $header['release_date']) {
+            $errors[] = sprintf(
+                'Release date mismatch: vendored=%s NOAA=%s',
+                (string) $manifest['release_date'],
+                $header['release_date']
+            );
+        }
+
+        $expectedSha = strtolower((string) $manifest['cof_sha256']);
+        if ($expectedSha !== $noaaSha256) {
+            $errors[] = sprintf(
+                'SHA-256 mismatch: vendored=%s NOAA=%s',
+                $expectedSha,
+                $noaaSha256
+            );
+        }
+
+        return [
+            'ok' => $errors === [],
+            'errors' => $errors,
+            'noaa' => $noaaSummary,
+        ];
+    }
+
+    /**
+     * Refresh golden fixture expected values from NOAA test vectors.
+     *
+     * Matches existing fixtures by decimal year, altitude, latitude, and longitude.
+     *
+     * @param string $testValuesContent Raw WMM*_TestValues.txt from NOAA zip
+     * @param array<string, mixed> $existingFixtureJson Parsed wmm-noaa-reference.json
+     * @return array{fixtures: array<int, array<string, mixed>>, missing: list<string>}
+     */
+    public static function refreshGoldenFixtures(string $testValuesContent, array $existingFixtureJson): array
+    {
+        $vectors = self::parseNoaaTestValues($testValuesContent);
+        $fixtures = $existingFixtureJson['fixtures'] ?? [];
+        if (!is_array($fixtures)) {
+            throw new \InvalidArgumentException('Fixture JSON missing fixtures array');
+        }
+
+        $missing = [];
+        $updated = [];
+        foreach ($fixtures as $fixture) {
+            if (!is_array($fixture)) {
+                continue;
+            }
+
+            $key = self::fixtureMatchKey(
+                (float) ($fixture['decimal_year'] ?? 0),
+                (float) ($fixture['altitude_km'] ?? 0),
+                (float) ($fixture['lat'] ?? 0),
+                (float) ($fixture['lon'] ?? 0)
+            );
+
+            if (!isset($vectors[$key])) {
+                $missing[] = $key;
+                $updated[] = $fixture;
+                continue;
+            }
+
+            [$declination, $inclination] = $vectors[$key];
+            $fixture['declination'] = $declination;
+            $fixture['inclination'] = $inclination;
+            $updated[] = $fixture;
+        }
+
+        return [
+            'fixtures' => $updated,
+            'missing' => $missing,
+        ];
+    }
+
+    /**
+     * Load and validate bundled manifest.json.
+     *
+     * @return array<string, mixed>
+     * @throws \RuntimeException When manifest is unreadable or invalid
+     */
+    public static function loadBundledManifest(): array
+    {
+        $path = WmmCoefficients::getBundledManifestPath();
+        if (!is_readable($path)) {
+            throw new \RuntimeException('Bundled WMM manifest is not readable: ' . $path);
+        }
+
+        $json = file_get_contents($path);
+        if ($json === false) {
+            throw new \RuntimeException('Failed to read bundled WMM manifest: ' . $path);
+        }
+
+        $manifest = json_decode($json, true);
+        if (!is_array($manifest) || json_last_error() !== JSON_ERROR_NONE) {
+            throw new \RuntimeException('Invalid bundled WMM manifest JSON: ' . json_last_error_msg());
+        }
+
+        return $manifest;
+    }
+
+    /**
+     * @return array<string, array{0: float, 1: float}>
+     */
+    private static function parseNoaaTestValues(string $testValuesContent): array
+    {
+        $vectors = [];
+        foreach (preg_split('/\R/', $testValuesContent) ?: [] as $line) {
+            $line = trim($line);
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+
+            $parts = preg_split('/\s+/', $line);
+            if ($parts === false || count($parts) < 6) {
+                continue;
+            }
+
+            $key = self::fixtureMatchKey(
+                (float) $parts[0],
+                (float) $parts[1],
+                (float) $parts[2],
+                (float) $parts[3]
+            );
+            $vectors[$key] = [(float) $parts[4], (float) $parts[5]];
+        }
+
+        return $vectors;
+    }
+
+    private static function fixtureMatchKey(float $decimalYear, float $altKm, float $lat, float $lon): string
+    {
+        return sprintf('%.1f|%d|%.0f|%.0f', $decimalYear, (int) round($altKm), $lat, $lon);
+    }
+
+    private static function httpGet(string $url): ?string
+    {
+        if (!function_exists('curl_init')) {
+            throw new \RuntimeException('PHP curl extension is required for NOAA WMM sync');
+        }
+
+        $ch = curl_init($url);
+        if ($ch === false) {
+            return null;
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_MAXREDIRS => 5,
+            CURLOPT_CONNECTTIMEOUT => 30,
+            CURLOPT_TIMEOUT => 120,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_USERAGENT => self::USER_AGENT,
+        ]);
+
+        $body = curl_exec($ch);
+        $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        if ($body === false || $code < 200 || $code >= 400) {
+            return null;
+        }
+
+        return $body;
+    }
+}

--- a/lib/wmm/WmmNoaaSync.php
+++ b/lib/wmm/WmmNoaaSync.php
@@ -305,6 +305,7 @@ final class WmmNoaaSync
      * @param string $testValuesContent Raw WMM*_TestValues.txt from NOAA zip
      * @param array<string, mixed> $existingFixtureJson Parsed wmm-noaa-reference.json
      * @return array{fixtures: array<int, array<string, mixed>>, missing: list<string>}
+     * @throws \InvalidArgumentException When fixture JSON is missing a fixtures array
      */
     public static function refreshGoldenFixtures(string $testValuesContent, array $existingFixtureJson): array
     {

--- a/lib/wmm/WmmNoaaSync.php
+++ b/lib/wmm/WmmNoaaSync.php
@@ -446,7 +446,7 @@ final class WmmNoaaSync
 
         $body = curl_exec($ch);
         $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
+        // CurlHandle frees at scope exit; curl_close() is a no-op since PHP 8.0 (deprecated 8.5).
 
         if ($body === false || $code < 200 || $code >= 400) {
             return null;

--- a/scripts/update-wmm-coefficients.php
+++ b/scripts/update-wmm-coefficients.php
@@ -85,7 +85,12 @@ if ($extracted['test_values'] === null) {
     wmmUpdateFail(['NOAA coefficient zip did not include a TestValues.txt file']);
 }
 
-$fixtureUpdates = WmmNoaaSync::refreshGoldenFixtures($extracted['test_values'], $fixtureJson);
+try {
+    $fixtureUpdates = WmmNoaaSync::refreshGoldenFixtures($extracted['test_values'], $fixtureJson);
+} catch (\InvalidArgumentException $e) {
+    wmmUpdateFail(['Golden fixture refresh failed: ' . $e->getMessage()]);
+}
+
 if ($fixtureUpdates['missing'] !== []) {
     wmmUpdateFail([
         'Golden fixtures missing from NOAA test vectors: ' . implode(', ', $fixtureUpdates['missing']),

--- a/scripts/update-wmm-coefficients.php
+++ b/scripts/update-wmm-coefficients.php
@@ -38,7 +38,12 @@ function wmmUpdateFail(array $errors): never
     exit(1);
 }
 
-$html = WmmNoaaSync::fetchSourcePageHtml();
+try {
+    $html = WmmNoaaSync::fetchSourcePageHtml();
+} catch (\RuntimeException $e) {
+    wmmUpdateFail([$e->getMessage()]);
+}
+
 $zipUrl = WmmNoaaSync::discoverCoefficientZipUrl($html);
 if ($zipUrl === null) {
     wmmUpdateFail(['Could not discover WMM coefficient zip URL on NOAA coefficients page']);

--- a/scripts/update-wmm-coefficients.php
+++ b/scripts/update-wmm-coefficients.php
@@ -1,0 +1,141 @@
+#!/usr/bin/env php
+<?php
+/**
+ * CLI: Maintainer tool to refresh vendored WMM coefficients from NOAA.
+ *
+ * Downloads the current WMM*COF.zip, updates data/wmm/WMM.COF and manifest.json,
+ * and refreshes golden fixture expected values in tests/Fixtures/wmm-noaa-reference.json.
+ *
+ * Does not commit or deploy. Run `make test-unit` (or test-ci) after updating, then open a PR.
+ *
+ * Usage:
+ *   php scripts/update-wmm-coefficients.php [--dry-run]
+ *
+ * @package AviationWX
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../lib/wmm/WmmCoefficients.php';
+require_once __DIR__ . '/../lib/wmm/WmmNoaaSync.php';
+
+$dryRun = in_array('--dry-run', $argv, true);
+
+$repoRoot = dirname(__DIR__);
+$cofPath = WmmCoefficients::getBundledCofPath();
+$manifestPath = WmmCoefficients::getBundledManifestPath();
+$fixturePath = $repoRoot . '/tests/Fixtures/wmm-noaa-reference.json';
+
+/**
+ * @param list<string> $errors
+ */
+function wmmUpdateFail(array $errors): never
+{
+    fwrite(STDERR, "WMM coefficient update failed:\n");
+    foreach ($errors as $error) {
+        fwrite(STDERR, "  - {$error}\n");
+    }
+    exit(1);
+}
+
+$html = WmmNoaaSync::fetchSourcePageHtml();
+$zipUrl = WmmNoaaSync::discoverCoefficientZipUrl($html);
+if ($zipUrl === null) {
+    wmmUpdateFail(['Could not discover WMM coefficient zip URL on NOAA coefficients page']);
+}
+
+$tempZip = null;
+try {
+    $tempZip = WmmNoaaSync::downloadZipToTempFile($zipUrl);
+    $extracted = WmmNoaaSync::extractZipContents($tempZip);
+} catch (\RuntimeException $e) {
+    wmmUpdateFail([$e->getMessage()]);
+} finally {
+    if ($tempZip !== null) {
+        @unlink($tempZip);
+    }
+}
+
+try {
+    $header = WmmNoaaSync::parseCofHeaderFromContent($extracted['cof']);
+} catch (\InvalidArgumentException $e) {
+    wmmUpdateFail(['NOAA WMM.COF header parse failed: ' . $e->getMessage()]);
+}
+
+$cofSha256 = hash('sha256', $extracted['cof']);
+$manifest = WmmNoaaSync::buildManifest($header, $cofSha256, $zipUrl);
+$manifestJson = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+
+$fixtureJsonRaw = file_get_contents($fixturePath);
+if ($fixtureJsonRaw === false) {
+    wmmUpdateFail(['Failed to read golden fixture file: ' . $fixturePath]);
+}
+
+$fixtureJson = json_decode($fixtureJsonRaw, true);
+if (!is_array($fixtureJson) || json_last_error() !== JSON_ERROR_NONE) {
+    wmmUpdateFail(['Invalid golden fixture JSON: ' . json_last_error_msg()]);
+}
+
+if ($extracted['test_values'] === null) {
+    wmmUpdateFail(['NOAA coefficient zip did not include a TestValues.txt file']);
+}
+
+$fixtureUpdates = WmmNoaaSync::refreshGoldenFixtures($extracted['test_values'], $fixtureJson);
+if ($fixtureUpdates['missing'] !== []) {
+    wmmUpdateFail([
+        'Golden fixtures missing from NOAA test vectors: ' . implode(', ', $fixtureUpdates['missing']),
+    ]);
+}
+
+$meta = $fixtureJson['_meta'] ?? [];
+if (!is_array($meta)) {
+    $meta = [];
+}
+$meta['coefficient_model'] = $header['model'];
+$meta['coefficient_epoch'] = $header['epoch'];
+$meta['source_file'] = basename((string) ($extracted['test_values_entry'] ?? 'WMM_TestValues.txt'))
+    . ' (NOAA ' . basename($zipUrl) . ')';
+
+$updatedFixture = [
+    '_meta' => $meta,
+    'fixtures' => $fixtureUpdates['fixtures'],
+];
+$fixtureOut = json_encode($updatedFixture, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+
+fwrite(STDOUT, "NOAA WMM coefficient update summary\n");
+fwrite(STDOUT, sprintf("  zip_url=%s\n", $zipUrl));
+fwrite(STDOUT, sprintf(
+    "  model=%s epoch=%s release_date=%s valid_through=%s\n",
+    $header['model'],
+    (string) $header['epoch'],
+    $header['release_date'],
+    (string) $manifest['valid_through_epoch']
+));
+fwrite(STDOUT, sprintf("  cof_sha256=%s\n", $cofSha256));
+$fixtureCount = count($fixtureUpdates['fixtures']);
+fwrite(STDOUT, sprintf("  fixtures_refreshed=%d\n", $fixtureCount));
+
+if ($dryRun) {
+    fwrite(STDOUT, "\nDry run: no files written.\n");
+    exit(0);
+}
+
+if (file_put_contents($cofPath, $extracted['cof']) === false) {
+    wmmUpdateFail(['Failed to write WMM.COF: ' . $cofPath]);
+}
+
+if (file_put_contents($manifestPath, $manifestJson) === false) {
+    wmmUpdateFail(['Failed to write manifest.json: ' . $manifestPath]);
+}
+
+if (file_put_contents($fixturePath, $fixtureOut) === false) {
+    wmmUpdateFail(['Failed to write golden fixtures: ' . $fixturePath]);
+}
+
+fwrite(STDOUT, "\nUpdated:\n");
+fwrite(STDOUT, "  - data/wmm/WMM.COF\n");
+fwrite(STDOUT, "  - data/wmm/manifest.json\n");
+fwrite(STDOUT, "  - tests/Fixtures/wmm-noaa-reference.json\n");
+fwrite(STDOUT, "\nNext: run make test-unit (or make test-ci), then commit and open a reviewed PR.\n");
+
+exit(0);

--- a/scripts/update-wmm-coefficients.php
+++ b/scripts/update-wmm-coefficients.php
@@ -69,7 +69,11 @@ try {
 
 $cofSha256 = hash('sha256', $extracted['cof']);
 $manifest = WmmNoaaSync::buildManifest($header, $cofSha256, $zipUrl);
-$manifestJson = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+$manifestEncoded = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+if ($manifestEncoded === false) {
+    wmmUpdateFail(['Failed to encode manifest JSON: ' . json_last_error_msg()]);
+}
+$manifestJson = $manifestEncoded . "\n";
 
 $fixtureJsonRaw = file_get_contents($fixturePath);
 if ($fixtureJsonRaw === false) {
@@ -110,7 +114,11 @@ $updatedFixture = [
     '_meta' => $meta,
     'fixtures' => $fixtureUpdates['fixtures'],
 ];
-$fixtureOut = json_encode($updatedFixture, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+$fixtureEncoded = json_encode($updatedFixture, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+if ($fixtureEncoded === false) {
+    wmmUpdateFail(['Failed to encode golden fixture JSON: ' . json_last_error_msg()]);
+}
+$fixtureOut = $fixtureEncoded . "\n";
 
 fwrite(STDOUT, "NOAA WMM coefficient update summary\n");
 fwrite(STDOUT, sprintf("  zip_url=%s\n", $zipUrl));

--- a/scripts/update-wmm-coefficients.php
+++ b/scripts/update-wmm-coefficients.php
@@ -6,7 +6,7 @@
  * Downloads the current WMM*COF.zip, updates data/wmm/WMM.COF and manifest.json,
  * and refreshes golden fixture expected values in tests/Fixtures/wmm-noaa-reference.json.
  *
- * Does not commit or deploy. Run `make test-unit` (or test-ci) after updating, then open a PR.
+ * Does not commit or deploy. Run `make test-ci` after updating, then open a PR.
  *
  * Usage:
  *   php scripts/update-wmm-coefficients.php [--dry-run]
@@ -146,6 +146,6 @@ fwrite(STDOUT, "\nUpdated:\n");
 fwrite(STDOUT, "  - data/wmm/WMM.COF\n");
 fwrite(STDOUT, "  - data/wmm/manifest.json\n");
 fwrite(STDOUT, "  - tests/Fixtures/wmm-noaa-reference.json\n");
-fwrite(STDOUT, "\nNext: run make test-unit (or make test-ci), then commit and open a reviewed PR.\n");
+fwrite(STDOUT, "\nNext: run make test-ci, then commit and open a reviewed PR.\n");
 
 exit(0);

--- a/scripts/verify-wmm-coefficients.php
+++ b/scripts/verify-wmm-coefficients.php
@@ -1,0 +1,113 @@
+#!/usr/bin/env php
+<?php
+/**
+ * CLI: Verify vendored WMM coefficients match NOAA's published coefficient zip.
+ *
+ * Discovers the current WMM*COF.zip link from NOAA's coefficients page, downloads it,
+ * and compares WMM.COF header fields and SHA-256 against data/wmm/manifest.json.
+ *
+ * Exit 0 when aligned; exit 1 on drift or fetch failures. Intended for weekly CI
+ * ({@see .github/workflows/weekly-wmm-coefficients.yml}) and `make verify-wmm-coefficients`.
+ *
+ * @package AviationWX
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../lib/wmm/WmmCoefficients.php';
+require_once __DIR__ . '/../lib/wmm/WmmNoaaSync.php';
+
+/**
+ * @param list<string> $errors
+ */
+function wmmVerifyFail(array $errors): never
+{
+    fwrite(STDERR, "WMM coefficient verify failed:\n");
+    foreach ($errors as $error) {
+        fwrite(STDERR, "  - {$error}\n");
+    }
+    fwrite(STDERR, "\nRun scripts/update-wmm-coefficients.php and open a reviewed PR when NOAA publishes new coefficients.\n");
+    exit(1);
+}
+
+try {
+    $manifest = WmmNoaaSync::loadBundledManifest();
+} catch (\RuntimeException $e) {
+    wmmVerifyFail([$e->getMessage()]);
+}
+
+$cofPath = WmmCoefficients::getBundledCofPath();
+if (!is_readable($cofPath)) {
+    wmmVerifyFail(['Bundled WMM.COF is not readable: ' . $cofPath]);
+}
+
+$localSha = hash_file('sha256', $cofPath);
+if (!is_string($localSha) || strtolower((string) ($manifest['cof_sha256'] ?? '')) !== $localSha) {
+    wmmVerifyFail([
+        sprintf(
+            'Bundled WMM.COF SHA-256 (%s) does not match manifest cof_sha256 (%s)',
+            $localSha ?: 'unknown',
+            (string) ($manifest['cof_sha256'] ?? 'missing')
+        ),
+    ]);
+}
+
+$sourcePage = isset($manifest['source_page']) && is_string($manifest['source_page'])
+    ? $manifest['source_page']
+    : WmmNoaaSync::SOURCE_PAGE;
+
+try {
+    $html = WmmNoaaSync::fetchSourcePageHtml($sourcePage);
+} catch (\RuntimeException $e) {
+    wmmVerifyFail([$e->getMessage()]);
+}
+
+$discoveredUrl = WmmNoaaSync::discoverCoefficientZipUrl($html);
+if ($discoveredUrl === null) {
+    wmmVerifyFail(['Could not discover WMM coefficient zip URL on NOAA page: ' . $sourcePage]);
+}
+
+$manifestZipUrl = isset($manifest['source_zip_url']) ? (string) $manifest['source_zip_url'] : '';
+$zipUrl = $discoveredUrl;
+$warnings = [];
+if ($manifestZipUrl !== '' && $manifestZipUrl !== $discoveredUrl) {
+    $warnings[] = sprintf(
+        'NOAA page now links %s (manifest records %s); comparing coefficient bytes from discovered URL',
+        $discoveredUrl,
+        $manifestZipUrl
+    );
+}
+
+$tempZip = null;
+try {
+    $tempZip = WmmNoaaSync::downloadZipToTempFile($zipUrl);
+    $extracted = WmmNoaaSync::extractZipContents($tempZip);
+} catch (\RuntimeException $e) {
+    wmmVerifyFail([$e->getMessage()]);
+} finally {
+    if ($tempZip !== null) {
+        @unlink($tempZip);
+    }
+}
+
+$result = WmmNoaaSync::compareNoaaCofToManifest($manifest, $extracted['cof']);
+
+foreach ($warnings as $warning) {
+    fwrite(STDOUT, "warning: {$warning}\n");
+}
+
+if (!$result['ok']) {
+    wmmVerifyFail($result['errors']);
+}
+
+fwrite(STDOUT, "WMM coefficients verified against NOAA.\n");
+fwrite(STDOUT, sprintf(
+    "  model=%s epoch=%s release_date=%s sha256=%s\n",
+    $result['noaa']['model'],
+    (string) $result['noaa']['epoch'],
+    $result['noaa']['release_date'],
+    $result['noaa']['cof_sha256']
+));
+fwrite(STDOUT, sprintf("  source_zip_url=%s\n", $zipUrl));
+
+exit(0);

--- a/tests/Unit/WmmNoaaSyncTest.php
+++ b/tests/Unit/WmmNoaaSyncTest.php
@@ -17,7 +17,7 @@ class WmmNoaaSyncTest extends TestCase
 
     private const SAMPLE_COF_HEADER = "    2025.0            WMM-2025     11/13/2024\n";
 
-    public function testDiscoverCoefficientZipUrl_PicksHighestModelYear(): void
+    public function testDiscoverCoefficientZipUrl_MultipleModelYears_ReturnsHighestYearUrl(): void
     {
         $url = \WmmNoaaSync::discoverCoefficientZipUrl(self::SAMPLE_HTML);
         $this->assertSame(
@@ -31,7 +31,7 @@ class WmmNoaaSyncTest extends TestCase
         $this->assertNull(\WmmNoaaSync::discoverCoefficientZipUrl('<html>no zip links</html>'));
     }
 
-    public function testDiscoverCoefficientZipUrl_IgnoresNonNoaaHosts(): void
+    public function testDiscoverCoefficientZipUrl_NonNoaaHostPresent_ReturnsNoaaUrl(): void
     {
         $html = <<<'HTML'
         <a href="https://evil.example/WMM2099COF.zip">fake</a>
@@ -53,7 +53,7 @@ class WmmNoaaSyncTest extends TestCase
         $this->assertSame('11/13/2024', $header['release_date']);
     }
 
-    public function testBuildManifest_IncludesFiveYearValidityWindow(): void
+    public function testBuildManifest_StandardHeader_SetsFiveYearValidityWindow(): void
     {
         $manifest = \WmmNoaaSync::buildManifest(
             ['epoch' => 2025.0, 'model' => 'WMM-2025', 'release_date' => '11/13/2024'],
@@ -97,10 +97,11 @@ class WmmNoaaSyncTest extends TestCase
         $this->assertStringContainsString('SHA-256 mismatch', $result['errors'][0]);
     }
 
-    public function testRefreshGoldenFixtures_UpdatesExpectedValues(): void
+    public function testRefreshGoldenFixtures_MatchingFixtureKey_UpdatesDeclinationAndInclination(): void
     {
         $testValues = <<<'TXT'
 # comment
+Field 1  Decimal year
 2025.000000      28      89    -121   -99.77    88.47
 2025.000000      48      80     -96   -29.91    87.77
 TXT;
@@ -126,7 +127,7 @@ TXT;
         $this->assertSame(88.47, $result['fixtures'][0]['inclination']);
     }
 
-    public function testExtractZipContents_ReadsBundledNoaaZip(): void
+    public function testExtractZipContents_ValidArchive_ReturnsCofAndEntryPaths(): void
     {
         if (!class_exists(\ZipArchive::class)) {
             $this->markTestSkipped('ZipArchive extension not available');

--- a/tests/Unit/WmmNoaaSyncTest.php
+++ b/tests/Unit/WmmNoaaSyncTest.php
@@ -6,7 +6,6 @@ namespace AviationWX\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
-require_once __DIR__ . '/../../lib/wmm/WmmCoefficients.php';
 require_once __DIR__ . '/../../lib/wmm/WmmNoaaSync.php';
 
 class WmmNoaaSyncTest extends TestCase

--- a/tests/Unit/WmmNoaaSyncTest.php
+++ b/tests/Unit/WmmNoaaSyncTest.php
@@ -31,6 +31,20 @@ class WmmNoaaSyncTest extends TestCase
         $this->assertNull(\WmmNoaaSync::discoverCoefficientZipUrl('<html>no zip links</html>'));
     }
 
+    public function testDiscoverCoefficientZipUrl_IgnoresNonNoaaHosts(): void
+    {
+        $html = <<<'HTML'
+        <a href="https://evil.example/WMM2099COF.zip">fake</a>
+        <a href="https://www.ncei.noaa.gov/sites/default/files/2024-12/WMM2025COF.zip">real</a>
+        HTML;
+
+        $url = \WmmNoaaSync::discoverCoefficientZipUrl($html);
+        $this->assertSame(
+            'https://www.ncei.noaa.gov/sites/default/files/2024-12/WMM2025COF.zip',
+            $url
+        );
+    }
+
     public function testParseCofHeaderFromContent_ValidHeader_ReturnsFields(): void
     {
         $header = \WmmNoaaSync::parseCofHeaderFromContent(self::SAMPLE_COF_HEADER);

--- a/tests/Unit/WmmNoaaSyncTest.php
+++ b/tests/Unit/WmmNoaaSyncTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AviationWX\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/wmm/WmmCoefficients.php';
+require_once __DIR__ . '/../../lib/wmm/WmmNoaaSync.php';
+
+class WmmNoaaSyncTest extends TestCase
+{
+    private const SAMPLE_HTML = <<<'HTML'
+    <a href="https://www.ncei.noaa.gov/sites/default/files/2020-01/WMM2020COF.zip">WMM2020</a>
+    <a href="https://www.ncei.noaa.gov/sites/default/files/2024-12/WMM2025COF.zip">WMM2025</a>
+    HTML;
+
+    private const SAMPLE_COF_HEADER = "    2025.0            WMM-2025     11/13/2024\n";
+
+    public function testDiscoverCoefficientZipUrl_PicksHighestModelYear(): void
+    {
+        $url = \WmmNoaaSync::discoverCoefficientZipUrl(self::SAMPLE_HTML);
+        $this->assertSame(
+            'https://www.ncei.noaa.gov/sites/default/files/2024-12/WMM2025COF.zip',
+            $url
+        );
+    }
+
+    public function testDiscoverCoefficientZipUrl_NoMatch_ReturnsNull(): void
+    {
+        $this->assertNull(\WmmNoaaSync::discoverCoefficientZipUrl('<html>no zip links</html>'));
+    }
+
+    public function testParseCofHeaderFromContent_ValidHeader_ReturnsFields(): void
+    {
+        $header = \WmmNoaaSync::parseCofHeaderFromContent(self::SAMPLE_COF_HEADER);
+        $this->assertSame(2025.0, $header['epoch']);
+        $this->assertSame('WMM-2025', $header['model']);
+        $this->assertSame('11/13/2024', $header['release_date']);
+    }
+
+    public function testBuildManifest_IncludesFiveYearValidityWindow(): void
+    {
+        $manifest = \WmmNoaaSync::buildManifest(
+            ['epoch' => 2025.0, 'model' => 'WMM-2025', 'release_date' => '11/13/2024'],
+            'abc123',
+            'https://example.com/WMM2025COF.zip'
+        );
+
+        $this->assertSame('WMM-2025', $manifest['model']);
+        $this->assertSame(2030.0, $manifest['valid_through_epoch']);
+        $this->assertSame('abc123', $manifest['cof_sha256']);
+    }
+
+    public function testCompareNoaaCofToManifest_MatchingManifest_ReturnsOk(): void
+    {
+        $cof = self::SAMPLE_COF_HEADER;
+        $sha = hash('sha256', $cof);
+        $manifest = [
+            'model' => 'WMM-2025',
+            'epoch' => 2025.0,
+            'release_date' => '11/13/2024',
+            'cof_sha256' => $sha,
+        ];
+
+        $result = \WmmNoaaSync::compareNoaaCofToManifest($manifest, $cof);
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['errors']);
+    }
+
+    public function testCompareNoaaCofToManifest_ShaMismatch_ReturnsErrors(): void
+    {
+        $manifest = [
+            'model' => 'WMM-2025',
+            'epoch' => 2025.0,
+            'release_date' => '11/13/2024',
+            'cof_sha256' => str_repeat('0', 64),
+        ];
+
+        $result = \WmmNoaaSync::compareNoaaCofToManifest($manifest, self::SAMPLE_COF_HEADER);
+        $this->assertFalse($result['ok']);
+        $this->assertNotEmpty($result['errors']);
+        $this->assertStringContainsString('SHA-256 mismatch', $result['errors'][0]);
+    }
+
+    public function testRefreshGoldenFixtures_UpdatesExpectedValues(): void
+    {
+        $testValues = <<<'TXT'
+# comment
+2025.000000      28      89    -121   -99.77    88.47
+2025.000000      48      80     -96   -29.91    87.77
+TXT;
+
+        $existing = [
+            '_meta' => ['tolerance_degrees' => 0.05],
+            'fixtures' => [
+                [
+                    'id' => 'sample',
+                    'decimal_year' => 2025.0,
+                    'altitude_km' => 28.0,
+                    'lat' => 89.0,
+                    'lon' => -121.0,
+                    'declination' => 0.0,
+                    'inclination' => 0.0,
+                ],
+            ],
+        ];
+
+        $result = \WmmNoaaSync::refreshGoldenFixtures($testValues, $existing);
+        $this->assertSame([], $result['missing']);
+        $this->assertSame(-99.77, $result['fixtures'][0]['declination']);
+        $this->assertSame(88.47, $result['fixtures'][0]['inclination']);
+    }
+
+    public function testExtractZipContents_ReadsBundledNoaaZip(): void
+    {
+        if (!class_exists(\ZipArchive::class)) {
+            $this->markTestSkipped('ZipArchive extension not available');
+        }
+
+        $zipPath = sys_get_temp_dir() . '/wmm-test-' . uniqid('', true) . '.zip';
+        $zip = new \ZipArchive();
+        $this->assertTrue($zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE) === true);
+        $zip->addFromString('WMM2025COF/WMM.COF', self::SAMPLE_COF_HEADER);
+        $zip->addFromString('WMM2025COF/WMM2025_TestValues.txt', "# header\n");
+        $zip->close();
+
+        try {
+            $extracted = \WmmNoaaSync::extractZipContents($zipPath);
+            $this->assertSame(self::SAMPLE_COF_HEADER, $extracted['cof']);
+            $this->assertSame('WMM2025COF/WMM.COF', $extracted['cof_entry']);
+        } finally {
+            @unlink($zipPath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `WmmNoaaSync` helper to discover NOAA WMM*COF.zip links, download/extract archives, and compare header fields + SHA-256 to `data/wmm/manifest.json`.
- Add `scripts/verify-wmm-coefficients.php` (weekly CI + `make verify-wmm-coefficients`) and `scripts/update-wmm-coefficients.php` (maintainer refresh with `--dry-run`).
- Weekly GitHub Actions workflow runs verify-only every Wednesday; fails clearly when NOAA coefficients drift from vendored data.

Closes #155

## Test plan
- [x] `make test-ci`
- [x] `php scripts/verify-wmm-coefficients.php` (passes against current WMM2025)
- [x] `php scripts/update-wmm-coefficients.php --dry-run` (30 fixtures matched)
- [x] Weekly workflow passes on merge (or run via workflow_dispatch)