### PR TITLE
Publish live SFTP SSH host key roster over HTTPS

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -33,6 +33,10 @@ Options -Indexes
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^robots\.txt$ public/robots.txt [L]
 
+    # Upload SFTP SSH host key roster (well-known JSON)
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^\.well-known/aviationwx-upload-ssh-host-keys\.json$ api/upload-ssh-host-keys.php [L]
+
     # Route API endpoints to api/ directory
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^weather\.php$ api/weather.php [L]

--- a/api/upload-ssh-host-keys.php
+++ b/api/upload-ssh-host-keys.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Upload SFTP SSH host key roster (well-known JSON).
+ *
+ * GET /.well-known/aviationwx-upload-ssh-host-keys.json
+ * Fingerprints are computed at request time from /etc/ssh/ssh_host_*_key.pub.
+ */
+
+require_once __DIR__ . '/../lib/cache-headers.php';
+require_once __DIR__ . '/../lib/logger.php';
+require_once __DIR__ . '/../lib/upload-ssh-host-keys.php';
+
+sendNoStoreCacheHeaders(60);
+header('Content-Type: application/json; charset=utf-8');
+
+$requestMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($requestMethod === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+if ($requestMethod !== 'GET') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed'], JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+$document = buildUploadSshHostKeysDocument();
+if ($document === null) {
+    aviationwx_log('error', 'upload ssh host keys roster unavailable', [
+        'ssh_dir' => UPLOAD_SSH_HOST_KEYS_DIR,
+    ], 'app');
+    http_response_code(503);
+    echo json_encode([
+        'error' => 'SSH host key roster unavailable',
+    ], JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+echo json_encode($document, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);

--- a/api/upload-ssh-host-keys.php
+++ b/api/upload-ssh-host-keys.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/../lib/cache-headers.php';
 require_once __DIR__ . '/../lib/logger.php';
 require_once __DIR__ . '/../lib/upload-ssh-host-keys.php';
 
-sendNoStoreCacheHeaders(60);
+sendNoStoreCacheHeaders();
 header('Content-Type: application/json; charset=utf-8');
 
 $requestMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';

--- a/api/upload-ssh-host-keys.php
+++ b/api/upload-ssh-host-keys.php
@@ -20,6 +20,7 @@ if ($requestMethod === 'OPTIONS') {
 }
 
 if ($requestMethod !== 'GET') {
+    header('Allow: GET, OPTIONS');
     http_response_code(405);
     echo json_encode(['error' => 'Method not allowed'], JSON_UNESCAPED_SLASHES);
     exit;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -442,7 +442,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        add_header Cache-Control "no-store, no-cache, must-revalidate, private, max-age=60, s-maxage=60" always;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, private, max-age=0, s-maxage=0" always;
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
     }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -434,6 +434,19 @@ server {
         add_header Cache-Control "public, max-age=86400";
     }
 
+    # Live SFTP SSH host key roster (upload hostname). Cache headers mirror getNoStoreCacheHeaders()
+    # in lib/cache-headers.php - belt-and-suspenders at the edge; stale pins cause SFTP outages.
+    location = /.well-known/aviationwx-upload-ssh-host-keys.json {
+        proxy_pass http://localhost:8080/api/upload-ssh-host-keys.php;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, private, max-age=60, s-maxage=60" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+    }
+
     # Webcam API
     location ~ ^/webcam\.php$ {
         # Rate limiting handled by PHP application-level rate limiting

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -442,6 +442,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_hide_header Cache-Control;
+        proxy_hide_header Pragma;
+        proxy_hide_header Expires;
         add_header Cache-Control "no-store, no-cache, must-revalidate, private, max-age=0, s-maxage=0" always;
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -894,6 +894,7 @@ For cameras that upload images to the server:
 **Connection details:**
 - SFTP: port from `config.network_ports.sftp` (default 2222), host from `upload_hostname` / `upload.{base_domain}`
 - FTP/FTPS: control port from `config.network_ports.ftp_control` (default 2121), same host as SFTP
+- **SSH host key roster:** `GET https://{upload_hostname}/.well-known/aviationwx-upload-ssh-host-keys.json` returns live SHA256 fingerprints from the container sshd host keys (`/etc/ssh/ssh_host_*_key.pub`). Responses use aggressive no-store cache headers (`max-age=60`, `s-maxage=60`). Clients can compare against `ssh-keyscan -p {sftp_port} {upload_hostname}`.
 - **Both protocols enabled**: Each push camera gets FTP and SFTP with the same credentials
 - Restricted client networks: set `config.network_ports.ftps_alt` for an extra inbound control port (NAT to `ftp_control`); `deploy-configure-firewall.sh` applies UFW and NAT on deploy. See [FTPS alternate control port (NAT redirect)](OPERATIONS.md#ftps-alternate-control-port-nat-redirect).
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -894,7 +894,7 @@ For cameras that upload images to the server:
 **Connection details:**
 - SFTP: port from `config.network_ports.sftp` (default 2222), host from `upload_hostname` / `upload.{base_domain}`
 - FTP/FTPS: control port from `config.network_ports.ftp_control` (default 2121), same host as SFTP
-- **SSH host key roster:** `GET https://{upload_hostname}/.well-known/aviationwx-upload-ssh-host-keys.json` returns live SHA256 fingerprints from the container sshd host keys (`/etc/ssh/ssh_host_*_key.pub`). Responses use aggressive no-store cache headers (`max-age=60`, `s-maxage=60`). Clients can compare against `ssh-keyscan -p {sftp_port} {upload_hostname}`.
+- **SSH host key roster:** `GET https://{upload_hostname}/.well-known/aviationwx-upload-ssh-host-keys.json` returns live SHA256 fingerprints from the container sshd host keys (`/etc/ssh/ssh_host_*_key.pub`). Responses use aggressive no-store cache headers (`no-store`, `max-age=0`, `s-maxage=0`). Clients can compare against `ssh-keyscan -p {sftp_port} {upload_hostname}`.
 - **Both protocols enabled**: Each push camera gets FTP and SFTP with the same credentials
 - Restricted client networks: set `config.network_ports.ftps_alt` for an extra inbound control port (NAT to `ftp_control`); `deploy-configure-firewall.sh` applies UFW and NAT on deploy. See [FTPS alternate control port (NAT redirect)](OPERATIONS.md#ftps-alternate-control-port-nat-redirect).
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -555,6 +555,15 @@ Production can run functional FTPS/SFTP upload probes and restart wedged daemons
 
 **Probe connect host:** Production Docker uses `network_mode: host`. Set `config.upload_health_probe.probe_connect_host` to `127.0.0.1` so on-box probes reach vsftpd and sshd locally. Leave empty only if probes succeed via `upload_hostname` without hairpin NAT. External cameras still use `upload_hostname`.
 
+**SFTP host key roster (HTTPS):** Bridge and other SFTP clients can fetch live sshd host key fingerprints from the upload hostname:
+
+```bash
+curl -fsS "https://$(jq -r '.config.upload_hostname // empty' ~/airports.json)/.well-known/aviationwx-upload-ssh-host-keys.json" | jq .
+ssh-keyscan -p 2222 upload.aviationwx.org | ssh-keygen -lf -
+```
+
+Every `SHA256:` from `ssh-keyscan` must appear in the JSON `sha256[]` array. Fingerprints are computed at request time from `/etc/ssh/ssh_host_*_key.pub` in the web container (same container that runs sshd). After an image rebuild, re-run the comparison to confirm the roster tracks new keys.
+
 **Probe files:** Each run overwrites `aviationwx-probe-healthcheck.txt` on the probe account (no per-run timestamp filenames).
 
 ```bash

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -558,8 +558,10 @@ Production can run functional FTPS/SFTP upload probes and restart wedged daemons
 **SFTP host key roster (HTTPS):** Bridge and other SFTP clients can fetch live sshd host key fingerprints from the upload hostname:
 
 ```bash
-curl -fsS "https://$(jq -r '.config.upload_hostname // empty' ~/airports.json)/.well-known/aviationwx-upload-ssh-host-keys.json" | jq .
-ssh-keyscan -p 2222 upload.aviationwx.org | ssh-keygen -lf -
+UPLOAD_HOST=$(jq -r '.config.upload_hostname // empty' ~/airports.json)
+SFTP_PORT=$(jq -r '.config.network_ports.sftp // 2222' ~/airports.json)
+curl -fsS "https://${UPLOAD_HOST}/.well-known/aviationwx-upload-ssh-host-keys.json" | jq .
+ssh-keyscan -p "${SFTP_PORT}" "${UPLOAD_HOST}" | ssh-keygen -lf -
 ```
 
 Every `SHA256:` from `ssh-keyscan` must appear in the JSON `sha256[]` array. Fingerprints are computed at request time from `/etc/ssh/ssh_host_*_key.pub` in the web container (same container that runs sshd). After an image rebuild, re-run the comparison to confirm the roster tracks new keys.

--- a/lib/cache-headers.php
+++ b/lib/cache-headers.php
@@ -76,14 +76,15 @@ function sendCacheHeaders(int $refreshInterval, ?int $browserMaxAge = null, bool
 /**
  * Cache headers for responses that must never be stored (e.g. live SSH host key roster).
  *
- * Belt-and-suspenders: no-store/no-cache plus explicit low max-age/s-maxage and Pragma/Expires
- * so browsers, CDNs, and proxy defaults cannot serve a stale roster. Cached host key pins that
+ * Belt-and-suspenders: no-store/no-cache plus explicit max-age=0/s-maxage=0 and Pragma/Expires
+ * so browsers, CDNs, and proxy defaults cannot serve a stale roster. A non-zero TTL would let
+ * intermediaries that ignore no-store but honor max-age cache briefly; cached host key pins that
  * lag a container rebuild would reject valid SFTP connections and cause upload outages.
  *
- * @param int $maxAgeSeconds Explicit max-age and s-maxage (default 60)
+ * @param int $maxAgeSeconds Explicit max-age and s-maxage (default 0)
  * @return array<string, string>
  */
-function getNoStoreCacheHeaders(int $maxAgeSeconds = 60): array
+function getNoStoreCacheHeaders(int $maxAgeSeconds = 0): array
 {
     $maxAgeSeconds = max(0, $maxAgeSeconds);
 
@@ -98,9 +99,9 @@ function getNoStoreCacheHeaders(int $maxAgeSeconds = 60): array
 /**
  * Send no-store cache headers (see getNoStoreCacheHeaders()).
  *
- * @param int $maxAgeSeconds Explicit max-age and s-maxage (default 60)
+ * @param int $maxAgeSeconds Explicit max-age and s-maxage (default 0)
  */
-function sendNoStoreCacheHeaders(int $maxAgeSeconds = 60): void
+function sendNoStoreCacheHeaders(int $maxAgeSeconds = 0): void
 {
     foreach (getNoStoreCacheHeaders($maxAgeSeconds) as $name => $value) {
         header($name . ': ' . $value);

--- a/lib/cache-headers.php
+++ b/lib/cache-headers.php
@@ -73,3 +73,37 @@ function sendCacheHeaders(int $refreshInterval, ?int $browserMaxAge = null, bool
     }
 }
 
+/**
+ * Cache headers for responses that must never be stored (e.g. live SSH host key roster).
+ *
+ * Belt-and-suspenders: no-store/no-cache plus explicit low max-age/s-maxage and Pragma/Expires
+ * so browsers, CDNs, and proxy defaults cannot serve a stale roster. Cached host key pins that
+ * lag a container rebuild would reject valid SFTP connections and cause upload outages.
+ *
+ * @param int $maxAgeSeconds Explicit max-age and s-maxage (default 60)
+ * @return array<string, string>
+ */
+function getNoStoreCacheHeaders(int $maxAgeSeconds = 60): array
+{
+    $maxAgeSeconds = max(0, $maxAgeSeconds);
+
+    return [
+        'Cache-Control' => 'no-store, no-cache, must-revalidate, private, max-age='
+            . $maxAgeSeconds . ', s-maxage=' . $maxAgeSeconds,
+        'Pragma' => 'no-cache',
+        'Expires' => '0',
+    ];
+}
+
+/**
+ * Send no-store cache headers (see getNoStoreCacheHeaders()).
+ *
+ * @param int $maxAgeSeconds Explicit max-age and s-maxage (default 60)
+ */
+function sendNoStoreCacheHeaders(int $maxAgeSeconds = 60): void
+{
+    foreach (getNoStoreCacheHeaders($maxAgeSeconds) as $name => $value) {
+        header($name . ': ' . $value);
+    }
+}
+

--- a/lib/config.php
+++ b/lib/config.php
@@ -590,8 +590,7 @@ function getUploadHostname(): string {
  *
  * @return int TCP port (default 2222)
  */
-function getSftpPort(): int
-{
+function getSftpPort(): int {
     $networkPorts = getGlobalConfig('network_ports');
     if (is_array($networkPorts) && isset($networkPorts['sftp']) && is_int($networkPorts['sftp'])) {
         return $networkPorts['sftp'];

--- a/lib/config.php
+++ b/lib/config.php
@@ -586,6 +586,21 @@ function getUploadHostname(): string {
 }
 
 /**
+ * SFTP listener port from config.network_ports.sftp (container sshd).
+ *
+ * @return int TCP port (default 2222)
+ */
+function getSftpPort(): int
+{
+    $networkPorts = getGlobalConfig('network_ports');
+    if (is_array($networkPorts) && isset($networkPorts['sftp']) && is_int($networkPorts['sftp'])) {
+        return $networkPorts['sftp'];
+    }
+
+    return 2222;
+}
+
+/**
  * Get dynamic DNS refresh interval from global config
  * 
  * When set to a positive value, the system will periodically re-resolve

--- a/lib/upload-ssh-host-keys.php
+++ b/lib/upload-ssh-host-keys.php
@@ -7,6 +7,7 @@
  */
 
 require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/logger.php';
 
 /** Default sshd host public key directory in the web/SFTP container. */
 const UPLOAD_SSH_HOST_KEYS_DIR = '/etc/ssh';
@@ -47,9 +48,9 @@ function sshPublicKeySha256Fingerprint(string $publicKeyLine): ?string
  * Collect SHA256 fingerprints from sshd host public keys in a directory.
  *
  * @param string $sshDir Directory containing ssh_host_*_key.pub files
- * @return list<string> Sorted unique fingerprints
+ * @return list<string>|null Sorted unique fingerprints, null when a matched file cannot be read
  */
-function collectSshHostKeySha256Fingerprints(string $sshDir = UPLOAD_SSH_HOST_KEYS_DIR): array
+function collectSshHostKeySha256Fingerprints(string $sshDir = UPLOAD_SSH_HOST_KEYS_DIR): ?array
 {
     $pattern = rtrim($sshDir, '/') . UPLOAD_SSH_HOST_PUBLIC_KEY_GLOB;
     $files = glob($pattern);
@@ -62,12 +63,20 @@ function collectSshHostKeySha256Fingerprints(string $sshDir = UPLOAD_SSH_HOST_KE
 
     foreach ($files as $path) {
         if (!is_readable($path)) {
-            continue;
+            aviationwx_log('error', 'upload ssh host key file unreadable', [
+                'path' => $path,
+            ], 'app');
+
+            return null;
         }
 
         $contents = file_get_contents($path);
         if ($contents === false) {
-            continue;
+            aviationwx_log('error', 'upload ssh host key file read failed', [
+                'path' => $path,
+            ], 'app');
+
+            return null;
         }
 
         foreach (preg_split('/\R/', $contents) ?: [] as $line) {
@@ -94,12 +103,12 @@ function collectSshHostKeySha256Fingerprints(string $sshDir = UPLOAD_SSH_HOST_KE
  *   port: int,
  *   sha256: list<string>,
  *   updated_at: string
- * }|null Null when no readable host keys were found
+ * }|null Null when no host keys were found or any matched file could not be read
  */
 function buildUploadSshHostKeysDocument(?string $sshDir = null): ?array
 {
     $fingerprints = collectSshHostKeySha256Fingerprints($sshDir ?? UPLOAD_SSH_HOST_KEYS_DIR);
-    if ($fingerprints === []) {
+    if ($fingerprints === null || $fingerprints === []) {
         return null;
     }
 

--- a/lib/upload-ssh-host-keys.php
+++ b/lib/upload-ssh-host-keys.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Live SFTP SSH host key fingerprint helpers.
+ *
+ * Reads ssh_host_*_key.pub from the container sshd config directory at request time
+ * so clients can pin the keys currently served on config.network_ports.sftp.
+ */
+
+require_once __DIR__ . '/config.php';
+
+/** Default sshd host public key directory in the web/SFTP container. */
+const UPLOAD_SSH_HOST_KEYS_DIR = '/etc/ssh';
+
+/** Glob for sshd host public keys (excludes private keys and non-host keys). */
+const UPLOAD_SSH_HOST_PUBLIC_KEY_GLOB = '/ssh_host_*_key.pub';
+
+/**
+ * Compute OpenSSH SHA256 fingerprint for one authorized_keys-style public key line.
+ *
+ * @param string $publicKeyLine Single-line OpenSSH public key
+ * @return string|null Fingerprint as SHA256:base64 or null when unparsable
+ */
+function sshPublicKeySha256Fingerprint(string $publicKeyLine): ?string
+{
+    $trimmed = trim($publicKeyLine);
+    if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+        return null;
+    }
+
+    $parts = preg_split('/\s+/', $trimmed, 3);
+    if (!is_array($parts) || count($parts) < 2 || $parts[1] === '') {
+        return null;
+    }
+
+    $keyBlob = base64_decode($parts[1], true);
+    if ($keyBlob === false) {
+        return null;
+    }
+
+    $hash = hash('sha256', $keyBlob, true);
+    $encoded = rtrim(base64_encode($hash), '=');
+
+    return 'SHA256:' . $encoded;
+}
+
+/**
+ * Collect SHA256 fingerprints from sshd host public keys in a directory.
+ *
+ * @param string $sshDir Directory containing ssh_host_*_key.pub files
+ * @return list<string> Sorted unique fingerprints
+ */
+function collectSshHostKeySha256Fingerprints(string $sshDir = UPLOAD_SSH_HOST_KEYS_DIR): array
+{
+    $pattern = rtrim($sshDir, '/') . UPLOAD_SSH_HOST_PUBLIC_KEY_GLOB;
+    $files = glob($pattern);
+    if ($files === false || $files === []) {
+        return [];
+    }
+
+    sort($files, SORT_STRING);
+    $fingerprints = [];
+
+    foreach ($files as $path) {
+        if (!is_readable($path)) {
+            continue;
+        }
+
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            continue;
+        }
+
+        foreach (preg_split('/\R/', $contents) ?: [] as $line) {
+            $fingerprint = sshPublicKeySha256Fingerprint((string) $line);
+            if ($fingerprint !== null) {
+                $fingerprints[$fingerprint] = true;
+            }
+        }
+    }
+
+    $unique = array_keys($fingerprints);
+    sort($unique, SORT_STRING);
+
+    return $unique;
+}
+
+/**
+ * Build the v1 upload SSH host key roster document.
+ *
+ * @param string|null $sshDir Override host key directory (for tests)
+ * @return array{
+ *   version: int,
+ *   hostname: string,
+ *   port: int,
+ *   sha256: list<string>,
+ *   updated_at: string
+ * }|null Null when no readable host keys were found
+ */
+function buildUploadSshHostKeysDocument(?string $sshDir = null): ?array
+{
+    $fingerprints = collectSshHostKeySha256Fingerprints($sshDir ?? UPLOAD_SSH_HOST_KEYS_DIR);
+    if ($fingerprints === []) {
+        return null;
+    }
+
+    return [
+        'version' => 1,
+        'hostname' => getUploadHostname(),
+        'port' => getSftpPort(),
+        'sha256' => $fingerprints,
+        'updated_at' => gmdate('Y-m-d\TH:i:s\Z'),
+    ];
+}

--- a/lib/upload-ssh-host-keys.php
+++ b/lib/upload-ssh-host-keys.php
@@ -16,7 +16,10 @@ const UPLOAD_SSH_HOST_KEYS_DIR = '/etc/ssh';
 const UPLOAD_SSH_HOST_PUBLIC_KEY_GLOB = '/ssh_host_*_key.pub';
 
 /**
- * Compute OpenSSH SHA256 fingerprint for one authorized_keys-style public key line.
+ * Compute OpenSSH SHA256 fingerprint for one public key line.
+ *
+ * Accepts standard host key .pub lines and authorized_keys-style lines (optional
+ * options or hostname prefix before the key type token).
  *
  * @param string $publicKeyLine Single-line OpenSSH public key
  * @return string|null Fingerprint as SHA256:base64 or null when unparsable
@@ -28,12 +31,24 @@ function sshPublicKeySha256Fingerprint(string $publicKeyLine): ?string
         return null;
     }
 
-    $parts = preg_split('/\s+/', $trimmed, 3);
-    if (!is_array($parts) || count($parts) < 2 || $parts[1] === '') {
+    $parts = preg_split('/\s+/', $trimmed);
+    if (!is_array($parts) || count($parts) < 2) {
         return null;
     }
 
-    $keyBlob = base64_decode($parts[1], true);
+    $keyTypeIndex = null;
+    foreach ($parts as $index => $part) {
+        if (preg_match('/^(ssh-(rsa|dss|ed25519)|ecdsa-sha2-|sk-ecdsa-sha2-|sk-ssh-ed25519)/', $part) === 1) {
+            $keyTypeIndex = $index;
+            break;
+        }
+    }
+
+    if ($keyTypeIndex === null || !isset($parts[$keyTypeIndex + 1]) || $parts[$keyTypeIndex + 1] === '') {
+        return null;
+    }
+
+    $keyBlob = base64_decode($parts[$keyTypeIndex + 1], true);
     if ($keyBlob === false) {
         return null;
     }

--- a/tests/Integration/UploadSshHostKeysEndpointTest.php
+++ b/tests/Integration/UploadSshHostKeysEndpointTest.php
@@ -102,8 +102,8 @@ class UploadSshHostKeysEndpointTest extends TestCase
         $cacheControl = $response['headers']['cache-control'] ?? '';
         $this->assertStringContainsString('no-store', $cacheControl);
         $this->assertStringContainsString('no-cache', $cacheControl);
-        $this->assertStringContainsString('max-age=60', $cacheControl);
-        $this->assertStringContainsString('s-maxage=60', $cacheControl);
+        $this->assertStringContainsString('max-age=0', $cacheControl);
+        $this->assertStringContainsString('s-maxage=0', $cacheControl);
         $this->assertSame('no-cache', $response['headers']['pragma'] ?? '');
     }
 }

--- a/tests/Integration/UploadSshHostKeysEndpointTest.php
+++ b/tests/Integration/UploadSshHostKeysEndpointTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for upload SFTP SSH host key roster endpoint.
+ */
+class UploadSshHostKeysEndpointTest extends TestCase
+{
+    private static string $baseUrl;
+
+    private static bool $serverAvailable = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$baseUrl = getenv('TEST_API_URL') ?: 'http://localhost:8080';
+
+        $ch = curl_init(self::$baseUrl);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_NOBODY, true);
+        curl_exec($ch);
+        self::$serverAvailable = curl_getinfo($ch, CURLINFO_HTTP_CODE) > 0;
+        curl_close($ch);
+    }
+
+    private function skipIfServerUnavailable(): void
+    {
+        if (!self::$serverAvailable) {
+            $this->markTestSkipped('Test server not running at ' . self::$baseUrl);
+        }
+    }
+
+    /**
+     * @return array{code: int, headers: array<string, string>, body: string, json: ?array}
+     */
+    private function fetchRoster(string $path): array
+    {
+        $url = self::$baseUrl . $path;
+
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Accept: application/json']);
+        curl_setopt($ch, CURLOPT_HEADER, true);
+
+        $response = curl_exec($ch);
+        $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+        $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        $headerStr = substr((string) $response, 0, $headerSize);
+        $body = substr((string) $response, $headerSize);
+
+        $headers = [];
+        foreach (explode("\r\n", $headerStr) as $line) {
+            if (strpos($line, ':') !== false) {
+                [$key, $value] = explode(':', $line, 2);
+                $headers[strtolower(trim($key))] = trim($value);
+            }
+        }
+
+        return [
+            'code' => $httpCode,
+            'headers' => $headers,
+            'body' => $body,
+            'json' => json_decode($body, true),
+        ];
+    }
+
+    public function testWellKnownPath_ReturnsValidJsonWhenKeysAvailable(): void
+    {
+        $this->skipIfServerUnavailable();
+
+        $response = $this->fetchRoster('/.well-known/aviationwx-upload-ssh-host-keys.json');
+        if ($response['code'] === 503) {
+            $this->markTestSkipped('Container has no readable ssh host keys in /etc/ssh');
+        }
+
+        $this->assertSame(200, $response['code']);
+        $this->assertIsArray($response['json']);
+        $this->assertSame(1, $response['json']['version']);
+        $this->assertSame(getUploadHostname(), $response['json']['hostname']);
+        $this->assertSame(getSftpPort(), $response['json']['port']);
+        $this->assertNotEmpty($response['json']['sha256']);
+        foreach ($response['json']['sha256'] as $fp) {
+            $this->assertMatchesRegularExpression('/^SHA256:[A-Za-z0-9+/]+$/', $fp);
+        }
+    }
+
+    public function testWellKnownPath_SendsAggressiveNoStoreCacheHeaders(): void
+    {
+        $this->skipIfServerUnavailable();
+
+        $response = $this->fetchRoster('/.well-known/aviationwx-upload-ssh-host-keys.json');
+        if ($response['code'] === 503) {
+            $this->markTestSkipped('Container has no readable ssh host keys in /etc/ssh');
+        }
+
+        $cacheControl = $response['headers']['cache-control'] ?? '';
+        $this->assertStringContainsString('no-store', $cacheControl);
+        $this->assertStringContainsString('no-cache', $cacheControl);
+        $this->assertStringContainsString('max-age=60', $cacheControl);
+        $this->assertStringContainsString('s-maxage=60', $cacheControl);
+        $this->assertSame('no-cache', $response['headers']['pragma'] ?? '');
+    }
+}

--- a/tests/Unit/UploadSshHostKeysTest.php
+++ b/tests/Unit/UploadSshHostKeysTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/cache-headers.php';
+require_once __DIR__ . '/../../lib/upload-ssh-host-keys.php';
+
+/**
+ * Unit tests for lib/upload-ssh-host-keys.php and no-store cache headers.
+ */
+class UploadSshHostKeysTest extends TestCase
+{
+    private string $tempSshDir = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempSshDir = sys_get_temp_dir() . '/aviationwx_ssh_host_keys_test_' . bin2hex(random_bytes(4));
+        mkdir($this->tempSshDir, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->tempSshDir !== '' && is_dir($this->tempSshDir)) {
+            foreach (glob($this->tempSshDir . '/*') ?: [] as $file) {
+                if (is_file($file)) {
+                    unlink($file);
+                }
+            }
+            rmdir($this->tempSshDir);
+        }
+        parent::tearDown();
+    }
+
+    public function testSshPublicKeySha256Fingerprint_MatchesSshKeygen(): void
+    {
+        $keyPath = $this->tempSshDir . '/test_host_key';
+        $genCmd = sprintf(
+            'ssh-keygen -t ed25519 -f %s -N %s -q 2>/dev/null',
+            escapeshellarg($keyPath),
+            escapeshellarg('')
+        );
+        exec($genCmd, $genOutput, $genExitCode);
+        if ($genExitCode !== 0 || !is_readable($keyPath . '.pub')) {
+            $this->markTestSkipped('ssh-keygen unavailable for fingerprint cross-check');
+        }
+
+        $pubLine = trim((string) file_get_contents($keyPath . '.pub'));
+        $lfCmd = sprintf('ssh-keygen -lf %s -E sha256 2>/dev/null', escapeshellarg($keyPath . '.pub'));
+        exec($lfCmd, $lfOutput, $lfExitCode);
+        if ($lfExitCode !== 0 || ($lfOutput[0] ?? '') === '') {
+            $this->markTestSkipped('ssh-keygen -lf unavailable for fingerprint cross-check');
+        }
+
+        preg_match('/SHA256:[^\s]+/', (string) $lfOutput[0], $matches);
+        $this->assertNotEmpty($matches[0] ?? null, 'ssh-keygen should emit SHA256 fingerprint');
+
+        $computed = sshPublicKeySha256Fingerprint($pubLine);
+        $this->assertSame($matches[0], $computed);
+    }
+
+    public function testCollectSshHostKeySha256Fingerprints_ReadsHostKeyGlob(): void
+    {
+        $sourceKey = $this->tempSshDir . '/source_key';
+        exec(sprintf('ssh-keygen -t ed25519 -f %s -N %s -q 2>/dev/null', escapeshellarg($sourceKey), escapeshellarg('')), $unused, $exitCode);
+        if ($exitCode !== 0) {
+            $this->markTestSkipped('ssh-keygen unavailable');
+        }
+
+        $hostPub = $this->tempSshDir . '/ssh_host_ed25519_key.pub';
+        copy($sourceKey . '.pub', $hostPub);
+
+        $fingerprints = collectSshHostKeySha256Fingerprints($this->tempSshDir);
+        $this->assertCount(1, $fingerprints);
+        $this->assertStringStartsWith('SHA256:', $fingerprints[0]);
+    }
+
+    public function testBuildUploadSshHostKeysDocument_UsesConfigHostnameAndPort(): void
+    {
+        $sourceKey = $this->tempSshDir . '/source_key';
+        exec(sprintf('ssh-keygen -t ed25519 -f %s -N %s -q 2>/dev/null', escapeshellarg($sourceKey), escapeshellarg('')), $unused, $exitCode);
+        if ($exitCode !== 0) {
+            $this->markTestSkipped('ssh-keygen unavailable');
+        }
+        copy($sourceKey . '.pub', $this->tempSshDir . '/ssh_host_ed25519_key.pub');
+
+        $document = buildUploadSshHostKeysDocument($this->tempSshDir);
+        $this->assertIsArray($document);
+        $this->assertSame(1, $document['version']);
+        $this->assertSame(getUploadHostname(), $document['hostname']);
+        $this->assertSame(getSftpPort(), $document['port']);
+        $this->assertNotEmpty($document['sha256']);
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/', $document['updated_at']);
+    }
+
+    public function testBuildUploadSshHostKeysDocument_ReturnsNullWhenNoKeys(): void
+    {
+        $emptyDir = $this->tempSshDir . '_empty';
+        mkdir($emptyDir, 0700, true);
+        $this->assertNull(buildUploadSshHostKeysDocument($emptyDir));
+        rmdir($emptyDir);
+    }
+
+    public function testGetNoStoreCacheHeaders_AreAggressiveWithLowTtl(): void
+    {
+        $headers = getNoStoreCacheHeaders(60);
+        $this->assertStringContainsString('no-store', $headers['Cache-Control']);
+        $this->assertStringContainsString('no-cache', $headers['Cache-Control']);
+        $this->assertStringContainsString('must-revalidate', $headers['Cache-Control']);
+        $this->assertStringContainsString('max-age=60', $headers['Cache-Control']);
+        $this->assertStringContainsString('s-maxage=60', $headers['Cache-Control']);
+        $this->assertSame('no-cache', $headers['Pragma']);
+        $this->assertSame('0', $headers['Expires']);
+    }
+}

--- a/tests/Unit/UploadSshHostKeysTest.php
+++ b/tests/Unit/UploadSshHostKeysTest.php
@@ -61,6 +61,28 @@ class UploadSshHostKeysTest extends TestCase
         $this->assertSame($matches[0], $computed);
     }
 
+    public function testSshPublicKeySha256Fingerprint_HandlesOptionsAndHostnamePrefix(): void
+    {
+        $keyPath = $this->tempSshDir . '/prefixed_key';
+        exec(sprintf('ssh-keygen -t ed25519 -f %s -N %s -q 2>/dev/null', escapeshellarg($keyPath), escapeshellarg('')), $unused, $exitCode);
+        if ($exitCode !== 0) {
+            $this->markTestSkipped('ssh-keygen unavailable');
+        }
+
+        $pubLine = trim((string) file_get_contents($keyPath . '.pub'));
+        $parts = preg_split('/\s+/', $pubLine, 3);
+        $this->assertIsArray($parts);
+        $this->assertCount(3, $parts);
+
+        $withOptions = 'from="127.0.0.1",restrict ' . $parts[0] . ' ' . $parts[1];
+        $withHost = 'upload.example.org ' . $parts[0] . ' ' . $parts[1];
+
+        $expected = sshPublicKeySha256Fingerprint($pubLine);
+        $this->assertNotNull($expected);
+        $this->assertSame($expected, sshPublicKeySha256Fingerprint($withOptions));
+        $this->assertSame($expected, sshPublicKeySha256Fingerprint($withHost));
+    }
+
     public function testCollectSshHostKeySha256Fingerprints_ReadsHostKeyGlob(): void
     {
         $sourceKey = $this->tempSshDir . '/source_key';

--- a/tests/Unit/UploadSshHostKeysTest.php
+++ b/tests/Unit/UploadSshHostKeysTest.php
@@ -95,6 +95,25 @@ class UploadSshHostKeysTest extends TestCase
         $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/', $document['updated_at']);
     }
 
+    public function testCollectSshHostKeySha256Fingerprints_ReturnsNullWhenHostKeyUnreadable(): void
+    {
+        $sourceKey = $this->tempSshDir . '/source_key';
+        exec(sprintf('ssh-keygen -t ed25519 -f %s -N %s -q 2>/dev/null', escapeshellarg($sourceKey), escapeshellarg('')), $unused, $exitCode);
+        if ($exitCode !== 0) {
+            $this->markTestSkipped('ssh-keygen unavailable');
+        }
+
+        $hostPub = $this->tempSshDir . '/ssh_host_ed25519_key.pub';
+        copy($sourceKey . '.pub', $hostPub);
+        chmod($hostPub, 0000);
+
+        try {
+            $this->assertNull(collectSshHostKeySha256Fingerprints($this->tempSshDir));
+        } finally {
+            chmod($hostPub, 0600);
+        }
+    }
+
     public function testBuildUploadSshHostKeysDocument_ReturnsNullWhenNoKeys(): void
     {
         $emptyDir = $this->tempSshDir . '_empty';

--- a/tests/Unit/UploadSshHostKeysTest.php
+++ b/tests/Unit/UploadSshHostKeysTest.php
@@ -108,6 +108,10 @@ class UploadSshHostKeysTest extends TestCase
         chmod($hostPub, 0000);
 
         try {
+            if (is_readable($hostPub)) {
+                $this->markTestSkipped('Cannot simulate unreadable host key file (likely running as root)');
+            }
+
             $this->assertNull(collectSshHostKeySha256Fingerprints($this->tempSshDir));
         } finally {
             chmod($hostPub, 0600);

--- a/tests/Unit/UploadSshHostKeysTest.php
+++ b/tests/Unit/UploadSshHostKeysTest.php
@@ -124,12 +124,12 @@ class UploadSshHostKeysTest extends TestCase
 
     public function testGetNoStoreCacheHeaders_AreAggressiveWithLowTtl(): void
     {
-        $headers = getNoStoreCacheHeaders(60);
+        $headers = getNoStoreCacheHeaders(0);
         $this->assertStringContainsString('no-store', $headers['Cache-Control']);
         $this->assertStringContainsString('no-cache', $headers['Cache-Control']);
         $this->assertStringContainsString('must-revalidate', $headers['Cache-Control']);
-        $this->assertStringContainsString('max-age=60', $headers['Cache-Control']);
-        $this->assertStringContainsString('s-maxage=60', $headers['Cache-Control']);
+        $this->assertStringContainsString('max-age=0', $headers['Cache-Control']);
+        $this->assertStringContainsString('s-maxage=0', $headers['Cache-Control']);
         $this->assertSame('no-cache', $headers['Pragma']);
         $this->assertSame('0', $headers['Expires']);
     }


### PR DESCRIPTION
## Summary

- Add `GET /.well-known/aviationwx-upload-ssh-host-keys.json` on the upload hostname with live SHA256 fingerprints read from `/etc/ssh/ssh_host_*_key.pub` at request time.
- Response includes `hostname` (`getUploadHostname()`), `port` (`getSftpPort()` / `config.network_ports.sftp`), and `updated_at`.
- Apply belt-and-suspenders no-store cache headers in PHP (`getNoStoreCacheHeaders()`) and nginx so stale host key pins cannot cause SFTP upload outages after container rebuilds.
- Route via `.htaccess` and `docker/nginx.conf`; document in `CONFIGURATION.md` and `OPERATIONS.md`.

## Type

- [x] Feature
- [x] Documentation

## Testing

- [x] `make test-ci`
- [x] `phpunit tests/Unit/UploadSshHostKeysTest.php` (fingerprint cross-check vs `ssh-keygen`, document builder, cache headers)
- [x] Post-deploy production smoke:
  ```bash
  curl -fsS https://upload.aviationwx.org/.well-known/aviationwx-upload-ssh-host-keys.json | jq .
  ssh-keyscan -p 2222 upload.aviationwx.org | ssh-keygen -lf -
  ```
  Every scanned `SHA256:` fingerprint must appear in `sha256[]`.

## Checklist

- [x] Tests pass
- [x] Documentation updated (if needed)
- [x] No sensitive data (API keys, passwords, credentials)
- [x] Code follows [CODE_STYLE.md](CODE_STYLE.md)

## Notes

- Bridge client trust integration is out of scope here (handled in aviationwx.org-bridge).
- Follow-up: consider failing closed when any matched host key file is unreadable instead of returning a partial roster.