### PR TITLE
Card conditions: availability-priority + grouped display

### DIFF
--- a/lib/embed-templates/card.php
+++ b/lib/embed-templates/card.php
@@ -248,13 +248,6 @@ function renderCardWidget($data, $options) {
     $windSpeedValue = $processed['windSpeedValue'];
     $windDirValue = $processed['windDirValue'];
     $gustValue = $processed['gustValue'];
-    $tempDisplay = $processed['tempDisplay'];
-    $dewpointDisplay = $processed['dewpointDisplay'];
-    $densityAltitudeDisplay = $processed['densityAltitudeDisplay'];
-    $secondMetricLabel = $processed['secondMetricLabel'];
-    $secondMetricValue = $processed['secondMetricValue'];
-    $pressureDisplay = $processed['pressureDisplay'];
-    $visDisplay = $processed['visDisplay'];
     $lastUpdated = $processed['lastUpdated'];
     $timezone = $processed['timezone'];
     $dataSource = $processed['dataSource'];
@@ -347,6 +340,16 @@ function renderCardWidget($data, $options) {
         ? '<span><span class="lg-petal">&#9646;</span> last hr</span>'
         : '';
 
+    // Condition tiles: availability-priority selection so METAR airports show
+    // Visibility/Ceiling while non-METAR airports fill those slots with the next
+    // highest-value available fields (Dewpoint Spread, Humidity, etc.) instead of
+    // blank tiles. Shared with the compact webcam widgets.
+    $conditionTilesHtml = '';
+    foreach (getCompactWidgetMetrics($weather, $options, $hasMetarData) as $metric) {
+        $conditionTilesHtml .= '<div class="tile"><span class="tl">' . htmlspecialchars($metric['label'])
+            . '</span><span class="tv">' . htmlspecialchars($metric['value']) . '</span></div>';
+    }
+
     // Escape dynamic text before interpolating it into the HTML below
     $windSummary = htmlspecialchars($windSummary);
     $peakTimeValue = htmlspecialchars($peakTimeValue);
@@ -381,14 +384,7 @@ function renderCardWidget($data, $options) {
             </div>
             <div class="wf-metrics">
                 <div class="col-h">Conditions</div>
-                <div class="wf-tiles">
-                    <div class="tile"><span class="tl">Temp</span><span class="tv">{$tempDisplay}</span></div>
-                    <div class="tile"><span class="tl">Dewpt</span><span class="tv">{$dewpointDisplay}</span></div>
-                    <div class="tile"><span class="tl">DA</span><span class="tv">{$densityAltitudeDisplay}</span></div>
-                    <div class="tile"><span class="tl">{$secondMetricLabel}</span><span class="tv">{$secondMetricValue}</span></div>
-                    <div class="tile"><span class="tl">Press</span><span class="tv">{$pressureDisplay}</span></div>
-                    <div class="tile"><span class="tl">Vis</span><span class="tv">{$visDisplay}</span></div>
-                </div>
+                <div class="wf-tiles">{$conditionTilesHtml}</div>
             </div>
         </div>
     </div></div>

--- a/lib/embed-templates/shared.php
+++ b/lib/embed-templates/shared.php
@@ -804,9 +804,22 @@ function getCompactWidgetMetrics($weather, $options, $hasMetarData) {
         }
     }
     
-    // Take only the first 6 metrics
+    // Select the top 6 by priority (importance / availability)...
     $metrics = array_slice($availableMetrics, 0, 6);
-    
+
+    // ...then reorder the chosen metrics into related groups so they scan
+    // cleanly: temperature/moisture, then altitude/pressure, then
+    // visibility/ceiling, then daily trends. Selection is unchanged.
+    $displayOrder = [
+        'Temp' => 10, 'Dewpt' => 11, 'Spread' => 12, 'Humidity' => 13,
+        'DA' => 20, 'Press' => 21, 'Press Alt' => 22,
+        'Vis' => 30, 'Ceiling' => 31,
+        'High' => 40, 'Low' => 41, 'Rainfall' => 42,
+    ];
+    usort($metrics, function ($a, $b) use ($displayOrder) {
+        return ($displayOrder[$a['label']] ?? 999) <=> ($displayOrder[$b['label']] ?? 999);
+    });
+
     // Ensure we always have 6 metrics (fill with '---' if needed)
     while (count($metrics) < 6) {
         $metrics[] = ['label' => '---', 'value' => '---'];


### PR DESCRIPTION
## Description

Two improvements to the embed card's condition tiles (and the compact webcam widgets that share the metric picker):

1. **Availability-priority tiles on the card.** The card previously rendered a fixed tile set including **Visibility**, which only exists at METAR airports - so PWS-only airports showed a permanent blank "Vis ---". The card now reuses `getCompactWidgetMetrics()`, so METAR airports keep Visibility/Ceiling while non-METAR airports fill those slots with the next highest-value available data (Dewpoint Spread, Humidity, Pressure Altitude, etc.).
2. **Grouped display order.** The metric picker still selects the top 6 by priority, but now reorders the chosen set into related groups for display: temperature/moisture -> altitude/pressure -> visibility/ceiling -> daily trends. Related values sit together for quick scanning instead of interleaving.

Example (PWS-only KPFC): tiles are now `Temp, Dewpt, Spread, Humidity, DA, Press` (a temperature/moisture cluster, then altitude/pressure) instead of a fixed set with a blank Visibility tile.

## Type

- [x] Refactor
- [x] Other (UX)

## Testing

- `make test-ci` passes (0 errors).
- Verified locally: KSPB (METAR) shows Visibility; KPFC / 69V (PWS-only) show Dewpoint Spread / Humidity instead of a blank tile; tiles render in grouped order on the card.

## Checklist

- [x] Tests pass
- [x] Documentation updated (if needed) - n/a
- [x] No sensitive data (API keys, passwords, credentials)
- [x] Code follows [CODE_STYLE.md](CODE_STYLE.md)

## Related

Follow-up to the wind-forward card (#163); shares `getCompactWidgetMetrics()` with the dual-only/multi-only widgets.