### PR TITLE
Wind-forward embed card layout

### DIFF
--- a/lib/embed-templates/card.php
+++ b/lib/embed-templates/card.php
@@ -290,8 +290,11 @@ function renderCardWidget($data, $options) {
         }
     }
 
-    // Compact summary line (shown when stacked, where the facts rail is below the fold)
-    if ($windSpeed === null || $windSpeed < 3) {
+    // Compact summary line (shown when stacked, where the facts rail is below the fold).
+    // Wind fields fail closed to null when stale: show '---' (unavailable), not 'Calm'.
+    if ($windSpeed === null) {
+        $windSummary = '---';
+    } elseif ($windSpeed < 3) {
         $windSummary = 'Calm';
     } else {
         $dirPart = $isVRB ? 'VRB' : (is_numeric($windDirection) ? round($windDirection) . '°' : '---');

--- a/lib/embed-templates/card.php
+++ b/lib/embed-templates/card.php
@@ -331,6 +331,11 @@ function renderCardWidget($data, $options) {
         ? '<span><span class="lg-petal">&#9646;</span> last hr</span>'
         : '';
 
+    // Escape dynamic text before interpolating it into the HTML below
+    $windSummary = htmlspecialchars($windSummary);
+    $peakTimeValue = htmlspecialchars($peakTimeValue);
+    $trueNorthLabel = htmlspecialchars($trueNorthLabel);
+
     // Build HTML - wrap entire card in link to dashboard
     $html = '<a href="' . htmlspecialchars($dashboardUrl) . '" class="embed-dashboard-link"' . $linkAttrs . '>';
     $html .= '<div class="style-card style-card-wf"><div class="wf-header">';

--- a/lib/embed-templates/card.php
+++ b/lib/embed-templates/card.php
@@ -267,7 +267,6 @@ function renderCardWidget($data, $options) {
 
     // Wind-forward layout values (compass is the hero; surrounding data is compact)
     $weather = $data['weather'];
-    $windUnit = $options['windUnit'];
     $windUnitLabel = $windUnit === 'kmh' ? 'km/h' : $windUnit;
 
     // Gust factor and today's peak gust (with time) for the wind facts rail

--- a/lib/embed-templates/card.php
+++ b/lib/embed-templates/card.php
@@ -303,7 +303,8 @@ function renderCardWidget($data, $options) {
 
     // Legend metadata (matches the compass: True North marker, wind arrow, runways, petals)
     $magDecl = $fullModeOptions['magneticDeclination'] ?? 0;
-    $magVarLabel = ($magDecl != 0) ? (abs(round($magDecl)) . '°' . ($magDecl > 0 ? 'E' : 'W')) : '';
+    $magDeclRounded = (int) round($magDecl);
+    $magVarLabel = ($magDeclRounded !== 0) ? (abs($magDeclRounded) . '°' . ($magDeclRounded > 0 ? 'E' : 'W')) : '';
     $trueNorthLabel = 'True N' . ($magVarLabel !== '' ? ' (' . $magVarLabel . ')' : '');
     $lastHourWind = $fullModeOptions['lastHourWind'] ?? null;
     $hasActivePetals = is_array($lastHourWind) && count($lastHourWind) === 16

--- a/lib/embed-templates/card.php
+++ b/lib/embed-templates/card.php
@@ -84,8 +84,15 @@ function processCardWidgetData($data, $options) {
     if ($pressureDisplay === '--') $pressureDisplay = '---';
     $windTextDisplay = formatEmbedWind($windDirection, $windSpeed, $gustSpeed, $windUnit);
     
-    // Wind speed value
-    $windSpeedValue = ($windSpeed !== null && $windSpeed >= 3) ? formatEmbedWindSpeed($windSpeed, $windUnit) : 'Calm';
+    // Wind speed value. Wind fields fail closed to null when stale: show '---'
+    // (unavailable), not 'Calm', so missing data is never read as calm winds.
+    if ($windSpeed === null) {
+        $windSpeedValue = '---';
+    } elseif ($windSpeed >= 3) {
+        $windSpeedValue = formatEmbedWindSpeed($windSpeed, $windUnit);
+    } else {
+        $windSpeedValue = 'Calm';
+    }
     
     // Wind direction value (use wind_direction_magnetic; fail closed with ---)
     $windDirValue = '---';

--- a/lib/embed-templates/card.php
+++ b/lib/embed-templates/card.php
@@ -284,7 +284,9 @@ function renderCardWidget($data, $options) {
             $dt->setTimezone($tz);
             $peakTimeValue = $dt->format('g:ia');
         } catch (Exception $e) {
-            $peakTimeValue = date('g:ia', $peakGustTime);
+            // Invalid airport timezone (config error): leave as '--' rather than
+            // rendering in the server timezone, which would vary by environment.
+            $peakTimeValue = '--';
         }
     }
 

--- a/lib/embed-templates/card.php
+++ b/lib/embed-templates/card.php
@@ -265,116 +265,124 @@ function renderCardWidget($data, $options) {
     $sourceAttribution = ' & ' . htmlspecialchars($dataSource);
     $canvasId = 'card-wind-canvas-' . uniqid();
 
-    // Build HTML - wrap entire card in link to dashboard
-    $html = '<a href="' . htmlspecialchars($dashboardUrl) . '" class="embed-dashboard-link"' . $linkAttrs . '>';
-    $html .= '<div class="style-card"><div class="card-header-v2">';
-    appendEmbedAirportTitleMarkup($html, $formalIdentifier, $processed['airportName']);
-    
-    // Flight category badge with emojis (using processed data)
-    // Always show badge if we have METAR data or emojis
+    // Wind-forward layout values (compass is the hero; surrounding data is compact)
+    $weather = $data['weather'];
+    $windUnit = $options['windUnit'];
+    $windUnitLabel = $windUnit === 'kmh' ? 'km/h' : $windUnit;
+
+    // Gust factor and today's peak gust (with time) for the wind facts rail
+    $gustFactorKt = $weather['gust_factor'] ?? null;
+    $gustFactorValue = ($gustFactorKt !== null && $gustFactorKt > 0) ? formatEmbedWindSpeed($gustFactorKt, $windUnit) : '--';
+
+    $peakGustKt = $weather['peak_gust_today'] ?? null;
+    $peakGustValue = ($peakGustKt !== null && $peakGustKt > 0) ? formatEmbedWindSpeed($peakGustKt, $windUnit) : '--';
+    $peakGustTime = $weather['peak_gust_time'] ?? null;
+    $peakTimeValue = '--';
+    if ($peakGustTime !== null && $peakGustKt !== null && $peakGustKt > 0) {
+        try {
+            $tz = new DateTimeZone($timezone);
+            $dt = new DateTime('@' . $peakGustTime);
+            $dt->setTimezone($tz);
+            $peakTimeValue = $dt->format('g:ia');
+        } catch (Exception $e) {
+            $peakTimeValue = date('g:ia', $peakGustTime);
+        }
+    }
+
+    // Compact summary line (shown when stacked, where the facts rail is below the fold)
+    if ($windSpeed === null || $windSpeed < 3) {
+        $windSummary = 'Calm';
+    } else {
+        $dirPart = $isVRB ? 'VRB' : (is_numeric($windDirection) ? round($windDirection) . '°' : '---');
+        $spdConv = $windUnit === 'mph' ? knotsToMph($windSpeed) : ($windUnit === 'kmh' ? knotsToKmh($windSpeed) : $windSpeed);
+        $gustSpeedKt = $processed['gustSpeed'] ?? null;
+        $gustPart = ($gustSpeedKt !== null && $gustSpeedKt > 0)
+            ? ' G' . round($windUnit === 'mph' ? knotsToMph($gustSpeedKt) : ($windUnit === 'kmh' ? knotsToKmh($gustSpeedKt) : $gustSpeedKt))
+            : '';
+        $windSummary = $dirPart . '@' . round($spdConv) . $gustPart . ' ' . $windUnitLabel;
+    }
+
+    // Legend metadata (matches the compass: True North marker, wind arrow, runways, petals)
+    $magDecl = $fullModeOptions['magneticDeclination'] ?? 0;
+    $magVarLabel = ($magDecl != 0) ? (abs(round($magDecl)) . '°' . ($magDecl > 0 ? 'E' : 'W')) : '';
+    $trueNorthLabel = 'True N' . ($magVarLabel !== '' ? ' (' . $magVarLabel . ')' : '');
+    $lastHourWind = $fullModeOptions['lastHourWind'] ?? null;
+    $hasActivePetals = is_array($lastHourWind) && count($lastHourWind) === 16
+        && count(array_filter($lastHourWind, function ($s) { return $s > 0; })) > 0;
+
+    // Direction value + magnetic sub-label when numeric
+    $magSub = ($windDirValue !== '---' && $windDirValue !== 'Variable') ? ' <span class="sub">Mag</span>' : '';
+
+    // Header: airport title + flight category / conditions badge
+    $headerBadge = '';
     if ($hasMetarData && $flightCategory) {
         $fcClass = $flightCategoryData['class'];
         $fcText = htmlspecialchars($flightCategoryData['text']);
         $emojiDisplay = $weatherEmojis ? ' ' . htmlspecialchars($weatherEmojis) : '';
-        $html .= "\n        <span class=\"flight-category-badge {$fcClass}\">{$fcText}{$emojiDisplay}</span>";
+        $headerBadge = "<span class=\"flight-category-badge {$fcClass}\">{$fcText}{$emojiDisplay}</span>";
     } else if ($hasMetarData && !$flightCategory) {
-        // METAR data but couldn't calculate category - show with emojis
         $emojiDisplay = $weatherEmojis ? ' ' . htmlspecialchars($weatherEmojis) : '';
-        $html .= "\n        <span class=\"flight-category-badge no-category\">METAR{$emojiDisplay}</span>";
+        $headerBadge = "<span class=\"flight-category-badge no-category\">METAR{$emojiDisplay}</span>";
     } else if (!$hasMetarData && $weatherEmojis) {
-        // For PWS sites, show emojis even without flight category
-        $html .= "\n        <span class=\"flight-category-badge no-category\">" . htmlspecialchars($weatherEmojis) . "</span>";
+        $headerBadge = "<span class=\"flight-category-badge no-category\">" . htmlspecialchars($weatherEmojis) . "</span>";
     }
-    
-    $html .= <<<HTML
 
-    </div>
-    
-    <div class="card-compass-section">
-        <div class="compass-side">
-            <canvas id="{$canvasId}" width="180" height="180"></canvas>
+    // Petal legend item only when there is recent wind-rose data
+    $petalLegend = $hasActivePetals
+        ? '<span><span class="lg-petal">&#9646;</span> last hr</span>'
+        : '';
+
+    // Build HTML - wrap entire card in link to dashboard
+    $html = '<a href="' . htmlspecialchars($dashboardUrl) . '" class="embed-dashboard-link"' . $linkAttrs . '>';
+    $html .= '<div class="style-card style-card-wf"><div class="wf-header">';
+    appendEmbedAirportTitleMarkup($html, $formalIdentifier, $processed['airportName']);
+    $html .= $headerBadge;
+    $html .= <<<HTML
+</div>
+    <div class="wf-body"><div class="wf-inner">
+        <div class="wf-compass">
+            <canvas id="{$canvasId}" width="300" height="300"></canvas>
+            <div class="wf-summary">{$windSummary}</div>
         </div>
-        <div class="wind-details-side">
-HTML;
-    
-    // Wind Speed row (using processed value)
-    $html .= <<<HTML
-
-            <div class="wind-detail-row">
-                <span class="wind-label">Wind Speed:</span>
-                <span class="wind-value">{$windSpeedValue}</span>
+        <div class="wf-side">
+            <div class="wf-wind">
+                <div class="col-h">Wind</div>
+                <div class="wf-row"><span class="k">Direction</span><span class="v">{$windDirValue}{$magSub}</span></div>
+                <div class="wf-row"><span class="k">Speed</span><span class="v">{$windSpeedValue}</span></div>
+                <div class="wf-row"><span class="k">Gusting</span><span class="v">{$gustValue}</span></div>
+                <div class="wf-row detail-extra"><span class="k">Gust Factor</span><span class="v">{$gustFactorValue}</span></div>
+                <div class="wf-row peak detail-extra"><span class="k">Peak Gust</span><span class="v">{$peakGustValue} <span class="sub">{$peakTimeValue}</span></span></div>
+                <div class="wf-legend detail-extra">
+                    <span><span class="lg-true">&#9733;</span> {$trueNorthLabel}</span>
+                    <span><span class="lg-wind">&#8594;</span> wind</span>
+                    <span><span class="lg-rwy">&#9644;</span> runways</span>
+                    {$petalLegend}
+                </div>
             </div>
-HTML;
-    
-    // Wind Direction row (using processed value)
-    $html .= <<<HTML
-
-            <div class="wind-detail-row">
-                <span class="wind-label">Wind Direction:</span>
-                <span class="wind-value">{$windDirValue}</span>
-            </div>
-HTML;
-    
-    // Gusting row (using processed value)
-    $html .= <<<HTML
-
-            <div class="wind-detail-row">
-                <span class="wind-label">Gusting:</span>
-                <span class="wind-value">{$gustValue}</span>
-            </div>
-HTML;
-    
-    $html .= <<<HTML
-
-        </div>
-    </div>
-    
-    <div class="card-metrics">
-        <div class="metric-row">
-            <div class="metric">
-                <span class="metric-label">Temp</span>
-                <span class="metric-value">{$tempDisplay}</span>
-            </div>
-            <div class="metric">
-                <span class="metric-label">Dewpt</span>
-                <span class="metric-value">{$dewpointDisplay}</span>
+            <div class="wf-metrics">
+                <div class="col-h">Conditions</div>
+                <div class="wf-tiles">
+                    <div class="tile"><span class="tl">Temp</span><span class="tv">{$tempDisplay}</span></div>
+                    <div class="tile"><span class="tl">Dewpt</span><span class="tv">{$dewpointDisplay}</span></div>
+                    <div class="tile"><span class="tl">DA</span><span class="tv">{$densityAltitudeDisplay}</span></div>
+                    <div class="tile"><span class="tl">{$secondMetricLabel}</span><span class="tv">{$secondMetricValue}</span></div>
+                    <div class="tile"><span class="tl">Press</span><span class="tv">{$pressureDisplay}</span></div>
+                    <div class="tile"><span class="tl">Vis</span><span class="tv">{$visDisplay}</span></div>
+                </div>
             </div>
         </div>
-        <div class="metric-row">
-            <div class="metric">
-                <span class="metric-label">DA</span>
-                <span class="metric-value">{$densityAltitudeDisplay}</span>
-            </div>
-            <div class="metric">
-                <span class="metric-label">{$secondMetricLabel}</span>
-                <span class="metric-value">{$secondMetricValue}</span>
-            </div>
-        </div>
-        <div class="metric-row">
-            <div class="metric">
-                <span class="metric-label">Press</span>
-                <span class="metric-value">{$pressureDisplay}</span>
-            </div>
-            <div class="metric">
-                <span class="metric-label">Vis</span>
-                <span class="metric-value">{$visDisplay}</span>
-            </div>
-        </div>
+    </div></div>
+
 HTML;
-    
-    // Removed humidity row to limit to maximum 6 cards
-    // Cards: Temp, Dewpt, DA, Ceiling/Spread, Press, Vis (6 total)
-    
-    $html .= "\n    </div>\n";
-    
+
     // Add footer
     $html .= renderEmbedFooter($lastUpdated, $timezone, $sourceAttribution);
-    
+
     $html .= "\n</div>\n";
     $html .= '</a>';
 
-    // Add wind compass script (full mode: runway segments, petals, staleness, matching dashboard)
-    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 180, $fullModeOptions);
+    // Compass hero: draw at 300 (matches the dashboard) and let CSS scale it responsively
+    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 300, $fullModeOptions);
 
     return $html;
 }

--- a/lib/embed-templates/card.php
+++ b/lib/embed-templates/card.php
@@ -304,13 +304,16 @@ function renderCardWidget($data, $options) {
     } elseif ($windSpeed < 3) {
         $windSummary = 'Calm';
     } else {
-        $dirPart = $isVRB ? 'VRB' : (is_numeric($windDirection) ? round($windDirection) . '°' : '---');
-        $spdConv = $windUnit === 'mph' ? knotsToMph($windSpeed) : ($windUnit === 'kmh' ? knotsToKmh($windSpeed) : $windSpeed);
+        // METAR-style wind group, no degree glyph: 3-digit direction + speed +
+        // optional gust + unit (e.g. 23015G20KT, VRB05KT). Direction is magnetic,
+        // consistent with the rest of the card.
+        $spd = round($windUnit === 'mph' ? knotsToMph($windSpeed) : ($windUnit === 'kmh' ? knotsToKmh($windSpeed) : $windSpeed));
         $gustSpeedKt = $processed['gustSpeed'] ?? null;
         $gustPart = ($gustSpeedKt !== null && $gustSpeedKt > 0)
-            ? ' G' . round($windUnit === 'mph' ? knotsToMph($gustSpeedKt) : ($windUnit === 'kmh' ? knotsToKmh($gustSpeedKt) : $gustSpeedKt))
+            ? 'G' . sprintf('%02d', round($windUnit === 'mph' ? knotsToMph($gustSpeedKt) : ($windUnit === 'kmh' ? knotsToKmh($gustSpeedKt) : $gustSpeedKt)))
             : '';
-        $windSummary = $dirPart . '@' . round($spdConv) . $gustPart . ' ' . $windUnitLabel;
+        $dirPart = $isVRB ? 'VRB' : (is_numeric($windDirection) ? sprintf('%03d', round($windDirection)) : '---');
+        $windSummary = $dirPart . sprintf('%02d', $spd) . $gustPart . strtoupper($windUnitLabel);
     }
 
     // Legend metadata (matches the compass: True North marker, wind arrow, runways, petals)

--- a/lib/embed-templates/card.php
+++ b/lib/embed-templates/card.php
@@ -271,12 +271,12 @@ function renderCardWidget($data, $options) {
 
     // Gust factor and today's peak gust (with time) for the wind facts rail
     $gustFactorKt = $weather['gust_factor'] ?? null;
-    $gustFactorValue = ($gustFactorKt !== null && $gustFactorKt > 0) ? formatEmbedWindSpeed($gustFactorKt, $windUnit) : '--';
+    $gustFactorValue = ($gustFactorKt !== null && $gustFactorKt > 0) ? formatEmbedWindSpeed($gustFactorKt, $windUnit) : '---';
 
     $peakGustKt = $weather['peak_gust_today'] ?? null;
-    $peakGustValue = ($peakGustKt !== null && $peakGustKt > 0) ? formatEmbedWindSpeed($peakGustKt, $windUnit) : '--';
+    $peakGustValue = ($peakGustKt !== null && $peakGustKt > 0) ? formatEmbedWindSpeed($peakGustKt, $windUnit) : '---';
     $peakGustTime = $weather['peak_gust_time'] ?? null;
-    $peakTimeValue = '--';
+    $peakTimeValue = '---';
     if ($peakGustTime !== null && $peakGustKt !== null && $peakGustKt > 0) {
         try {
             $tz = new DateTimeZone($timezone);
@@ -284,9 +284,9 @@ function renderCardWidget($data, $options) {
             $dt->setTimezone($tz);
             $peakTimeValue = $dt->format('g:ia');
         } catch (Exception $e) {
-            // Invalid airport timezone (config error): leave as '--' rather than
+            // Invalid airport timezone (config error): leave as '---' rather than
             // rendering in the server timezone, which would vary by environment.
-            $peakTimeValue = '--';
+            $peakTimeValue = '---';
         }
     }
 

--- a/pages/embed.php
+++ b/pages/embed.php
@@ -8,6 +8,7 @@
 
 require_once __DIR__ . '/../lib/config.php';
 require_once __DIR__ . '/../lib/seo.php';
+require_once __DIR__ . '/../lib/version.php';
 require_once __DIR__ . '/../lib/weather/utils.php';
 require_once __DIR__ . '/../lib/cache-paths.php';
 require_once __DIR__ . '/../lib/webcam-metadata.php';
@@ -132,6 +133,9 @@ $options = [
 $embedPageTitle = formatAirportNameWithIdentifier($airport['name'] ?? 'Unknown Airport', $airport)
     . ' Weather Widget';
 
+// Cache-bust embed CSS/JS on deploy so widget updates reach embedded pages promptly
+$embedAssetVersion = getBuildVersionInfo()['hash_short'] ?? '';
+
 // Determine theme class
 // For auto mode, we'll let JavaScript handle it, but set initial class
 $themeClass = getThemeClass($theme);
@@ -182,9 +186,9 @@ switch ($style) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="noindex, nofollow">
     <title><?= htmlspecialchars($embedPageTitle) ?></title>
-    <link rel="stylesheet" href="/public/css/embed-widgets.css">
-    <script src="/public/js/runway-label-layout.js"></script>
-    <script src="/public/js/wind-visual.js"></script>
+    <link rel="stylesheet" href="/public/css/embed-widgets.css?v=<?= htmlspecialchars($embedAssetVersion) ?>">
+    <script src="/public/js/runway-label-layout.js?v=<?= htmlspecialchars($embedAssetVersion) ?>"></script>
+    <script src="/public/js/wind-visual.js?v=<?= htmlspecialchars($embedAssetVersion) ?>"></script>
     <style>
         /* Ensure full viewport usage for iframe */
         html, body {

--- a/public/css/embed-widgets.css
+++ b/public/css/embed-widgets.css
@@ -738,6 +738,222 @@ a {
 }
 
 /* ============================================
+   WIND-FORWARD CARD
+   Compass is the hero; surrounding weather data is compact.
+   Concept 2 (wide split) >= 480cqi, reflowing to Concept 3 (stacked) below.
+   ============================================ */
+
+.style-card-wf {
+    min-height: 0;
+    height: auto;
+    display: flex;
+    flex-direction: column;
+    cursor: pointer;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+/* Header */
+.style-card-wf .wf-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--card-bg);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.style-card-wf .airport-title {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.style-card-wf .airport-title .identifier {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--accent-color);
+    letter-spacing: 0.5px;
+}
+
+.style-card-wf .airport-title .name {
+    font-size: 0.7rem;
+    color: var(--muted-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Body is the reflow container */
+.style-card-wf .wf-body {
+    container-type: inline-size;
+    flex: 1;
+}
+
+.style-card-wf .wf-inner {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Compass hero: draws at 300, scales down responsively */
+.style-card-wf .wf-compass {
+    width: 100%;
+    background: var(--wind-compass-bg);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 0.6rem;
+    gap: 0.25rem;
+}
+
+.style-card-wf .wf-compass canvas {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-width: 300px;
+}
+
+.style-card-wf .wf-summary {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--text-color);
+}
+
+/* Side rail */
+.style-card-wf .wf-side {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Wind facts */
+.style-card-wf .wf-wind {
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.style-card-wf .col-h {
+    font-size: 0.66rem;
+    font-weight: 700;
+    color: var(--accent-color);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 0.25rem;
+}
+
+.style-card-wf .wf-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 0.12rem 0;
+    font-size: 0.8rem;
+}
+
+.style-card-wf .wf-row .k { color: var(--muted-color); }
+.style-card-wf .wf-row .v { font-weight: 700; color: var(--text-color); }
+.style-card-wf .wf-row .sub { font-size: 0.62rem; color: var(--muted-color); font-weight: 400; }
+.style-card-wf .wf-row.peak .v { color: #ff9500; }
+
+.style-card-wf .wf-legend {
+    margin-top: 0.4rem;
+    font-size: 0.6rem;
+    color: var(--muted-color);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.style-card-wf .wf-legend span { white-space: nowrap; }
+
+/* Legend markers match the compass palette per theme */
+.style-card-wf .lg-wind,
+.style-card-wf .lg-petal { color: #dc3545; }
+.style-card-wf .lg-true { color: #4a7; }
+.style-card-wf .lg-rwy { color: #0066cc; }
+.theme-dark .style-card-wf .lg-true { color: #6b9; }
+.theme-dark .style-card-wf .lg-rwy { color: #4a9eff; }
+
+@media (prefers-color-scheme: dark) {
+    .theme-auto .style-card-wf .lg-true { color: #6b9; }
+    .theme-auto .style-card-wf .lg-rwy { color: #4a9eff; }
+}
+
+/* Metrics - tight tiles by default */
+.style-card-wf .wf-metrics {
+    padding: 0.5rem 0.75rem;
+}
+
+.style-card-wf .wf-tiles {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.4rem;
+}
+
+.style-card-wf .tile {
+    background: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    padding: 0.3rem 0.5rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.style-card-wf .tile .tl {
+    font-size: 0.58rem;
+    color: var(--muted-color);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.style-card-wf .tile .tv {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--text-color);
+}
+
+/* Wide split: compass left hero, compact rail right */
+@container (min-width: 480px) {
+    .style-card-wf .wf-inner {
+        flex-direction: row;
+        align-items: stretch;
+    }
+    .style-card-wf .wf-compass {
+        flex: 0 0 55%;
+        border-right: 1px solid var(--border-color);
+    }
+    .style-card-wf .wf-side {
+        flex: 1;
+        min-width: 0;
+    }
+    /* The facts rail covers the same data in wide mode */
+    .style-card-wf .wf-summary { display: none; }
+}
+
+/* Very small: dense key:value rows, hide secondary wind rows (keep the summary line) */
+@container (max-width: 360px) {
+    .style-card-wf .wf-tiles {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+    }
+    .style-card-wf .tile {
+        background: transparent;
+        border: none;
+        border-bottom: 1px solid var(--border-color);
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: baseline;
+        padding: 0.18rem 0;
+        border-radius: 0;
+    }
+    .style-card-wf .tile:last-child { border-bottom: none; }
+    .style-card-wf .wf-wind .detail-extra { display: none; }
+}
+
+/* ============================================
    WEBCAM STYLE (450x450)
    ============================================ */
 

--- a/public/css/embed-widgets.css
+++ b/public/css/embed-widgets.css
@@ -740,7 +740,7 @@ a {
 /* ============================================
    WIND-FORWARD CARD
    Compass is the hero; surrounding weather data is compact.
-   Concept 2 (wide split) >= 480cqi, reflowing to Concept 3 (stacked) below.
+   Concept 2 (wide split) at container width >= 480px, reflowing to Concept 3 (stacked) below.
    ============================================ */
 
 .style-card-wf {


### PR DESCRIPTION
## Description

Redesign the embed **card** so the runway wind compass is the hero and the surrounding weather data is compact - the approved wind-forward design. Scope is the card's weather-data regions; webcam-dominant styles are untouched.

- **Compass hero**: draws at 300 (same renderer/size as the dashboard) and scales down responsively (`max-width: 300px`), so it stays legible.
- **Responsive reflow** via a container query on the card body: a **wide split** (compass left ~55%, compact rail right) at `>= 480px` that reflows to a **stacked compass-hero** below.
- **Wind facts (dashboard parity)**: Direction + "Magnetic", Speed, Gusting, **Gust Factor**, **Today's Peak Gust + time**, plus a themed **legend** (True N + declination, current wind, runways, wind rose petal).
- **Automatic metric density**: tight tiles when there's room; collapse to dense key:value rows at very small widths, where the secondary wind rows hide and a compact summary line under the compass carries the wind.
- **Embed asset cache-busting**: version `embed-widgets.css` / `wind-visual.js` / `runway-label-layout.js` on the embed page with the build hash (as the dashboard already does), so deployed embed style/script changes reach embeds promptly.

The compass renderer is unchanged (used as-is at hero size); this is layout + template work on top of the shared `wind-visual.js`.

## Type

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [x] Other

## Testing

- `make test-ci` passes (0 errors).
- Verified locally across widths and themes:
  - **Wide split (620px, light)**: compass hero left, full wind-facts rail + legend + 6 condition tiles right.
  - **Stacked very-small (340px, dark)**: compass + summary line on top, condensed wind facts, metrics as dense rows; dark palette correct.
  - Reflow at the 480px breakpoint and density switch at the very-small breakpoint behave as designed.

## Checklist

- [x] Tests pass
- [x] Documentation updated (if needed) - n/a
- [x] No sensitive data (API keys, passwords, credentials)
- [x] Code follows [CODE_STYLE.md](CODE_STYLE.md)

## Notes / follow-up

- The old card inner CSS (`card-compass-section`, `card-metrics`, etc.) is now orphaned by the new `wf-*` structure (the shared `.style-card` base + flight-category badge + footer rules are still used via the dual class). A focused follow-up will remove the orphaned rules to keep this PR's diff reviewable.

## Related Issues

Builds on the shared `wind-visual.js` module (#161, #162).