### PR TITLE
Give the full-* embed compass a larger, size-aware share

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,9 @@ test-ci: ## Run all tests that GitHub CI runs (comprehensive)
 	@echo "5a1b️⃣  Runway Label Layout Tests (JS)..."
 	@node tests/js/runway-label-layout.test.js || { echo "❌ Runway label layout JS tests failed"; exit 1; }
 	@echo ""
+	@echo "5a1b2️⃣  Wind Compass Resize Tests (JS)..."
+	@node tests/js/wind-compass-resize.test.js || { echo "❌ Wind compass resize JS tests failed"; exit 1; }
+	@echo ""
 	@echo "5a1c️⃣  Status local calendar Tests (JS)..."
 	@node tests/js/status-local-calendar.test.js || { echo "❌ Status local calendar JS tests failed"; exit 1; }
 	@echo ""

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -230,7 +230,7 @@ server {
     }
 
     # Embed assets: same short cache as widget.js for consistency
-    location ~ ^/public/(js/(widget|embed-helpers|wind-visual|embed-wind-compass|runway-label-layout)\.js|css/embed-widgets\.css)$ {
+    location ~ ^/public/(js/(widget|embed-helpers|wind-visual|wind-compass-resize-utils|embed-wind-compass|runway-label-layout)\.js|css/embed-widgets\.css)$ {
         proxy_pass http://localhost:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/lib/embed-templates/full.php
+++ b/lib/embed-templates/full.php
@@ -467,7 +467,7 @@ HTML;
     $html .= '</a>';
     $html .= "\n</div>\n";
 
-    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 200, $fullModeOptions);
+    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 240, $fullModeOptions);
 
     return $html;
 }
@@ -632,7 +632,7 @@ HTML;
     $html .= '</a>';
     $html .= "\n</div>\n";
 
-    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 200, $fullModeOptions);
+    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 240, $fullModeOptions);
 
     return $html;
 }
@@ -799,7 +799,7 @@ HTML;
     $html .= '</a>';
     $html .= "\n</div>\n";
 
-    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 200, $fullModeOptions);
+    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 240, $fullModeOptions);
 
     return $html;
 }

--- a/lib/embed-templates/full.php
+++ b/lib/embed-templates/full.php
@@ -284,7 +284,7 @@ function buildFullWindSection(array $weather, array $options, ?array $fullModeOp
     return <<<HTML
             <div class="wind-section">
                 <div class="wind-viz-container">
-                    <canvas id="{$canvasId}" width="200" height="200"></canvas>
+                    <canvas id="{$canvasId}" width="240" height="240"></canvas>
                 </div>
                 <div class="wind-details">
                     <div class="column-header">💨 Wind</div>

--- a/lib/embed-templates/shared.php
+++ b/lib/embed-templates/shared.php
@@ -990,7 +990,7 @@ function renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, 
             }
 
             if (fullModeData && window.AviationWX.observeWindCompassCanvas) {
-                window.AviationWX.observeWindCompassCanvas(canvas, renderCompass);
+                window.AviationWX.observeWindCompassCanvas(canvas, renderCompass, {$size});
             } else {
                 renderCompass();
             }

--- a/lib/embed-templates/shared.php
+++ b/lib/embed-templates/shared.php
@@ -972,6 +972,7 @@ function renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, 
                 isDarkValue = detectDarkMode();
             }
             
+            var fullModeData = {$fullModeJson};
             var opts = {
                 windSpeed: {$windSpeedJson},
                 windDirection: {$windDirectionJson},
@@ -980,11 +981,19 @@ function renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, 
                 isDark: isDarkValue,
                 size: {$sizeVariantJson}
             };
-            var fullModeData = {$fullModeJson};
             if (fullModeData) {
                 opts.fullMode = fullModeData;
             }
-            window.AviationWX.drawWindCompass(canvas, opts);
+
+            function renderCompass() {
+                window.AviationWX.drawWindCompass(canvas, opts);
+            }
+
+            if (fullModeData && window.AviationWX.observeWindCompassCanvas) {
+                window.AviationWX.observeWindCompassCanvas(canvas, renderCompass);
+            } else {
+                renderCompass();
+            }
         }
         
         // Draw compass immediately if ready

--- a/pages/embed.php
+++ b/pages/embed.php
@@ -188,6 +188,7 @@ switch ($style) {
     <title><?= htmlspecialchars($embedPageTitle) ?></title>
     <link rel="stylesheet" href="/public/css/embed-widgets.css?v=<?= htmlspecialchars($embedAssetVersion) ?>">
     <script src="/public/js/runway-label-layout.js?v=<?= htmlspecialchars($embedAssetVersion) ?>"></script>
+    <script src="/public/js/wind-compass-resize-utils.js?v=<?= htmlspecialchars($embedAssetVersion) ?>"></script>
     <script src="/public/js/wind-visual.js?v=<?= htmlspecialchars($embedAssetVersion) ?>"></script>
     <style>
         /* Ensure full viewport usage for iframe */

--- a/public/css/embed-widgets.css
+++ b/public/css/embed-widgets.css
@@ -978,12 +978,15 @@ a {
     justify-content: center;
     align-items: center;
     padding: 0.75rem;
-    min-width: 160px;
+    flex: 1 1 52%;
+    min-width: 140px;
+    max-width: min(52%, 280px);
 }
 
 .style-full .wind-section .wind-details {
     padding: 0.4rem 0.5rem;
     border-left: 1px solid var(--border-color);
+    flex: 1 1 auto;
     min-width: 100px;
 }
 
@@ -1028,6 +1031,10 @@ a {
 
 .style-full .wind-viz-container canvas {
     display: block;
+    width: 100%;
+    height: auto;
+    max-width: 280px;
+    aspect-ratio: 1;
 }
 
 .style-full .metrics-section {
@@ -1166,11 +1173,14 @@ a {
     .style-full .wind-viz-container {
         padding: 0.5rem;
         min-width: unset;
+        max-width: none;
+        width: 100%;
+        align-items: center;
     }
     
     .style-full .wind-viz-container canvas {
-        width: 100px;
-        height: 100px;
+        width: min(100%, 240px);
+        max-width: 240px;
     }
     
     .style-full .wind-section .wind-details {

--- a/public/css/embed-widgets.css
+++ b/public/css/embed-widgets.css
@@ -980,7 +980,8 @@ a {
     padding: 0.75rem;
     flex: 1 1 52%;
     min-width: 140px;
-    max-width: min(52%, 280px);
+    width: 52%;
+    max-width: 280px;
 }
 
 .style-full .wind-section .wind-details {
@@ -1179,7 +1180,7 @@ a {
     }
     
     .style-full .wind-viz-container canvas {
-        width: min(100%, 240px);
+        width: 100%;
         max-width: 240px;
     }
     

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -696,19 +696,40 @@
                 `${BASE_URL}/public/js/embed-helpers.js`
             ];
             
-            for (const src of scripts) {
-                await new Promise((resolve, reject) => {
-                    if (document.querySelector(`script[src="${src}"]`)) {
-                        setTimeout(resolve, 10);
+            const scriptLoads = window.__aviationwxScriptLoads = window.__aviationwxScriptLoads || {};
+
+            const loadOneScript = (src) => {
+                if (scriptLoads[src]) {
+                    return scriptLoads[src];
+                }
+
+                scriptLoads[src] = new Promise((resolve, reject) => {
+                    const existing = document.querySelector(`script[src="${src}"]`);
+                    if (existing) {
+                        if (existing.dataset.aviationwxLoaded === '1') {
+                            resolve();
+                            return;
+                        }
+                        existing.addEventListener('load', () => resolve(), { once: true });
+                        existing.addEventListener('error', reject, { once: true });
                         return;
                     }
 
                     const script = document.createElement('script');
                     script.src = src;
-                    script.onload = () => setTimeout(resolve, 10);
+                    script.onload = () => {
+                        script.dataset.aviationwxLoaded = '1';
+                        setTimeout(resolve, 10);
+                    };
                     script.onerror = reject;
                     document.head.appendChild(script);
                 });
+
+                return scriptLoads[src];
+            };
+
+            for (const src of scripts) {
+                await loadOneScript(src);
             }
         }
 

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -728,44 +728,60 @@
                     return scriptLoads[src];
                 }
 
-                scriptLoads[src] = new Promise((resolve, reject) => {
+                scriptLoads[src] = new Promise((resolve) => {
+                    const settle = (el) => {
+                        if (el) {
+                            markScriptLoaded(el);
+                        }
+                        resolve();
+                    };
+
                     const existing = document.querySelector(`script[src="${src}"]`);
                     if (existing) {
                         if (existing.dataset.aviationwxLoaded === '1' || isScriptReady(src)) {
-                            markScriptLoaded(existing);
-                            resolve();
+                            settle(existing);
                             return;
                         }
                         const readyState = existing.readyState;
                         if (readyState === 'complete' || readyState === 'loaded') {
-                            if (isScriptReady(src)) {
-                                markScriptLoaded(existing);
-                                resolve();
-                            } else {
+                            if (!isScriptReady(src)) {
                                 console.warn(
                                     'AviationWX: shared script finished loading but expected globals are missing:',
                                     src
                                 );
-                                markScriptLoaded(existing);
-                                resolve();
                             }
+                            settle(existing);
                             return;
                         }
+                        const timeoutMs = 10000;
+                        const timeoutId = setTimeout(() => {
+                            console.warn(
+                                'AviationWX: timed out waiting for shared script to load; continuing without it:',
+                                src
+                            );
+                            settle(existing);
+                        }, timeoutMs);
                         existing.addEventListener('load', () => {
-                            markScriptLoaded(existing);
-                            resolve();
+                            clearTimeout(timeoutId);
+                            settle(existing);
                         }, { once: true });
-                        existing.addEventListener('error', reject, { once: true });
+                        existing.addEventListener('error', () => {
+                            clearTimeout(timeoutId);
+                            console.warn('AviationWX: shared script failed to load; continuing without it:', src);
+                            settle(existing);
+                        }, { once: true });
                         return;
                     }
 
                     const script = document.createElement('script');
                     script.src = src;
                     script.onload = () => {
-                        markScriptLoaded(script);
-                        resolve();
+                        settle(script);
                     };
-                    script.onerror = reject;
+                    script.onerror = () => {
+                        console.warn('AviationWX: shared script failed to load; continuing without it:', src);
+                        settle(script);
+                    };
                     document.head.appendChild(script);
                 });
 

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -736,6 +736,16 @@
                             resolve();
                             return;
                         }
+                        const readyState = existing.readyState;
+                        if (readyState === 'complete' || readyState === 'loaded') {
+                            if (isScriptReady(src)) {
+                                markScriptLoaded(existing);
+                                resolve();
+                            } else {
+                                reject(new Error(`Shared script did not initialize expected globals: ${src}`));
+                            }
+                            return;
+                        }
                         existing.addEventListener('load', () => {
                             markScriptLoaded(existing);
                             resolve();

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -694,24 +694,20 @@
                 `${BASE_URL}/public/js/embed-helpers.js`
             ];
             
-            const loadPromises = scripts.map(src => {
-                return new Promise((resolve, reject) => {
-                    // Check if already loaded
+            for (const src of scripts) {
+                await new Promise((resolve, reject) => {
                     if (document.querySelector(`script[src="${src}"]`)) {
-                        // Wait a bit for script to execute
                         setTimeout(resolve, 10);
                         return;
                     }
-                    
+
                     const script = document.createElement('script');
                     script.src = src;
-                    script.onload = () => setTimeout(resolve, 10); // Small delay for execution
+                    script.onload = () => setTimeout(resolve, 10);
                     script.onerror = reject;
                     document.head.appendChild(script);
                 });
-            });
-            
-            await Promise.all(loadPromises);
+            }
         }
 
 

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -742,7 +742,12 @@
                                 markScriptLoaded(existing);
                                 resolve();
                             } else {
-                                reject(new Error(`Shared script did not initialize expected globals: ${src}`));
+                                console.warn(
+                                    'AviationWX: shared script finished loading but expected globals are missing:',
+                                    src
+                                );
+                                markScriptLoaded(existing);
+                                resolve();
                             }
                             return;
                         }

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -622,10 +622,7 @@
                     const fullMode = weather.wind_compass_full_mode || null;
                     const isFullModeCanvas = !!fullMode || !!canvas.closest('.wind-viz-container');
 
-                    const drawOne = () => {
-                        const cssSize = (window.AviationWX.syncWindCompassCanvasPixels && isFullModeCanvas)
-                            ? window.AviationWX.syncWindCompassCanvasPixels(canvas, 240)
-                            : canvas.width;
+                    const renderCompass = (cssSize) => {
                         let size = 'medium';
                         if (cssSize >= 240) size = 'full';
                         else if (cssSize >= 100) size = 'large';
@@ -651,9 +648,14 @@
                     };
 
                     if (isFullModeCanvas && window.AviationWX.observeWindCompassCanvas) {
-                        window.AviationWX.observeWindCompassCanvas(canvas, drawOne, 240);
+                        window.AviationWX.observeWindCompassCanvas(canvas, () => {
+                            renderCompass(canvas.clientWidth || 240);
+                        }, 240);
                     } else {
-                        drawOne();
+                        const cssSize = (window.AviationWX.syncWindCompassCanvasPixels && isFullModeCanvas)
+                            ? window.AviationWX.syncWindCompassCanvasPixels(canvas, 240)
+                            : canvas.width;
+                        renderCompass(cssSize);
                     }
                 });
             };

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -624,7 +624,7 @@
 
                     const drawOne = () => {
                         const cssSize = (window.AviationWX.syncWindCompassCanvasPixels && isFullModeCanvas)
-                            ? window.AviationWX.syncWindCompassCanvasPixels(canvas, canvas.width || 240)
+                            ? window.AviationWX.syncWindCompassCanvasPixels(canvas, 240)
                             : canvas.width;
                         let size = 'medium';
                         if (cssSize >= 240) size = 'full';
@@ -651,7 +651,7 @@
                     };
 
                     if (isFullModeCanvas && window.AviationWX.observeWindCompassCanvas) {
-                        window.AviationWX.observeWindCompassCanvas(canvas, drawOne, canvas.width || 240);
+                        window.AviationWX.observeWindCompassCanvas(canvas, drawOne, 240);
                     } else {
                         drawOne();
                     }

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -652,9 +652,10 @@
                             renderCompass(canvas.clientWidth || 240);
                         }, 240);
                     } else {
+                        const fallbackCssSize = isFullModeCanvas ? 240 : canvas.width;
                         const cssSize = (window.AviationWX.syncWindCompassCanvasPixels && isFullModeCanvas)
-                            ? window.AviationWX.syncWindCompassCanvasPixels(canvas, 240)
-                            : canvas.width;
+                            ? window.AviationWX.syncWindCompassCanvasPixels(canvas, fallbackCssSize)
+                            : fallbackCssSize;
                         renderCompass(cssSize);
                     }
                 });
@@ -698,6 +699,30 @@
             
             const scriptLoads = window.__aviationwxScriptLoads = window.__aviationwxScriptLoads || {};
 
+            const scriptReadyChecks = {
+                [`${BASE_URL}/public/js/runway-label-layout.js`]: () => (
+                    window.AviationWX && window.AviationWX.runwayLabelLayout
+                ),
+                [`${BASE_URL}/public/js/wind-compass-resize-utils.js`]: () => (
+                    window.AviationWX && window.AviationWX.windCompassResize
+                ),
+                [`${BASE_URL}/public/js/wind-visual.js`]: () => (
+                    window.AviationWX && typeof window.AviationWX.drawWindCompass === 'function'
+                ),
+                [`${BASE_URL}/public/js/embed-helpers.js`]: () => (
+                    window.AviationWX && window.AviationWX.helpers
+                ),
+            };
+
+            const markScriptLoaded = (el) => {
+                el.dataset.aviationwxLoaded = '1';
+            };
+
+            const isScriptReady = (src) => {
+                const check = scriptReadyChecks[src];
+                return check ? !!check() : false;
+            };
+
             const loadOneScript = (src) => {
                 if (scriptLoads[src]) {
                     return scriptLoads[src];
@@ -706,11 +731,15 @@
                 scriptLoads[src] = new Promise((resolve, reject) => {
                     const existing = document.querySelector(`script[src="${src}"]`);
                     if (existing) {
-                        if (existing.dataset.aviationwxLoaded === '1') {
+                        if (existing.dataset.aviationwxLoaded === '1' || isScriptReady(src)) {
+                            markScriptLoaded(existing);
                             resolve();
                             return;
                         }
-                        existing.addEventListener('load', () => resolve(), { once: true });
+                        existing.addEventListener('load', () => {
+                            markScriptLoaded(existing);
+                            resolve();
+                        }, { once: true });
                         existing.addEventListener('error', reject, { once: true });
                         return;
                     }
@@ -718,8 +747,8 @@
                     const script = document.createElement('script');
                     script.src = src;
                     script.onload = () => {
-                        script.dataset.aviationwxLoaded = '1';
-                        setTimeout(resolve, 10);
+                        markScriptLoaded(script);
+                        resolve();
                     };
                     script.onerror = reject;
                     document.head.appendChild(script);

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -618,33 +618,43 @@
                 const isDark = detectDarkMode();
                 
                 canvases.forEach((canvas) => {
-                    const width = canvas.width;
-                    let size = 'medium';
-                    if (width >= 100) size = 'large';
-                    else if (width >= 80) size = 'medium';
-                    else if (width >= 60) size = 'small';
-                    else size = 'mini';
-                    
-                    // Clear canvas first
-                    const ctx = canvas.getContext('2d');
-                    ctx.clearRect(0, 0, canvas.width, canvas.height);
-                    
                     const runways = airport.runways || [];
                     const fullMode = weather.wind_compass_full_mode || null;
-                    
-                    // Draw compass (full mode: runways + wind rose petals when available)
-                    const wd = weather.wind_direction;
-                    const windDir = (wd && typeof wd === 'object') ? (wd.magnetic_north ?? null) : (weather.wind_direction_magnetic ?? null);
-                    const isVRB = (wd && typeof wd === 'object') ? !!wd.variable : (weather.wind_direction_text || '') === 'VRB';
-                    window.AviationWX.drawWindCompass(canvas, {
-                        windSpeed: weather.wind_speed ?? null,
-                        windDirection: windDir,
-                        isVRB: isVRB,
-                        runways: runways,
-                        isDark: isDark,
-                        size: size,
-                        fullMode: fullMode
-                    });
+                    const isFullModeCanvas = !!fullMode || !!canvas.closest('.wind-viz-container');
+
+                    const drawOne = () => {
+                        const cssSize = (window.AviationWX.syncWindCompassCanvasPixels && isFullModeCanvas)
+                            ? window.AviationWX.syncWindCompassCanvasPixels(canvas, canvas.width || 240)
+                            : canvas.width;
+                        let size = 'medium';
+                        if (cssSize >= 240) size = 'full';
+                        else if (cssSize >= 100) size = 'large';
+                        else if (cssSize >= 80) size = 'medium';
+                        else if (cssSize >= 60) size = 'small';
+                        else size = 'mini';
+
+                        const ctx = canvas.getContext('2d');
+                        ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+                        const wd = weather.wind_direction;
+                        const windDir = (wd && typeof wd === 'object') ? (wd.magnetic_north ?? null) : (weather.wind_direction_magnetic ?? null);
+                        const isVRB = (wd && typeof wd === 'object') ? !!wd.variable : (weather.wind_direction_text || '') === 'VRB';
+                        window.AviationWX.drawWindCompass(canvas, {
+                            windSpeed: weather.wind_speed ?? null,
+                            windDirection: windDir,
+                            isVRB: isVRB,
+                            runways: runways,
+                            isDark: isDark,
+                            size: size,
+                            fullMode: fullMode
+                        });
+                    };
+
+                    if (isFullModeCanvas && window.AviationWX.observeWindCompassCanvas) {
+                        window.AviationWX.observeWindCompassCanvas(canvas, drawOne);
+                    } else {
+                        drawOne();
+                    }
                 });
             };
             
@@ -679,6 +689,7 @@
             
             const scripts = [
                 `${BASE_URL}/public/js/runway-label-layout.js`,
+                `${BASE_URL}/public/js/wind-compass-resize-utils.js`,
                 `${BASE_URL}/public/js/wind-visual.js`,
                 `${BASE_URL}/public/js/embed-helpers.js`
             ];

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -651,7 +651,7 @@
                     };
 
                     if (isFullModeCanvas && window.AviationWX.observeWindCompassCanvas) {
-                        window.AviationWX.observeWindCompassCanvas(canvas, drawOne);
+                        window.AviationWX.observeWindCompassCanvas(canvas, drawOne, canvas.width || 240);
                     } else {
                         drawOne();
                     }

--- a/public/js/wind-compass-resize-utils.js
+++ b/public/js/wind-compass-resize-utils.js
@@ -60,4 +60,4 @@
             computeWindCompassPixelSize,
         };
     }
-})(typeof window !== 'undefined' ? window : globalThis);
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/public/js/wind-compass-resize-utils.js
+++ b/public/js/wind-compass-resize-utils.js
@@ -1,0 +1,63 @@
+/**
+ * Wind compass resize helpers for full-* embeds.
+ *
+ * Keeps the canvas bitmap in sync with its displayed box so narrow columns
+ * get a crisp redraw instead of a CSS-downscaled bitmap.
+ *
+ * @module wind-compass-resize-utils
+ */
+(function (global) {
+    'use strict';
+
+    const MIN_CSS_SIZE = 48;
+    const MAX_CSS_SIZE = 280;
+
+    /**
+     * Clamp and round the CSS box size used for a square wind compass.
+     *
+     * @param {number} clientWidth Measured container/client width in CSS pixels
+     * @param {number} [fallback=200] Fallback when width is unavailable
+     * @returns {number} CSS pixel size (width and height)
+     */
+    function resolveWindCompassCssSize(clientWidth, fallback) {
+        const base = Number.isFinite(clientWidth) && clientWidth > 0
+            ? clientWidth
+            : (fallback || 200);
+        return Math.max(MIN_CSS_SIZE, Math.min(MAX_CSS_SIZE, Math.round(base)));
+    }
+
+    /**
+     * Map a CSS display size to canvas backing-store pixels.
+     *
+     * @param {number} cssSize Display width/height in CSS pixels
+     * @param {number} [devicePixelRatio=1] Window/device pixel ratio
+     * @returns {{cssSize: number, pixelSize: number}}
+     */
+    function computeWindCompassPixelSize(cssSize, devicePixelRatio) {
+        const safeCss = resolveWindCompassCssSize(cssSize, cssSize);
+        const dpr = Number.isFinite(devicePixelRatio) && devicePixelRatio > 0
+            ? devicePixelRatio
+            : 1;
+        return {
+            cssSize: safeCss,
+            pixelSize: Math.max(1, Math.round(safeCss * dpr)),
+        };
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            MIN_CSS_SIZE,
+            MAX_CSS_SIZE,
+            resolveWindCompassCssSize,
+            computeWindCompassPixelSize,
+        };
+    } else {
+        global.AviationWX = global.AviationWX || {};
+        global.AviationWX.windCompassResize = {
+            MIN_CSS_SIZE,
+            MAX_CSS_SIZE,
+            resolveWindCompassCssSize,
+            computeWindCompassPixelSize,
+        };
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/public/js/wind-compass-resize-utils.js
+++ b/public/js/wind-compass-resize-utils.js
@@ -10,7 +10,7 @@
     'use strict';
 
     const MIN_CSS_SIZE = 48;
-    const MAX_CSS_SIZE = 280;
+    const MAX_CSS_SIZE = 300;
 
     /**
      * Clamp and round the CSS box size used for a square wind compass.

--- a/public/js/wind-visual.js
+++ b/public/js/wind-visual.js
@@ -677,10 +677,11 @@
             return fallbackCssSize || 200;
         }
 
-        const rect = canvas.getBoundingClientRect();
-        const measured = rect.width > 0
-            ? rect.width
-            : (canvas.offsetWidth || fallbackCssSize || 200);
+        const measured = canvas.clientWidth > 0
+            ? canvas.clientWidth
+            : (rect.width > 0
+                ? rect.width
+                : (canvas.offsetWidth || fallbackCssSize || 200));
         const dpr = window.devicePixelRatio || 1;
         const compute = resizeUtils.computeWindCompassPixelSize;
         const resolved = typeof compute === 'function'
@@ -704,14 +705,34 @@
      * @param {HTMLCanvasElement} canvas
      * @param {Function} drawFn Callback that draws using the current canvas pixels
      */
-    function observeWindCompassCanvas(canvas, drawFn) {
+    function observeWindCompassCanvas(canvas, drawFn, fallbackCssSize) {
         if (!canvas || typeof drawFn !== 'function') {
             return;
         }
 
+        const fallback = fallbackCssSize || 240;
+        canvas._aviationwxWindCompassRedraw = drawFn;
+
         const redraw = function() {
-            syncWindCompassCanvasPixels(canvas);
-            drawFn();
+            if (!canvas.isConnected) {
+                const obs = compassObservers && compassObservers.get(canvas);
+                if (obs && typeof obs.disconnect === 'function') {
+                    obs.disconnect();
+                }
+                if (compassObservers) {
+                    compassObservers.delete(canvas);
+                }
+                delete canvas._aviationwxWindCompassRedraw;
+                return;
+            }
+
+            const latestDraw = canvas._aviationwxWindCompassRedraw;
+            if (typeof latestDraw !== 'function') {
+                return;
+            }
+
+            syncWindCompassCanvasPixels(canvas, fallback);
+            latestDraw();
         };
 
         if (compassObservers && !compassObservers.has(canvas)) {
@@ -729,6 +750,7 @@
                 compassObservers.set(canvas, {
                     disconnect: function() {
                         window.removeEventListener('resize', onResize);
+                        delete canvas._aviationwxWindCompassRedraw;
                     },
                 });
             }

--- a/public/js/wind-visual.js
+++ b/public/js/wind-visual.js
@@ -677,6 +677,7 @@
             return fallbackCssSize || 200;
         }
 
+        const rect = canvas.getBoundingClientRect();
         const measured = canvas.clientWidth > 0
             ? canvas.clientWidth
             : (rect.width > 0

--- a/public/js/wind-visual.js
+++ b/public/js/wind-visual.js
@@ -690,11 +690,14 @@
                 : (canvas.offsetWidth || fallbackCssSize || 200));
         const dpr = window.devicePixelRatio || 1;
         const compute = getWindCompassResizeUtils().computeWindCompassPixelSize;
+        const utils = getWindCompassResizeUtils();
+        const minCss = utils.MIN_CSS_SIZE || 48;
+        const maxCss = utils.MAX_CSS_SIZE || 300;
         const resolved = typeof compute === 'function'
             ? compute(measured, dpr)
             : {
-                cssSize: Math.max(48, Math.round(measured || fallbackCssSize || 200)),
-                pixelSize: Math.max(1, Math.round(Math.max(48, Math.round(measured || fallbackCssSize || 200)) * dpr)),
+                cssSize: Math.max(minCss, Math.min(maxCss, Math.round(measured || fallbackCssSize || 200))),
+                pixelSize: Math.max(1, Math.round(Math.max(minCss, Math.min(maxCss, Math.round(measured || fallbackCssSize || 200))) * dpr)),
             };
 
         if (canvas.width !== resolved.pixelSize || canvas.height !== resolved.pixelSize) {

--- a/public/js/wind-visual.js
+++ b/public/js/wind-visual.js
@@ -676,21 +676,25 @@
         if (!canvas) {
             return fallbackCssSize || 200;
         }
-        const parent = canvas.parentElement;
-        const measured = parent ? parent.clientWidth : canvas.clientWidth;
+
+        const rect = canvas.getBoundingClientRect();
+        const measured = rect.width > 0
+            ? rect.width
+            : (canvas.offsetWidth || fallbackCssSize || 200);
+        const dpr = window.devicePixelRatio || 1;
         const compute = resizeUtils.computeWindCompassPixelSize;
         const resolved = typeof compute === 'function'
-            ? compute(measured, window.devicePixelRatio || 1)
+            ? compute(measured, dpr)
             : {
                 cssSize: Math.max(48, Math.round(measured || fallbackCssSize || 200)),
-                pixelSize: Math.max(48, Math.round(measured || fallbackCssSize || 200)),
+                pixelSize: Math.max(1, Math.round(Math.max(48, Math.round(measured || fallbackCssSize || 200)) * dpr)),
             };
+
         if (canvas.width !== resolved.pixelSize || canvas.height !== resolved.pixelSize) {
             canvas.width = resolved.pixelSize;
             canvas.height = resolved.pixelSize;
         }
-        canvas.style.width = resolved.cssSize + 'px';
-        canvas.style.height = resolved.cssSize + 'px';
+
         return resolved.cssSize;
     }
 
@@ -711,12 +715,11 @@
         };
 
         if (compassObservers && !compassObservers.has(canvas)) {
-            const target = canvas.parentElement || canvas;
             if (typeof ResizeObserver !== 'undefined') {
                 const ro = new ResizeObserver(function() {
                     redraw();
                 });
-                ro.observe(target);
+                ro.observe(canvas);
                 compassObservers.set(canvas, ro);
             } else {
                 const onResize = function() {

--- a/public/js/wind-visual.js
+++ b/public/js/wind-visual.js
@@ -662,8 +662,13 @@
         ctx.fillText('CALM', cx, cy);
     }
 
-    const resizeUtils = (window.AviationWX && window.AviationWX.windCompassResize) || {};
-    const compassObservers = typeof WeakMap !== 'undefined' ? new WeakMap() : null;
+    const compassObservers = typeof WeakMap !== 'undefined'
+        ? new WeakMap()
+        : (typeof Map !== 'undefined' ? new Map() : null);
+
+    function getWindCompassResizeUtils() {
+        return (window.AviationWX && window.AviationWX.windCompassResize) || {};
+    }
 
     /**
      * Resize a wind compass canvas backing store to match its displayed box.
@@ -684,7 +689,7 @@
                 ? rect.width
                 : (canvas.offsetWidth || fallbackCssSize || 200));
         const dpr = window.devicePixelRatio || 1;
-        const compute = resizeUtils.computeWindCompassPixelSize;
+        const compute = getWindCompassResizeUtils().computeWindCompassPixelSize;
         const resolved = typeof compute === 'function'
             ? compute(measured, dpr)
             : {
@@ -745,6 +750,14 @@
                 compassObservers.set(canvas, ro);
             } else {
                 const onResize = function() {
+                    if (!canvas.isConnected) {
+                        window.removeEventListener('resize', onResize);
+                        if (compassObservers) {
+                            compassObservers.delete(canvas);
+                        }
+                        delete canvas._aviationwxWindCompassRedraw;
+                        return;
+                    }
                     redraw();
                 };
                 window.addEventListener('resize', onResize);

--- a/public/js/wind-visual.js
+++ b/public/js/wind-visual.js
@@ -713,6 +713,7 @@
      *
      * @param {HTMLCanvasElement} canvas
      * @param {Function} drawFn Callback that draws using the current canvas pixels
+     * @param {number} [fallbackCssSize=240] CSS-pixel size when layout is not ready
      */
     function observeWindCompassCanvas(canvas, drawFn, fallbackCssSize) {
         if (!canvas || typeof drawFn !== 'function') {

--- a/public/js/wind-visual.js
+++ b/public/js/wind-visual.js
@@ -662,9 +662,83 @@
         ctx.fillText('CALM', cx, cy);
     }
 
+    const resizeUtils = (window.AviationWX && window.AviationWX.windCompassResize) || {};
+    const compassObservers = typeof WeakMap !== 'undefined' ? new WeakMap() : null;
+
+    /**
+     * Resize a wind compass canvas backing store to match its displayed box.
+     *
+     * @param {HTMLCanvasElement} canvas
+     * @param {number} [fallbackCssSize=200]
+     * @returns {number} CSS pixel size used
+     */
+    function syncWindCompassCanvasPixels(canvas, fallbackCssSize) {
+        if (!canvas) {
+            return fallbackCssSize || 200;
+        }
+        const parent = canvas.parentElement;
+        const measured = parent ? parent.clientWidth : canvas.clientWidth;
+        const compute = resizeUtils.computeWindCompassPixelSize;
+        const resolved = typeof compute === 'function'
+            ? compute(measured, window.devicePixelRatio || 1)
+            : {
+                cssSize: Math.max(48, Math.round(measured || fallbackCssSize || 200)),
+                pixelSize: Math.max(48, Math.round(measured || fallbackCssSize || 200)),
+            };
+        if (canvas.width !== resolved.pixelSize || canvas.height !== resolved.pixelSize) {
+            canvas.width = resolved.pixelSize;
+            canvas.height = resolved.pixelSize;
+        }
+        canvas.style.width = resolved.cssSize + 'px';
+        canvas.style.height = resolved.cssSize + 'px';
+        return resolved.cssSize;
+    }
+
+    /**
+     * Observe container size and redraw a full-mode compass at the displayed size.
+     *
+     * @param {HTMLCanvasElement} canvas
+     * @param {Function} drawFn Callback that draws using the current canvas pixels
+     */
+    function observeWindCompassCanvas(canvas, drawFn) {
+        if (!canvas || typeof drawFn !== 'function') {
+            return;
+        }
+
+        const redraw = function() {
+            syncWindCompassCanvasPixels(canvas);
+            drawFn();
+        };
+
+        if (compassObservers && !compassObservers.has(canvas)) {
+            const target = canvas.parentElement || canvas;
+            if (typeof ResizeObserver !== 'undefined') {
+                const ro = new ResizeObserver(function() {
+                    redraw();
+                });
+                ro.observe(target);
+                compassObservers.set(canvas, ro);
+            } else {
+                const onResize = function() {
+                    redraw();
+                };
+                window.addEventListener('resize', onResize);
+                compassObservers.set(canvas, {
+                    disconnect: function() {
+                        window.removeEventListener('resize', onResize);
+                    },
+                });
+            }
+        }
+
+        redraw();
+    }
+
     window.AviationWX = window.AviationWX || {};
     window.AviationWX.drawWindCompass = drawWindCompass;
     window.AviationWX.getWindCompassColors = getWindCompassColors;
     window.AviationWX.CALM_WIND_THRESHOLD = CALM_WIND_THRESHOLD;
+    window.AviationWX.syncWindCompassCanvasPixels = syncWindCompassCanvasPixels;
+    window.AviationWX.observeWindCompassCanvas = observeWindCompassCanvas;
 
 })(window);

--- a/tests/js/wind-compass-resize.test.js
+++ b/tests/js/wind-compass-resize.test.js
@@ -1,0 +1,61 @@
+/**
+ * Wind compass resize utility tests (mocked, CI-safe).
+ *
+ * Run with: node tests/js/wind-compass-resize.test.js
+ */
+
+const {
+    MIN_CSS_SIZE,
+    MAX_CSS_SIZE,
+    resolveWindCompassCssSize,
+    computeWindCompassPixelSize,
+} = require('../../public/js/wind-compass-resize-utils.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`  ✓ ${name}`);
+        passed++;
+    } catch (e) {
+        console.error(`  ✗ ${name}`);
+        console.error(`    ${e.message}`);
+        failed++;
+    }
+}
+
+function assertEqual(actual, expected, message) {
+    if (actual !== expected) {
+        throw new Error(`${message}: expected ${expected}, got ${actual}`);
+    }
+}
+
+console.log('\nWind Compass Resize Tests\n' + '='.repeat(50));
+
+test('resolveWindCompassCssSize clamps to min/max', () => {
+    assertEqual(resolveWindCompassCssSize(20, 200), MIN_CSS_SIZE, 'min clamp');
+    assertEqual(resolveWindCompassCssSize(400, 200), MAX_CSS_SIZE, 'max clamp');
+    assertEqual(resolveWindCompassCssSize(180, 200), 180, 'in-range');
+});
+
+test('resolveWindCompassCssSize falls back when width is invalid', () => {
+    assertEqual(resolveWindCompassCssSize(0, 200), 200, 'zero width');
+    assertEqual(resolveWindCompassCssSize(NaN, 220), 220, 'NaN width');
+});
+
+test('computeWindCompassPixelSize honors devicePixelRatio', () => {
+    const result = computeWindCompassPixelSize(200, 2);
+    assertEqual(result.cssSize, 200, 'css size');
+    assertEqual(result.pixelSize, 400, 'pixel size');
+});
+
+test('computeWindCompassPixelSize defaults DPR to 1', () => {
+    const result = computeWindCompassPixelSize(160, 0);
+    assertEqual(result.pixelSize, 160, 'pixel size without DPR');
+});
+
+console.log('\n' + '='.repeat(50));
+console.log(`Results: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/js/wind-compass-resize.test.js
+++ b/tests/js/wind-compass-resize.test.js
@@ -36,7 +36,7 @@ console.log('\nWind Compass Resize Tests\n' + '='.repeat(50));
 
 test('resolveWindCompassCssSize clamps to min/max', () => {
     assertEqual(resolveWindCompassCssSize(20, 200), MIN_CSS_SIZE, 'min clamp');
-    assertEqual(resolveWindCompassCssSize(400, 200), 300, 'max clamp');
+    assertEqual(resolveWindCompassCssSize(400, 200), MAX_CSS_SIZE, 'max clamp');
     assertEqual(resolveWindCompassCssSize(180, 200), 180, 'in-range');
 });
 

--- a/tests/js/wind-compass-resize.test.js
+++ b/tests/js/wind-compass-resize.test.js
@@ -36,7 +36,7 @@ console.log('\nWind Compass Resize Tests\n' + '='.repeat(50));
 
 test('resolveWindCompassCssSize clamps to min/max', () => {
     assertEqual(resolveWindCompassCssSize(20, 200), MIN_CSS_SIZE, 'min clamp');
-    assertEqual(resolveWindCompassCssSize(400, 200), MAX_CSS_SIZE, 'max clamp');
+    assertEqual(resolveWindCompassCssSize(400, 200), 300, 'max clamp');
     assertEqual(resolveWindCompassCssSize(180, 200), 180, 'in-range');
 });
 


### PR DESCRIPTION
## Summary

Makes the full-* embed wind compass scale to its container and redraw at the displayed size so pilots get a larger, sharper runway diagram in narrow third-party columns.

## What changed

- Added `public/js/wind-compass-resize-utils.js` with clamped CSS/pixel size helpers (tested in CI).
- `wind-visual.js` now exposes `syncWindCompassCanvasPixels()` and `observeWindCompassCanvas()` (ResizeObserver with resize fallback).
- `renderWindCompassScript()` and `widget.js` use the observer for full-mode compasses; iframe embeds load the utils script before `wind-visual.js`.
- CSS: increased the compass flex share in `.style-full .wind-section`, set responsive `width`/`aspect-ratio` on the canvas, and removed the 100px CSS-only shrink at the narrowest breakpoint.
- Full-* templates start from a 240px canvas fallback before JS sizing runs.

## Tests

- New `tests/js/wind-compass-resize.test.js` (4 tests, mocked).
- `make test-ci` green (0 errors).

## Merge sequence

This is **PR 3 of 3** in the stacked embed series. Merge in order:

1. #172 (tokens) - `feature/embed-shared-design-tokens` into `main`
2. #173 (dead CSS) - `feature/embed-card-dead-css-cleanup` into #172 tip
3. **This PR (#168)** - `feature/embed-full-compass-sizing` into #173 tip

Closes #168