### PR TITLE
Add ops.aviationwx.org nginx vhost (proxy to :8091)

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -474,6 +474,7 @@ jobs:
             "docker/Dockerfile"
             "docker/nginx.conf"
             "lib/nginx-embed-vhost-verify.php"
+            "lib/nginx-server-block-extract.php"
             "scripts/verify-embed-nginx-conf.php"
             "tests/Unit/NginxEmbedVhostConfigTest.php"
             "lib/nginx-ops-vhost-verify.php"
@@ -623,7 +624,7 @@ jobs:
             echo "⚠ Guides directory not found - skipping validation"
           fi
           
-          # Embed nginx routing is covered by tests/Unit/NginxEmbedVhostConfigTest.php (QA workflow)
+          # Embed and ops nginx routing: tests/Unit/NginxEmbedVhostConfigTest.php, NginxOpsVhostConfigTest.php (QA workflow)
           # and verified on the server inside the web container after image build (see Deploy via Docker Compose).
           
           # Final check

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -624,7 +624,7 @@ jobs:
             echo "⚠ Guides directory not found - skipping validation"
           fi
           
-          # Embed and ops nginx routing: tests/Unit/NginxEmbedVhostConfigTest.php, NginxOpsVhostConfigTest.php (QA workflow)
+          # Embed and ops nginx routing: tests/Unit/NginxEmbedVhostConfigTest.php, tests/Unit/NginxOpsVhostConfigTest.php (QA workflow)
           # and verified on the server inside the web container after image build (see Deploy via Docker Compose).
           
           # Final check

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -476,6 +476,9 @@ jobs:
             "lib/nginx-embed-vhost-verify.php"
             "scripts/verify-embed-nginx-conf.php"
             "tests/Unit/NginxEmbedVhostConfigTest.php"
+            "lib/nginx-ops-vhost-verify.php"
+            "scripts/verify-ops-nginx-conf.php"
+            "tests/Unit/NginxOpsVhostConfigTest.php"
           )
           
           for file in "${CRITICAL_FILES[@]}"; do
@@ -1715,6 +1718,17 @@ jobs:
               "1. Fix docker/nginx.conf embed server block (rewrite + location /v1/)\n2. Run locally: php scripts/verify-embed-nginx-conf.php docker/nginx.conf\n3. See docs/DEPLOYMENT.md (Nginx and embed.aviationwx.org)"
           fi
           echo "✓ docker/nginx.conf passes embed Public API v1 checks (web image)"
+
+          echo "Verifying ops nginx.conf in deployed web image (ops.aviationwx.org proxy)..."
+          if ! docker compose -f docker/docker-compose.prod.yml exec -T web /usr/local/bin/php \
+            /var/www/html/scripts/verify-ops-nginx-conf.php \
+            /var/www/html/docker/nginx.conf; then
+            deployment_error \
+              "Ops nginx verification" \
+              "docker/nginx.conf in the web container failed ops.aviationwx.org proxy checks" \
+              "1. Fix docker/nginx.conf ops server block (proxy_pass 127.0.0.1:8091)\n2. Run locally: php scripts/verify-ops-nginx-conf.php docker/nginx.conf\n3. See docs/DEPLOYMENT.md (Nginx and ops.aviationwx.org)"
+          fi
+          echo "✓ docker/nginx.conf passes ops.aviationwx.org proxy checks (web image)"
           
           # Clean up Docker resources conditionally (only if disk usage is high)
           # Check disk usage before cleanup to avoid unnecessary operations

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -14,7 +14,7 @@ server {
 # HTTP server - allow Let's Encrypt validation, redirect everything else to HTTPS
 server {
     listen 80;
-    server_name aviationwx.org *.aviationwx.org api.aviationwx.org embed.aviationwx.org;
+    server_name aviationwx.org *.aviationwx.org api.aviationwx.org embed.aviationwx.org ops.aviationwx.org;
     
     # Allow Let's Encrypt validation (must be before redirect)
     location /.well-known/acme-challenge/ {
@@ -274,6 +274,32 @@ server {
     }
 }
 
+# Operator console (ops.aviationwx.org) - separate compose stack on host loopback :8091
+# Auth (e.g. Authelia) belongs in the aviationwx-ops stack, not this vhost.
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name ops.aviationwx.org;
+
+    ssl_certificate /etc/nginx/ssl/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+
+    access_log /dev/stdout json_access;
+    error_log /dev/stderr warn;
+
+    # Do not apply dashboard CSP or airport routing here; ops sets its own headers.
+    location / {
+        proxy_pass http://127.0.0.1:8091;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+}
+
     # HTTPS server (main site and airport subdomains)
 server {
     listen 443 ssl;
@@ -289,7 +315,7 @@ server {
     # Handle wildcard subdomains (any ICAO code)
     # Examples: kspb.aviationwx.org, kxxx.aviationwx.org
     # Works with ANY subdomain without creating them individually!
-    # Note: embed.aviationwx.org is handled by its own server block above
+    # Note: api.aviationwx.org, embed.aviationwx.org, and ops.aviationwx.org have dedicated server blocks above
 
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -287,8 +287,16 @@ server {
     access_log /dev/stdout json_access;
     error_log /dev/stderr warn;
 
+    # Discourage search indexing (ops is private; auth is separate). App also sets X-Robots-Tag.
+    location = /robots.txt {
+        default_type text/plain;
+        add_header X-Robots-Tag "noindex, nofollow" always;
+        return 200 "User-agent: *\nDisallow: /\n";
+    }
+
     # Do not apply dashboard CSP or airport routing here; ops sets its own headers.
     location / {
+        add_header X-Robots-Tag "noindex, nofollow" always;
         proxy_pass http://127.0.0.1:8091;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -300,7 +300,7 @@ server {
     }
 }
 
-    # HTTPS server (main site and airport subdomains)
+# HTTPS server (main site and airport subdomains)
 server {
     listen 443 ssl;
     http2 on;

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -521,6 +521,10 @@ See `.github/workflows/deploy-docker.yml` for workflow details.
 
 CD **rsyncs** `docker/nginx.conf` to `~/aviationwx/` and bind-mounts it into the nginx container (`docker/docker-compose.prod.yml`). **`embed.aviationwx.org`** routing ships with application commits; nginx does not read `airports.json`. **Quality Assurance** CI runs **`tests/Unit/NginxEmbedVhostConfigTest.php`** against `docker/nginx.conf`. Deploy runs **`scripts/verify-embed-nginx-conf.php`** **inside the `web` container** after `docker compose up --build` (same pattern as **`docker compose exec` PHP** for `sync-push-config.php`), against **`/var/www/html/docker/nginx.conf`** in the built image. The embed server block keeps Public API v1 on-host (rewrite + `location /v1/`) so browsers get CORS on the first hop for `/api/v1/...` requests.
 
+### Nginx and `ops.aviationwx.org` (pass-through)
+
+The operator console runs in the separate **`aviationwx-ops`** compose project on **`127.0.0.1:8091`**. Main-site nginx exposes **`ops.aviationwx.org`** via a dedicated server block that **only** `proxy_pass`es to that loopback port. **Do not** add Authelia or `auth_request` to this vhost; authentication belongs in the ops stack (edge proxy + Authelia sidecar in `aviationwx-ops`). CI runs **`tests/Unit/NginxOpsVhostConfigTest.php`**; deploy runs **`scripts/verify-ops-nginx-conf.php`** in the web container after build.
+
 ## Maintenance
 
 ### Update Application

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -523,7 +523,7 @@ CD **rsyncs** `docker/nginx.conf` to `~/aviationwx/` and bind-mounts it into the
 
 ### Nginx and `ops.aviationwx.org` (pass-through)
 
-The operator console runs in the separate **`aviationwx-ops`** compose project on **`127.0.0.1:8091`**. Main-site nginx exposes **`ops.aviationwx.org`** via a dedicated server block that **only** `proxy_pass`es to that loopback port. **Do not** add Authelia or `auth_request` to this vhost; authentication belongs in the ops stack (edge proxy + Authelia sidecar in `aviationwx-ops`). CI runs **`tests/Unit/NginxOpsVhostConfigTest.php`**; deploy runs **`scripts/verify-ops-nginx-conf.php`** in the web container after build.
+The operator console runs in the separate **`aviationwx-ops`** compose project on **`127.0.0.1:8091`**. Main-site nginx exposes **`ops.aviationwx.org`** via a dedicated server block that **only** `proxy_pass`es to that loopback port. The ops vhost also serves **`/robots.txt`** (`Disallow: /`) and **`X-Robots-Tag: noindex, nofollow`** on all proxied responses. **Do not** add Authelia or `auth_request` to this vhost; authentication belongs in the ops stack (edge proxy + Authelia sidecar in `aviationwx-ops`). CI runs **`tests/Unit/NginxOpsVhostConfigTest.php`**; deploy runs **`scripts/verify-ops-nginx-conf.php`** in the web container after build.
 
 ## Maintenance
 

--- a/lib/nginx-embed-vhost-verify.php
+++ b/lib/nginx-embed-vhost-verify.php
@@ -10,6 +10,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/nginx-server-block-extract.php';
+
 /**
  * Extract the server { ... } block for embed.aviationwx.org from raw nginx config.
  *
@@ -18,37 +20,7 @@ declare(strict_types=1);
  */
 function nginx_extract_embed_aviationwx_server_block(string $content): string
 {
-    $marker = 'server_name embed.aviationwx.org;';
-    $pos = strpos($content, $marker);
-    if ($pos === false) {
-        return '';
-    }
-    $slice = substr($content, 0, $pos);
-    $serverKw = strrpos($slice, 'server {');
-    if ($serverKw === false) {
-        return '';
-    }
-    $prefix = substr($content, $serverKw, 12);
-    $braceRel = strpos($prefix, '{');
-    if ($braceRel === false) {
-        return '';
-    }
-    $braceOpen = $serverKw + $braceRel;
-    $depth = 0;
-    $len = strlen($content);
-    for ($i = $braceOpen; $i < $len; $i++) {
-        $c = $content[$i];
-        if ($c === '{') {
-            $depth++;
-        } elseif ($c === '}') {
-            $depth--;
-            if ($depth === 0) {
-                return substr($content, $serverKw, $i - $serverKw + 1);
-            }
-        }
-    }
-
-    return '';
+    return nginx_extract_server_block($content, 'server_name embed.aviationwx.org;');
 }
 
 /**

--- a/lib/nginx-ops-vhost-verify.php
+++ b/lib/nginx-ops-vhost-verify.php
@@ -71,10 +71,12 @@ function nginx_verify_ops_server_block(string $block, string $fullContent = ''):
     }
 
     if ($fullContent !== '') {
-        $wildcardMarker = "server_name aviationwx.org *.aviationwx.org;\n";
         $opsPos = strpos($fullContent, 'server_name ops.aviationwx.org;');
-        $wildcardPos = strpos($fullContent, $wildcardMarker);
-        if ($opsPos === false || $wildcardPos === false || $opsPos > $wildcardPos) {
+        $wildcardPos = null;
+        if (preg_match('/^\s*server_name aviationwx\.org \*\.aviationwx\.org;/m', $fullContent, $m, PREG_OFFSET_CAPTURE)) {
+            $wildcardPos = $m[0][1];
+        }
+        if ($opsPos === false || $wildcardPos === null || $opsPos > $wildcardPos) {
             $errors[] = 'ops.aviationwx.org server block must appear before the *.aviationwx.org wildcard HTTPS block';
         }
     }

--- a/lib/nginx-ops-vhost-verify.php
+++ b/lib/nginx-ops-vhost-verify.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Validates ops.aviationwx.org nginx server block in docker/nginx.conf.
+ *
+ * Ensures the operator console vhost proxies to the ops stack on loopback :8091,
+ * does not reuse dashboard port 8080, and does not embed Authelia in main nginx.
+ *
+ * @package AviationWX
+ */
+
+declare(strict_types=1);
+
+/**
+ * Extract the server { ... } block for ops.aviationwx.org from raw nginx config.
+ *
+ * @param string $content Full nginx.conf contents
+ * @return string Ops server block including outer braces, or empty string if not found
+ */
+function nginx_extract_ops_aviationwx_server_block(string $content): string
+{
+    $marker = 'server_name ops.aviationwx.org;';
+    $pos = strpos($content, $marker);
+    if ($pos === false) {
+        return '';
+    }
+    $slice = substr($content, 0, $pos);
+    $serverKw = strrpos($slice, 'server {');
+    if ($serverKw === false) {
+        return '';
+    }
+    $prefix = substr($content, $serverKw, 12);
+    $braceRel = strpos($prefix, '{');
+    if ($braceRel === false) {
+        return '';
+    }
+    $braceOpen = $serverKw + $braceRel;
+    $depth = 0;
+    $len = strlen($content);
+    for ($i = $braceOpen; $i < $len; $i++) {
+        $c = $content[$i];
+        if ($c === '{') {
+            $depth++;
+        } elseif ($c === '}') {
+            $depth--;
+            if ($depth === 0) {
+                return substr($content, $serverKw, $i - $serverKw + 1);
+            }
+        }
+    }
+
+    return '';
+}
+
+/**
+ * Verify the ops vhost is a pass-through proxy to the ops compose bind port.
+ *
+ * @param string $block Extracted ops.aviationwx.org server block
+ * @param string $fullContent Full nginx.conf for ordering checks
+ * @return array<int, string> Human-readable errors; empty when valid
+ */
+function nginx_verify_ops_server_block(string $block, string $fullContent = ''): array
+{
+    $errors = [];
+    if ($block === '') {
+        $errors[] = 'Could not extract ops.aviationwx.org server block';
+
+        return $errors;
+    }
+
+    if (!str_contains($block, 'server_name ops.aviationwx.org;')) {
+        $errors[] = 'ops server block must declare server_name ops.aviationwx.org';
+    }
+    if (!preg_match('#proxy_pass\s+http://127\.0\.0\.1:8091#', $block)) {
+        $errors[] = 'ops server block must proxy_pass to http://127.0.0.1:8091 (aviationwx-ops web bind)';
+    }
+    if (preg_match('#proxy_pass\s+http://localhost:8080#', $block)) {
+        $errors[] = 'ops server block must not proxy_pass to dashboard port 8080';
+    }
+    if (str_contains($block, 'auth_request')) {
+        $errors[] = 'ops vhost in main nginx must not use auth_request; keep Authelia in the ops stack';
+    }
+    if (str_contains($block, 'Content-Security-Policy')) {
+        $errors[] = 'ops vhost must not copy dashboard CSP headers';
+    }
+
+    if ($fullContent !== '') {
+        $wildcardMarker = "server_name aviationwx.org *.aviationwx.org;\n";
+        $opsPos = strpos($fullContent, 'server_name ops.aviationwx.org;');
+        $wildcardPos = strpos($fullContent, $wildcardMarker);
+        if ($opsPos === false || $wildcardPos === false || $opsPos > $wildcardPos) {
+            $errors[] = 'ops.aviationwx.org server block must appear before the *.aviationwx.org wildcard HTTPS block';
+        }
+    }
+
+    return $errors;
+}

--- a/lib/nginx-ops-vhost-verify.php
+++ b/lib/nginx-ops-vhost-verify.php
@@ -68,8 +68,11 @@ function nginx_verify_ops_server_block(string $block, string $fullContent = ''):
     } elseif (!preg_match('/add_header\s+X-Robots-Tag\s+"noindex,\s*nofollow"/', $rootLocation)) {
         $errors[] = 'ops location / must set X-Robots-Tag "noindex, nofollow" on proxied responses';
     }
-    if (!str_contains($block, 'location = /robots.txt')) {
+    $robotsLocation = nginx_extract_location_block($block, 'location = /robots.txt');
+    if ($robotsLocation === '') {
         $errors[] = 'ops vhost must serve /robots.txt with Disallow: /';
+    } elseif (!preg_match('/Disallow:\s*\//', $robotsLocation)) {
+        $errors[] = 'ops location = /robots.txt must return Disallow: /';
     }
 
     if ($fullContent !== '') {

--- a/lib/nginx-ops-vhost-verify.php
+++ b/lib/nginx-ops-vhost-verify.php
@@ -10,6 +10,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/nginx-server-block-extract.php';
+
 /**
  * Extract the server { ... } block for ops.aviationwx.org from raw nginx config.
  *
@@ -18,37 +20,7 @@ declare(strict_types=1);
  */
 function nginx_extract_ops_aviationwx_server_block(string $content): string
 {
-    $marker = 'server_name ops.aviationwx.org;';
-    $pos = strpos($content, $marker);
-    if ($pos === false) {
-        return '';
-    }
-    $slice = substr($content, 0, $pos);
-    $serverKw = strrpos($slice, 'server {');
-    if ($serverKw === false) {
-        return '';
-    }
-    $prefix = substr($content, $serverKw, 12);
-    $braceRel = strpos($prefix, '{');
-    if ($braceRel === false) {
-        return '';
-    }
-    $braceOpen = $serverKw + $braceRel;
-    $depth = 0;
-    $len = strlen($content);
-    for ($i = $braceOpen; $i < $len; $i++) {
-        $c = $content[$i];
-        if ($c === '{') {
-            $depth++;
-        } elseif ($c === '}') {
-            $depth--;
-            if ($depth === 0) {
-                return substr($content, $serverKw, $i - $serverKw + 1);
-            }
-        }
-    }
-
-    return '';
+    return nginx_extract_server_block($content, 'server_name ops.aviationwx.org;');
 }
 
 /**
@@ -73,8 +45,14 @@ function nginx_verify_ops_server_block(string $block, string $fullContent = ''):
     if (!preg_match('#proxy_pass\s+http://127\.0\.0\.1:8091#', $block)) {
         $errors[] = 'ops server block must proxy_pass to http://127.0.0.1:8091 (aviationwx-ops web bind)';
     }
-    if (preg_match('#proxy_pass\s+http://localhost:8080#', $block)) {
+    if (preg_match('#proxy_pass\s+http://(localhost|127\.0\.0\.1):8080#', $block)) {
         $errors[] = 'ops server block must not proxy_pass to dashboard port 8080';
+    }
+    if (preg_match('#return\s+301\s+https?://[^;]*:8080/#', $block)) {
+        $errors[] = 'ops server block must not redirect to dashboard port 8080';
+    }
+    if (str_contains($block, 'airport=ops')) {
+        $errors[] = 'ops server block must not use airport-style routing';
     }
     if (str_contains($block, 'auth_request')) {
         $errors[] = 'ops vhost in main nginx must not use auth_request; keep Authelia in the ops stack';

--- a/lib/nginx-ops-vhost-verify.php
+++ b/lib/nginx-ops-vhost-verify.php
@@ -63,6 +63,8 @@ function nginx_verify_ops_server_block(string $block, string $fullContent = ''):
     $rootLocation = nginx_extract_location_block($block, 'location / {');
     if ($rootLocation === '') {
         $errors[] = 'ops vhost must define a location / block for proxy_pass';
+    } elseif (!preg_match('#proxy_pass\s+http://127\.0\.0\.1:8091#', $rootLocation)) {
+        $errors[] = 'ops location / must proxy_pass to http://127.0.0.1:8091';
     } elseif (!preg_match('/add_header\s+X-Robots-Tag\s+"noindex,\s*nofollow"/', $rootLocation)) {
         $errors[] = 'ops location / must set X-Robots-Tag "noindex, nofollow" on proxied responses';
     }

--- a/lib/nginx-ops-vhost-verify.php
+++ b/lib/nginx-ops-vhost-verify.php
@@ -60,6 +60,12 @@ function nginx_verify_ops_server_block(string $block, string $fullContent = ''):
     if (str_contains($block, 'Content-Security-Policy')) {
         $errors[] = 'ops vhost must not copy dashboard CSP headers';
     }
+    if (!str_contains($block, 'X-Robots-Tag') || !str_contains($block, 'noindex')) {
+        $errors[] = 'ops vhost must set X-Robots-Tag noindex, nofollow';
+    }
+    if (!str_contains($block, 'location = /robots.txt')) {
+        $errors[] = 'ops vhost must serve /robots.txt with Disallow: /';
+    }
 
     if ($fullContent !== '') {
         $wildcardMarker = "server_name aviationwx.org *.aviationwx.org;\n";

--- a/lib/nginx-ops-vhost-verify.php
+++ b/lib/nginx-ops-vhost-verify.php
@@ -42,7 +42,7 @@ function nginx_verify_ops_server_block(string $block, string $fullContent = ''):
     if (!str_contains($block, 'server_name ops.aviationwx.org;')) {
         $errors[] = 'ops server block must declare server_name ops.aviationwx.org';
     }
-    if (!preg_match('#proxy_pass\s+http://127\.0\.0\.1:8091#', $block)) {
+    if (!preg_match('#proxy_pass\s+http://127\.0\.0\.1:8091(?=[;/\s]|$)#', $block)) {
         $errors[] = 'ops server block must proxy_pass to http://127.0.0.1:8091 (aviationwx-ops web bind)';
     }
     if (preg_match('#proxy_pass\s+http://(localhost|127\.0\.0\.1):8080#', $block)) {
@@ -63,7 +63,7 @@ function nginx_verify_ops_server_block(string $block, string $fullContent = ''):
     $rootLocation = nginx_extract_location_block($block, 'location / {');
     if ($rootLocation === '') {
         $errors[] = 'ops vhost must define a location / block for proxy_pass';
-    } elseif (!preg_match('#proxy_pass\s+http://127\.0\.0\.1:8091#', $rootLocation)) {
+    } elseif (!preg_match('#proxy_pass\s+http://127\.0\.0\.1:8091(?=[;/\s]|$)#', $rootLocation)) {
         $errors[] = 'ops location / must proxy_pass to http://127.0.0.1:8091';
     } elseif (!preg_match('/add_header\s+X-Robots-Tag\s+"noindex,\s*nofollow"/', $rootLocation)) {
         $errors[] = 'ops location / must set X-Robots-Tag "noindex, nofollow" on proxied responses';

--- a/lib/nginx-ops-vhost-verify.php
+++ b/lib/nginx-ops-vhost-verify.php
@@ -60,8 +60,11 @@ function nginx_verify_ops_server_block(string $block, string $fullContent = ''):
     if (str_contains($block, 'Content-Security-Policy')) {
         $errors[] = 'ops vhost must not copy dashboard CSP headers';
     }
-    if (!str_contains($block, 'X-Robots-Tag') || !str_contains($block, 'noindex')) {
-        $errors[] = 'ops vhost must set X-Robots-Tag noindex, nofollow';
+    $rootLocation = nginx_extract_location_block($block, 'location / {');
+    if ($rootLocation === '') {
+        $errors[] = 'ops vhost must define a location / block for proxy_pass';
+    } elseif (!preg_match('/add_header\s+X-Robots-Tag\s+"noindex,\s*nofollow"/', $rootLocation)) {
+        $errors[] = 'ops location / must set X-Robots-Tag "noindex, nofollow" on proxied responses';
     }
     if (!str_contains($block, 'location = /robots.txt')) {
         $errors[] = 'ops vhost must serve /robots.txt with Disallow: /';

--- a/lib/nginx-ops-vhost-verify.php
+++ b/lib/nginx-ops-vhost-verify.php
@@ -65,8 +65,8 @@ function nginx_verify_ops_server_block(string $block, string $fullContent = ''):
         $errors[] = 'ops vhost must define a location / block for proxy_pass';
     } elseif (!preg_match('#proxy_pass\s+http://127\.0\.0\.1:8091(?=[;/\s]|$)#', $rootLocation)) {
         $errors[] = 'ops location / must proxy_pass to http://127.0.0.1:8091';
-    } elseif (!preg_match('/add_header\s+X-Robots-Tag\s+"noindex,\s*nofollow"/', $rootLocation)) {
-        $errors[] = 'ops location / must set X-Robots-Tag "noindex, nofollow" on proxied responses';
+    } elseif (!preg_match('/add_header\s+X-Robots-Tag\s+"noindex,\s*nofollow"\s+always;/', $rootLocation)) {
+        $errors[] = 'ops location / must set X-Robots-Tag "noindex, nofollow" always on proxied responses';
     }
     $robotsLocation = nginx_extract_location_block($block, 'location = /robots.txt');
     if ($robotsLocation === '') {

--- a/lib/nginx-server-block-extract.php
+++ b/lib/nginx-server-block-extract.php
@@ -47,3 +47,38 @@ function nginx_extract_server_block(string $content, string $serverNameMarker): 
 
     return '';
 }
+
+/**
+ * Extract a location { ... } block by its opening marker (e.g. "location / {").
+ *
+ * @param string $content Server block or larger nginx.conf slice
+ * @param string $locationMarker Unique marker at the start of the location block
+ * @return string Location block including outer braces, or empty string if not found
+ */
+function nginx_extract_location_block(string $content, string $locationMarker): string
+{
+    $pos = strpos($content, $locationMarker);
+    if ($pos === false) {
+        return '';
+    }
+    $braceOpen = strpos(substr($content, $pos), '{');
+    if ($braceOpen === false) {
+        return '';
+    }
+    $braceOpen += $pos;
+    $depth = 0;
+    $len = strlen($content);
+    for ($i = $braceOpen; $i < $len; $i++) {
+        $c = $content[$i];
+        if ($c === '{') {
+            $depth++;
+        } elseif ($c === '}') {
+            $depth--;
+            if ($depth === 0) {
+                return substr($content, $pos, $i - $pos + 1);
+            }
+        }
+    }
+
+    return '';
+}

--- a/lib/nginx-server-block-extract.php
+++ b/lib/nginx-server-block-extract.php
@@ -82,3 +82,44 @@ function nginx_extract_location_block(string $content, string $locationMarker): 
 
     return '';
 }
+
+/**
+ * Extract the server { ... } block that contains an inner marker (e.g. a location).
+ *
+ * @param string $content Full nginx.conf contents
+ * @param string $innerMarker Unique substring inside the target server block
+ * @return string Server block including outer braces, or empty string if not found
+ */
+function nginx_extract_server_block_containing(string $content, string $innerMarker): string
+{
+    $pos = strpos($content, $innerMarker);
+    if ($pos === false) {
+        return '';
+    }
+    $slice = substr($content, 0, $pos);
+    $serverKw = strrpos($slice, 'server {');
+    if ($serverKw === false) {
+        return '';
+    }
+    $prefix = substr($content, $serverKw, 12);
+    $braceRel = strpos($prefix, '{');
+    if ($braceRel === false) {
+        return '';
+    }
+    $braceOpen = $serverKw + $braceRel;
+    $depth = 0;
+    $len = strlen($content);
+    for ($i = $braceOpen; $i < $len; $i++) {
+        $c = $content[$i];
+        if ($c === '{') {
+            $depth++;
+        } elseif ($c === '}') {
+            $depth--;
+            if ($depth === 0) {
+                return substr($content, $serverKw, $i - $serverKw + 1);
+            }
+        }
+    }
+
+    return '';
+}

--- a/lib/nginx-server-block-extract.php
+++ b/lib/nginx-server-block-extract.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Extract nginx server { ... } blocks from docker/nginx.conf by server_name marker.
+ *
+ * @package AviationWX
+ */
+
+declare(strict_types=1);
+
+/**
+ * Extract a server block that contains the given server_name line.
+ *
+ * @param string $content Full nginx.conf contents
+ * @param string $serverNameMarker Unique marker inside the block (e.g. "server_name embed.aviationwx.org;")
+ * @return string Server block including outer braces, or empty string if not found
+ */
+function nginx_extract_server_block(string $content, string $serverNameMarker): string
+{
+    $pos = strpos($content, $serverNameMarker);
+    if ($pos === false) {
+        return '';
+    }
+    $slice = substr($content, 0, $pos);
+    $serverKw = strrpos($slice, 'server {');
+    if ($serverKw === false) {
+        return '';
+    }
+    $prefix = substr($content, $serverKw, 12);
+    $braceRel = strpos($prefix, '{');
+    if ($braceRel === false) {
+        return '';
+    }
+    $braceOpen = $serverKw + $braceRel;
+    $depth = 0;
+    $len = strlen($content);
+    for ($i = $braceOpen; $i < $len; $i++) {
+        $c = $content[$i];
+        if ($c === '{') {
+            $depth++;
+        } elseif ($c === '}') {
+            $depth--;
+            if ($depth === 0) {
+                return substr($content, $serverKw, $i - $serverKw + 1);
+            }
+        }
+    }
+
+    return '';
+}

--- a/scripts/verify-ops-nginx-conf.php
+++ b/scripts/verify-ops-nginx-conf.php
@@ -1,0 +1,46 @@
+#!/usr/bin/env php
+<?php
+/**
+ * CLI: verify docker/nginx.conf ops vhost proxies to 127.0.0.1:8091.
+ *
+ * Exit 0 when valid, 1 when validation fails, 2 when file/path error.
+ * Used by deploy (docker compose exec on the web container) and locally.
+ *
+ * Usage: php scripts/verify-ops-nginx-conf.php [path/to/nginx.conf]
+ *
+ * @package AviationWX
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/lib/nginx-ops-vhost-verify.php';
+
+$path = $argv[1] ?? 'docker/nginx.conf';
+if (!is_readable($path)) {
+    fwrite(STDERR, "Cannot read nginx config: {$path}\n");
+
+    exit(2);
+}
+
+$content = file_get_contents($path);
+if ($content === false) {
+    fwrite(STDERR, "Failed to read nginx config: {$path}\n");
+
+    exit(2);
+}
+
+$block = nginx_extract_ops_aviationwx_server_block($content);
+$errors = nginx_verify_ops_server_block($block, $content);
+
+if ($errors !== []) {
+    fwrite(STDERR, "Ops nginx vhost verification failed for {$path}:\n");
+    foreach ($errors as $msg) {
+        fwrite(STDERR, "  - {$msg}\n");
+    }
+
+    exit(1);
+}
+
+fwrite(STDOUT, "OK: ops.aviationwx.org server block passes ops proxy checks ({$path})\n");
+
+exit(0);

--- a/tests/Unit/NginxOpsVhostConfigTest.php
+++ b/tests/Unit/NginxOpsVhostConfigTest.php
@@ -72,7 +72,7 @@ NGINX;
         $content = file_get_contents($path);
         $this->assertIsString($content);
         $this->assertMatchesRegularExpression(
-            '/server_name aviationwx\.org \*\.aviationwx\.org api\.aviationwx\.org embed\.aviationwx\.org ops\.aviationwx\.org;/',
+            '/server_name\b[^;]*\bops\.aviationwx\.org\b/',
             $content
         );
     }

--- a/tests/Unit/NginxOpsVhostConfigTest.php
+++ b/tests/Unit/NginxOpsVhostConfigTest.php
@@ -27,7 +27,7 @@ class NginxOpsVhostConfigTest extends TestCase
     /**
      * Ops vhost must proxy to 127.0.0.1:8091 without main-site auth or CSP.
      */
-    public function testOpsVhostProxiesToOpsStackPort(): void
+    public function testNginxVerifyOpsServerBlock_DockerNginxConf_ReturnsNoErrors(): void
     {
         $path = self::nginxConfPath();
         $this->assertFileExists($path, 'docker/nginx.conf must exist');

--- a/tests/Unit/NginxOpsVhostConfigTest.php
+++ b/tests/Unit/NginxOpsVhostConfigTest.php
@@ -71,9 +71,12 @@ NGINX;
         $path = self::nginxConfPath();
         $content = file_get_contents($path);
         $this->assertIsString($content);
-        $this->assertMatchesRegularExpression(
-            '/server_name\b[^;]*\bops\.aviationwx\.org\b/',
-            $content
+        $httpBlock = nginx_extract_server_block(
+            $content,
+            'server_name aviationwx.org *.aviationwx.org api.aviationwx.org embed.aviationwx.org ops.aviationwx.org;'
         );
+        $this->assertNotSame('', $httpBlock, 'HTTP ACME server block must exist');
+        $this->assertMatchesRegularExpression('/listen\s+80;/', $httpBlock);
+        $this->assertStringContainsString('ops.aviationwx.org', $httpBlock);
     }
 }

--- a/tests/Unit/NginxOpsVhostConfigTest.php
+++ b/tests/Unit/NginxOpsVhostConfigTest.php
@@ -71,12 +71,16 @@ NGINX;
         $path = self::nginxConfPath();
         $content = file_get_contents($path);
         $this->assertIsString($content);
-        $httpBlock = nginx_extract_server_block(
+        $httpBlock = nginx_extract_server_block_containing(
             $content,
-            'server_name aviationwx.org *.aviationwx.org api.aviationwx.org embed.aviationwx.org ops.aviationwx.org;'
+            'location /.well-known/acme-challenge/'
         );
         $this->assertNotSame('', $httpBlock, 'HTTP ACME server block must exist');
         $this->assertMatchesRegularExpression('/listen\s+80;/', $httpBlock);
-        $this->assertStringContainsString('ops.aviationwx.org', $httpBlock);
+        $this->assertMatchesRegularExpression(
+            '/server_name\b[^;]*\bops\.aviationwx\.org\b/',
+            $httpBlock,
+            'HTTP ACME server_name must include ops.aviationwx.org'
+        );
     }
 }

--- a/tests/Unit/NginxOpsVhostConfigTest.php
+++ b/tests/Unit/NginxOpsVhostConfigTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Regression tests for docker/nginx.conf ops.aviationwx.org routing.
+ *
+ * Ensures the operator console subdomain proxies to the ops stack on loopback :8091
+ * and is not handled by the airport wildcard or dashboard port 8080.
+ *
+ * @package AviationWX\Tests\Unit
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/lib/nginx-ops-vhost-verify.php';
+
+class NginxOpsVhostConfigTest extends TestCase
+{
+    /**
+     * Path to nginx config relative to repository root.
+     *
+     * @return string Absolute filesystem path
+     */
+    private static function nginxConfPath(): string
+    {
+        return dirname(__DIR__, 2) . '/docker/nginx.conf';
+    }
+
+    /**
+     * Ops vhost must proxy to 127.0.0.1:8091 without main-site auth or CSP.
+     */
+    public function testOpsVhostProxiesToOpsStackPort(): void
+    {
+        $path = self::nginxConfPath();
+        $this->assertFileExists($path, 'docker/nginx.conf must exist');
+        $content = file_get_contents($path);
+        $this->assertIsString($content);
+        $block = nginx_extract_ops_aviationwx_server_block($content);
+        $errors = nginx_verify_ops_server_block($block, $content);
+        $this->assertSame(
+            [],
+            $errors,
+            $errors !== [] ? implode('; ', $errors) : ''
+        );
+    }
+
+    /**
+     * HTTP ACME server_name list must include ops alongside api and embed.
+     */
+    public function testHttpServerNameListIncludesOps(): void
+    {
+        $path = self::nginxConfPath();
+        $content = file_get_contents($path);
+        $this->assertIsString($content);
+        $this->assertMatchesRegularExpression(
+            '/server_name aviationwx\.org \*\.aviationwx\.org api\.aviationwx\.org embed\.aviationwx\.org ops\.aviationwx\.org;/',
+            $content
+        );
+    }
+}

--- a/tests/Unit/NginxOpsVhostConfigTest.php
+++ b/tests/Unit/NginxOpsVhostConfigTest.php
@@ -64,6 +64,28 @@ NGINX;
     }
 
     /**
+     * Verifier must require Disallow: / in location = /robots.txt, not only the location marker.
+     */
+    public function testOpsVerifierRequiresRobotsDisallowInRobotsTxtLocation(): void
+    {
+        $block = <<<'NGINX'
+server {
+    location = /robots.txt {
+        add_header X-Robots-Tag "noindex, nofollow" always;
+        return 200 "User-agent: *\nAllow: /\n";
+    }
+    location / {
+        add_header X-Robots-Tag "noindex, nofollow" always;
+        proxy_pass http://127.0.0.1:8091;
+    }
+}
+NGINX;
+        $errors = nginx_verify_ops_server_block($block);
+        $this->assertNotSame([], $errors);
+        $this->assertStringContainsString('Disallow: /', implode('; ', $errors));
+    }
+
+    /**
      * HTTP ACME server_name list must include ops alongside api and embed.
      */
     public function testHttpServerNameListIncludesOps(): void

--- a/tests/Unit/NginxOpsVhostConfigTest.php
+++ b/tests/Unit/NginxOpsVhostConfigTest.php
@@ -45,7 +45,7 @@ class NginxOpsVhostConfigTest extends TestCase
     /**
      * Verifier must require X-Robots-Tag on location /, not only /robots.txt.
      */
-    public function testOpsVerifierRequiresRobotsHeaderOnLocationRoot(): void
+    public function testNginxVerifyOpsServerBlock_MissingRobotsHeaderOnLocationRoot_ReturnsError(): void
     {
         $block = <<<'NGINX'
 server {
@@ -66,7 +66,7 @@ NGINX;
     /**
      * Verifier must require Disallow: / in location = /robots.txt, not only the location marker.
      */
-    public function testOpsVerifierRequiresRobotsDisallowInRobotsTxtLocation(): void
+    public function testNginxVerifyOpsServerBlock_RobotsTxtAllowsCrawl_ReturnsError(): void
     {
         $block = <<<'NGINX'
 server {
@@ -88,9 +88,10 @@ NGINX;
     /**
      * HTTP ACME server_name list must include ops alongside api and embed.
      */
-    public function testHttpServerNameListIncludesOps(): void
+    public function testHttpAcmeServerName_IncludesOpsHost_MatchesOpsPattern(): void
     {
         $path = self::nginxConfPath();
+        $this->assertFileExists($path, 'docker/nginx.conf must exist');
         $content = file_get_contents($path);
         $this->assertIsString($content);
         $httpBlock = nginx_extract_server_block_containing(

--- a/tests/Unit/NginxOpsVhostConfigTest.php
+++ b/tests/Unit/NginxOpsVhostConfigTest.php
@@ -43,6 +43,27 @@ class NginxOpsVhostConfigTest extends TestCase
     }
 
     /**
+     * Verifier must require X-Robots-Tag on location /, not only /robots.txt.
+     */
+    public function testOpsVerifierRequiresRobotsHeaderOnLocationRoot(): void
+    {
+        $block = <<<'NGINX'
+server {
+    location = /robots.txt {
+        add_header X-Robots-Tag "noindex, nofollow" always;
+        return 200 "User-agent: *\nDisallow: /\n";
+    }
+    location / {
+        proxy_pass http://127.0.0.1:8091;
+    }
+}
+NGINX;
+        $errors = nginx_verify_ops_server_block($block);
+        $this->assertNotSame([], $errors);
+        $this->assertStringContainsString('location / must set X-Robots-Tag', implode('; ', $errors));
+    }
+
+    /**
      * HTTP ACME server_name list must include ops alongside api and embed.
      */
     public function testHttpServerNameListIncludesOps(): void

--- a/tests/Unit/NginxOpsVhostConfigTest.php
+++ b/tests/Unit/NginxOpsVhostConfigTest.php
@@ -43,6 +43,28 @@ class NginxOpsVhostConfigTest extends TestCase
     }
 
     /**
+     * Verifier must require X-Robots-Tag always on location /, not only on success responses.
+     */
+    public function testNginxVerifyOpsServerBlock_MissingRobotsHeaderAlwaysOnLocationRoot_ReturnsError(): void
+    {
+        $block = <<<'NGINX'
+server {
+    location = /robots.txt {
+        add_header X-Robots-Tag "noindex, nofollow" always;
+        return 200 "User-agent: *\nDisallow: /\n";
+    }
+    location / {
+        add_header X-Robots-Tag "noindex, nofollow";
+        proxy_pass http://127.0.0.1:8091;
+    }
+}
+NGINX;
+        $errors = nginx_verify_ops_server_block($block);
+        $this->assertNotSame([], $errors);
+        $this->assertStringContainsString('always', implode('; ', $errors));
+    }
+
+    /**
      * Verifier must require X-Robots-Tag on location /, not only /robots.txt.
      */
     public function testNginxVerifyOpsServerBlock_MissingRobotsHeaderOnLocationRoot_ReturnsError(): void


### PR DESCRIPTION
## Summary

- Adds a dedicated `ops.aviationwx.org` server block in `docker/nginx.conf` that proxies to the operator console on `127.0.0.1:8091`.
- Prevents the `*.aviationwx.org` wildcard from treating `ops` as an airport ICAO (which caused redirects to `:8080/health/?airport=ops`).
- **Pass-through only** - no `auth_request` or dashboard CSP on this vhost. Authelia stays in the `aviationwx-ops` stack (future edge proxy + sidecar), not main nginx.
- Adds CI/deploy verification mirroring the embed vhost checks.

Closes #177

## Safety considerations

| Risk | Mitigation |
|------|------------|
| Wildcard steals ops traffic | Exact `server_name ops.aviationwx.org` block placed **before** `*.aviationwx.org` HTTPS block; regression test enforces ordering |
| Wrong upstream (8080) | Verify script asserts `proxy_pass` targets `127.0.0.1:8091` only |
| Main-site CSP breaks ops UI | Ops block does not copy dashboard security headers |
| Authelia in main nginx | Explicitly forbidden in verify script; auth is ops-stack responsibility |
| Airport subdomains | `kspb.aviationwx.org` etc. unchanged (still wildcard) |

## Authelia (ops container, not this PR)

Recommended follow-up in `aviationwx-ops`:

1. Add an **edge** nginx (or Caddy) service in ops compose, bound to `127.0.0.1:8091`.
2. Apache (`web`) listens on an internal compose port only.
3. Edge nginx uses `auth_request` against an **Authelia** sidecar on the ops Docker network.
4. Exempt `/health` at the ops edge for CD/monitoring.

Main-site nginx remains a dumb TLS terminator + loopback proxy.

## Test plan

- [x] `php scripts/verify-ops-nginx-conf.php docker/nginx.conf`
- [x] `phpunit tests/Unit/NginxOpsVhostConfigTest.php`
- [x] After merge + main-site deploy: `curl -fsS https://ops.aviationwx.org/health` (requires ops stack running on :8091)
- [x] Confirm `https://kspb.aviationwx.org/` still returns airport page