### PR TITLE
Redesign full-* wind section for dashboard parity

### DIFF
--- a/lib/embed-templates/full.php
+++ b/lib/embed-templates/full.php
@@ -223,7 +223,6 @@ function buildFullWidgetMetrics($weather, $options, $hasMetarData) {
  */
 function buildFullWindSection(array $weather, array $options, ?array $fullModeOptions, string $canvasId, string $timezone): string {
     $windUnit = $options['windUnit'];
-    $windUnitLabel = $windUnit === 'kmh' ? 'km/h' : $windUnit;
 
     [$windDirection, $isVRB] = getEmbedWindFromWeather($weather);
     $windSpeed = $weather['wind_speed'] ?? null;
@@ -243,20 +242,6 @@ function buildFullWindSection(array $weather, array $options, ?array $fullModeOp
     // Detail-row direction keeps the degree label + Magnetic sublabel
     $windDirDisplay = $isVRB ? 'VRB' : (is_numeric($windDirection) ? round($windDirection) . '°' : '---');
     $magSub = ($windDirDisplay !== '---' && $windDirDisplay !== 'VRB') ? ' <span class="sub">Mag</span>' : '';
-
-    // METAR-style compact summary (no degree glyph), consistent with the card.
-    // Only show it when there is actual wind to report: the compass already
-    // indicates Calm / no-data in its center, so a "CALM" or "---" line below
-    // it would be redundant.
-    $windSummary = '';
-    if ($windSpeed !== null && $windSpeed >= 3) {
-        $spd = round($windUnit === 'mph' ? knotsToMph($windSpeed) : ($windUnit === 'kmh' ? knotsToKmh($windSpeed) : $windSpeed));
-        $gustPart = ($gustSpeed !== null && $gustSpeed > 0)
-            ? 'G' . sprintf('%02d', round($windUnit === 'mph' ? knotsToMph($gustSpeed) : ($windUnit === 'kmh' ? knotsToKmh($gustSpeed) : $gustSpeed)))
-            : '';
-        $dirPart = $isVRB ? 'VRB' : (is_numeric($windDirection) ? sprintf('%03d', round($windDirection)) : '---');
-        $windSummary = $dirPart . sprintf('%02d', $spd) . $gustPart . strtoupper($windUnitLabel);
-    }
 
     // Field values (fail closed to '---')
     $speedValue = ($windSpeed === null) ? '---' : ($windSpeed < 3 ? 'Calm' : formatEmbedWindSpeed($windSpeed, $windUnit));
@@ -288,16 +273,10 @@ function buildFullWindSection(array $weather, array $options, ?array $fullModeOp
     $peakTimeValue = htmlspecialchars($peakTimeValue);
     $trueNorthLabel = htmlspecialchars($trueNorthLabel);
 
-    // Only render the summary line below the compass when there is wind to show
-    $summaryHtml = $windSummary !== ''
-        ? '<div class="wind-summary"><span class="wind-value">' . htmlspecialchars($windSummary) . '</span></div>'
-        : '';
-
     return <<<HTML
             <div class="wind-section">
                 <div class="wind-viz-container">
                     <canvas id="{$canvasId}" width="200" height="200"></canvas>
-                    {$summaryHtml}
                 </div>
                 <div class="wind-details">
                     <div class="column-header">💨 Wind</div>

--- a/lib/embed-templates/full.php
+++ b/lib/embed-templates/full.php
@@ -207,95 +207,133 @@ function buildFullWidgetMetrics($weather, $options, $hasMetarData) {
 }
 
 /**
- * Build the shared wind section (compass + wind details) for full-* widgets.
+ * Build the shared wind section (compass + wind facts) for full-* widgets.
  *
- * Shared by full-single, full-dual, and full-multi so the wind compass and
- * facts render identically across them.
+ * Shared by full-single, full-dual, and full-multi. Computes the displayed
+ * wind facts from the airport weather so all three render identically, with
+ * dashboard-parity fields (Gust Factor, Peak Gust + time), a METAR-style
+ * compact summary, and a themed legend. Wind fields fail closed to "---".
  *
+ * @param array $weather Weather data for the airport
+ * @param array $options Widget options (windUnit, etc.)
+ * @param array|null $fullModeOptions Compass full-mode options (magneticDeclination, lastHourWind)
  * @param string $canvasId Canvas element id for the compass
- * @param string $windDir Formatted wind direction (e.g. "180°", "VRB", "---")
- * @param float|string $windSpd Pre-formatted wind speed for the summary line (round() result, or "---")
- * @param string $gustVal Formatted gust value for the summary line (e.g. "G12" or "")
- * @param string $windUnitLabel Wind speed unit label (e.g. "kt")
- * @param float|null $windSpeed Wind speed in knots (for the Speed row)
- * @param string $windUnit Wind speed unit code (kt/mph/kmh)
- * @param float|null $gustSpeed Gust speed in knots
- * @param float|null $peakGustToday Today's peak gust in knots
- * @param int|null $peakGustTime Peak gust observation time (Unix seconds)
  * @param string $timezone Airport timezone for the peak gust time
  * @return string Wind section HTML
  */
-function buildFullWindSection(string $canvasId, string $windDir, float|string $windSpd, string $gustVal, string $windUnitLabel, ?float $windSpeed, string $windUnit, ?float $gustSpeed, ?float $peakGustToday, ?int $peakGustTime, string $timezone): string {
-    $html = <<<HTML
-            <div class="wind-section">
-                <div class="wind-viz-container">
-                    <canvas id="{$canvasId}" width="200" height="200"></canvas>
-                    <div class="wind-summary">
-                        <span class="wind-value">{$windDir}@{$windSpd}{$gustVal}{$windUnitLabel}</span>
-                    </div>
-                </div>
-                <div class="wind-details">
-                    <div class="column-header">💨 Wind</div>
-                    <div class="metric-item">
-                        <span class="label">Direction</span>
-                        <span class="value">{$windDir}</span>
-                    </div>
-                    <div class="metric-item">
-                        <span class="label">Speed</span>
-                        <span class="value">
-HTML;
-    $html .= formatEmbedWindSpeed($windSpeed, $windUnit);
-    $html .= <<<HTML
-</span>
-                    </div>
-                    <div class="metric-item">
-                        <span class="label">Gusting</span>
-                        <span class="value">
-HTML;
-    if ($gustSpeed !== null && $gustSpeed > 0) {
-        $html .= formatEmbedWindSpeed($gustSpeed, $windUnit);
-    } else {
-        $html .= '--';
+function buildFullWindSection(array $weather, array $options, ?array $fullModeOptions, string $canvasId, string $timezone): string {
+    $windUnit = $options['windUnit'];
+    $windUnitLabel = $windUnit === 'kmh' ? 'km/h' : $windUnit;
+
+    [$windDirection, $isVRB] = getEmbedWindFromWeather($weather);
+    $windSpeed = $weather['wind_speed'] ?? null;
+    $gustSpeed = $weather['gust_speed'] ?? null;
+    $gustFactor = $weather['gust_factor'] ?? null;
+    $peakGustToday = $weather['peak_gust_today'] ?? null;
+    $peakGustTime = $weather['peak_gust_time'] ?? null;
+
+    $fmo = $fullModeOptions ?? [];
+    $magDeclRounded = (int) round($fmo['magneticDeclination'] ?? 0);
+    $magVarLabel = ($magDeclRounded !== 0) ? (abs($magDeclRounded) . '°' . ($magDeclRounded > 0 ? 'E' : 'W')) : '';
+    $trueNorthLabel = 'True N' . ($magVarLabel !== '' ? ' (' . $magVarLabel . ')' : '');
+    $lastHourWind = $fmo['lastHourWind'] ?? null;
+    $hasActivePetals = is_array($lastHourWind) && count($lastHourWind) === 16
+        && count(array_filter($lastHourWind, function ($s) { return $s > 0; })) > 0;
+
+    // Detail-row direction keeps the degree label + Magnetic sublabel
+    $windDirDisplay = $isVRB ? 'VRB' : (is_numeric($windDirection) ? round($windDirection) . '°' : '---');
+    $magSub = ($windDirDisplay !== '---' && $windDirDisplay !== 'VRB') ? ' <span class="sub">Mag</span>' : '';
+
+    // METAR-style compact summary (no degree glyph), consistent with the card.
+    // Only show it when there is actual wind to report: the compass already
+    // indicates Calm / no-data in its center, so a "CALM" or "---" line below
+    // it would be redundant.
+    $windSummary = '';
+    if ($windSpeed !== null && $windSpeed >= 3) {
+        $spd = round($windUnit === 'mph' ? knotsToMph($windSpeed) : ($windUnit === 'kmh' ? knotsToKmh($windSpeed) : $windSpeed));
+        $gustPart = ($gustSpeed !== null && $gustSpeed > 0)
+            ? 'G' . sprintf('%02d', round($windUnit === 'mph' ? knotsToMph($gustSpeed) : ($windUnit === 'kmh' ? knotsToKmh($gustSpeed) : $gustSpeed)))
+            : '';
+        $dirPart = $isVRB ? 'VRB' : (is_numeric($windDirection) ? sprintf('%03d', round($windDirection)) : '---');
+        $windSummary = $dirPart . sprintf('%02d', $spd) . $gustPart . strtoupper($windUnitLabel);
     }
-    $html .= <<<HTML
-</span>
-                    </div>
-                    <div class="metric-item peak-item">
-                        <span class="label">Peak Gust</span>
-                        <span class="value">
-HTML;
-    if ($peakGustToday !== null && $peakGustToday > 0) {
-        $html .= formatEmbedWindSpeed($peakGustToday, $windUnit);
-    } else {
-        $html .= '--';
-    }
-    $html .= <<<HTML
-</span>
-                    </div>
-                    <div class="metric-item peak-time-item">
-                        <span class="label">@ Time</span>
-                        <span class="value">
-HTML;
+
+    // Field values (fail closed to '---')
+    $speedValue = ($windSpeed === null) ? '---' : ($windSpeed < 3 ? 'Calm' : formatEmbedWindSpeed($windSpeed, $windUnit));
+    $gustingValue = ($gustSpeed !== null && $gustSpeed > 0) ? formatEmbedWindSpeed($gustSpeed, $windUnit) : '---';
+    $gustFactorValue = ($gustFactor !== null && $gustFactor > 0) ? formatEmbedWindSpeed($gustFactor, $windUnit) : '---';
+    $peakGustValue = ($peakGustToday !== null && $peakGustToday > 0) ? formatEmbedWindSpeed($peakGustToday, $windUnit) : '---';
+    $peakTimeValue = '---';
     if ($peakGustTime > 0 && $peakGustToday !== null && $peakGustToday > 0) {
         try {
             $tz = new DateTimeZone($timezone);
             $dt = new DateTime('@' . $peakGustTime);
             $dt->setTimezone($tz);
-            $peakTimeDisplay = $dt->format('g:ia');
+            $peakTimeValue = $dt->format('g:ia');
         } catch (Exception $e) {
-            $peakTimeDisplay = date('g:ia', $peakGustTime);
+            // Invalid airport timezone (config error): leave as '---' rather than
+            // rendering in the server timezone, which would vary by environment.
+            $peakTimeValue = '---';
         }
-        $html .= htmlspecialchars($peakTimeDisplay);
-    } else {
-        $html .= '--';
     }
-    $html .= <<<HTML
-</span>
+
+    $petalLegend = $hasActivePetals ? '<span><span class="lg-petal">&#9646;</span> last hr</span>' : '';
+
+    // Escape dynamic text before interpolating into the HTML
+    $windDirDisplay = htmlspecialchars($windDirDisplay);
+    $speedValue = htmlspecialchars($speedValue);
+    $gustingValue = htmlspecialchars($gustingValue);
+    $gustFactorValue = htmlspecialchars($gustFactorValue);
+    $peakGustValue = htmlspecialchars($peakGustValue);
+    $peakTimeValue = htmlspecialchars($peakTimeValue);
+    $trueNorthLabel = htmlspecialchars($trueNorthLabel);
+
+    // Only render the summary line below the compass when there is wind to show
+    $summaryHtml = $windSummary !== ''
+        ? '<div class="wind-summary"><span class="wind-value">' . htmlspecialchars($windSummary) . '</span></div>'
+        : '';
+
+    return <<<HTML
+            <div class="wind-section">
+                <div class="wind-viz-container">
+                    <canvas id="{$canvasId}" width="200" height="200"></canvas>
+                    {$summaryHtml}
+                </div>
+                <div class="wind-details">
+                    <div class="column-header">💨 Wind</div>
+                    <div class="metric-item">
+                        <span class="label">Direction</span>
+                        <span class="value">{$windDirDisplay}{$magSub}</span>
+                    </div>
+                    <div class="metric-item">
+                        <span class="label">Speed</span>
+                        <span class="value">{$speedValue}</span>
+                    </div>
+                    <div class="metric-item">
+                        <span class="label">Gusting</span>
+                        <span class="value">{$gustingValue}</span>
+                    </div>
+                    <div class="metric-item">
+                        <span class="label">Gust Factor</span>
+                        <span class="value">{$gustFactorValue}</span>
+                    </div>
+                    <div class="metric-item peak-item">
+                        <span class="label">Peak Gust</span>
+                        <span class="value">{$peakGustValue}</span>
+                    </div>
+                    <div class="metric-item peak-time-item">
+                        <span class="label">@ Time</span>
+                        <span class="value">{$peakTimeValue}</span>
+                    </div>
+                    <div class="wf-legend">
+                        <span><span class="lg-true">&#9733;</span> {$trueNorthLabel}</span>
+                        <span><span class="lg-wind">&#8594;</span> wind</span>
+                        <span><span class="lg-rwy">&#9644;</span> runways</span>
+                        {$petalLegend}
                     </div>
                 </div>
             </div>
 HTML;
-    return $html;
 }
 
 /**
@@ -341,10 +379,6 @@ function renderFullSingleWidget($data, $options) {
     $humidity = $weather['humidity'] ?? null;
     $rainfallToday = $weather['rainfall_today'] ?? null;
     
-    // Peak wind data
-    $peakGustToday = $weather['peak_gust_today'] ?? null;
-    $peakGustTime = $weather['peak_gust_time'] ?? null;
-    
     // Temperature extremes
     $tempHighToday = $weather['temp_high_today'] ?? null;
     $tempLowToday = $weather['temp_low_today'] ?? null;
@@ -375,12 +409,6 @@ function renderFullSingleWidget($data, $options) {
     $canvasId = 'full-wind-canvas-' . uniqid();
     $fullModeOptions = buildWindCompassFullModeOptions($airportId, $airport, $weather);
 
-    // Format wind display parts (use wind_direction_magnetic; fail closed with ---)
-    $windDir = $isVRB ? 'VRB' : ($windDirection !== null ? (is_numeric($windDirection) ? round($windDirection) . '°' : $windDirection) : '---');
-    $windSpd = $windSpeed !== null ? round($windUnit === 'mph' ? knotsToMph($windSpeed) : ($windUnit === 'kmh' ? knotsToKmh($windSpeed) : $windSpeed)) : '---';
-    $gustVal = ($gustSpeed !== null && $gustSpeed > 0) ? 'G' . round($windUnit === 'mph' ? knotsToMph($gustSpeed) : ($windUnit === 'kmh' ? knotsToKmh($gustSpeed) : $gustSpeed)) : '';
-    $windUnitLabel = $windUnit === 'kmh' ? 'km/h' : $windUnit;
-    
     // Weather emojis
     $weatherEmojis = '';
     if ($hasMetarData) {
@@ -429,7 +457,7 @@ function renderFullSingleWidget($data, $options) {
     $html .= '</div></a>';
     $html .= '<a href="' . htmlspecialchars($dashboardUrl) . '" class="embed-dashboard-link"' . $linkAttrs . '>';
     $html .= '<div class="data-row">';
-    $html .= buildFullWindSection($canvasId, $windDir, $windSpd, $gustVal, $windUnitLabel, $windSpeed, $windUnit, $gustSpeed, $peakGustToday, $peakGustTime, $timezone);
+    $html .= buildFullWindSection($weather, $options, $fullModeOptions, $canvasId, $timezone);
     $html .= <<<HTML
             <div class="metrics-section">
 HTML;
@@ -499,8 +527,6 @@ function renderFullDualWidget($data, $options) {
     $ceiling = $weather['ceiling'] ?? null;
     $humidity = $weather['humidity'] ?? null;
     $rainfallToday = $weather['rainfall_today'] ?? null;
-    $peakGustToday = $weather['peak_gust_today'] ?? null;
-    $peakGustTime = $weather['peak_gust_time'] ?? null;
     $tempHighToday = $weather['temp_high_today'] ?? null;
     $tempLowToday = $weather['temp_low_today'] ?? null;
     
@@ -516,12 +542,6 @@ function renderFullDualWidget($data, $options) {
     $target = $options['target'] ?? '_blank';
     $linkAttrs = buildEmbedLinkAttrs($target);
 
-    // Format wind display (use wind_direction_magnetic; fail closed with ---)
-    $windDir = $isVRB ? 'VRB' : ($windDirection !== null ? (is_numeric($windDirection) ? round($windDirection) . '°' : $windDirection) : '---');
-    $windSpd = $windSpeed !== null ? round($windUnit === 'mph' ? knotsToMph($windSpeed) : ($windUnit === 'kmh' ? knotsToKmh($windSpeed) : $windSpeed)) : '---';
-    $gustVal = ($gustSpeed !== null && $gustSpeed > 0) ? 'G' . round($windUnit === 'mph' ? knotsToMph($gustSpeed) : ($windUnit === 'kmh' ? knotsToKmh($gustSpeed) : $gustSpeed)) : '';
-    $windUnitLabel = $windUnit === 'kmh' ? 'km/h' : $windUnit;
-    
     // Weather emojis
     $weatherEmojis = '';
     if ($hasMetarData) {
@@ -602,7 +622,7 @@ function renderFullDualWidget($data, $options) {
     $html .= '</div></div>';
     $html .= '<a href="' . htmlspecialchars($dashboardUrl) . '" class="embed-dashboard-link"' . $linkAttrs . '>';
     $html .= '<div class="data-row">';
-    $html .= buildFullWindSection($canvasId, $windDir, $windSpd, $gustVal, $windUnitLabel, $windSpeed, $windUnit, $gustSpeed, $peakGustToday, $peakGustTime, $timezone);
+    $html .= buildFullWindSection($weather, $options, $fullModeOptions, $canvasId, $timezone);
     $html .= <<<HTML
             <div class="metrics-section">
 HTML;
@@ -672,8 +692,6 @@ function renderFullMultiWidget($data, $options) {
     $ceiling = $weather['ceiling'] ?? null;
     $humidity = $weather['humidity'] ?? null;
     $rainfallToday = $weather['rainfall_today'] ?? null;
-    $peakGustToday = $weather['peak_gust_today'] ?? null;
-    $peakGustTime = $weather['peak_gust_time'] ?? null;
     $tempHighToday = $weather['temp_high_today'] ?? null;
     $tempLowToday = $weather['temp_low_today'] ?? null;
     
@@ -689,12 +707,6 @@ function renderFullMultiWidget($data, $options) {
     $target = $options['target'] ?? '_blank';
     $linkAttrs = buildEmbedLinkAttrs($target);
 
-    // Format wind display (use wind_direction_magnetic; fail closed with ---)
-    $windDir = $isVRB ? 'VRB' : ($windDirection !== null ? (is_numeric($windDirection) ? round($windDirection) . '°' : $windDirection) : '---');
-    $windSpd = $windSpeed !== null ? round($windUnit === 'mph' ? knotsToMph($windSpeed) : ($windUnit === 'kmh' ? knotsToKmh($windSpeed) : $windSpeed)) : '---';
-    $gustVal = ($gustSpeed !== null && $gustSpeed > 0) ? 'G' . round($windUnit === 'mph' ? knotsToMph($gustSpeed) : ($windUnit === 'kmh' ? knotsToKmh($gustSpeed) : $gustSpeed)) : '';
-    $windUnitLabel = $windUnit === 'kmh' ? 'km/h' : $windUnit;
-    
     // Weather emojis
     $weatherEmojis = '';
     if ($hasMetarData) {
@@ -777,7 +789,7 @@ function renderFullMultiWidget($data, $options) {
     $html .= '</div></div>';
     $html .= '<a href="' . htmlspecialchars($dashboardUrl) . '" class="embed-dashboard-link"' . $linkAttrs . '>';
     $html .= '<div class="data-row">';
-    $html .= buildFullWindSection($canvasId, $windDir, $windSpd, $gustVal, $windUnitLabel, $windSpeed, $windUnit, $gustSpeed, $peakGustToday, $peakGustTime, $timezone);
+    $html .= buildFullWindSection($weather, $options, $fullModeOptions, $canvasId, $timezone);
     $html .= <<<HTML
             <div class="metrics-section">
 HTML;

--- a/lib/embed-templates/full.php
+++ b/lib/embed-templates/full.php
@@ -211,8 +211,9 @@ function buildFullWidgetMetrics($weather, $options, $hasMetarData) {
  *
  * Shared by full-single, full-dual, and full-multi. Computes the displayed
  * wind facts from the airport weather so all three render identically, with
- * dashboard-parity fields (Gust Factor, Peak Gust + time), a METAR-style
- * compact summary, and a themed legend. Wind fields fail closed to "---".
+ * dashboard-parity fields (Gust Factor, Peak Gust + time) and a themed
+ * legend. Direction is suppressed to "---" when calm (matching the card and
+ * dashboard), and all wind fields fail closed to "---" when stale.
  *
  * @param array $weather Weather data for the airport
  * @param array $options Widget options (windUnit, etc.)
@@ -239,9 +240,16 @@ function buildFullWindSection(array $weather, array $options, ?array $fullModeOp
     $hasActivePetals = is_array($lastHourWind) && count($lastHourWind) === 16
         && count(array_filter($lastHourWind, function ($s) { return $s > 0; })) > 0;
 
-    // Detail-row direction keeps the degree label + Magnetic sublabel
-    $windDirDisplay = $isVRB ? 'VRB' : (is_numeric($windDirection) ? round($windDirection) . '°' : '---');
-    $magSub = ($windDirDisplay !== '---' && $windDirDisplay !== 'VRB') ? ' <span class="sub">Mag</span>' : '';
+    // Direction display, matching the card/dashboard: 'Variable' for VRB,
+    // a numeric magnetic bearing only when there is reportable wind (>= 3 kt),
+    // otherwise '---'. Direction is meaningless when calm, so it is suppressed.
+    $windDirDisplay = '---';
+    if ($isVRB) {
+        $windDirDisplay = 'Variable';
+    } elseif ($windDirection !== null && $windSpeed !== null && $windSpeed >= 3) {
+        $windDirDisplay = round($windDirection) . '°';
+    }
+    $magSub = ($windDirDisplay !== '---' && $windDirDisplay !== 'Variable') ? ' <span class="sub">Mag</span>' : '';
 
     // Field values (fail closed to '---')
     $speedValue = ($windSpeed === null) ? '---' : ($windSpeed < 3 ? 'Calm' : formatEmbedWindSpeed($windSpeed, $windUnit));

--- a/public/css/embed-widgets.css
+++ b/public/css/embed-widgets.css
@@ -1449,17 +1449,6 @@ a {
     display: block;
 }
 
-.style-full .wind-summary {
-    text-align: center;
-    margin-top: 0.25rem;
-}
-
-.style-full .wind-summary .wind-value {
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--text-color);
-}
-
 .style-full .metrics-section {
     flex: 1;
     background: var(--bg-color);
@@ -1607,10 +1596,6 @@ a {
         border-left: none;
         border-top: 1px solid var(--border-color);
         width: 100%;
-    }
-    
-    .style-full .wind-summary .wind-value {
-        font-size: 0.75rem;
     }
 }
 

--- a/public/css/embed-widgets.css
+++ b/public/css/embed-widgets.css
@@ -854,10 +854,13 @@ a {
 
 .style-card-wf .wf-row .k { color: var(--muted-color); }
 .style-card-wf .wf-row .v { font-weight: 700; color: var(--text-color); }
-.style-card-wf .wf-row .sub { font-size: 0.62rem; color: var(--muted-color); font-weight: 400; }
 .style-card-wf .wf-row.peak .v { color: #ff9500; }
 
-.style-card-wf .wf-legend {
+/* Inline sublabel (e.g. "Mag") - shared by the card and full-* wind facts */
+.embed-container .sub { font-size: 0.62rem; color: var(--muted-color); font-weight: 400; }
+
+/* Compass legend - shared by the wind-forward card and full-* wind sections */
+.embed-container .wf-legend {
     margin-top: 0.4rem;
     font-size: 0.6rem;
     color: var(--muted-color);
@@ -866,19 +869,19 @@ a {
     gap: 0.5rem;
 }
 
-.style-card-wf .wf-legend span { white-space: nowrap; }
+.embed-container .wf-legend span { white-space: nowrap; }
 
 /* Legend markers match the compass palette per theme */
-.style-card-wf .lg-wind,
-.style-card-wf .lg-petal { color: #dc3545; }
-.style-card-wf .lg-true { color: #4a7; }
-.style-card-wf .lg-rwy { color: #0066cc; }
-.theme-dark .style-card-wf .lg-true { color: #6b9; }
-.theme-dark .style-card-wf .lg-rwy { color: #4a9eff; }
+.embed-container .lg-wind,
+.embed-container .lg-petal { color: #dc3545; }
+.embed-container .lg-true { color: #4a7; }
+.embed-container .lg-rwy { color: #0066cc; }
+.theme-dark .lg-true { color: #6b9; }
+.theme-dark .lg-rwy { color: #4a9eff; }
 
 @media (prefers-color-scheme: dark) {
-    .theme-auto .style-card-wf .lg-true { color: #6b9; }
-    .theme-auto .style-card-wf .lg-rwy { color: #4a9eff; }
+    .theme-auto .lg-true { color: #6b9; }
+    .theme-auto .lg-rwy { color: #4a9eff; }
 }
 
 /* Metrics - tight tiles by default */

--- a/public/css/embed-widgets.css
+++ b/public/css/embed-widgets.css
@@ -876,12 +876,19 @@ a {
 .embed-container .lg-petal { color: #dc3545; }
 .embed-container .lg-true { color: #4a7; }
 .embed-container .lg-rwy { color: #0066cc; }
-.theme-dark .lg-true { color: #6b9; }
-.theme-dark .lg-rwy { color: #4a9eff; }
+/* Theme class sits on .embed-container (iframe embed) or on an ancestor
+   (web component), so scope both forms to avoid bleeding onto any future
+   non-embed elements that reuse .lg-* markers. */
+.embed-container.theme-dark .lg-true,
+.theme-dark .embed-container .lg-true { color: #6b9; }
+.embed-container.theme-dark .lg-rwy,
+.theme-dark .embed-container .lg-rwy { color: #4a9eff; }
 
 @media (prefers-color-scheme: dark) {
-    .theme-auto .lg-true { color: #6b9; }
-    .theme-auto .lg-rwy { color: #4a9eff; }
+    .embed-container.theme-auto .lg-true,
+    .theme-auto .embed-container .lg-true { color: #6b9; }
+    .embed-container.theme-auto .lg-rwy,
+    .theme-auto .embed-container .lg-rwy { color: #4a9eff; }
 }
 
 /* Metrics - tight tiles by default */

--- a/tests/Unit/BuildFullWindSectionTest.php
+++ b/tests/Unit/BuildFullWindSectionTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Unit Tests for buildFullWindSection()
+ *
+ * Safety-critical: the full-* embed wind block drives pilot decision-making.
+ * Verifies the dashboard-parity facts (Gust Factor, Peak Gust, legend), the
+ * fail-closed "---" behavior for stale/missing wind, and that the redundant
+ * compass summary line is not rendered.
+ *
+ * @package AviationWX\Tests\Unit
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/units.php';
+require_once __DIR__ . '/../../lib/embed-templates/full.php';
+
+class BuildFullWindSectionTest extends TestCase
+{
+    /** @var array<string, mixed> */
+    private array $options = ['windUnit' => 'kt'];
+
+    /** @var array<string, mixed> */
+    private array $fullModeOptions = ['magneticDeclination' => 13, 'lastHourWind' => []];
+
+    private function render(array $weather, ?array $fullModeOptions = null): string
+    {
+        return buildFullWindSection(
+            $weather,
+            $this->options,
+            $fullModeOptions ?? $this->fullModeOptions,
+            'test-canvas',
+            'America/Los_Angeles'
+        );
+    }
+
+    /**
+     * A windy site renders the full dashboard-parity facts and legend.
+     */
+    public function testWindySite_RendersFactsAndLegend(): void
+    {
+        $html = $this->render([
+            'wind_direction_magnetic' => 290,
+            'wind_speed' => 12,
+            'gust_speed' => 18,
+            'gust_factor' => 6,
+            'peak_gust_today' => 20,
+            'peak_gust_time' => 1700000000,
+        ]);
+
+        $this->assertStringContainsString('💨 Wind', $html);
+        $this->assertStringContainsString('Direction', $html);
+        $this->assertStringContainsString('290°', $html);
+        $this->assertStringContainsString('<span class="sub">Mag</span>', $html);
+        $this->assertStringContainsString('Gust Factor', $html);
+        $this->assertStringContainsString('Peak Gust', $html);
+        $this->assertStringContainsString('wf-legend', $html);
+        $this->assertStringContainsString('lg-true', $html);
+        $this->assertStringContainsString('True N (13°E)', $html);
+    }
+
+    /**
+     * The redundant METAR summary line below the compass is not rendered.
+     */
+    public function testNoSummaryLineBelowCompass(): void
+    {
+        $html = $this->render([
+            'wind_direction_magnetic' => 290,
+            'wind_speed' => 12,
+            'gust_speed' => 18,
+        ]);
+
+        $this->assertStringNotContainsString('wind-summary', $html);
+    }
+
+    /**
+     * Calm wind shows "Calm" for speed and never a summary line.
+     */
+    public function testCalmWind_ShowsCalm(): void
+    {
+        $html = $this->render([
+            'wind_direction_magnetic' => 240,
+            'wind_speed' => 1,
+        ]);
+
+        $this->assertStringContainsString('Calm', $html);
+        $this->assertStringNotContainsString('wind-summary', $html);
+    }
+
+    /**
+     * Stale/missing wind fails closed to "---" rather than showing 0 or Calm.
+     */
+    public function testStaleWind_FailsClosed(): void
+    {
+        $html = $this->render([
+            'wind_direction_magnetic' => null,
+            'wind_speed' => null,
+            'gust_speed' => null,
+            'gust_factor' => null,
+        ]);
+
+        // Direction, Speed, Gusting, and Gust Factor all fall back to ---
+        $this->assertStringContainsString('---', $html);
+        $this->assertStringNotContainsString('Calm', $html);
+        $this->assertStringNotContainsString('<span class="sub">Mag</span>', $html);
+    }
+
+    /**
+     * The "last hr" petal legend appears only when recent wind data exists.
+     */
+    public function testPetalLegend_OnlyWhenRecentWindPresent(): void
+    {
+        $weather = ['wind_direction_magnetic' => 290, 'wind_speed' => 12];
+
+        $active = array_fill(0, 16, 0);
+        $active[7] = 5;
+        $withPetals = $this->render($weather, ['magneticDeclination' => 13, 'lastHourWind' => $active]);
+        $this->assertStringContainsString('last hr', $withPetals);
+        $this->assertStringContainsString('lg-petal', $withPetals);
+
+        $withoutPetals = $this->render($weather, ['magneticDeclination' => 13, 'lastHourWind' => array_fill(0, 16, 0)]);
+        $this->assertStringNotContainsString('last hr', $withoutPetals);
+    }
+
+    /**
+     * Zero magnetic declination omits the misleading "0°" variation label.
+     */
+    public function testZeroDeclination_OmitsVariationLabel(): void
+    {
+        $html = $this->render(
+            ['wind_direction_magnetic' => 290, 'wind_speed' => 12],
+            ['magneticDeclination' => 0, 'lastHourWind' => []]
+        );
+
+        $this->assertStringContainsString('True N', $html);
+        $this->assertStringNotContainsString('True N (0°', $html);
+    }
+}

--- a/tests/Unit/BuildFullWindSectionTest.php
+++ b/tests/Unit/BuildFullWindSectionTest.php
@@ -74,9 +74,11 @@ class BuildFullWindSectionTest extends TestCase
     }
 
     /**
-     * Calm wind shows "Calm" for speed and never a summary line.
+     * Calm wind shows "Calm" for speed, suppresses direction to "---" (a
+     * bearing is meaningless when calm), drops the "Mag" sublabel, and never
+     * renders a summary line - matching the card and dashboard.
      */
-    public function testCalmWind_ShowsCalm(): void
+    public function testCalmWind_ShowsCalmAndSuppressesDirection(): void
     {
         $html = $this->render([
             'wind_direction_magnetic' => 240,
@@ -84,7 +86,24 @@ class BuildFullWindSectionTest extends TestCase
         ]);
 
         $this->assertStringContainsString('Calm', $html);
+        $this->assertStringNotContainsString('240°', $html);
+        $this->assertStringNotContainsString('<span class="sub">Mag</span>', $html);
         $this->assertStringNotContainsString('wind-summary', $html);
+    }
+
+    /**
+     * Variable wind (VRB) shows "Variable" for direction with no "Mag" label.
+     */
+    public function testVariableWind_ShowsVariable(): void
+    {
+        $html = $this->render([
+            'wind_direction_magnetic' => null,
+            'wind_direction_text' => 'VRB',
+            'wind_speed' => 6,
+        ]);
+
+        $this->assertStringContainsString('Variable', $html);
+        $this->assertStringNotContainsString('<span class="sub">Mag</span>', $html);
     }
 
     /**


### PR DESCRIPTION
## Summary

Brings the full-* embeds (`full-single`, `full-dual`, `full-multi`) up to dashboard parity for the wind block, and unifies the markup so all three render identically. Continues the wind-forward work from the card (#163) and the shared-helper extraction (#164).

## What changed

`buildFullWindSection()` now computes the wind facts from the airport weather internally (instead of receiving pre-formatted strings from each renderer), and the section gains:

- **Gust Factor** row alongside Peak Gust + time, matching the dashboard.
- **Themed legend** (True N + magnetic variation, wind, runways, last hr) reused from the wind-forward card.
- Wind fields **fail closed to `---`** when stale/missing.
- **Removed the compass summary line** entirely: the METAR-style line below the compass duplicated the Direction/Speed/Gusting facts already in the wind-details column and stole vertical space from the diagram.

CSS: generalized the shared `.wf-legend`, `.lg-*` marker, and `.sub` styles from the `.style-card-wf` scope to `.embed-container` so both the card and full-* reuse one definition. The per-theme legend marker overrides are scoped to `.embed-container` (covering the theme class on the container itself for iframe embeds and on an ancestor for web components).

Removed the now-dead per-renderer wind formatting blocks and the unused `.style-full .wind-summary` styles - the helper owns that logic now.

## Affected functions

- `buildFullWindSection()` - new signature `(array \$weather, array \$options, ?array \$fullModeOptions, string \$canvasId, string \$timezone)`; computes + renders the section.
- `renderFullSingleWidget()`, `renderFullDualWidget()`, `renderFullMultiWidget()` - call the helper with the airport weather; dropped dead local formatting.

## Tests

- New `tests/Unit/BuildFullWindSectionTest.php` (6 tests): dashboard-parity facts, legend (incl. petal-legend gating and zero-declination label), fail-closed `---`, calm handling, and that no summary line is rendered.
- `make test-ci` green (0 errors).
- Verified visually across `full-single` (METAR: KSPB; non-METAR/PWS: KPFC), `full-dual`, `full-multi`, in light + dark, and at narrow/stacked widths. Non-METAR sites correctly omit the visibility/Conditions column (unchanged metrics logic) while still showing the full wind block; legend marker colors track the compass palette per theme.