### PR TITLE
Fail closed: hide all supplemental remote weather during on-field outage

### DIFF
--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -395,7 +395,7 @@ The unified weather pipeline uses `WeatherAggregator` with `AggregationPolicy` t
    - **Rule**: For LOCAL_FIELDS (wind, temperature, dewpoint, humidity, pressure, precip_accum), on-field measurements **always override** supplemental remote data when both have valid data, regardless of freshness
    - **Rationale**: Wind and temperature at the airport can differ significantly from nearby locations. Using supplemental remote data for these fields could mislead pilots
    - **Fill-in allowed**: Supplemental remote sources may fill in missing aviation fields (typically visibility, ceiling, cloud_cover from METAR) when on-field sensors are healthy but lack those measurements
-   - **Fill-in forbidden during site outage**: When all on-field infrastructure is stale or unavailable, supplemental remote weather fields are hidden (fail closed) in addition to the outage banner
+   - **Fill-in forbidden during site outage**: When all on-field infrastructure is stale or unavailable, all supplemental remote weather fields are hidden (fail closed) in addition to the outage banner
    - **Classification**: Co-located vs supplemental is determined from the active reporting identity (for METAR: station ICAO from aggregated weather data vs `airport.icao`). The same distinction governs aggregation, site health, and fail-closed display (see [Data outage detection](#data-outage-detection)).
 
 5. **Aggregation Process**:
@@ -858,13 +858,13 @@ The system tracks daily extremes that reset at local midnight:
 **Display when in outage:**
 
 - Standard banner copy: local data sources offline (not the `limited_availability` battery/solar message unless that flag is set)
-- **Fail closed on supplemental remote weather:** fields from supplemental remote sources (typically METAR visibility, ceiling, and cloud_cover) are nulled in cache serve and API responses while the site is in outage, so pilots do not see uncorroborated remote data
+- **Fail closed on supplemental remote weather:** all fields from supplemental remote sources are nulled in cache serve and API responses while the site is in outage, so pilots do not see uncorroborated remote data (wind, temperature, visibility, ceiling, and derived values)
 
 **Examples:**
 
 | Airport | On-field down | Supplemental remote | Co-located weather | Outage banner? |
 |---------|---------------|---------------------|--------------------|----------------|
-| 7S9 | Tempest + webcams stale | KUAO METAR fresh | n/a | **Yes**; hide supplemental fields |
+| 7S9 | Tempest + webcams stale | KUAO METAR fresh | n/a | **Yes**; hide all supplemental fields |
 | KSPB | Tempest stale | n/a | KSPB METAR fresh | **No** (on-field ASOS still up) |
 | KSPB | Tempest + KSPB METAR stale | n/a | both stale | **Yes** |
 | METAR-only (co-located) | n/a | n/a | METAR stale | **Yes** |

--- a/docs/SAFETY_CRITICAL_CALCULATIONS.md
+++ b/docs/SAFETY_CRITICAL_CALCULATIONS.md
@@ -468,7 +468,7 @@ For LOCAL_FIELDS (wind_speed, wind_direction, gust_speed, temperature, dewpoint,
 - **On-site weather source (aggregation)**: On-site sensors (Tempest, Ambient, etc.) or **co-located** observations (e.g. KSPB METAR for KSPB)
 - **Supplemental (remote) source**: Observations from a different location (e.g. KUAO METAR for 7S9). Used only when configured under operator equivalence rules
 - **Fill-in allowed**: Supplemental remote sources may fill missing fields (typically METAR visibility, ceiling, cloud_cover) when on-field sensors are healthy but lack those fields
-- **Fill-in forbidden during site outage**: When all on-field infrastructure is down, supplemental remote weather fields are hidden (fail closed) and the local-outage banner is shown
+- **Fill-in forbidden during site outage**: When all on-field infrastructure is down, all supplemental remote weather fields are hidden (fail closed) and the local-outage banner is shown
 
 ### Site health rule
 
@@ -478,7 +478,7 @@ Outage detection considers **on-field infrastructure** only: non-METAR weather s
 
 - **Aggregation (METAR today)**: `lib/weather/WeatherAggregator.php`, `AggregationPolicy::LOCAL_FIELDS`
 - **Detection (METAR today)**: `WeatherSnapshot.metarStationId` and `_field_station_map` vs `localAirportIcao` (`airport.icao`)
-- **Outage / fail-closed (METAR target first)**: `lib/weather/outage-detection.php`, `lib/weather/cache-utils.php` (see [DATA_FLOW.md](DATA_FLOW.md#data-outage-detection))
+- **Outage / fail-closed (METAR target first)**: `lib/weather/outage-detection.php`, `lib/weather/cache-utils.php`, `lib/weather/weather-locality.php` (`nullSupplementalRemoteWeatherDisplayFields`)
 - **Other source types**: Same policy intent; systematic code enforcement may follow per adapter
 - **Tests**: `tests/Unit/WeatherAggregatorTest.php` (on-field overrides supplemental when fresher)
 

--- a/lib/weather/AggregationPolicy.php
+++ b/lib/weather/AggregationPolicy.php
@@ -104,6 +104,24 @@ class AggregationPolicy {
         'density_altitude',   // Calculated from pressure + temp + elevation
         'flight_category',    // VFR/MVFR/IFR/LIFR from ceiling + visibility
     ];
+
+    /**
+     * Additional display fields nulled during supplemental remote outage fail-closed.
+     *
+     * @see nullSupplementalRemoteWeatherDisplayFields() in weather-locality.php
+     */
+    public const SUPPLEMENTAL_OUTAGE_DISPLAY_EXTRAS = [
+        'wind_direction_magnetic',
+        'peak_gust_today',
+        'peak_gust_time',
+        'temp_high_today',
+        'temp_low_today',
+        'temp_high_ts',
+        'temp_low_ts',
+        'raw_metar',
+        'metar_visibility_reported',
+        'metar_ceiling_reported',
+    ];
     
     /**
      * Recovery cycles threshold

--- a/lib/weather/cache-utils.php
+++ b/lib/weather/cache-utils.php
@@ -146,7 +146,7 @@ function applyFailclosedStaleness(&$data, ?array $airport = null, bool $isMetarO
 }
 
 /**
- * Hide supplemental remote METAR fields when on-field infrastructure is in outage.
+ * Hide all supplemental remote weather display fields when on-field infrastructure is in outage.
  *
  * @param array $data Weather payload (modified in place)
  * @param array $airport Airport configuration
@@ -166,16 +166,6 @@ function hideSupplementalRemoteFieldsDuringOutage(array &$data, array $airport, 
         return;
     }
 
-    foreach (['visibility', 'ceiling', 'cloud_cover'] as $field) {
-        if (array_key_exists($field, $data)) {
-            $data[$field] = null;
-        }
-    }
-
-    $data['visibility_greater_than'] = false;
-
-    if (function_exists('calculateFlightCategory')) {
-        $data['flight_category'] = calculateFlightCategory($data);
-    }
+    nullSupplementalRemoteWeatherDisplayFields($data);
 }
 

--- a/lib/weather/weather-locality.php
+++ b/lib/weather/weather-locality.php
@@ -155,3 +155,41 @@ function newestOnFieldOutageTimestamp(array $sources, array $sourceTimestamps): 
 
     return $newest;
 }
+
+/**
+ * Null supplemental remote weather display fields during on-field outage (fail-closed).
+ *
+ * @param array $data Weather payload (modified in place)
+ * @return void
+ * @see \AviationWX\Weather\AggregationPolicy::ALL_FIELDS
+ * @see \AviationWX\Weather\AggregationPolicy::SUPPLEMENTAL_OUTAGE_DISPLAY_EXTRAS
+ */
+function nullSupplementalRemoteWeatherDisplayFields(array &$data): void
+{
+    require_once __DIR__ . '/AggregationPolicy.php';
+    require_once __DIR__ . '/calculator.php';
+
+    $policy = \AviationWX\Weather\AggregationPolicy::class;
+
+    foreach ($policy::ALL_FIELDS as $field) {
+        if (array_key_exists($field, $data)) {
+            $data[$field] = null;
+        }
+    }
+
+    foreach ($policy::CALCULATED_FIELDS as $field) {
+        if (array_key_exists($field, $data)) {
+            $data[$field] = null;
+        }
+    }
+
+    foreach ($policy::SUPPLEMENTAL_OUTAGE_DISPLAY_EXTRAS as $field) {
+        if (array_key_exists($field, $data)) {
+            $data[$field] = null;
+        }
+    }
+
+    $data['visibility_greater_than'] = false;
+
+    calculateAndSetFlightCategory($data);
+}

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -1884,16 +1884,55 @@ function isSupplementalMetarForOutageClient() {
 }
 
 /**
- * Hide supplemental METAR fields when on-field infrastructure is in outage.
+ * Fields nulled during supplemental remote outage fail-closed (dashboard client).
+ * Keep in sync with AggregationPolicy in lib/weather/AggregationPolicy.php.
+ */
+const SUPPLEMENTAL_OUTAGE_HIDDEN_FIELDS = [
+    'temperature',
+    'dewpoint',
+    'humidity',
+    'pressure',
+    'precip_accum',
+    'wind_speed',
+    'wind_direction',
+    'gust_speed',
+    'visibility',
+    'ceiling',
+    'cloud_cover',
+    'temperature_f',
+    'dewpoint_f',
+    'dewpoint_spread',
+    'gust_factor',
+    'pressure_altitude',
+    'density_altitude',
+    'flight_category',
+    'flight_category_class',
+    'wind_direction_magnetic',
+    'peak_gust_today',
+    'peak_gust_time',
+    'temp_high_today',
+    'temp_low_today',
+    'temp_high_ts',
+    'temp_low_ts',
+    'raw_metar',
+    'metar_visibility_reported',
+    'metar_ceiling_reported',
+];
+
+/**
+ * Hide all supplemental remote weather fields when on-field infrastructure is in outage.
  */
 function hideSupplementalRemoteFieldsIfOutage(inOutage) {
     if (!inOutage || !currentWeatherData || !isSupplementalMetarForOutageClient()) {
         return;
     }
-    currentWeatherData.visibility = null;
-    currentWeatherData.ceiling = null;
-    currentWeatherData.cloud_cover = null;
+    for (const field of SUPPLEMENTAL_OUTAGE_HIDDEN_FIELDS) {
+        if (Object.prototype.hasOwnProperty.call(currentWeatherData, field)) {
+            currentWeatherData[field] = null;
+        }
+    }
     currentWeatherData.visibility_greater_than = false;
+    currentWeatherData.flight_category_class = '';
     if (typeof displayWeather === 'function') {
         displayWeather(currentWeatherData);
     }

--- a/tests/Unit/FailClosedStalenessTest.php
+++ b/tests/Unit/FailClosedStalenessTest.php
@@ -313,6 +313,164 @@ class FailClosedStalenessTest extends TestCase
         ];
         file_put_contents($weatherCacheFile, json_encode($weatherData));
 
+        $this->seedStaleWebcamForOutage($airportId, $staleTimestamp);
+
+        applyFailclosedStaleness($weatherData, $airport, false, $airportId);
+
+        $this->assertNull($weatherData['visibility']);
+        $this->assertNull($weatherData['ceiling']);
+        $this->assertNull($weatherData['cloud_cover']);
+        $this->assertNull($weatherData['temperature'], 'Stale on-field primary fields are fail-closed during outage');
+
+        $this->cleanupSupplementalOutageFixtures($airportId, $weatherCacheFile);
+    }
+
+    /**
+     * 7S9 production-shaped case: fresh supplemental METAR fills LOCAL_FIELDS during outage.
+     */
+    public function testSupplementalMetarAllFieldsHiddenWhenFreshMetarFillsLocalFieldsDuringOutage(): void
+    {
+        require_once __DIR__ . '/../../lib/cache-paths.php';
+        require_once __DIR__ . '/../../lib/weather/cache-utils.php';
+        require_once __DIR__ . '/../../lib/weather/outage-detection.php';
+
+        $airportId = 'test-supplemental-failclosed-all';
+        $airport = [
+            'faa' => '7S9',
+            'weather_sources' => [
+                ['type' => 'tempest', 'station_id' => '216638'],
+                ['type' => 'metar', 'station_id' => 'KUAO'],
+            ],
+            'webcams' => [
+                ['name' => 'East', 'url' => 'http://example.com/east.jpg'],
+                ['name' => 'West', 'url' => 'http://example.com/west.jpg'],
+            ],
+        ];
+
+        $staleTimestamp = time() - (4 * 3600);
+        $freshMetarTimestamp = time() - 60;
+        $weatherCacheFile = getWeatherCachePath($airportId);
+        $fieldObsTimes = [
+            'wind_speed' => $freshMetarTimestamp,
+            'wind_direction' => $freshMetarTimestamp,
+            'visibility' => $freshMetarTimestamp,
+            'ceiling' => $freshMetarTimestamp,
+            'cloud_cover' => $freshMetarTimestamp,
+            'temperature' => $freshMetarTimestamp,
+            'dewpoint' => $freshMetarTimestamp,
+            'humidity' => $freshMetarTimestamp,
+            'pressure' => $freshMetarTimestamp,
+            'precip_accum' => $freshMetarTimestamp,
+        ];
+        $fieldStationMap = array_fill_keys(array_keys($fieldObsTimes), 'KUAO');
+        $fieldSourceMap = array_fill_keys(array_keys($fieldObsTimes), 'metar');
+        $weatherData = [
+            'wind_speed' => 4,
+            'wind_direction' => 0,
+            'visibility' => 10.0,
+            'ceiling' => 5500,
+            'cloud_cover' => 'OVC',
+            'temperature' => 18.3,
+            'dewpoint' => 8.3,
+            'humidity' => 52,
+            'pressure' => 30.1,
+            'precip_accum' => 0,
+            'temperature_f' => 64.9,
+            'dewpoint_f' => 46.9,
+            'dewpoint_spread' => 10,
+            'flight_category' => 'VFR',
+            'flight_category_class' => 'status-vfr',
+            'pressure_altitude' => -15,
+            'density_altitude' => 377,
+            'wind_direction_magnetic' => 346,
+            'obs_time_primary' => $staleTimestamp,
+            'last_updated_primary' => $staleTimestamp,
+            'obs_time_metar' => $freshMetarTimestamp,
+            'last_updated_metar' => $freshMetarTimestamp,
+            '_field_obs_time_map' => $fieldObsTimes,
+            '_field_source_map' => $fieldSourceMap,
+            '_field_station_map' => $fieldStationMap,
+            'raw_metar' => 'METAR KUAO 302153Z VRB04KT 10SM OVC055 18/08 A3010',
+        ];
+        file_put_contents($weatherCacheFile, json_encode($weatherData));
+
+        $this->seedStaleWebcamForOutage($airportId, $staleTimestamp);
+
+        applyFailclosedStaleness($weatherData, $airport, false, $airportId);
+
+        $this->assertNull($weatherData['wind_speed'], 'Supplemental wind must be hidden during outage');
+        $this->assertNull($weatherData['temperature'], 'Supplemental temperature must be hidden during outage');
+        $this->assertNull($weatherData['pressure'], 'Supplemental pressure must be hidden during outage');
+        $this->assertNull($weatherData['humidity'], 'Supplemental humidity must be hidden during outage');
+        $this->assertNull($weatherData['visibility']);
+        $this->assertNull($weatherData['ceiling']);
+        $this->assertNull($weatherData['cloud_cover']);
+        $this->assertNull($weatherData['temperature_f']);
+        $this->assertNull($weatherData['flight_category']);
+        $this->assertSame('', $weatherData['flight_category_class']);
+        $this->assertNull($weatherData['raw_metar']);
+
+        $this->cleanupSupplementalOutageFixtures($airportId, $weatherCacheFile);
+    }
+
+    /**
+     * KSPB-shaped: co-located METAR is local; supplemental fail-closed must not apply.
+     */
+    public function testCoLocatedMetarFieldsNotHiddenForSupplementalFailClosed(): void
+    {
+        require_once __DIR__ . '/../../lib/cache-paths.php';
+        require_once __DIR__ . '/../../lib/weather/cache-utils.php';
+        require_once __DIR__ . '/../../lib/weather/outage-detection.php';
+
+        $airportId = 'test-supplemental-failclosed-colocated';
+        $airport = [
+            'icao' => 'KSPB',
+            'weather_sources' => [
+                ['type' => 'tempest', 'station_id' => '12345'],
+                ['type' => 'metar', 'station_id' => 'KSPB'],
+            ],
+            'webcams' => [
+                ['name' => 'North', 'url' => 'http://example.com/north.jpg'],
+            ],
+        ];
+
+        $staleTimestamp = time() - (4 * 3600);
+        $freshMetarTimestamp = time() - 60;
+        $weatherCacheFile = getWeatherCachePath($airportId);
+        $weatherData = [
+            'wind_speed' => 8,
+            'temperature' => 15.0,
+            'visibility' => 10.0,
+            'obs_time_primary' => $staleTimestamp,
+            'last_updated_primary' => $staleTimestamp,
+            'obs_time_metar' => $freshMetarTimestamp,
+            'last_updated_metar' => $freshMetarTimestamp,
+            '_field_station_map' => [
+                'wind_speed' => 'KSPB',
+                'temperature' => 'KSPB',
+                'visibility' => 'KSPB',
+            ],
+            '_field_obs_time_map' => [
+                'wind_speed' => $freshMetarTimestamp,
+                'temperature' => $freshMetarTimestamp,
+                'visibility' => $freshMetarTimestamp,
+            ],
+        ];
+        file_put_contents($weatherCacheFile, json_encode($weatherData));
+
+        $this->seedStaleWebcamForOutage($airportId, $staleTimestamp);
+
+        applyFailclosedStaleness($weatherData, $airport, false, $airportId);
+
+        $this->assertSame(8, $weatherData['wind_speed']);
+        $this->assertSame(15.0, $weatherData['temperature']);
+        $this->assertSame(10.0, $weatherData['visibility']);
+
+        $this->cleanupSupplementalOutageFixtures($airportId, $weatherCacheFile);
+    }
+
+    private function seedStaleWebcamForOutage(string $airportId, int $staleTimestamp): void
+    {
         $webcamDir = CACHE_WEBCAMS_DIR;
         ensureCacheDir($webcamDir);
         require_once __DIR__ . '/../../lib/webcam-format-generation.php';
@@ -322,16 +480,13 @@ class FailClosedStalenessTest extends TestCase
             mkdir($webcamDir, 0755, true);
         }
         touch($webcamFile, $staleTimestamp);
+    }
 
-        applyFailclosedStaleness($weatherData, $airport, false, $airportId);
-
-        $this->assertNull($weatherData['visibility']);
-        $this->assertNull($weatherData['ceiling']);
-        $this->assertNull($weatherData['cloud_cover']);
-        $this->assertNull($weatherData['temperature'], 'Stale on-field primary fields are fail-closed during outage');
-
+    private function cleanupSupplementalOutageFixtures(string $airportId, string $weatherCacheFile): void
+    {
+        require_once __DIR__ . '/../../lib/webcam-format-generation.php';
         @unlink($weatherCacheFile);
-        @unlink($webcamFile);
+        @unlink(getCacheSymlinkPath($airportId, 0, 'jpg'));
         @unlink(getOutageCachePath($airportId));
     }
 }


### PR DESCRIPTION
## Summary

- Extends supplemental remote weather fail-closed (#179 follow-up): when on-field infrastructure is down, **all** supplemental remote fields are hidden, not only visibility/ceiling/cloud cover.
- Fixes 7S9 production gap where fresh KUAO METAR still showed wind, temperature, pressure, and derived values while Tempest and webcams were stale.
- Co-located METAR (KSPB) behavior unchanged.

Closes #181

## Technical changes

| Area | Change |
|------|--------|
| `lib/weather/weather-locality.php` | New `nullSupplementalRemoteWeatherDisplayFields()` nulls `AggregationPolicy::ALL_FIELDS`, calculated fields, and outage display extras |
| `lib/weather/AggregationPolicy.php` | `SUPPLEMENTAL_OUTAGE_DISPLAY_EXTRAS` constant (daily stats, raw METAR, magnetic wind, etc.) |
| `lib/weather/cache-utils.php` | `hideSupplementalRemoteFieldsDuringOutage()` delegates to shared null helper |
| `public/js/airport-dashboard.js` | `SUPPLEMENTAL_OUTAGE_HIDDEN_FIELDS` mirrors PHP; client hide on outage |
| `docs/DATA_FLOW.md`, `docs/SAFETY_CRITICAL_CALCULATIONS.md` | Policy aligned to all-field hide during outage |

## Tests

- `testSupplementalMetarAllFieldsHiddenWhenFreshMetarFillsLocalFieldsDuringOutage` - 7S9 production-shaped (fresh KUAO per-field obs times)
- `testCoLocatedMetarFieldsNotHiddenForSupplementalFailClosed` - KSPB regression guard
- Existing supplemental outage test refactored with shared fixture helpers

## Test plan

- [x] `make test-ci` passes locally
- [x] Deploy and verify 7S9 shows outage banner with `--` for all weather fields when Tempest/webcams down
- [x] KSPB with fresh co-located METAR still shows weather per existing rules