### PR TITLE
Fail closed: supplemental remote METAR must not mask on-field outage

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -70,6 +70,17 @@ function nullStaleFieldsBySource(&$data, $maxStaleSeconds) {
 - Do not use the Unicode em dash (U+2014).
 - In prose, headings, and table cell text, use a **single ASCII hyphen** (`-`) for a break or aside. Avoid a **double hyphen** (`--`) in those places. Keep `--` (and `---`) where Markdown or tooling needs them (horizontal rules, CLI examples in fenced code, HTML comments, and similar).
 
+### Durable policy and architecture docs (`docs/`)
+
+Policy and data-flow guides (for example `docs/DATA_FLOW.md`, `docs/SAFETY_CRITICAL_CALCULATIONS.md`) describe **required behavior** as timeless statements: what the system must do and why, not what code has or has not shipped.
+
+- ✅ **DO** state rules, invariants, and safety rationale in present tense (for example "supplemental remote METAR does not count toward site health").
+- ✅ **DO** use examples (7S9, KSPB) to illustrate policy without tying them to a release or gap list.
+- ❌ **DON'T** include **implementation status**, **current code vs target code**, **not yet implemented**, or similar tracking in these docs.
+- ❌ **DON'T** label sections **target behavior** or mark policy as aspirational when the doc is meant to be the source of truth for logic.
+
+Track gaps, rollout, and migration in **GitHub issues and pull requests**, not in policy docs. When code catches up, update the doc only if the **required behavior** changed, not to check off delivery.
+
 ### Comment Philosophy
 
 **Keep comments concise and focused on critical logic.**

--- a/api/weather.php
+++ b/api/weather.php
@@ -367,7 +367,7 @@ function generateMockWeatherData($airportId, $airport) {
                     }
                 }
             }
-            applyFailclosedStaleness($cached, $airport, $isMetarOnly);
+            applyFailclosedStaleness($cached, $airport, $isMetarOnly, $airportId);
             
             // Set cache headers for cached responses
             // Browser cache uses remaining time until refresh, CDN uses half of refresh interval
@@ -435,7 +435,7 @@ function generateMockWeatherData($airportId, $airport) {
                     }
                 }
             }
-            applyFailclosedStaleness($staleData, $airport, $isMetarOnlyStale);
+            applyFailclosedStaleness($staleData, $airport, $isMetarOnlyStale, $airportId);
             
             $hasStaleCache = true;
             

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -708,7 +708,7 @@ METAR data from NOAA Aviation Weather provides aviation-specific observations in
 ]
 ```
 
-`nearby_stations` provides fallback stations if the primary METAR station is unavailable.
+`nearby_stations` provides fallback stations if the primary METAR station is unavailable. Whether a METAR source is co-located or supplemental for site health and display is determined at runtime (active station ICAO vs `airport.icao`), not by config key placement. The same co-located vs supplemental principles apply to other remote weather source types; see [Supplemental remote weather policy](DATA_FLOW.md#supplemental-remote-weather-policy).
 
 The scheduler also refreshes the shared AWC METAR bulk gzip when **more than one airport is enabled** (`scripts/refresh-metar-bulk.php`, interval `METAR_BULK_REFRESH_INTERVAL_SECONDS` in `lib/constants.php`) and writes per-ICAO JSON slices under `cache/metar-bulk/stations/`. A successful refresh also writes `cache/metar-bulk/meta.json` with `fetched_at`, `written`, and `scanned` row counts; logs include `metar_bulk_age_seconds` (seconds since that snapshot). Failed refreshes log the last known age when meta is present. Weather workers read a fresh slice before calling the per-station HTTP API in that mode (`metarResolveStationResponse()` from `UnifiedFetcher` and `fetchMETARFromStation()`). Bulk ingest requires the gzip CSV header to match the canonical AWC column list in `lib/metar-bulk-csv-schema.php` (tests fail on drift). A **single enabled airport** uses per-station HTTP only (no national gzip download).
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -189,7 +189,7 @@ Remote supplemental data is not a substitute for on-field infrastructure.
 
 **Preference:** On-field sensor data always takes precedence over any remote source when both are available. Source attribution in the dashboard identifies which source supplied each field (see existing attribution UI; no additional copy required).
 
-**Policy scope vs code:** This policy covers all weather source types. **METAR** is the primary case implemented today for aggregation locality, outage detection, and fail-closed hiding. Other remote source types should follow the same intent; per-source enforcement in code may lag until extended.
+**Scope:** This policy applies to all weather source types. METAR is the most common supplemental source; the same rules apply to NWS, AWOSnet, and other remote sources that observe a location other than the field.
 
 **Configuration shapes (METAR examples):**
 
@@ -222,7 +222,7 @@ Important distinctions:
 
 - **METAR station ICAO** is always present on the wire for a valid METAR product. AviationWX `station_id` values must be ICAO-format (see [CONFIGURATION.md](CONFIGURATION.md)).
 - **Airport identifier** (ICAO, FAA LID, etc.) is not always the same code as the METAR station. Many strips have no on-field METAR. US private-field AWOS may use an identifier unrelated to the airport LID (FAA Order JO 7350.9).
-- **Co-located** for AviationWX means the active METAR station ICAO matches `airport.icao` when that field is set. Airports without `icao` (for example FAA-only 7S9) treat any configured METAR as supplemental when on-site sensors or webcams are present. The same co-located vs supplemental distinction applies to other source types under [Supplemental remote weather policy](#supplemental-remote-weather-policy); METAR locality is the reference implementation.
+- **Co-located** for AviationWX means the active METAR station ICAO matches `airport.icao` when that field is set. Airports without `icao` (for example FAA-only 7S9) treat any configured METAR as supplemental when on-site sensors or webcams are present. The same co-located vs supplemental distinction applies to other source types under [Supplemental remote weather policy](#supplemental-remote-weather-policy); METAR locality is the reference pattern for classifying remote sources.
 
 ### METAR fetch and supplementation (technical)
 
@@ -390,12 +390,12 @@ The unified weather pipeline uses `WeatherAggregator` with `AggregationPolicy` t
 
 4. **Local vs supplemental remote weather** (Safety-Critical):
    - **On-site weather source (aggregation)**: On-site sensors (Tempest, Ambient, etc.) or **co-located** observations (e.g. KSPB METAR for KSPB). Webcams are on-field for [site health](#data-outage-detection) but are not weather aggregation inputs.
-   - **Supplemental (remote) source**: Observations from a different location (e.g. KUAO METAR for 7S9, or KVUO METAR fallback when KSPB primary fails). METAR is the primary implemented case; see [supplemental remote weather policy](#supplemental-remote-weather-policy)
+   - **Supplemental (remote) source**: Observations from a different location (e.g. KUAO METAR for 7S9, or KVUO METAR fallback when KSPB primary fails). See [supplemental remote weather policy](#supplemental-remote-weather-policy).
    - **Rule**: For LOCAL_FIELDS (wind, temperature, dewpoint, humidity, pressure, precip_accum), on-field measurements **always override** supplemental remote data when both have valid data, regardless of freshness
    - **Rationale**: Wind and temperature at the airport can differ significantly from nearby locations. Using supplemental remote data for these fields could mislead pilots
    - **Fill-in allowed**: Supplemental remote sources may fill in missing aviation fields (typically visibility, ceiling, cloud_cover from METAR) when on-field sensors are healthy but lack those measurements
    - **Fill-in forbidden during site outage**: When all on-field infrastructure is stale or unavailable, supplemental remote weather fields are hidden (fail closed) in addition to the outage banner
-   - **Implementation (METAR today)**: `WeatherSnapshot.metarStationId` and `_field_station_map` identify the METAR station; `localAirportIcao` from airport config distinguishes co-located vs supplemental for aggregation. Site-health and fail-closed rules use the same distinction for METAR (see [Data outage detection](#data-outage-detection)); extension to other source types is policy-aligned but not yet universal in code
+   - **Classification**: Co-located vs supplemental is determined from the active reporting identity (for METAR: station ICAO from aggregated weather data vs `airport.icao`). The same distinction governs aggregation, site health, and fail-closed display (see [Data outage detection](#data-outage-detection)).
 
 5. **Aggregation Process**:
    1. Fetch all configured sources in parallel using `curl_multi`
@@ -842,11 +842,11 @@ The system tracks daily extremes that reset at local midnight:
 - Webcams
 - **Co-located weather sources** only: sources that observe the airport itself (e.g. KSPB ASOS METAR while displaying KSPB; on-field Tempest; on-field AWOSnet). Co-located sources may use different power or internet than other on-site equipment; they still observe the field and are treated as local until they go stale.
 
-**Supplemental remote weather does not count toward site health.** A remote source (e.g. KUAO METAR for 7S9) may continue reporting while Tempest and webcams are down during a power outage. Fresh supplemental remote data must **not** suppress the outage banner. This applies to any remote weather source type under policy; METAR is the primary enforcement target in code.
+**Supplemental remote weather does not count toward site health.** A remote source (e.g. KUAO METAR for 7S9) may continue reporting while Tempest and webcams are down during a power outage. Fresh supplemental remote data must **not** suppress the outage banner. The same rule applies to all remote weather source types under [Supplemental remote weather policy](#supplemental-remote-weather-policy).
 
 **Outage threshold:** Default fail-closed staleness for on-field sources (`getStaleFailclosedSeconds()`, typically 3 hours). Airports with `limited_availability: true` use `getOutageBannerThresholdSeconds()` (default 30 minutes) and a different banner message.
 
-**Detection logic (target behavior):**
+**Detection logic:**
 
 1. Uses shared `getSourceTimestamps()` to read timestamps from weather cache and webcam metadata
 2. Builds the set of **on-field** sources (primary, backup, webcams, and co-located weather sources such as on-field METAR)
@@ -868,8 +868,6 @@ The system tracks daily extremes that reset at local midnight:
 | KSPB | Tempest + KSPB METAR stale | n/a | both stale | **Yes** |
 | METAR-only (co-located) | n/a | n/a | METAR stale | **Yes** |
 
-**Implementation status:** Co-located vs supplemental rules and supplemental fail-closed hiding are documented here as the target policy for all remote source types; code changes to match are tracked separately. **Current code:** `limited_availability` airports exclude all METAR from outage checks when on-field sources exist; normal airports such as 7S9 count supplemental METAR toward site health (the 7S9 gap). Enforcement for non-METAR remote sources is not yet systematic. **Target code:** distinguish co-located sources (count toward site health) from supplemental remote sources (excluded from site health; fields hidden during outage), starting with METAR. `nearby_stations` HTTP fallback is implemented in legacy `fetchMETAR()` but not yet in `UnifiedFetcher`.
-
 **Outage State File Persistence**:
 - Creates `cache/outage_{airport_id}.json` when outage is first detected
 - Preserves original outage start time across brief recoveries (grace period matches `getOutageBannerThresholdSeconds()` for the airport)
@@ -877,7 +875,7 @@ The system tracks daily extremes that reset at local midnight:
 - Automatically cleans up after full recovery (grace period expires)
 - Logs outage start and end events for operational visibility
 
-**Fallback Chain for Outage Start Time** (on-field sources only, target behavior):
+**Fallback Chain for Outage Start Time** (on-field sources only):
 1. Existing outage state file (preserves original start time)
 2. Newest timestamp from stale on-field sources (via `getSourceTimestamps()`)
 3. Webcam cache file modification times (if weather cache is lost)
@@ -886,7 +884,7 @@ The system tracks daily extremes that reset at local midnight:
 **Display Behavior**:
 - Red banner at top of page (similar to maintenance banner); standard local-outage copy unless `limited_availability` is set
 - Only shown when airport is **NOT** in maintenance mode and all on-field infrastructure is stale
-- Supplemental METAR fields hidden while banner is active (target behavior; policy extends to other remote source types)
+- Supplemental remote weather fields are hidden while the banner is active
 - Includes newest on-field stale timestamp to help identify when the local outage started
 
 **Frontend Updates**:

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -171,12 +171,66 @@ All weather sources are configured in a unified `weather_sources` array. Each so
   - Precipitation (inches)
   - Observation timestamp (ISO 8601, parsed to Unix seconds)
 
-### METAR Supplementation
+### Supplemental remote weather policy
 
-When a primary source is configured, METAR data is fetched to supplement:
+**Guiding principle:** Pilot safety is the prime directive for weather sourcing. It takes precedence over filling coverage gaps. When safety and completeness conflict, fail closed: show less data, show an outage banner, or do not configure a remote source rather than display weather that could mislead pilots about conditions at the field.
+
+When an airport has on-field sensors but needs additional weather fields, a **remote** source may be configured to supplement on-site data. **METAR** is the most common case (ceiling, visibility, cloud cover), but the same policy applies to **any remote weather source** (for example NWS, AWOSnet, or federation data from another airport) when that source observes conditions away from the field.
+
+Remote supplemental data is not a substitute for on-field infrastructure.
+
+**Terminology:**
+
+- **On-field** and **on-site** mean equipment or observations at the airport (Tempest, webcams, co-located ASOS/METAR, on-field AWOSnet).
+- **Co-located source** observes the airport itself (for METAR: active station ICAO matches `airport.icao` when set; for other source types: configured to report conditions at this field).
+- **Supplemental (remote) source** observes a different location (for example KUAO METAR when displaying 7S9, or NWS data from a station that is not co-located with the airport).
+
+**Operator rule (configuration):** A remote source is added only when conditions at that location are **equivalent to the airport within VFR standards**, based on local geography, terrain, and climate. Examples of acceptable pairings: similar elevation, no intervening terrain or weather regimes that routinely diverge on ceiling height or visibility. If weather is not equivalent under VFR standards, do **not** configure a remote source for that airport.
+
+**Preference:** On-field sensor data always takes precedence over any remote source when both are available. Source attribution in the dashboard identifies which source supplied each field (see existing attribution UI; no additional copy required).
+
+**Policy scope vs code:** This policy covers all weather source types. **METAR** is the primary case implemented today for aggregation locality, outage detection, and fail-closed hiding. Other remote source types should follow the same intent; per-source enforcement in code may lag until extended.
+
+**Configuration shapes (METAR examples):**
+
+| Pattern | Example | Meaning |
+|---------|---------|---------|
+| Co-located METAR | KSPB: `station_id: "KSPB"` with `icao: "KSPB"` | On-field ASOS/METAR; counts as **local** infrastructure for site health |
+| Remote primary METAR | 7S9: Tempest + webcams + `station_id: "KUAO"` (no on-field METAR) | KUAO is the only METAR source; **supplemental** for aggregation and outage logic |
+| `nearby_stations` fallback | KSPB: primary `KSPB`, `nearby_stations: ["KVUO", "KHIO"]` | Fetch fallback when the primary METAR HTTP/bulk request fails; does not define supplemental vs co-located by itself |
+
+Whether a source is **co-located** or **supplemental** is determined at runtime from the **active reporting identity** (for METAR: station ICAO from aggregated weather data vs `airport.icao`), not by which config key (`station_id` vs `nearby_stations`) holds the code.
+
+**Fields supplemental remote sources may contribute** (when on-field sensors lack them and on-field infrastructure is healthy):
+
+- Visibility (flight category) - typically METAR
+- Ceiling (flight category) - typically METAR
+- Cloud cover - typically METAR
+- Other fields only when the remote source is operator-approved as equivalent and on-field sensors do not provide them
+
+**Fields that must come from on-field sources when available:** wind, temperature, dewpoint, humidity, pressure, precipitation (see [Data aggregation](#data-aggregation-unified-fetcher) and [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md#local-vs-supplemental-remote-weather)).
+
+**When all on-field infrastructure is down:** Show the standard local-outage banner and **hide supplemental remote weather fields** in the API and dashboard. Without on-site sensors or webcams to corroborate conditions, remote data could mislead pilots (for example a power outage at 7S9 while KUAO METAR continues reporting). Co-located sources at airports such as KSPB remain **local**: they may use different power or internet than Tempest or webcams, but they observe the field and count toward site health until they go stale.
+
+See also [Data outage detection](#data-outage-detection) and [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md#local-vs-supplemental-remote-weather).
+
+### METAR station identifiers (standards)
+
+Every METAR report identifies the **observing station** with a four-character **ICAO location indicator** in the identification group (WMO FM 15 / Annex 3; FAA AIM; NOAA AWC product documentation). The authoritative listing is **ICAO Doc 7910** (*Location Indicators*).
+
+Important distinctions:
+
+- **METAR station ICAO** is always present on the wire for a valid METAR product. AviationWX `station_id` values must be ICAO-format (see [CONFIGURATION.md](CONFIGURATION.md)).
+- **Airport identifier** (ICAO, FAA LID, etc.) is not always the same code as the METAR station. Many strips have no on-field METAR. US private-field AWOS may use an identifier unrelated to the airport LID (FAA Order JO 7350.9).
+- **Co-located** for AviationWX means the active METAR station ICAO matches `airport.icao` when that field is set. Airports without `icao` (for example FAA-only 7S9) treat any configured METAR as supplemental when on-site sensors or webcams are present. The same co-located vs supplemental distinction applies to other source types under [Supplemental remote weather policy](#supplemental-remote-weather-policy); METAR locality is the reference implementation.
+
+### METAR fetch and supplementation (technical)
+
+When a primary on-site source is configured, METAR data is fetched to supplement:
+
 - **Visibility**: Required for flight category calculation
 - **Ceiling**: Required for flight category calculation
-- **Cloud Cover**: Additional aviation context
+- **Cloud cover**: Additional aviation context
 
 METAR fetching logic (per station ID):
 1. **Test mode**: `getMockHttpResponse` supplies canned JSON so PHPUnit stays deterministic.
@@ -334,19 +388,20 @@ The unified weather pipeline uses `WeatherAggregator` with `AggregationPolicy` t
    - **All Other Fields** (temperature, dewpoint, humidity, pressure, visibility, ceiling, cloud_cover, precip_accum): Selects the freshest non-stale observation from any source
    - METAR typically provides ceiling and cloud_cover (other sources do not provide these fields)
 
-4. **Local vs Neighboring METAR** (Safety-Critical):
-   - **Local source**: On-site sensors (Tempest, Ambient, etc.) or METAR from the same station as the airport (e.g., KSPB METAR for KSPB airport)
-   - **Neighboring METAR**: METAR from a different station (e.g., KVUO METAR when displaying KSPB airport)
-   - **Rule**: For LOCAL_FIELDS (wind, temperature, dewpoint, humidity, pressure, precip_accum), local measurements **always override** neighboring METAR when both have valid data, regardless of freshness
-   - **Rationale**: Wind and temperature at the airport can differ significantly from nearby airports. Using neighboring METAR for these fields could mislead pilots
-   - **Fill-in allowed**: Neighboring METAR may fill in missing fields (visibility, ceiling, cloud_cover) when local sources have no data
-   - **Implementation**: `WeatherSnapshot.metarStationId` identifies the METAR station; `localAirportIcao` from airport config enables the override logic
+4. **Local vs supplemental remote weather** (Safety-Critical):
+   - **On-site weather source (aggregation)**: On-site sensors (Tempest, Ambient, etc.) or **co-located** observations (e.g. KSPB METAR for KSPB). Webcams are on-field for [site health](#data-outage-detection) but are not weather aggregation inputs.
+   - **Supplemental (remote) source**: Observations from a different location (e.g. KUAO METAR for 7S9, or KVUO METAR fallback when KSPB primary fails). METAR is the primary implemented case; see [supplemental remote weather policy](#supplemental-remote-weather-policy)
+   - **Rule**: For LOCAL_FIELDS (wind, temperature, dewpoint, humidity, pressure, precip_accum), on-field measurements **always override** supplemental remote data when both have valid data, regardless of freshness
+   - **Rationale**: Wind and temperature at the airport can differ significantly from nearby locations. Using supplemental remote data for these fields could mislead pilots
+   - **Fill-in allowed**: Supplemental remote sources may fill in missing aviation fields (typically visibility, ceiling, cloud_cover from METAR) when on-field sensors are healthy but lack those measurements
+   - **Fill-in forbidden during site outage**: When all on-field infrastructure is stale or unavailable, supplemental remote weather fields are hidden (fail closed) in addition to the outage banner
+   - **Implementation (METAR today)**: `WeatherSnapshot.metarStationId` and `_field_station_map` identify the METAR station; `localAirportIcao` from airport config distinguishes co-located vs supplemental for aggregation. Site-health and fail-closed rules use the same distinction for METAR (see [Data outage detection](#data-outage-detection)); extension to other source types is policy-aligned but not yet universal in code
 
 5. **Aggregation Process**:
    1. Fetch all configured sources in parallel using `curl_multi`
    2. Parse each response into `WeatherSnapshot` with per-field observation times (METAR adapter sets `metarStationId` from source config)
-   3. For wind group: Prefer local sources over neighboring METAR; among same type, select freshest complete wind data
-   4. For each other field: Prefer local over neighboring METAR when both have valid data; otherwise select freshest non-stale value
+   3. For wind group: Prefer on-field sources over supplemental remote data; among the same class, select freshest complete wind data
+   4. For each other field: Prefer on-field over supplemental remote data when both have valid data; otherwise select freshest non-stale value
    5. Build aggregated result with `_field_source_map` (which source provided each field) and `_field_obs_time_map` (observation time for each field)
    6. Validate all fields against climate bounds (catches unit errors, sensor malfunctions)
    7. Fix pressure unit issues automatically (values > 100 inHg divided by 100)
@@ -370,7 +425,7 @@ The unified weather pipeline uses `WeatherAggregator` with `AggregationPolicy` t
    | wind_speed | 6 kts | 3 kts | **METAR** (fresher) |
    | temperature | -2°C | -2°C | **METAR** (fresher) |
 
-   **Note**: If METAR is from a neighboring station (different ICAO) and NWS/local source has data, local wins regardless of freshness.
+   **Note**: If a source is supplemental (remote, not co-located with the airport) and an on-field or co-located source has data, on-field wins regardless of freshness.
 
 7. **Data Classes**:
    - `WeatherSnapshot`: Complete weather state from one source; `metarStationId` set for METAR source (station ICAO)
@@ -779,35 +834,60 @@ The system tracks daily extremes that reset at local midnight:
 
 ### Data Outage Detection
 
-**Purpose**: Warn users when all data sources are offline (complete site outage)
+**Purpose**: Warn users when **on-field infrastructure** is offline (complete local site outage). This is distinct from `limited_availability` (off-grid/solar sites that expect periodic downtime; see [CONFIGURATION.md](CONFIGURATION.md)).
 
-**Outage Threshold**: 1.5 hours (configurable via `DATA_OUTAGE_BANNER_HOURS`)
+**On-field infrastructure** (sources that count toward site health):
 
-**Detection Logic**:
-- Uses shared `getSourceTimestamps()` function to extract timestamps from all configured sources
-- Checks all configured data sources (primary weather, METAR, webcams)
-- Banner appears only when **ALL** sources exceed the threshold
-- Banner shows newest timestamp among all stale sources to identify outage start time
-- Banner automatically hides when any source recovers
+- Non-METAR weather sources configured for the airport (Tempest, NWS, AWOSnet, etc.)
+- Webcams
+- **Co-located weather sources** only: sources that observe the airport itself (e.g. KSPB ASOS METAR while displaying KSPB; on-field Tempest; on-field AWOSnet). Co-located sources may use different power or internet than other on-site equipment; they still observe the field and are treated as local until they go stale.
+
+**Supplemental remote weather does not count toward site health.** A remote source (e.g. KUAO METAR for 7S9) may continue reporting while Tempest and webcams are down during a power outage. Fresh supplemental remote data must **not** suppress the outage banner. This applies to any remote weather source type under policy; METAR is the primary enforcement target in code.
+
+**Outage threshold:** Default fail-closed staleness for on-field sources (`getStaleFailclosedSeconds()`, typically 3 hours). Airports with `limited_availability: true` use `getOutageBannerThresholdSeconds()` (default 30 minutes) and a different banner message.
+
+**Detection logic (target behavior):**
+
+1. Uses shared `getSourceTimestamps()` to read timestamps from weather cache and webcam metadata
+2. Builds the set of **on-field** sources (primary, backup, webcams, and co-located weather sources such as on-field METAR)
+3. Site is **in outage** when **all** on-field sources exceed the outage threshold
+4. Banner shows the newest stale timestamp among on-field sources (not supplemental remote data)
+5. Banner clears when any on-field source recovers fresh data
+
+**Display when in outage:**
+
+- Standard banner copy: local data sources offline (not the `limited_availability` battery/solar message unless that flag is set)
+- **Fail closed on supplemental remote weather:** fields from supplemental remote sources (typically METAR visibility, ceiling, and cloud_cover) are nulled in cache serve and API responses while the site is in outage, so pilots do not see uncorroborated remote data
+
+**Examples:**
+
+| Airport | On-field down | Supplemental remote | Co-located weather | Outage banner? |
+|---------|---------------|---------------------|--------------------|----------------|
+| 7S9 | Tempest + webcams stale | KUAO METAR fresh | n/a | **Yes**; hide supplemental fields |
+| KSPB | Tempest stale | n/a | KSPB METAR fresh | **No** (on-field ASOS still up) |
+| KSPB | Tempest + KSPB METAR stale | n/a | both stale | **Yes** |
+| METAR-only (co-located) | n/a | n/a | METAR stale | **Yes** |
+
+**Implementation status:** Co-located vs supplemental rules and supplemental fail-closed hiding are documented here as the target policy for all remote source types; code changes to match are tracked separately. **Current code:** `limited_availability` airports exclude all METAR from outage checks when on-field sources exist; normal airports such as 7S9 count supplemental METAR toward site health (the 7S9 gap). Enforcement for non-METAR remote sources is not yet systematic. **Target code:** distinguish co-located sources (count toward site health) from supplemental remote sources (excluded from site health; fields hidden during outage), starting with METAR. `nearby_stations` HTTP fallback is implemented in legacy `fetchMETAR()` but not yet in `UnifiedFetcher`.
 
 **Outage State File Persistence**:
 - Creates `cache/outage_{airport_id}.json` when outage is first detected
-- Preserves original outage start time across brief recoveries (grace period: 1.5 hours)
+- Preserves original outage start time across brief recoveries (grace period matches `getOutageBannerThresholdSeconds()` for the airport)
 - Handles back-to-back outages as single continuous event
 - Automatically cleans up after full recovery (grace period expires)
 - Logs outage start and end events for operational visibility
 
-**Fallback Chain for Outage Start Time**:
+**Fallback Chain for Outage Start Time** (on-field sources only, target behavior):
 1. Existing outage state file (preserves original start time)
-2. Newest timestamp from stale sources (via `getSourceTimestamps()`)
+2. Newest timestamp from stale on-field sources (via `getSourceTimestamps()`)
 3. Webcam cache file modification times (if weather cache is lost)
 4. Current time (final fallback)
 
 **Display Behavior**:
-- Red banner at top of page (similar to maintenance banner)
-- Only shown when airport is **NOT** in maintenance mode
-- Message indicates data is stale and cannot be trusted
-- Includes newest data timestamp to help identify when outage started
+- Red banner at top of page (similar to maintenance banner); standard local-outage copy unless `limited_availability` is set
+- Only shown when airport is **NOT** in maintenance mode and all on-field infrastructure is stale
+- Supplemental METAR fields hidden while banner is active (target behavior; policy extends to other remote source types)
+- Includes newest on-field stale timestamp to help identify when the local outage started
 
 **Frontend Updates**:
 - Client-side checks every 30 seconds for immediate feedback

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1,6 +1,8 @@
 # Weather, Webcam, and NOTAM Data Flow Documentation
 
-This document describes how weather, webcam, and NOTAM data is fetched, processed, calculated, transformed, and displayed in the AviationWX dashboard. It also summarizes the **airport country resolution** aggregate (geometry-only ISO hints merged at config load). This is written in human-readable format to serve as a reference for understanding the complete data pipeline.
+This document describes how weather, webcam, and NOTAM data is fetched, processed, calculated, transformed, and displayed in the AviationWX dashboard. It also summarizes the **airport country resolution** aggregate (geometry-only ISO hints merged at config load).
+
+**Document role:** Checked-in reference for **required pipeline logic** - what the system must do, in present tense. It is not a project plan, rollout tracker, or implementation status log. Delivery gaps belong in GitHub issues and pull requests (see `CODE_STYLE.md`).
 
 ## Table of Contents
 
@@ -46,7 +48,7 @@ All weather sources are configured in a unified `weather_sources` array. Each so
 
 **Purpose**: Provides redundancy when primary weather source becomes stale or fails.
 
-**Current Implementation**:
+**Behavior**:
 - Backup source is treated as another source in the unified aggregation system
 - Fetched in parallel with all other sources on every weather fetch
 - No special activation thresholds - always fetched if configured
@@ -158,8 +160,7 @@ All weather sources are configured in a unified `weather_sources` array. Each so
 
 #### METAR-Only Source
 - **Endpoint**: `https://aviationweather.gov/api/data/metar?ids={station}&format=json&taf=false&hours=0`
-- **Bulk cache (production, multi-airport only):** When **more than one airport** is enabled in config, the scheduler starts `scripts/refresh-metar-bulk.php` in the background on `METAR_BULK_REFRESH_INTERVAL_SECONDS` (see `lib/constants.php`); download, CSV ingest, and slice writes run inside that worker so the scheduler loop stays non-blocking. It downloads AWC `metars.cache.csv.gz`, maps each configured METAR `station_id` (plus `nearby_stations`) to a one-station JSON envelope under `cache/metar-bulk/stations/{ICAO}.json`, and `fetchMETARFromStation` prefers that file when its mtime is within `METAR_BULK_STATION_FILE_MAX_AGE_SECONDS`. Ingest **rejects the gzip** unless the CSV header row matches the canonical 44-column AWC layout in `lib/metar-bulk-csv-schema.php` (and `tests/Fixtures/metar-bulk-csv-header-line.txt`); a mismatch is logged with a short column diff summary and workers fall back to per-station HTTP. Rows shorter than 44 columns are skipped (`skipped_short_rows` in refresh logs). With **only one enabled airport**, bulk download and slice reads are skipped so the install uses per-station METAR HTTP only (typical small or OSS single-site configs). Stale or missing slices fall back to the JSON endpoint above so behavior stays safe if the bulk job fails.
-- **Post-deploy validation (multi-airport):** After deploy, confirm `cache/metar-bulk/stations/{ICAO}.json` updates on the scheduler cadence, `app.log` shows `metar_bulk: refresh complete` without `bad_csv_header_schema`, and METAR still serves when slices are removed or aged past `METAR_BULK_STATION_FILE_MAX_AGE_SECONDS` (per-station HTTP fallback).
+- **Bulk cache (multi-airport only):** When **more than one airport** is enabled in config, the scheduler starts `scripts/refresh-metar-bulk.php` in the background on `METAR_BULK_REFRESH_INTERVAL_SECONDS` (see `lib/constants.php`); download, CSV ingest, and slice writes run inside that worker so the scheduler loop stays non-blocking. It downloads AWC `metars.cache.csv.gz`, maps each configured METAR `station_id` (plus `nearby_stations`) to a one-station JSON envelope under `cache/metar-bulk/stations/{ICAO}.json`, and `fetchMETARFromStation` prefers that file when its mtime is within `METAR_BULK_STATION_FILE_MAX_AGE_SECONDS`. Ingest **rejects the gzip** unless the CSV header row matches the canonical 44-column AWC layout in `lib/metar-bulk-csv-schema.php` (and `tests/Fixtures/metar-bulk-csv-header-line.txt`); a mismatch is logged with a short column diff summary and workers fall back to per-station HTTP. Rows shorter than 44 columns are skipped (`skipped_short_rows` in refresh logs). With **only one enabled airport**, bulk download and slice reads are skipped; per-station METAR HTTP is used. Stale or missing slices always fall back to the JSON endpoint above so METAR still serves when bulk ingest fails or a slice ages out.
 - **Data Provided**:
   - Temperature (Celsius)
   - Dewpoint (Celsius)
@@ -187,7 +188,7 @@ Remote supplemental data is not a substitute for on-field infrastructure.
 
 **Operator rule (configuration):** A remote source is added only when conditions at that location are **equivalent to the airport within VFR standards**, based on local geography, terrain, and climate. Examples of acceptable pairings: similar elevation, no intervening terrain or weather regimes that routinely diverge on ceiling height or visibility. If weather is not equivalent under VFR standards, do **not** configure a remote source for that airport.
 
-**Preference:** On-field sensor data always takes precedence over any remote source when both are available. Source attribution in the dashboard identifies which source supplied each field (see existing attribution UI; no additional copy required).
+**Preference:** On-field sensor data always takes precedence over any remote source when both are available. Source attribution in the dashboard identifies which source supplied each field.
 
 **Scope:** This policy applies to all weather source types. METAR is the most common supplemental source; the same rules apply to NWS, AWOSnet, and other remote sources that observe a location other than the field.
 
@@ -588,7 +589,7 @@ Pressure Altitude = Station Elevation + [(29.92 - Altimeter Setting) × 1000]
    - Subtract 120 feet of density altitude for every degree Celsius below ISA
    - Result: Density altitude
 
-**Critical Implementation Details**:
+**Critical calculation requirements**:
 - Step 2 MUST use pressure altitude, not station elevation
 - The 120 coefficient is for Celsius, NOT Fahrenheit (using Fahrenheit overestimates by ~80%)
 - This matters most at high airports, on low-pressure days, and in hot conditions
@@ -615,7 +616,7 @@ Pressure Altitude = Station Elevation + [(29.92 - Altimeter Setting) × 1000]
 
 **Testing**: 
 - Reference tests: `tests/Unit/SafetyCriticalReferenceTest.php` (23 tests with known-good values from E6B manuals)
-- Implementation tests: `tests/Unit/WeatherCalculationsTest.php` (real-world scenarios)
+- Unit tests: `tests/Unit/WeatherCalculationsTest.php` (real-world scenarios)
 
 **Sources**:
 - FAA Pilot's Handbook of Aeronautical Knowledge (FAA-H-8083-25C)
@@ -1354,7 +1355,7 @@ Safe Zone → Center-crop to 4:3 → 1368x1026
 Otherwise → Output 640x480 (FAA minimum)
 ```
 
-**Implementation**: `lib/image-transform.php` - `transformImageFaa()`, `getFaaTransformedImagePath()`
+**Module:** `lib/image-transform.php` - `transformImageFaa()`, `getFaaTransformedImagePath()`
 
 ### Webcam Metadata Caching
 
@@ -1732,9 +1733,9 @@ Production access is browser-only (`lib/notam/map-api-access.php`).
 **Two policies on purpose**:
 
 1. **Aggregate JSON `last_updated` / `last_updated_iso`**: PHP computes a **maximum** across observation and fetch candidates so the payload carries a single "freshest metadata" stamp for staleness and APIs. That max can be driven by fetch time when it is newer than observation metadata.
-2. **Human "Last updated" on the airport dashboard**: The browser uses `pickObservationUnixTimestamp` and `lastUpdatedDateFromWeather` in `public/js/weather-timestamp-utils.js`, which take the **maximum of observation candidates only**, then fall back to fetch times **only if** no observation metadata exists. Legacy `pickWeatherUnixTimestamp` remains max-of-all for backward compatibility and diagnostics.
+2. **Human "Last updated" on the airport dashboard**: The browser uses `pickObservationUnixTimestamp` and `lastUpdatedDateFromWeather` in `public/js/weather-timestamp-utils.js`, which take the **maximum of observation candidates only**, then fall back to fetch times **only if** no observation metadata exists. `pickWeatherUnixTimestamp` (max of all candidates) is for diagnostics only and must not drive the pilot-facing line.
 
-**Regression protection**: Node tests in `tests/js/weather-timestamp-utils.test.js` assert this split (including real-world-style payloads). Changing the UI to prefer fetch over observation without an explicit product decision would fail those tests.
+**Invariant:** When observation metadata exists, the dashboard must not show a fetch time that is newer than the underlying observation time. Automated tests in `tests/js/weather-timestamp-utils.test.js` enforce this split.
 
 ### Weather Data Display
 
@@ -2027,4 +2028,4 @@ This system provides a robust, fault-tolerant data pipeline that:
 7. **Fetches** webcam images from various protocols (MJPEG, RTSP, static)
 8. **Displays** all data with proper timestamps, units, and formatting
 
-The system prioritizes **safety** (accurate, timely data), **performance** (fast responses), and **reliability** (graceful degradation when sources fail).
+The system prioritizes **safety** (accurate, timely data), **performance** (fast responses), and **reliability** (graceful degradation when sources fail). Policy rules for supplemental remote weather, staleness, and outage detection are stated as required behavior throughout this document; they are not tracked here as a delivery checklist.

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1,8 +1,8 @@
 # Weather, Webcam, and NOTAM Data Flow Documentation
 
-This document describes how weather, webcam, and NOTAM data is fetched, processed, calculated, transformed, and displayed in the AviationWX dashboard. It also summarizes the **airport country resolution** aggregate (geometry-only ISO hints merged at config load).
+This document describes how weather, webcam, and NOTAM data is fetched, processed, calculated, transformed, and displayed in the AviationWX dashboard.
 
-**Document role:** Checked-in reference for **required pipeline logic** - what the system must do, in present tense. It is not a project plan, rollout tracker, or implementation status log. Delivery gaps belong in GitHub issues and pull requests (see `CODE_STYLE.md`).
+**Document role:** Checked-in reference for **required pipeline logic** - what the system must do, in present tense. It is not a project plan, rollout tracker, or implementation status log. Delivery gaps belong in GitHub issues and pull requests (see `CODE_STYLE.md`). Use this document to understand system intent, then verify in code that behavior matches. Logic stated here can be audited against the implementation to find safety or functional gaps.
 
 ## Table of Contents
 

--- a/docs/SAFETY_CRITICAL_CALCULATIONS.md
+++ b/docs/SAFETY_CRITICAL_CALCULATIONS.md
@@ -17,7 +17,7 @@ This document provides a comprehensive reference for all safety-critical weather
 6. [Wind Calculations](#wind-calculations)
 7. [Wind Direction: True North](#wind-direction-true-north)
 8. [METAR Visibility Parsing](#metar-visibility-parsing)
-9. [Local vs Neighboring METAR Aggregation](#local-vs-neighboring-metar-aggregation)
+9. [Local vs Supplemental Remote Weather](#local-vs-supplemental-remote-weather)
 
 ---
 
@@ -451,28 +451,40 @@ Per **ICAO METAR format, visibility group**:
 
 ---
 
-## Local vs Neighboring METAR Aggregation
+## Local vs Supplemental Remote Weather
 
-**⚠️ SAFETY CRITICAL**: Wind and temperature at an airport can differ significantly from nearby airports. Using neighboring METAR data for local measurements could mislead pilots about actual conditions at the field.
+**Guiding principle:** Pilot safety is the prime directive for weather sourcing. It takes precedence over filling coverage gaps. See [Supplemental remote weather policy](DATA_FLOW.md#supplemental-remote-weather-policy) in DATA_FLOW.md.
 
-### Rule
+**⚠️ SAFETY CRITICAL**: Wind and temperature at an airport can differ significantly from nearby locations. Using supplemental (remote) weather data for local measurements could mislead pilots about actual conditions at the field. Supplemental remote data must not imply the on-site installation is operational when local sensors and webcams are down.
 
-For LOCAL_FIELDS (wind_speed, wind_direction, gust_speed, temperature, dewpoint, humidity, pressure, precip_accum), **local sources always override neighboring METAR** when both have valid data, regardless of observation freshness.
+This applies to **any remote weather source** (METAR, NWS, AWOSnet, federation from another airport, etc.). METAR is the most common case and the primary reference implementation in code today.
 
-- **Local source**: On-site sensors (Tempest, Ambient, etc.) or METAR from the same station as the airport (e.g., KSPB METAR for KSPB airport)
-- **Neighboring METAR**: METAR from a different station (e.g., KVUO when displaying KSPB)
-- **Fill-in allowed**: Neighboring METAR may fill in missing fields (visibility, ceiling, cloud_cover) when local has no data
+Operator policy (when to configure remote sources, equivalence within VFR standards, and configuration examples) is in [DATA_FLOW.md](DATA_FLOW.md#supplemental-remote-weather-policy).
+
+### Aggregation rule
+
+For LOCAL_FIELDS (wind_speed, wind_direction, gust_speed, temperature, dewpoint, humidity, pressure, precip_accum), **on-field and co-located sources always override supplemental remote data** when both have valid data, regardless of observation freshness.
+
+- **On-site weather source (aggregation)**: On-site sensors (Tempest, Ambient, etc.) or **co-located** observations (e.g. KSPB METAR for KSPB)
+- **Supplemental (remote) source**: Observations from a different location (e.g. KUAO METAR for 7S9). Used only when configured under operator equivalence rules
+- **Fill-in allowed**: Supplemental remote sources may fill missing fields (typically METAR visibility, ceiling, cloud_cover) when on-field sensors are healthy but lack those fields
+- **Fill-in forbidden during site outage**: When all on-field infrastructure is down, supplemental remote weather fields are hidden (fail closed) and the local-outage banner is shown
+
+### Site health rule
+
+Outage detection considers **on-field infrastructure** only: non-METAR weather sources that observe the field, webcams, and co-located weather sources (e.g. on-field METAR). Supplemental remote weather freshness does not clear an outage. Co-located sources (e.g. KSPB ASOS) may use separate power or internet from Tempest or webcams but still count as local until stale.
 
 ### Implementation
 
-- **File**: `lib/weather/WeatherAggregator.php`
-- **Policy**: `AggregationPolicy::LOCAL_FIELDS`
-- **Detection**: `WeatherSnapshot.metarStationId` vs `localAirportIcao` (from airport config)
-- **Tests**: `tests/Unit/WeatherAggregatorTest.php` (testLocalWindOverridesNeighboringMetar_EvenWhenMetarFresher, etc.)
+- **Aggregation (METAR today)**: `lib/weather/WeatherAggregator.php`, `AggregationPolicy::LOCAL_FIELDS`
+- **Detection (METAR today)**: `WeatherSnapshot.metarStationId` and `_field_station_map` vs `localAirportIcao` (`airport.icao`)
+- **Outage / fail-closed (METAR target first)**: `lib/weather/outage-detection.php`, `lib/weather/cache-utils.php` (see [DATA_FLOW.md](DATA_FLOW.md#data-outage-detection))
+- **Other source types**: Same policy intent; systematic code enforcement may follow per adapter
+- **Tests**: `tests/Unit/WeatherAggregatorTest.php` (on-field overrides supplemental when fresher)
 
 ### Rationale
 
-Wind and temperature vary with local terrain, elevation, and microclimate. A METAR from an airport 10 nm away may report different conditions. Pilots need accurate local data for takeoff/landing decisions.
+Wind and temperature vary with local terrain, elevation, and microclimate. Observations from a remote source even a short distance away may report different conditions. Ceiling and visibility from a supplemental source without corroborating on-site data during a local outage could imply the field is observable when cameras and sensors are offline.
 
 ---
 

--- a/lib/weather/AggregationPolicy.php
+++ b/lib/weather/AggregationPolicy.php
@@ -62,7 +62,7 @@ class AggregationPolicy {
      * on-site sensors when available. Neighboring METAR (different station)
      * may fill in missing fields but must not override local measurements.
      *
-     * @see docs/DATA_FLOW.md Local vs Neighboring METAR
+     * @see docs/DATA_FLOW.md Supplemental remote weather policy
      */
     public const LOCAL_FIELDS = [
         'wind_speed',

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -21,6 +21,7 @@ require_once __DIR__ . '/data/WeatherSnapshot.php';
 require_once __DIR__ . '/AggregationPolicy.php';
 require_once __DIR__ . '/aggregate-timestamps.php';
 require_once __DIR__ . '/WeatherAggregator.php';
+require_once __DIR__ . '/weather-locality.php';
 require_once __DIR__ . '/adapter/tempest-v1.php';
 require_once __DIR__ . '/adapter/ambient-v1.php';
 require_once __DIR__ . '/adapter/synopticdata-v1.php';
@@ -94,7 +95,8 @@ function fetchWeatherUnified(array $airport, string $airportId): array {
         $localAirportIcao = null;
     }
     $aggregator = new WeatherAggregator();
-    $result = $aggregator->aggregate($snapshots, null, $localAirportIcao);
+    $hasOnFieldInfrastructure = airportHasOnFieldInfrastructure($airport);
+    $result = $aggregator->aggregate($snapshots, null, $localAirportIcao, $hasOnFieldInfrastructure);
 
     // METAR ICAO completeness flags: copy from the METAR snapshot that contributed each field
     applyMetarCompletenessFlagsFromAggregation($result, $snapshots);

--- a/lib/weather/WeatherAggregator.php
+++ b/lib/weather/WeatherAggregator.php
@@ -27,6 +27,9 @@ class WeatherAggregator {
     
     /** @var int Current timestamp (injectable for testing) */
     private int $now;
+
+    /** @var bool When true, METAR without matching airport ICAO is supplemental remote */
+    private bool $hasOnFieldInfrastructure = false;
     
     /**
      * Create a new aggregator
@@ -55,13 +58,21 @@ class WeatherAggregator {
      * @param array<WeatherSnapshot> $snapshots Snapshots in preference order
      * @param array<string, int>|null $maxAges Optional per-source max age overrides (source => seconds)
      * @param string|null $localAirportIcao Airport ICAO (e.g. KSPB) for local vs neighboring METAR detection
+     * @param bool $hasOnFieldInfrastructure True when non-METAR sources or webcams are configured
      * @return array<string, mixed> Aggregated weather data with field attribution. Includes
      *         `last_updated` / `last_updated_iso` from normalizeAggregateLastUpdatedTimes() (max of
      *         observation and fetch candidates for API/staleness). The airport dashboard uses
      *         observation-first display for the human "Last updated" line; see
      *         docs/DATA_FLOW.md#airport-last-updated-observation-vs-fetch-time.
      */
-    public function aggregate(array $snapshots, ?array $maxAges = null, ?string $localAirportIcao = null): array {
+    public function aggregate(
+        array $snapshots,
+        ?array $maxAges = null,
+        ?string $localAirportIcao = null,
+        bool $hasOnFieldInfrastructure = false
+    ): array {
+        $this->hasOnFieldInfrastructure = $hasOnFieldInfrastructure;
+
         if (empty($snapshots)) {
             return $this->emptyResult();
         }
@@ -158,19 +169,22 @@ class WeatherAggregator {
      *
      * @param WeatherSnapshot $snapshot
      * @param string|null $localAirportIcao Airport ICAO (e.g. KSPB)
-     * @return bool True if local; when localAirportIcao is null, all sources are treated as local
+     * @return bool True if local on-site or co-located METAR
      */
     private function isLocalSource(WeatherSnapshot $snapshot, ?string $localAirportIcao): bool {
-        if ($localAirportIcao === null || $localAirportIcao === '') {
-            return true;
-        }
         if ($snapshot->source !== 'metar') {
             return true;
         }
         if ($snapshot->metarStationId === null) {
-            return true;
+            return !$this->hasOnFieldInfrastructure;
         }
-        return strcasecmp($snapshot->metarStationId, $localAirportIcao) === 0;
+        if ($localAirportIcao !== null && $localAirportIcao !== '') {
+            return strcasecmp($snapshot->metarStationId, $localAirportIcao) === 0;
+        }
+        if ($this->hasOnFieldInfrastructure) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/lib/weather/cache-utils.php
+++ b/lib/weather/cache-utils.php
@@ -13,6 +13,7 @@
 
 require_once __DIR__ . '/../constants.php';
 require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/weather-locality.php';
 
 /**
  * Null out stale weather fields in cached data (failclosed tier)
@@ -130,12 +131,51 @@ function nullStaleFieldsBySource(&$data, $failclosedSeconds, $failclosedSecondsM
  * @param array &$data Weather data array (modified in place)
  * @param array|null $airport Airport config for threshold override
  * @param bool $isMetarOnly True if this is a METAR-only source
+ * @param string|null $airportId Airport id for supplemental fail-closed during outage
  * @return void
  */
-function applyFailclosedStaleness(&$data, ?array $airport = null, bool $isMetarOnly = false): void {
+function applyFailclosedStaleness(&$data, ?array $airport = null, bool $isMetarOnly = false, ?string $airportId = null): void {
     $failclosedSeconds = getStaleFailclosedSeconds($airport);
     $failclosedSecondsMetar = getMetarStaleFailclosedSeconds();
     
     nullStaleFieldsBySource($data, $failclosedSeconds, $failclosedSecondsMetar, $isMetarOnly);
+
+    if ($airport !== null && $airportId !== null && $airportId !== '') {
+        hideSupplementalRemoteFieldsDuringOutage($data, $airport, $airportId);
+    }
+}
+
+/**
+ * Hide supplemental remote METAR fields when on-field infrastructure is in outage.
+ *
+ * @param array $data Weather payload (modified in place)
+ * @param array $airport Airport configuration
+ * @param string $airportId Airport identifier
+ * @return void
+ */
+function hideSupplementalRemoteFieldsDuringOutage(array &$data, array $airport, string $airportId): void
+{
+    if (!isSupplementalMetarForOutage($airport, $data)) {
+        return;
+    }
+
+    require_once __DIR__ . '/outage-detection.php';
+
+    $outageStatus = checkDataOutageStatus($airportId, $airport);
+    if ($outageStatus === null) {
+        return;
+    }
+
+    foreach (['visibility', 'ceiling', 'cloud_cover'] as $field) {
+        if (array_key_exists($field, $data)) {
+            $data[$field] = null;
+        }
+    }
+
+    $data['visibility_greater_than'] = false;
+
+    if (function_exists('calculateFlightCategory')) {
+        $data['flight_category'] = calculateFlightCategory($data);
+    }
 }
 

--- a/lib/weather/cache-utils.php
+++ b/lib/weather/cache-utils.php
@@ -161,7 +161,7 @@ function hideSupplementalRemoteFieldsDuringOutage(array &$data, array $airport, 
 
     require_once __DIR__ . '/outage-detection.php';
 
-    $outageStatus = checkDataOutageStatus($airportId, $airport);
+    $outageStatus = checkDataOutageStatus($airportId, $airport, $data);
     if ($outageStatus === null) {
         return;
     }

--- a/lib/weather/outage-detection.php
+++ b/lib/weather/outage-detection.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/../config.php';
 require_once __DIR__ . '/../constants.php';
 require_once __DIR__ . '/../logger.php';
 require_once __DIR__ . '/source-timestamps.php';
+require_once __DIR__ . '/weather-locality.php';
 
 /**
  * Check if all configured data sources are stale (data outage condition)
@@ -112,26 +113,25 @@ function checkDataOutageStatus(string $airportId, array $airport): ?array {
         }
     }
     
-    // Check if ALL configured sources are stale
-    // For limited_availability (off-grid/solar/battery) airports: exclude METAR from the check
-    // when local sources (primary, webcams) exist. METAR comes from a nearby airport and stays
-    // fresh when the local site powers down; pilots need to know when local data is unavailable.
+    // Supplemental remote METAR must not clear outage when on-field infrastructure is down.
+    // Co-located METAR (e.g. KSPB) still counts as local site health.
     $sourcesToCheck = $sources;
     $newestTimestampLocal = $newestTimestamp;
-    $hasLocalSources = isset($sources['primary']) || isset($sources['webcams']);
-    if (isAirportLimitedAvailability($airport) && $hasLocalSources) {
-        unset($sourcesToCheck['metar']);
-        // Use newest from local sources only (primary, webcams) for banner timestamp
-        $newestTimestampLocal = 0;
-        if (isset($sources['primary']) && $sources['primary']['timestamp'] > 0) {
-            $newestTimestampLocal = max($newestTimestampLocal, $sources['primary']['timestamp']);
-        }
-        if (isset($sources['webcams'])) {
-            $webcamTs = $sourceTimestamps['webcams']['newest_timestamp'] ?? 0;
-            if ($webcamTs > 0) {
-                $newestTimestampLocal = max($newestTimestampLocal, $webcamTs);
+    $weatherDataForLocality = null;
+    if (isset($sources['metar']) && airportHasOnFieldInfrastructure($airport)) {
+        $weatherCacheFile = getWeatherCachePath($airportId);
+        if (file_exists($weatherCacheFile)) {
+            $decoded = @json_decode(@file_get_contents($weatherCacheFile), true);
+            if (is_array($decoded)) {
+                $weatherDataForLocality = $decoded;
             }
         }
+    }
+    $excludeSupplementalMetar = isset($sources['metar'])
+        && isSupplementalMetarForOutage($airport, $weatherDataForLocality);
+    if ($excludeSupplementalMetar) {
+        unset($sourcesToCheck['metar']);
+        $newestTimestampLocal = newestOnFieldOutageTimestamp($sources, $sourceTimestamps);
     }
 
     $allStale = true;
@@ -174,9 +174,8 @@ function checkDataOutageStatus(string $airportId, array $airport): ?array {
             }
         }
         
-        // If no existing outage start, use newest timestamp from stale sources
-        // For limited_availability, use local sources only (not METAR)
-        $tsForOutage = isAirportLimitedAvailability($airport) ? $newestTimestampLocal : $newestTimestamp;
+        // If no existing outage start, use newest timestamp from stale on-field sources
+        $tsForOutage = $excludeSupplementalMetar ? $newestTimestampLocal : $newestTimestamp;
         if ($outageStart === 0 && $tsForOutage > 0) {
             $outageStart = $tsForOutage;
         }

--- a/lib/weather/outage-detection.php
+++ b/lib/weather/outage-detection.php
@@ -29,9 +29,10 @@ require_once __DIR__ . '/weather-locality.php';
  * 
  * @param string $airportId Airport identifier
  * @param array $airport Airport configuration array
+ * @param array|null $cachedWeather Optional decoded weather cache (avoids re-read for locality checks)
  * @return array|null Returns array with 'newest_timestamp' if all sources are stale, null otherwise
  */
-function checkDataOutageStatus(string $airportId, array $airport): ?array {
+function checkDataOutageStatus(string $airportId, array $airport, ?array $cachedWeather = null): ?array {
     // Don't show outage banner if airport is in maintenance mode
     if (isAirportInMaintenance($airport)) {
         return null;
@@ -119,11 +120,15 @@ function checkDataOutageStatus(string $airportId, array $airport): ?array {
     $newestTimestampLocal = $newestTimestamp;
     $weatherDataForLocality = null;
     if (isset($sources['metar']) && airportHasOnFieldInfrastructure($airport)) {
-        $weatherCacheFile = getWeatherCachePath($airportId);
-        if (file_exists($weatherCacheFile)) {
-            $decoded = @json_decode(@file_get_contents($weatherCacheFile), true);
-            if (is_array($decoded)) {
-                $weatherDataForLocality = $decoded;
+        if (is_array($cachedWeather)) {
+            $weatherDataForLocality = $cachedWeather;
+        } else {
+            $weatherCacheFile = getWeatherCachePath($airportId);
+            if (file_exists($weatherCacheFile)) {
+                $decoded = @json_decode(@file_get_contents($weatherCacheFile), true);
+                if (is_array($decoded)) {
+                    $weatherDataForLocality = $decoded;
+                }
             }
         }
     }

--- a/lib/weather/weather-locality.php
+++ b/lib/weather/weather-locality.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Local vs supplemental remote weather helpers
+ *
+ * Co-located sources observe the airport; supplemental remote sources (e.g. KUAO for 7S9)
+ * may fill gaps when on-field infrastructure is healthy but must not clear outage detection.
+ *
+ * @see docs/DATA_FLOW.md#supplemental-remote-weather-policy
+ */
+
+/**
+ * True when the airport has on-field infrastructure beyond supplemental remote METAR.
+ *
+ * On-field means non-METAR weather sources and/or webcams configured for the airport.
+ *
+ * @param array $airport Airport configuration
+ * @return bool
+ */
+function airportHasOnFieldInfrastructure(array $airport): bool
+{
+    if (isset($airport['webcams']) && is_array($airport['webcams']) && count($airport['webcams']) > 0) {
+        return true;
+    }
+
+    if (!isset($airport['weather_sources']) || !is_array($airport['weather_sources'])) {
+        return false;
+    }
+
+    foreach ($airport['weather_sources'] as $source) {
+        if (!empty($source['type']) && $source['type'] !== 'metar') {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * METAR station_id from the first configured METAR weather source.
+ *
+ * @param array $airport Airport configuration
+ * @return string|null Uppercase station id
+ */
+function getConfiguredMetarStationId(array $airport): ?string
+{
+    if (!isset($airport['weather_sources']) || !is_array($airport['weather_sources'])) {
+        return null;
+    }
+
+    foreach ($airport['weather_sources'] as $source) {
+        if (($source['type'] ?? '') === 'metar' && !empty($source['station_id'])) {
+            return strtoupper(trim((string) $source['station_id']));
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Active METAR station from cached weather attribution, with config fallback.
+ *
+ * @param array|null $weatherData Cached or aggregated weather payload
+ * @param array|null $airport Airport configuration for configured station fallback
+ * @return string|null Uppercase station id
+ */
+function getActiveMetarStationId(?array $weatherData, ?array $airport = null): ?string
+{
+    if (is_array($weatherData) && isset($weatherData['_field_station_map']) && is_array($weatherData['_field_station_map'])) {
+        foreach (['visibility', 'ceiling', 'cloud_cover', 'wind_speed', 'temperature'] as $field) {
+            if (!empty($weatherData['_field_station_map'][$field])) {
+                return strtoupper(trim((string) $weatherData['_field_station_map'][$field]));
+            }
+        }
+    }
+
+    if ($airport !== null) {
+        return getConfiguredMetarStationId($airport);
+    }
+
+    return null;
+}
+
+/**
+ * True when the METAR station observes the airport (airport ICAO matches station).
+ *
+ * @param string|null $metarStationId Active or configured METAR station
+ * @param array $airport Airport configuration
+ * @return bool
+ */
+function isCoLocatedMetarStation(?string $metarStationId, array $airport): bool
+{
+    $icao = isset($airport['icao']) ? trim((string) $airport['icao']) : '';
+    if ($icao === '' || $metarStationId === null || $metarStationId === '') {
+        return false;
+    }
+
+    return strcasecmp($metarStationId, $icao) === 0;
+}
+
+/**
+ * True when configured METAR is supplemental remote for outage and fail-closed policy.
+ *
+ * METAR-only airports treat METAR as primary. When on-field infrastructure exists,
+ * only co-located METAR counts toward site health.
+ *
+ * @param array $airport Airport configuration
+ * @param array|null $weatherData Cached weather for active station attribution
+ * @return bool
+ */
+function isSupplementalMetarForOutage(array $airport, ?array $weatherData = null): bool
+{
+    if (!airportHasOnFieldInfrastructure($airport)) {
+        return false;
+    }
+
+    if (getConfiguredMetarStationId($airport) === null) {
+        return false;
+    }
+
+    $activeStation = getActiveMetarStationId($weatherData, $airport);
+
+    return !isCoLocatedMetarStation($activeStation, $airport);
+}
+
+/**
+ * Newest timestamp from on-field sources only (primary, webcams), for outage banner anchoring.
+ *
+ * @param array $sources Outage source status map from checkDataOutageStatus
+ * @param array $sourceTimestamps Timestamps from getSourceTimestamps()
+ * @return int Unix timestamp, or 0 when none available
+ */
+function newestOnFieldOutageTimestamp(array $sources, array $sourceTimestamps): int
+{
+    $newest = 0;
+
+    if (isset($sources['primary']) && $sources['primary']['timestamp'] > 0) {
+        $newest = max($newest, (int) $sources['primary']['timestamp']);
+    }
+
+    if (isset($sources['webcams'])) {
+        $webcamTs = (int) ($sourceTimestamps['webcams']['newest_timestamp'] ?? 0);
+        if ($webcamTs > 0) {
+            $newest = max($newest, $webcamTs);
+        }
+    }
+
+    return $newest;
+}

--- a/lib/weather/weather-locality.php
+++ b/lib/weather/weather-locality.php
@@ -137,6 +137,15 @@ function newestOnFieldOutageTimestamp(array $sources, array $sourceTimestamps): 
         $newest = max($newest, (int) $sources['primary']['timestamp']);
     }
 
+    if (isset($sources['backup']) && $sources['backup']['timestamp'] > 0) {
+        $newest = max($newest, (int) $sources['backup']['timestamp']);
+    }
+
+    $backupTimestamp = (int) ($sourceTimestamps['backup']['timestamp'] ?? 0);
+    if ($backupTimestamp > 0) {
+        $newest = max($newest, $backupTimestamp);
+    }
+
     if (isset($sources['webcams'])) {
         $webcamTs = (int) ($sourceTimestamps['webcams']['newest_timestamp'] ?? 0);
         if ($webcamTs > 0) {

--- a/pages/airport.php
+++ b/pages/airport.php
@@ -1411,7 +1411,15 @@ const AIRPORT_DATA = <?php
 
 // Initial banner state for status banners (maintenance, outage, limited-availability)
 const INITIAL_BANNER_STATE = <?php
-    $outageStatus = checkDataOutageStatus($airportId, $airport);
+    $initialCachedWeatherForBanner = null;
+    $weatherCacheFileForPage = getWeatherCachePath($airportId);
+    if (file_exists($weatherCacheFileForPage)) {
+        $decodedWeatherForPage = @json_decode(@file_get_contents($weatherCacheFileForPage), true);
+        if (is_array($decodedWeatherForPage)) {
+            $initialCachedWeatherForBanner = $decodedWeatherForPage;
+        }
+    }
+    $outageStatus = checkDataOutageStatus($airportId, $airport, $initialCachedWeatherForBanner);
     echo json_encode([
         'maintenance' => isAirportInMaintenance($airport),
         'in_outage' => $outageStatus !== null,
@@ -1422,30 +1430,26 @@ const INITIAL_BANNER_STATE = <?php
 
 // Initial weather data (embedded from cache for immediate display)
 const INITIAL_WEATHER_DATA = <?php
-    // Load cached weather data for immediate display
-    $weatherCacheFile = getWeatherCachePath($airportId);
     $initialWeatherData = null;
-    if (file_exists($weatherCacheFile)) {
-        $cachedWeather = @json_decode(@file_get_contents($weatherCacheFile), true);
-        if (is_array($cachedWeather)) {
-            // Apply staleness checks to ensure we don't show stale data
-            require_once __DIR__ . '/../lib/constants.php';
-            require_once __DIR__ . '/../lib/weather/cache-utils.php';
-            
-            // isMetarOnly = all configured sources are METAR type
-            $isMetarOnly = true;
-            if (isset($airport['weather_sources']) && is_array($airport['weather_sources'])) {
-                foreach ($airport['weather_sources'] as $source) {
-                    if (!empty($source['type']) && $source['type'] !== 'metar') {
-                        $isMetarOnly = false;
-                        break;
-                    }
+    if (is_array($initialCachedWeatherForBanner ?? null)) {
+        $cachedWeather = $initialCachedWeatherForBanner;
+        // Apply staleness checks to ensure we don't show stale data
+        require_once __DIR__ . '/../lib/constants.php';
+        require_once __DIR__ . '/../lib/weather/cache-utils.php';
+
+        // isMetarOnly = all configured sources are METAR type
+        $isMetarOnly = true;
+        if (isset($airport['weather_sources']) && is_array($airport['weather_sources'])) {
+            foreach ($airport['weather_sources'] as $source) {
+                if (!empty($source['type']) && $source['type'] !== 'metar') {
+                    $isMetarOnly = false;
+                    break;
                 }
             }
-            applyFailclosedStaleness($cachedWeather, $airport, $isMetarOnly, $airportId);
-            
-            $initialWeatherData = $cachedWeather;
         }
+        applyFailclosedStaleness($cachedWeather, $airport, $isMetarOnly, $airportId);
+
+        $initialWeatherData = $cachedWeather;
     }
     
     // Defensive JSON encoding with error handling

--- a/pages/airport.php
+++ b/pages/airport.php
@@ -1432,11 +1432,6 @@ const INITIAL_WEATHER_DATA = <?php
             require_once __DIR__ . '/../lib/constants.php';
             require_once __DIR__ . '/../lib/weather/cache-utils.php';
             
-            // Get failclosed thresholds for staleness checks
-            $failclosedSeconds = getStaleFailclosedSeconds($airport);
-            $failclosedSecondsMetar = getMetarStaleFailclosedSeconds();
-            
-            // Null out stale fields before embedding (using failclosed threshold)
             // isMetarOnly = all configured sources are METAR type
             $isMetarOnly = true;
             if (isset($airport['weather_sources']) && is_array($airport['weather_sources'])) {
@@ -1447,7 +1442,7 @@ const INITIAL_WEATHER_DATA = <?php
                     }
                 }
             }
-            nullStaleFieldsBySource($cachedWeather, $failclosedSeconds, $failclosedSecondsMetar, $isMetarOnly);
+            applyFailclosedStaleness($cachedWeather, $airport, $isMetarOnly, $airportId);
             
             $initialWeatherData = $cachedWeather;
         }

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -1887,6 +1887,9 @@ function hideSupplementalRemoteFieldsIfOutage(inOutage) {
     currentWeatherData.ceiling = null;
     currentWeatherData.cloud_cover = null;
     currentWeatherData.visibility_greater_than = false;
+    if (typeof displayWeather === 'function') {
+        displayWeather(currentWeatherData);
+    }
 }
 
 /**

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -1862,7 +1862,14 @@ function isSupplementalMetarForOutageClient() {
     }
     const airportIcao = AIRPORT_DATA?.icao ? String(AIRPORT_DATA.icao).toUpperCase() : '';
     const stationMap = currentWeatherData?._field_station_map || {};
-    let activeStation = stationMap.visibility || stationMap.ceiling || stationMap.wind_speed || null;
+    const stationFields = ['visibility', 'ceiling', 'cloud_cover', 'wind_speed', 'temperature'];
+    let activeStation = null;
+    for (const field of stationFields) {
+        if (stationMap[field]) {
+            activeStation = stationMap[field];
+            break;
+        }
+    }
     if (!activeStation) {
         const metarSource = AIRPORT_DATA.weather_sources.find(s => s.type === 'metar');
         activeStation = metarSource?.station_id || null;

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -1846,6 +1846,50 @@ async function fetchOutageStatus() {
 }
 
 /**
+ * True when configured METAR is supplemental remote (does not count for site health).
+ */
+function isSupplementalMetarForOutageClient() {
+    const hasSources = AIRPORT_DATA && AIRPORT_DATA.weather_sources && AIRPORT_DATA.weather_sources.length > 0;
+    const hasPrimarySource = hasSources && !AIRPORT_DATA.weather_sources.every(s => s.type === 'metar');
+    const hasWebcams = AIRPORT_DATA?.webcams?.length > 0;
+    const hasOnFieldInfrastructure = hasPrimarySource || hasWebcams;
+    if (!hasOnFieldInfrastructure) {
+        return false;
+    }
+    const hasMetar = hasSources && AIRPORT_DATA.weather_sources.some(s => s.type === 'metar');
+    if (!hasMetar) {
+        return false;
+    }
+    const airportIcao = AIRPORT_DATA?.icao ? String(AIRPORT_DATA.icao).toUpperCase() : '';
+    const stationMap = currentWeatherData?._field_station_map || {};
+    let activeStation = stationMap.visibility || stationMap.ceiling || stationMap.wind_speed || null;
+    if (!activeStation) {
+        const metarSource = AIRPORT_DATA.weather_sources.find(s => s.type === 'metar');
+        activeStation = metarSource?.station_id || null;
+    }
+    if (activeStation) {
+        activeStation = String(activeStation).toUpperCase();
+    }
+    if (airportIcao && activeStation && activeStation === airportIcao) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Hide supplemental METAR fields when on-field infrastructure is in outage.
+ */
+function hideSupplementalRemoteFieldsIfOutage(inOutage) {
+    if (!inOutage || !currentWeatherData || !isSupplementalMetarForOutageClient()) {
+        return;
+    }
+    currentWeatherData.visibility = null;
+    currentWeatherData.ceiling = null;
+    currentWeatherData.cloud_cover = null;
+    currentWeatherData.visibility_greater_than = false;
+}
+
+/**
  * Check if all configured data sources are stale and sync banner state
  * Called after weather data updates and webcam updates
  * Uses client-side data for immediate feedback
@@ -1923,10 +1967,9 @@ function checkAndUpdateOutageBanner() {
                 newestTimestamp = webcamNewestTimestamp;
             }
         }
-        // For limited_availability airports, exclude METAR from outage check when local sources exist
-        // (METAR from nearby airport stays fresh when local site powers down)
-        const hasLocalSources = hasPrimarySource || (AIRPORT_DATA?.webcams?.length > 0);
-        const sourcesToCheck = limitedAvailability && hasLocalSources
+        // Supplemental remote METAR must not clear outage when on-field infrastructure is down
+        const excludeSupplementalMetar = hasMetar && isSupplementalMetarForOutageClient();
+        const sourcesToCheck = excludeSupplementalMetar
             ? sources.filter(s => s.name !== 'metar')
             : sources;
         let allStale = sourcesToCheck.length > 0 && sourcesToCheck.every(s => s.stale);
@@ -1934,9 +1977,8 @@ function checkAndUpdateOutageBanner() {
             syncBannerState({ maintenance, in_outage: false, limited_availability: false, newest_timestamp: 0 });
             return;
         }
-        // For limited_availability outage, use newest from local sources only (not METAR)
         let tsForBanner = newestTimestamp;
-        if (limitedAvailability && allStale && hasLocalSources) {
+        if (excludeSupplementalMetar && allStale) {
             tsForBanner = 0;
             const primarySrc = sources.find(s => s.name === 'primary');
             if (primarySrc && primarySrc.timestamp) {
@@ -1947,10 +1989,11 @@ function checkAndUpdateOutageBanner() {
                 tsForBanner = Math.max(tsForBanner, webcamSrc.newestTimestamp);
             }
             if (tsForBanner === 0) {
-                tsForBanner = now; // Fallback so banner can display
+                tsForBanner = now;
             }
         }
         const inOutage = !maintenance && allStale && tsForBanner > 0;
+        hideSupplementalRemoteFieldsIfOutage(inOutage);
         syncBannerState({
             maintenance,
             in_outage: inOutage,

--- a/tests/Unit/FailClosedStalenessTest.php
+++ b/tests/Unit/FailClosedStalenessTest.php
@@ -328,7 +328,7 @@ class FailClosedStalenessTest extends TestCase
         $this->assertNull($weatherData['visibility']);
         $this->assertNull($weatherData['ceiling']);
         $this->assertNull($weatherData['cloud_cover']);
-        $this->assertEquals(12.0, $weatherData['temperature'], 'On-field fields follow normal fail-closed rules');
+        $this->assertNull($weatherData['temperature'], 'Stale on-field primary fields are fail-closed during outage');
 
         @unlink($weatherCacheFile);
         @unlink($webcamFile);

--- a/tests/Unit/FailClosedStalenessTest.php
+++ b/tests/Unit/FailClosedStalenessTest.php
@@ -275,5 +275,64 @@ class FailClosedStalenessTest extends TestCase
         // Temperature should be preserved (under failclosed threshold)
         $this->assertEquals(15.0, $data['temperature']);
     }
+
+    /**
+     * Supplemental remote METAR fields are hidden during on-field outage (fail-closed).
+     */
+    public function testSupplementalMetarFieldsHiddenDuringOnFieldOutage(): void
+    {
+        require_once __DIR__ . '/../../lib/cache-paths.php';
+        require_once __DIR__ . '/../../lib/weather/cache-utils.php';
+        require_once __DIR__ . '/../../lib/weather/outage-detection.php';
+
+        $airportId = 'test-supplemental-failclosed';
+        $airport = [
+            'faa' => '7S9',
+            'weather_sources' => [
+                ['type' => 'tempest', 'station_id' => '216638'],
+                ['type' => 'metar', 'station_id' => 'KUAO'],
+            ],
+            'webcams' => [
+                ['name' => 'North', 'url' => 'http://example.com/north.jpg'],
+            ],
+        ];
+
+        $staleTimestamp = time() - (4 * 3600);
+        $freshMetarTimestamp = time() - 60;
+        $weatherCacheFile = getWeatherCachePath($airportId);
+        $weatherData = [
+            'temperature' => 12.0,
+            'visibility' => 10.0,
+            'ceiling' => 5000,
+            'cloud_cover' => 'FEW',
+            'obs_time_primary' => $staleTimestamp,
+            'last_updated_primary' => $staleTimestamp,
+            'obs_time_metar' => $freshMetarTimestamp,
+            'last_updated_metar' => $freshMetarTimestamp,
+            '_field_station_map' => ['visibility' => 'KUAO', 'ceiling' => 'KUAO'],
+        ];
+        file_put_contents($weatherCacheFile, json_encode($weatherData));
+
+        $webcamDir = CACHE_WEBCAMS_DIR;
+        ensureCacheDir($webcamDir);
+        require_once __DIR__ . '/../../lib/webcam-format-generation.php';
+        $webcamFile = getCacheSymlinkPath($airportId, 0, 'jpg');
+        $webcamDir = dirname($webcamFile);
+        if (!is_dir($webcamDir)) {
+            mkdir($webcamDir, 0755, true);
+        }
+        touch($webcamFile, $staleTimestamp);
+
+        applyFailclosedStaleness($weatherData, $airport, false, $airportId);
+
+        $this->assertNull($weatherData['visibility']);
+        $this->assertNull($weatherData['ceiling']);
+        $this->assertNull($weatherData['cloud_cover']);
+        $this->assertEquals(12.0, $weatherData['temperature'], 'On-field fields follow normal fail-closed rules');
+
+        @unlink($weatherCacheFile);
+        @unlink($webcamFile);
+        @unlink(getOutageCachePath($airportId));
+    }
 }
 

--- a/tests/Unit/OutageDetectionTest.php
+++ b/tests/Unit/OutageDetectionTest.php
@@ -440,6 +440,86 @@ class OutageDetectionTest extends TestCase
     }
     
     /**
+     * 7S9-shaped airport: fresh supplemental METAR must not clear outage when on-field infra is down.
+     */
+    public function testCheckDataOutageStatus_SupplementalMetarFresh_OnFieldStale_ReturnsOutage(): void
+    {
+        $airport = [
+            'faa' => '7S9',
+            'weather_sources' => [
+                ['type' => 'tempest', 'station_id' => '216638'],
+                ['type' => 'metar', 'station_id' => 'KUAO'],
+            ],
+            'webcams' => [
+                ['name' => 'North', 'url' => 'http://example.com/north.jpg'],
+            ],
+        ];
+
+        $staleTimestamp = time() - (4 * 3600);
+        $freshMetarTimestamp = time() - 60;
+        $weatherCacheFile = getWeatherCachePath($this->testAirportId);
+        $weatherData = [
+            'obs_time_primary' => $staleTimestamp,
+            'last_updated_primary' => $staleTimestamp,
+            'obs_time_metar' => $freshMetarTimestamp,
+            'last_updated_metar' => $freshMetarTimestamp,
+            '_field_station_map' => ['visibility' => 'KUAO'],
+        ];
+        file_put_contents($weatherCacheFile, json_encode($weatherData));
+
+        $webcamDir = CACHE_WEBCAMS_DIR;
+        ensureCacheDir($webcamDir);
+        require_once __DIR__ . '/../../lib/webcam-format-generation.php';
+        $webcamFile = getCacheSymlinkPath($this->testAirportId, 0, 'jpg');
+        $webcamDir = dirname($webcamFile);
+        if (!is_dir($webcamDir)) {
+            mkdir($webcamDir, 0755, true);
+        }
+        touch($webcamFile, $staleTimestamp);
+
+        $result = checkDataOutageStatus($this->testAirportId, $airport);
+
+        $this->assertNotNull(
+            $result,
+            'Supplemental METAR must not mask on-field outage (7S9 fail-closed)'
+        );
+        $this->assertGreaterThan(0, $result['newest_timestamp']);
+    }
+
+    /**
+     * KSPB-shaped airport: co-located METAR is local infrastructure and clears outage.
+     */
+    public function testCheckDataOutageStatus_CoLocatedMetarFresh_PrimaryStale_NoOutage(): void
+    {
+        $airport = [
+            'icao' => 'KSPB',
+            'weather_sources' => [
+                ['type' => 'tempest', 'station_id' => '12345'],
+                ['type' => 'metar', 'station_id' => 'KSPB'],
+            ],
+        ];
+
+        $staleTimestamp = time() - (4 * 3600);
+        $freshMetarTimestamp = time() - 60;
+        $weatherCacheFile = getWeatherCachePath($this->testAirportId);
+        $weatherData = [
+            'obs_time_primary' => $staleTimestamp,
+            'last_updated_primary' => $staleTimestamp,
+            'obs_time_metar' => $freshMetarTimestamp,
+            'last_updated_metar' => $freshMetarTimestamp,
+            '_field_station_map' => ['visibility' => 'KSPB'],
+        ];
+        file_put_contents($weatherCacheFile, json_encode($weatherData));
+
+        $result = checkDataOutageStatus($this->testAirportId, $airport);
+
+        $this->assertNull(
+            $result,
+            'Co-located METAR should count as healthy local infrastructure'
+        );
+    }
+
+    /**
      * Test that no banner is shown when some sources are fresh
      */
     public function testCheckDataOutageStatus_SomeSourcesFresh_ReturnsNull(): void

--- a/tests/Unit/WeatherAggregatorTest.php
+++ b/tests/Unit/WeatherAggregatorTest.php
@@ -485,9 +485,9 @@ class WeatherAggregatorTest extends TestCase {
     }
 
     /**
-     * When localAirportIcao is null, preserve existing freshness-based behavior.
+     * METAR-only airport without on-field infrastructure: freshest observation wins.
      */
-    public function testNullLocalAirportIcao_PreservesFreshnessBehavior(): void {
+    public function testNullLocalAirportIcao_MetarOnly_FreshestWins(): void {
         $localTime = $this->now - 600;
         $local = $this->createSnapshot('tempest', [
             'wind_speed' => 8,
@@ -501,10 +501,33 @@ class WeatherAggregatorTest extends TestCase {
         ], $metarTime, 'KVUO');
 
         $aggregator = new WeatherAggregator($this->now);
-        $result = $aggregator->aggregate([$local, $metar], null, null);
+        $result = $aggregator->aggregate([$local, $metar], null, null, false);
 
-        $this->assertEquals(12, $result['wind_speed'], 'Without localAirportIcao, freshest wins');
+        $this->assertEquals(12, $result['wind_speed'], 'METAR-only config: freshest wins');
         $this->assertEquals('metar', $result['_field_source_map']['wind_speed']);
+    }
+
+    /**
+     * On-field sensors with no airport ICAO: supplemental METAR does not override local wind.
+     */
+    public function testNullLocalAirportIcao_OnFieldInfra_PrefersLocalSensors(): void {
+        $localTime = $this->now - 120;
+        $local = $this->createSnapshot('tempest', [
+            'wind_speed' => 8,
+            'wind_direction' => 270,
+        ], $localTime);
+
+        $metarTime = $this->now - 60;
+        $metar = $this->createSnapshot('metar', [
+            'wind_speed' => 12,
+            'wind_direction' => 180,
+        ], $metarTime, 'KUAO');
+
+        $aggregator = new WeatherAggregator($this->now);
+        $result = $aggregator->aggregate([$local, $metar], null, null, true);
+
+        $this->assertEquals(8, $result['wind_speed'], 'On-field Tempest overrides supplemental METAR');
+        $this->assertEquals('tempest', $result['_field_source_map']['wind_speed']);
     }
 
     /**

--- a/tests/Unit/WeatherLocalityTest.php
+++ b/tests/Unit/WeatherLocalityTest.php
@@ -101,4 +101,18 @@ class WeatherLocalityTest extends TestCase
 
         $this->assertSame('KUAO', getActiveMetarStationId($weatherData, null));
     }
+
+    public function testNewestOnFieldOutageTimestamp_IncludesBackupSource(): void
+    {
+        $sources = [
+            'primary' => ['timestamp' => 1000],
+            'backup' => ['timestamp' => 2000],
+        ];
+        $sourceTimestamps = [
+            'backup' => ['timestamp' => 2500],
+            'webcams' => ['newest_timestamp' => 1500],
+        ];
+
+        $this->assertSame(2500, newestOnFieldOutageTimestamp($sources, $sourceTimestamps));
+    }
 }

--- a/tests/Unit/WeatherLocalityTest.php
+++ b/tests/Unit/WeatherLocalityTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Unit tests for local vs supplemental remote weather helpers.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/weather/weather-locality.php';
+
+class WeatherLocalityTest extends TestCase
+{
+    public function testAirportHasOnFieldInfrastructure_TempestAndWebcams(): void
+    {
+        $airport = [
+            'weather_sources' => [
+                ['type' => 'tempest', 'station_id' => '216638'],
+                ['type' => 'metar', 'station_id' => 'KUAO'],
+            ],
+            'webcams' => [['name' => 'North', 'url' => 'http://example.com/n.jpg']],
+        ];
+
+        $this->assertTrue(airportHasOnFieldInfrastructure($airport));
+    }
+
+    public function testAirportHasOnFieldInfrastructure_MetarOnly_ReturnsFalse(): void
+    {
+        $airport = [
+            'weather_sources' => [['type' => 'metar', 'station_id' => 'KUAO']],
+        ];
+
+        $this->assertFalse(airportHasOnFieldInfrastructure($airport));
+    }
+
+    public function testIsCoLocatedMetarStation_MatchingIcao(): void
+    {
+        $airport = ['icao' => 'KSPB'];
+
+        $this->assertTrue(isCoLocatedMetarStation('KSPB', $airport));
+        $this->assertFalse(isCoLocatedMetarStation('KUAO', $airport));
+    }
+
+    public function testIsCoLocatedMetarStation_NoAirportIcao_ReturnsFalse(): void
+    {
+        $airport = ['faa' => '7S9'];
+
+        $this->assertFalse(isCoLocatedMetarStation('KUAO', $airport));
+    }
+
+    public function testIsSupplementalMetarForOutage_7S9Shaped_ReturnsTrue(): void
+    {
+        $airport = [
+            'faa' => '7S9',
+            'weather_sources' => [
+                ['type' => 'tempest', 'station_id' => '216638'],
+                ['type' => 'metar', 'station_id' => 'KUAO'],
+            ],
+            'webcams' => [['name' => 'North', 'url' => 'http://example.com/n.jpg']],
+        ];
+
+        $weatherData = [
+            '_field_station_map' => ['visibility' => 'KUAO'],
+        ];
+
+        $this->assertTrue(isSupplementalMetarForOutage($airport, $weatherData));
+    }
+
+    public function testIsSupplementalMetarForOutage_CoLocatedKspb_ReturnsFalse(): void
+    {
+        $airport = [
+            'icao' => 'KSPB',
+            'weather_sources' => [
+                ['type' => 'tempest', 'station_id' => '12345'],
+                ['type' => 'metar', 'station_id' => 'KSPB'],
+            ],
+        ];
+
+        $weatherData = [
+            '_field_station_map' => ['visibility' => 'KSPB'],
+        ];
+
+        $this->assertFalse(isSupplementalMetarForOutage($airport, $weatherData));
+    }
+
+    public function testIsSupplementalMetarForOutage_MetarOnly_ReturnsFalse(): void
+    {
+        $airport = [
+            'weather_sources' => [['type' => 'metar', 'station_id' => 'KUAO']],
+        ];
+
+        $this->assertFalse(isSupplementalMetarForOutage($airport, null));
+    }
+
+    public function testGetActiveMetarStationId_UsesFieldStationMapFirst(): void
+    {
+        $weatherData = [
+            '_field_station_map' => [
+                'visibility' => 'KUAO',
+                'wind_speed' => 'KPDX',
+            ],
+        ];
+
+        $this->assertSame('KUAO', getActiveMetarStationId($weatherData, null));
+    }
+}


### PR DESCRIPTION
Closes #180

## Summary

- Enforces supplemental remote weather policy in code: when on-field infrastructure (Tempest, webcams, co-located METAR) is down, fresh supplemental METAR (e.g. KUAO for 7S9) no longer clears the outage banner or shows ceiling/visibility.
- Adds shared locality helpers (`lib/weather/weather-locality.php`) and wires them through outage detection, API/dashboard serve paths, aggregation, and client-side banner logic.
- Documents the policy in `docs/DATA_FLOW.md` and cross-links from configuration and safety-critical guides.

## Technical changes

| Area | Change |
|------|--------|
| Outage detection | Excludes supplemental METAR from `sourcesToCheck`; co-located METAR (KSPB) still counts |
| Fail-closed serve | `applyFailclosedStaleness()` hides supplemental METAR fields during on-field outage |
| Aggregation | `WeatherAggregator` treats METAR as supplemental when airport has on-field infra but no ICAO |
| Dashboard JS | `checkAndUpdateOutageBanner()` mirrors PHP supplemental logic |

## Tests (TDD)

- `WeatherLocalityTest` - co-located vs supplemental classification
- `OutageDetectionTest` - 7S9-shaped outage with fresh KUAO; KSPB co-located METAR clears outage
- `FailClosedStalenessTest` - supplemental fields hidden during outage
- `WeatherAggregatorTest` - on-field sensors override supplemental METAR without airport ICAO

## Test plan

- [x] `make test-ci` (Docker)
- [x] Manual: configure 7S9-shaped airport with stale Tempest/webcams and fresh KUAO METAR; confirm outage banner and hidden supplemental fields
- [x] Manual: KSPB with stale Tempest and fresh co-located METAR; confirm no outage banner

## Policy reference

See `docs/DATA_FLOW.md` - Supplemental remote weather policy.

## Out of scope (follow-up PRs)

- `nearby_stations` wiring in UnifiedFetcher
- Systematic enforcement for non-METAR remote source types