### PR TITLE
Extract shared wind section for full-* embeds

### DIFF
--- a/lib/embed-templates/full.php
+++ b/lib/embed-templates/full.php
@@ -225,7 +225,7 @@ function buildFullWidgetMetrics($weather, $options, $hasMetarData) {
  * @param string $timezone Airport timezone for the peak gust time
  * @return string Wind section HTML
  */
-function buildFullWindSection(string $canvasId, string $windDir, $windSpd, string $gustVal, string $windUnitLabel, ?float $windSpeed, string $windUnit, ?float $gustSpeed, ?float $peakGustToday, ?int $peakGustTime, string $timezone): string {
+function buildFullWindSection(string $canvasId, string $windDir, float|string $windSpd, string $gustVal, string $windUnitLabel, ?float $windSpeed, string $windUnit, ?float $gustSpeed, ?float $peakGustToday, ?int $peakGustTime, string $timezone): string {
     $html = <<<HTML
             <div class="wind-section">
                 <div class="wind-viz-container">

--- a/lib/embed-templates/full.php
+++ b/lib/embed-templates/full.php
@@ -207,6 +207,98 @@ function buildFullWidgetMetrics($weather, $options, $hasMetarData) {
 }
 
 /**
+ * Build the shared wind section (compass + wind details) for full-* widgets.
+ *
+ * Shared by full-single, full-dual, and full-multi so the wind compass and
+ * facts render identically across them.
+ *
+ * @param string $canvasId Canvas element id for the compass
+ * @param string $windDir Formatted wind direction (e.g. "180°", "VRB", "---")
+ * @param string $windSpd Formatted wind speed value for the summary line
+ * @param string $gustVal Formatted gust value for the summary line (e.g. "G12" or "")
+ * @param string $windUnitLabel Wind speed unit label (e.g. "kt")
+ * @param float|null $windSpeed Wind speed in knots (for the Speed row)
+ * @param string $windUnit Wind speed unit code (kt/mph/kmh)
+ * @param float|null $gustSpeed Gust speed in knots
+ * @param float|null $peakGustToday Today's peak gust in knots
+ * @param int|null $peakGustTime Peak gust observation time (Unix seconds)
+ * @param string $timezone Airport timezone for the peak gust time
+ * @return string Wind section HTML
+ */
+function buildFullWindSection(string $canvasId, string $windDir, $windSpd, string $gustVal, string $windUnitLabel, $windSpeed, string $windUnit, $gustSpeed, $peakGustToday, $peakGustTime, string $timezone): string {
+    $html = <<<HTML
+            <div class="wind-section">
+                <div class="wind-viz-container">
+                    <canvas id="{$canvasId}" width="200" height="200"></canvas>
+                    <div class="wind-summary">
+                        <span class="wind-value">{$windDir}@{$windSpd}{$gustVal}{$windUnitLabel}</span>
+                    </div>
+                </div>
+                <div class="wind-details">
+                    <div class="column-header">💨 Wind</div>
+                    <div class="metric-item">
+                        <span class="label">Direction</span>
+                        <span class="value">{$windDir}</span>
+                    </div>
+                    <div class="metric-item">
+                        <span class="label">Speed</span>
+                        <span class="value">
+HTML;
+    $html .= formatEmbedWindSpeed($windSpeed, $windUnit);
+    $html .= <<<HTML
+</span>
+                    </div>
+                    <div class="metric-item">
+                        <span class="label">Gusting</span>
+                        <span class="value">
+HTML;
+    if ($gustSpeed !== null && $gustSpeed > 0) {
+        $html .= formatEmbedWindSpeed($gustSpeed, $windUnit);
+    } else {
+        $html .= '--';
+    }
+    $html .= <<<HTML
+</span>
+                    </div>
+                    <div class="metric-item peak-item">
+                        <span class="label">Peak Gust</span>
+                        <span class="value">
+HTML;
+    if ($peakGustToday !== null && $peakGustToday > 0) {
+        $html .= formatEmbedWindSpeed($peakGustToday, $windUnit);
+    } else {
+        $html .= '--';
+    }
+    $html .= <<<HTML
+</span>
+                    </div>
+                    <div class="metric-item peak-time-item">
+                        <span class="label">@ Time</span>
+                        <span class="value">
+HTML;
+    if ($peakGustTime !== null && $peakGustToday !== null && $peakGustToday > 0) {
+        try {
+            $tz = new DateTimeZone($timezone);
+            $dt = new DateTime('@' . $peakGustTime);
+            $dt->setTimezone($tz);
+            $peakTimeDisplay = $dt->format('g:ia');
+        } catch (Exception $e) {
+            $peakTimeDisplay = date('g:ia', $peakGustTime);
+        }
+        $html .= htmlspecialchars($peakTimeDisplay);
+    } else {
+        $html .= '--';
+    }
+    $html .= <<<HTML
+</span>
+                    </div>
+                </div>
+            </div>
+HTML;
+    return $html;
+}
+
+/**
  * Render full-single style widget (single webcam with detailed weather)
  * 
  * @param array $data Widget data
@@ -337,77 +429,8 @@ function renderFullSingleWidget($data, $options) {
     $html .= '</div></a>';
     $html .= '<a href="' . htmlspecialchars($dashboardUrl) . '" class="embed-dashboard-link"' . $linkAttrs . '>';
     $html .= '<div class="data-row">';
+    $html .= buildFullWindSection($canvasId, $windDir, $windSpd, $gustVal, $windUnitLabel, $windSpeed, $windUnit, $gustSpeed, $peakGustToday, $peakGustTime, $timezone);
     $html .= <<<HTML
-            <div class="wind-section">
-                <div class="wind-viz-container">
-                    <canvas id="{$canvasId}" width="200" height="200"></canvas>
-                    <div class="wind-summary">
-                        <span class="wind-value">{$windDir}@{$windSpd}{$gustVal}{$windUnitLabel}</span>
-                    </div>
-                </div>
-                <div class="wind-details">
-                    <div class="column-header">💨 Wind</div>
-                    <div class="metric-item">
-                        <span class="label">Direction</span>
-                        <span class="value">{$windDir}</span>
-                    </div>
-                    <div class="metric-item">
-                        <span class="label">Speed</span>
-                        <span class="value">
-HTML;
-    $html .= formatEmbedWindSpeed($windSpeed, $windUnit);
-    $html .= <<<HTML
-</span>
-                    </div>
-                    <div class="metric-item">
-                        <span class="label">Gusting</span>
-                        <span class="value">
-HTML;
-    // Always show Gusting field
-    if ($gustSpeed !== null && $gustSpeed > 0) {
-        $html .= formatEmbedWindSpeed($gustSpeed, $windUnit);
-    } else {
-        $html .= '--';
-    }
-    $html .= <<<HTML
-</span>
-                    </div>
-                    <div class="metric-item peak-item">
-                        <span class="label">Peak Gust</span>
-                        <span class="value">
-HTML;
-    // Always show Peak Gust field
-    if ($peakGustToday !== null && $peakGustToday > 0) {
-        $html .= formatEmbedWindSpeed($peakGustToday, $windUnit);
-    } else {
-        $html .= '--';
-    }
-    $html .= <<<HTML
-</span>
-                    </div>
-                    <div class="metric-item peak-time-item">
-                        <span class="label">@ Time</span>
-                        <span class="value">
-HTML;
-    // Always show @ Time field
-    if ($peakGustTime !== null && $peakGustToday !== null && $peakGustToday > 0) {
-        try {
-            $tz = new DateTimeZone($timezone);
-            $dt = new DateTime('@' . $peakGustTime);
-            $dt->setTimezone($tz);
-            $peakTimeDisplay = $dt->format('g:ia');
-        } catch (Exception $e) {
-            $peakTimeDisplay = date('g:ia', $peakGustTime);
-        }
-        $html .= htmlspecialchars($peakTimeDisplay);
-    } else {
-        $html .= '--';
-    }
-    $html .= <<<HTML
-</span>
-                    </div>
-                </div>
-            </div>
             <div class="metrics-section">
 HTML;
     $html .= buildFullWidgetMetrics($weather, $options, $hasMetarData);
@@ -579,77 +602,8 @@ function renderFullDualWidget($data, $options) {
     $html .= '</div></div>';
     $html .= '<a href="' . htmlspecialchars($dashboardUrl) . '" class="embed-dashboard-link"' . $linkAttrs . '>';
     $html .= '<div class="data-row">';
+    $html .= buildFullWindSection($canvasId, $windDir, $windSpd, $gustVal, $windUnitLabel, $windSpeed, $windUnit, $gustSpeed, $peakGustToday, $peakGustTime, $timezone);
     $html .= <<<HTML
-            <div class="wind-section">
-                <div class="wind-viz-container">
-                    <canvas id="{$canvasId}" width="200" height="200"></canvas>
-                    <div class="wind-summary">
-                        <span class="wind-value">{$windDir}@{$windSpd}{$gustVal}{$windUnitLabel}</span>
-                    </div>
-                </div>
-                <div class="wind-details">
-                    <div class="column-header">💨 Wind</div>
-                    <div class="metric-item">
-                        <span class="label">Direction</span>
-                        <span class="value">{$windDir}</span>
-                    </div>
-                    <div class="metric-item">
-                        <span class="label">Speed</span>
-                        <span class="value">
-HTML;
-    $html .= formatEmbedWindSpeed($windSpeed, $windUnit);
-    $html .= <<<HTML
-</span>
-                    </div>
-                    <div class="metric-item">
-                        <span class="label">Gusting</span>
-                        <span class="value">
-HTML;
-    // Always show Gusting field
-    if ($gustSpeed !== null && $gustSpeed > 0) {
-        $html .= formatEmbedWindSpeed($gustSpeed, $windUnit);
-    } else {
-        $html .= '--';
-    }
-    $html .= <<<HTML
-</span>
-                    </div>
-                    <div class="metric-item peak-item">
-                        <span class="label">Peak Gust</span>
-                        <span class="value">
-HTML;
-    // Always show Peak Gust field
-    if ($peakGustToday !== null && $peakGustToday > 0) {
-        $html .= formatEmbedWindSpeed($peakGustToday, $windUnit);
-    } else {
-        $html .= '--';
-    }
-    $html .= <<<HTML
-</span>
-                    </div>
-                    <div class="metric-item peak-time-item">
-                        <span class="label">@ Time</span>
-                        <span class="value">
-HTML;
-    // Always show @ Time field
-    if ($peakGustTime !== null && $peakGustToday !== null && $peakGustToday > 0) {
-        try {
-            $tz = new DateTimeZone($timezone);
-            $dt = new DateTime('@' . $peakGustTime);
-            $dt->setTimezone($tz);
-            $peakTimeDisplay = $dt->format('g:ia');
-        } catch (Exception $e) {
-            $peakTimeDisplay = date('g:ia', $peakGustTime);
-        }
-        $html .= htmlspecialchars($peakTimeDisplay);
-    } else {
-        $html .= '--';
-    }
-    $html .= <<<HTML
-</span>
-                    </div>
-                </div>
-            </div>
             <div class="metrics-section">
 HTML;
     $html .= buildFullWidgetMetrics($weather, $options, $hasMetarData);
@@ -823,77 +777,8 @@ function renderFullMultiWidget($data, $options) {
     $html .= '</div></div>';
     $html .= '<a href="' . htmlspecialchars($dashboardUrl) . '" class="embed-dashboard-link"' . $linkAttrs . '>';
     $html .= '<div class="data-row">';
+    $html .= buildFullWindSection($canvasId, $windDir, $windSpd, $gustVal, $windUnitLabel, $windSpeed, $windUnit, $gustSpeed, $peakGustToday, $peakGustTime, $timezone);
     $html .= <<<HTML
-            <div class="wind-section">
-                <div class="wind-viz-container">
-                    <canvas id="{$canvasId}" width="200" height="200"></canvas>
-                    <div class="wind-summary">
-                        <span class="wind-value">{$windDir}@{$windSpd}{$gustVal}{$windUnitLabel}</span>
-                    </div>
-                </div>
-                <div class="wind-details">
-                    <div class="column-header">💨 Wind</div>
-                    <div class="metric-item">
-                        <span class="label">Direction</span>
-                        <span class="value">{$windDir}</span>
-                    </div>
-                    <div class="metric-item">
-                        <span class="label">Speed</span>
-                        <span class="value">
-HTML;
-    $html .= formatEmbedWindSpeed($windSpeed, $windUnit);
-    $html .= <<<HTML
-</span>
-                    </div>
-                    <div class="metric-item">
-                        <span class="label">Gusting</span>
-                        <span class="value">
-HTML;
-    // Always show Gusting field
-    if ($gustSpeed !== null && $gustSpeed > 0) {
-        $html .= formatEmbedWindSpeed($gustSpeed, $windUnit);
-    } else {
-        $html .= '--';
-    }
-    $html .= <<<HTML
-</span>
-                    </div>
-                    <div class="metric-item peak-item">
-                        <span class="label">Peak Gust</span>
-                        <span class="value">
-HTML;
-    // Always show Peak Gust field
-    if ($peakGustToday !== null && $peakGustToday > 0) {
-        $html .= formatEmbedWindSpeed($peakGustToday, $windUnit);
-    } else {
-        $html .= '--';
-    }
-    $html .= <<<HTML
-</span>
-                    </div>
-                    <div class="metric-item peak-time-item">
-                        <span class="label">@ Time</span>
-                        <span class="value">
-HTML;
-    // Always show @ Time field
-    if ($peakGustTime !== null && $peakGustToday !== null && $peakGustToday > 0) {
-        try {
-            $tz = new DateTimeZone($timezone);
-            $dt = new DateTime('@' . $peakGustTime);
-            $dt->setTimezone($tz);
-            $peakTimeDisplay = $dt->format('g:ia');
-        } catch (Exception $e) {
-            $peakTimeDisplay = date('g:ia', $peakGustTime);
-        }
-        $html .= htmlspecialchars($peakTimeDisplay);
-    } else {
-        $html .= '--';
-    }
-    $html .= <<<HTML
-</span>
-                    </div>
-                </div>
-            </div>
             <div class="metrics-section">
 HTML;
     $html .= buildFullWidgetMetrics($weather, $options, $hasMetarData);

--- a/lib/embed-templates/full.php
+++ b/lib/embed-templates/full.php
@@ -276,7 +276,7 @@ HTML;
                         <span class="label">@ Time</span>
                         <span class="value">
 HTML;
-    if ($peakGustTime !== null && $peakGustToday !== null && $peakGustToday > 0) {
+    if ($peakGustTime > 0 && $peakGustToday !== null && $peakGustToday > 0) {
         try {
             $tz = new DateTimeZone($timezone);
             $dt = new DateTime('@' . $peakGustTime);

--- a/lib/embed-templates/full.php
+++ b/lib/embed-templates/full.php
@@ -214,7 +214,7 @@ function buildFullWidgetMetrics($weather, $options, $hasMetarData) {
  *
  * @param string $canvasId Canvas element id for the compass
  * @param string $windDir Formatted wind direction (e.g. "180°", "VRB", "---")
- * @param string $windSpd Formatted wind speed value for the summary line
+ * @param float|string $windSpd Pre-formatted wind speed for the summary line (round() result, or "---")
  * @param string $gustVal Formatted gust value for the summary line (e.g. "G12" or "")
  * @param string $windUnitLabel Wind speed unit label (e.g. "kt")
  * @param float|null $windSpeed Wind speed in knots (for the Speed row)
@@ -225,7 +225,7 @@ function buildFullWidgetMetrics($weather, $options, $hasMetarData) {
  * @param string $timezone Airport timezone for the peak gust time
  * @return string Wind section HTML
  */
-function buildFullWindSection(string $canvasId, string $windDir, $windSpd, string $gustVal, string $windUnitLabel, $windSpeed, string $windUnit, $gustSpeed, $peakGustToday, $peakGustTime, string $timezone): string {
+function buildFullWindSection(string $canvasId, string $windDir, $windSpd, string $gustVal, string $windUnitLabel, ?float $windSpeed, string $windUnit, ?float $gustSpeed, ?float $peakGustToday, ?int $peakGustTime, string $timezone): string {
     $html = <<<HTML
             <div class="wind-section">
                 <div class="wind-viz-container">


### PR DESCRIPTION
## Description

`full-single`, `full-dual`, and `full-multi` each carried a byte-identical copy of the compass + wind-details markup (~70 lines each). Extract it into one `buildFullWindSection()` helper and call it from all three, removing ~210 lines of duplication. This sets up the wind-forward weather-region redesign to land in one shared place (follow-up), mirroring how `wind-visual.js` was extracted before enhancing.

## Type

- [x] Refactor

## Behavior change (intentional, minor)

The markup is otherwise identical, with one deliberate correctness fix surfaced during review: the "Peak Gust @ Time" row now requires `peak_gust_time > 0` (previously `!== null`). A zero/invalid timestamp (e.g. a failed `strtotime()` upstream) would have rendered the epoch (midnight); it now falls back to `--`. Output is unchanged for all valid timestamps.

## Testing

- `make test-ci` passes (0 errors).
- All three full-* styles render locally (HTTP 200); output is identical to before except the peak-time edge case noted above.

## Checklist

- [x] Tests pass
- [x] Documentation updated (if needed) - n/a
- [x] No sensitive data (API keys, passwords, credentials)
- [x] Code follows [CODE_STYLE.md](CODE_STYLE.md)

## Follow-up

Next PR: the wind-forward redesign of the full-* weather region (larger compass, Gust Factor + legend, METAR summary, compact metric columns) applied to `buildFullWindSection()`; webcam layout untouched.

## Related

Continues the embed wind-forward work (#161, #162, #163).