### PR TITLE
Anchor Last updated to on-field sensors during supplemental outage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,9 @@ test-ci: ## Run all tests that GitHub CI runs (comprehensive)
 	@echo "5a️⃣  Wind Rose Safety Tests (JS)..."
 	@node tests/js/wind-rose.test.js || { echo "❌ Wind rose JS tests failed"; exit 1; }
 	@echo ""
+	@echo "5a0️⃣  Wind Calm Policy Tests (JS)..."
+	@node tests/js/wind-calm-policy.test.js || { echo "❌ Wind calm policy JS tests failed"; exit 1; }
+	@echo ""
 	@echo "5a1️⃣  Weather Timestamp Utilities Tests (JS)..."
 	@node tests/js/weather-timestamp-utils.test.js || { echo "❌ Weather timestamp JS tests failed"; exit 1; }
 	@echo ""

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1737,6 +1737,8 @@ Production access is browser-only (`lib/notam/map-api-access.php`).
 
 **Invariant:** When observation metadata exists, the dashboard must not show a fetch time that is newer than the underlying observation time. Automated tests in `tests/js/weather-timestamp-utils.test.js` enforce this split.
 
+3. **Supplemental remote outage fail-closed**: When on-field infrastructure is in outage and supplemental METAR fields are hidden, display timestamps are anchored to **on-field** observation and fetch metadata only (`obs_time_primary`, `last_updated_primary`, backup, and non-METAR `_field_obs_time_map` entries). Supplemental METAR obs/fetch times are stripped so a fresh remote station cannot make local sensors look current.
+
 ### Weather Data Display
 
 #### Flight Category Display

--- a/docs/SAFETY_CRITICAL_CALCULATIONS.md
+++ b/docs/SAFETY_CRITICAL_CALCULATIONS.md
@@ -478,7 +478,7 @@ Outage detection considers **on-field infrastructure** only: non-METAR weather s
 
 - **Aggregation (METAR today)**: `lib/weather/WeatherAggregator.php`, `AggregationPolicy::LOCAL_FIELDS`
 - **Detection (METAR today)**: `WeatherSnapshot.metarStationId` and `_field_station_map` vs `localAirportIcao` (`airport.icao`)
-- **Outage / fail-closed (METAR target first)**: `lib/weather/outage-detection.php`, `lib/weather/cache-utils.php`, `lib/weather/weather-locality.php` (`nullSupplementalRemoteWeatherDisplayFields`)
+- **Outage / fail-closed (METAR target first)**: `lib/weather/outage-detection.php`, `lib/weather/cache-utils.php`, `lib/weather/weather-locality.php` (`nullSupplementalRemoteWeatherDisplayFields`, `anchorSupplementalOutageDisplayTimestamps`)
 - **Other source types**: Same policy intent; systematic code enforcement may follow per adapter
 - **Tests**: `tests/Unit/WeatherAggregatorTest.php` (on-field overrides supplemental when fresher)
 

--- a/lib/weather/weather-locality.php
+++ b/lib/weather/weather-locality.php
@@ -212,11 +212,16 @@ function anchorSupplementalOutageDisplayTimestamps(array &$data): void
     $data['obs_time_metar'] = null;
     $data['last_updated_metar'] = null;
 
-    $sourceMap = $data['_field_source_map'] ?? [];
+    $sourceMap = $data['_field_source_map'] ?? null;
     if (isset($data['_field_obs_time_map']) && is_array($data['_field_obs_time_map'])) {
-        foreach (array_keys($data['_field_obs_time_map']) as $field) {
-            if (($sourceMap[$field] ?? null) === 'metar') {
-                unset($data['_field_obs_time_map'][$field]);
+        if (!is_array($sourceMap)) {
+            $data['_field_obs_time_map'] = [];
+        } else {
+            foreach (array_keys($data['_field_obs_time_map']) as $field) {
+                $source = $sourceMap[$field] ?? null;
+                if ($source === null || $source === 'metar') {
+                    unset($data['_field_obs_time_map'][$field]);
+                }
             }
         }
     }

--- a/lib/weather/weather-locality.php
+++ b/lib/weather/weather-locality.php
@@ -192,4 +192,63 @@ function nullSupplementalRemoteWeatherDisplayFields(array &$data): void
     $data['visibility_greater_than'] = false;
 
     calculateAndSetFlightCategory($data);
+
+    anchorSupplementalOutageDisplayTimestamps($data);
+}
+
+/**
+ * Anchor display timestamps to on-field infrastructure during supplemental outage fail-closed.
+ *
+ * Fresh supplemental METAR metadata must not drive the airport "Last updated" line when fields
+ * are hidden because on-field sensors and webcams are down.
+ *
+ * @param array $data Weather payload (modified in place)
+ * @return void
+ */
+function anchorSupplementalOutageDisplayTimestamps(array &$data): void
+{
+    require_once __DIR__ . '/aggregate-timestamps.php';
+
+    $data['obs_time_metar'] = null;
+    $data['last_updated_metar'] = null;
+
+    $sourceMap = $data['_field_source_map'] ?? [];
+    if (isset($data['_field_obs_time_map']) && is_array($data['_field_obs_time_map'])) {
+        foreach (array_keys($data['_field_obs_time_map']) as $field) {
+            if (($sourceMap[$field] ?? null) === 'metar') {
+                unset($data['_field_obs_time_map'][$field]);
+            }
+        }
+    }
+
+    $onFieldCandidates = [];
+    foreach (['obs_time_primary', 'last_updated_primary', 'obs_time_backup', 'last_updated_backup'] as $key) {
+        if (!array_key_exists($key, $data)) {
+            continue;
+        }
+        $ts = weather_positive_aggregate_timestamp($data[$key]);
+        if ($ts !== null) {
+            $onFieldCandidates[] = $ts;
+        }
+    }
+
+    if (isset($data['_field_obs_time_map']) && is_array($data['_field_obs_time_map'])) {
+        foreach ($data['_field_obs_time_map'] as $field => $value) {
+            $ts = weather_positive_aggregate_timestamp($value);
+            if ($ts !== null) {
+                $onFieldCandidates[] = $ts;
+            }
+        }
+    }
+
+    if ($onFieldCandidates === []) {
+        $data['last_updated'] = null;
+        unset($data['last_updated_iso']);
+
+        return;
+    }
+
+    $onFieldTs = max($onFieldCandidates);
+    $data['last_updated'] = $onFieldTs;
+    $data['last_updated_iso'] = date('c', $onFieldTs);
 }

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -1972,6 +1972,13 @@ function hideSupplementalRemoteFieldsIfOutage(inOutage) {
     if (typeof displayWeather === 'function') {
         displayWeather(currentWeatherData);
     }
+    if (typeof updateWindVisual === 'function') {
+        try {
+            updateWindVisual(currentWeatherData);
+        } catch (e) {
+            console.error('[Weather] updateWindVisual failed (supplemental fail-closed):', e);
+        }
+    }
     refreshWeatherLastUpdatedFromCurrentData();
 }
 

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -1950,11 +1950,8 @@ function refreshWeatherLastUpdatedFromCurrentData() {
     if (!currentWeatherData) {
         return;
     }
-    const updatedDate = resolveWeatherLastUpdatedDate(currentWeatherData);
-    if (updatedDate !== null) {
-        weatherLastUpdated = updatedDate;
-        updateWeatherTimestamp();
-    }
+    weatherLastUpdated = resolveWeatherLastUpdatedDate(currentWeatherData);
+    updateWeatherTimestamp();
 }
 
 /**

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -1920,6 +1920,44 @@ const SUPPLEMENTAL_OUTAGE_HIDDEN_FIELDS = [
 ];
 
 /**
+ * Anchor display timestamps to on-field infrastructure during supplemental outage fail-closed.
+ *
+ * @param {object} weather Weather payload (modified in place)
+ * @returns {void}
+ */
+function anchorSupplementalOutageDisplayTimestampsClient(weather) {
+    const wt = window.AviationWX && window.AviationWX.weatherTimestamp;
+    if (!wt || typeof wt.stripSupplementalMetarTimestampMetadata !== 'function') {
+        return;
+    }
+    wt.stripSupplementalMetarTimestampMetadata(weather);
+    const onFieldTs = typeof wt.pickOnFieldObservationUnixTimestamp === 'function'
+        ? wt.pickOnFieldObservationUnixTimestamp(weather)
+        : null;
+    if (onFieldTs === null) {
+        weather.last_updated = null;
+        weather.last_updated_iso = null;
+        return;
+    }
+    weather.last_updated = onFieldTs;
+    weather.last_updated_iso = new Date(onFieldTs * 1000).toISOString();
+}
+
+/**
+ * Refresh wind/weather "Last updated" from currentWeatherData after supplemental fail-closed.
+ */
+function refreshWeatherLastUpdatedFromCurrentData() {
+    if (!currentWeatherData) {
+        return;
+    }
+    const updatedDate = resolveWeatherLastUpdatedDate(currentWeatherData);
+    if (updatedDate !== null) {
+        weatherLastUpdated = updatedDate;
+        updateWeatherTimestamp();
+    }
+}
+
+/**
  * Hide all supplemental remote weather fields when on-field infrastructure is in outage.
  */
 function hideSupplementalRemoteFieldsIfOutage(inOutage) {
@@ -1933,9 +1971,11 @@ function hideSupplementalRemoteFieldsIfOutage(inOutage) {
     }
     currentWeatherData.visibility_greater_than = false;
     currentWeatherData.flight_category_class = '';
+    anchorSupplementalOutageDisplayTimestampsClient(currentWeatherData);
     if (typeof displayWeather === 'function') {
         displayWeather(currentWeatherData);
     }
+    refreshWeatherLastUpdatedFromCurrentData();
 }
 
 /**

--- a/public/js/weather-timestamp-utils.js
+++ b/public/js/weather-timestamp-utils.js
@@ -149,6 +149,72 @@
     }
 
     /**
+     * Unix second for on-field infrastructure only (primary, backup, non-METAR field map).
+     * Does not use supplemental METAR obs/fetch metadata. Used after
+     * {@link stripSupplementalMetarTimestampMetadata} during supplemental outage fail-closed.
+     *
+     * @param {object|null|undefined} w Weather object from cache or API
+     * @returns {number|null} Unix seconds, or null if no valid on-field time
+     */
+    function pickOnFieldObservationUnixTimestamp(w) {
+        if (w === null || w === undefined || typeof w !== 'object') {
+            return null;
+        }
+        const nums = [];
+        ['obs_time_primary', 'last_updated_primary', 'obs_time_backup', 'last_updated_backup'].forEach(function (k) {
+            const t = toPositiveUnixSeconds(w[k]);
+            if (t !== null) {
+                nums.push(t);
+            }
+        });
+        const map = w._field_obs_time_map;
+        const sourceMap = w._field_source_map;
+        if (map && typeof map === 'object' && !Array.isArray(map) && sourceMap && typeof sourceMap === 'object') {
+            const keys = Object.keys(map);
+            for (let i = 0; i < keys.length; i++) {
+                const field = keys[i];
+                if (sourceMap[field] === 'metar') {
+                    continue;
+                }
+                const t = toPositiveUnixSeconds(map[field]);
+                if (t !== null) {
+                    nums.push(t);
+                }
+            }
+        }
+        if (nums.length === 0) {
+            return null;
+        }
+        return Math.max.apply(null, nums);
+    }
+
+    /**
+     * Remove supplemental METAR timestamp metadata from a weather payload (in place).
+     *
+     * @param {object|null|undefined} w Weather object from cache or API
+     * @returns {void}
+     */
+    function stripSupplementalMetarTimestampMetadata(w) {
+        if (w === null || w === undefined || typeof w !== 'object') {
+            return;
+        }
+        w.obs_time_metar = null;
+        w.last_updated_metar = null;
+        const map = w._field_obs_time_map;
+        const sourceMap = w._field_source_map;
+        if (!map || typeof map !== 'object' || Array.isArray(map) || !sourceMap || typeof sourceMap !== 'object') {
+            return;
+        }
+        const keys = Object.keys(map);
+        for (let i = 0; i < keys.length; i++) {
+            const field = keys[i];
+            if (sourceMap[field] === 'metar') {
+                delete map[field];
+            }
+        }
+    }
+
+    /**
      * Safe Date for airport "last updated" line: **observation** time when available.
      *
      * @param {object|null|undefined} w Weather object from cache or API
@@ -166,7 +232,9 @@
     const api = {
         pickFetchUnixTimestamp: pickFetchUnixTimestamp,
         pickObservationUnixTimestamp: pickObservationUnixTimestamp,
+        pickOnFieldObservationUnixTimestamp: pickOnFieldObservationUnixTimestamp,
         pickWeatherUnixTimestamp: pickWeatherUnixTimestamp,
+        stripSupplementalMetarTimestampMetadata: stripSupplementalMetarTimestampMetadata,
         lastUpdatedDateFromWeather: lastUpdatedDateFromWeather
     };
 

--- a/public/js/weather-timestamp-utils.js
+++ b/public/js/weather-timestamp-utils.js
@@ -173,7 +173,8 @@
             const keys = Object.keys(map);
             for (let i = 0; i < keys.length; i++) {
                 const field = keys[i];
-                if (sourceMap[field] === 'metar') {
+                const source = sourceMap[field];
+                if (source === undefined || source === null || source === 'metar') {
                     continue;
                 }
                 const t = toPositiveUnixSeconds(map[field]);
@@ -202,13 +203,18 @@
         w.last_updated_metar = null;
         const map = w._field_obs_time_map;
         const sourceMap = w._field_source_map;
-        if (!map || typeof map !== 'object' || Array.isArray(map) || !sourceMap || typeof sourceMap !== 'object') {
+        if (!map || typeof map !== 'object' || Array.isArray(map)) {
+            return;
+        }
+        if (!sourceMap || typeof sourceMap !== 'object' || Array.isArray(sourceMap)) {
+            w._field_obs_time_map = {};
             return;
         }
         const keys = Object.keys(map);
         for (let i = 0; i < keys.length; i++) {
             const field = keys[i];
-            if (sourceMap[field] === 'metar') {
+            const source = sourceMap[field];
+            if (source === undefined || source === null || source === 'metar') {
                 delete map[field];
             }
         }

--- a/public/js/wind-visual.js
+++ b/public/js/wind-visual.js
@@ -26,6 +26,16 @@
 
     const CALM_WIND_THRESHOLD = 3; // Winds below 3 knots are considered calm in aviation
 
+    /**
+     * True when wind speed is a valid calm reading (not missing/unavailable).
+     *
+     * @param {number|null|undefined} windSpeed Wind speed in knots
+     * @returns {boolean}
+     */
+    function isCalmWindSpeed(windSpeed) {
+        return windSpeed !== null && windSpeed !== undefined && Number.isFinite(windSpeed) && windSpeed < CALM_WIND_THRESHOLD;
+    }
+
     // Canonical wind compass palettes. light/dark serve the embeds; night is
     // cockpit night-vision used only by the dashboard. Exposed via
     // getWindCompassColors so the dashboard legend and the canvas share one source.
@@ -162,7 +172,8 @@
 
         const windSpeed = options.windSpeed ?? null;
         const isVRB = options.isVRB ?? false;
-        const willShowCenterText = !windStale && (windSpeed === null || windSpeed === undefined || windSpeed < CALM_WIND_THRESHOLD || isVRB);
+        const willShowCenterText = !windStale && windSpeed !== null && windSpeed !== undefined
+            && (isCalmWindSpeed(windSpeed) || isVRB);
 
         segments.forEach(function(seg) {
             const sx = (seg.start && seg.start[0]) || 0;
@@ -244,7 +255,7 @@
                     ctx.fillStyle = colors.vrbText;
                     ctx.fillText('VRB', cx, cy);
                 }
-            } else if (ws === null || ws < CALM_WIND_THRESHOLD) {
+            } else if (isCalmWindSpeed(ws)) {
                 ctx.font = 'bold 20px sans-serif';
                 ctx.textAlign = 'center';
                 ctx.strokeStyle = colors.labelOutline;
@@ -562,7 +573,7 @@
             drawWindArrow(ctx, cx, cy, r, windSpeed, windDir, width, isDark);
         } else if (isVRB && windSpeed !== null && windSpeed >= CALM_WIND_THRESHOLD) {
             drawVRBIndicator(ctx, cx, cy, width, isDark);
-        } else {
+        } else if (isCalmWindSpeed(windSpeed)) {
             drawCalmIndicator(ctx, cx, cy, width, isDark);
         }
     }
@@ -781,7 +792,15 @@
     window.AviationWX.drawWindCompass = drawWindCompass;
     window.AviationWX.getWindCompassColors = getWindCompassColors;
     window.AviationWX.CALM_WIND_THRESHOLD = CALM_WIND_THRESHOLD;
+    window.AviationWX.isCalmWindSpeed = isCalmWindSpeed;
     window.AviationWX.syncWindCompassCanvasPixels = syncWindCompassCanvasPixels;
     window.AviationWX.observeWindCompassCanvas = observeWindCompassCanvas;
 
-})(window);
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            isCalmWindSpeed: isCalmWindSpeed,
+            CALM_WIND_THRESHOLD: CALM_WIND_THRESHOLD
+        };
+    }
+
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tests/Unit/FailClosedStalenessTest.php
+++ b/tests/Unit/FailClosedStalenessTest.php
@@ -409,8 +409,36 @@ class FailClosedStalenessTest extends TestCase
         $this->assertNull($weatherData['flight_category']);
         $this->assertSame('', $weatherData['flight_category_class']);
         $this->assertNull($weatherData['raw_metar']);
+        $this->assertNull($weatherData['obs_time_metar'], 'Display timestamps must not use supplemental METAR obs time');
+        $this->assertNull($weatherData['last_updated_metar']);
+        $this->assertSame($staleTimestamp, $weatherData['last_updated'], 'Last updated must anchor to on-field primary time');
+        $this->assertArrayNotHasKey('wind_speed', $weatherData['_field_obs_time_map'] ?? []);
 
         $this->cleanupSupplementalOutageFixtures($airportId, $weatherCacheFile);
+    }
+
+    /**
+     * When no on-field timestamp exists, aggregate last_updated must not retain supplemental freshness.
+     */
+    public function testSupplementalOutageDisplayTimestampsFailClosedWithoutOnFieldMetadata(): void
+    {
+        require_once __DIR__ . '/../../lib/weather/weather-locality.php';
+
+        $freshMetarTimestamp = time() - 60;
+        $weatherData = [
+            'obs_time_metar' => $freshMetarTimestamp,
+            'last_updated_metar' => $freshMetarTimestamp,
+            'last_updated' => $freshMetarTimestamp,
+            'last_updated_iso' => date('c', $freshMetarTimestamp),
+            '_field_obs_time_map' => ['wind_speed' => $freshMetarTimestamp],
+            '_field_source_map' => ['wind_speed' => 'metar'],
+        ];
+
+        anchorSupplementalOutageDisplayTimestamps($weatherData);
+
+        $this->assertNull($weatherData['obs_time_metar']);
+        $this->assertNull($weatherData['last_updated']);
+        $this->assertArrayNotHasKey('last_updated_iso', $weatherData);
     }
 
     /**

--- a/tests/Unit/FailClosedStalenessTest.php
+++ b/tests/Unit/FailClosedStalenessTest.php
@@ -442,6 +442,52 @@ class FailClosedStalenessTest extends TestCase
     }
 
     /**
+     * Unknown per-field source attribution must not anchor last_updated during fail-closed scrub.
+     */
+    public function testSupplementalOutageDisplayTimestampsFailClosedWithMissingSourceMap(): void
+    {
+        require_once __DIR__ . '/../../lib/weather/weather-locality.php';
+
+        $freshMetarTimestamp = time() - 60;
+        $weatherData = [
+            'obs_time_metar' => $freshMetarTimestamp,
+            'last_updated_metar' => $freshMetarTimestamp,
+            'last_updated' => $freshMetarTimestamp,
+            'last_updated_iso' => date('c', $freshMetarTimestamp),
+            '_field_obs_time_map' => ['wind_speed' => $freshMetarTimestamp],
+        ];
+
+        anchorSupplementalOutageDisplayTimestamps($weatherData);
+
+        $this->assertNull($weatherData['obs_time_metar']);
+        $this->assertSame([], $weatherData['_field_obs_time_map']);
+        $this->assertNull($weatherData['last_updated']);
+        $this->assertArrayNotHasKey('last_updated_iso', $weatherData);
+    }
+
+    /**
+     * Per-field entries with missing source keys must not anchor last_updated.
+     */
+    public function testSupplementalOutageDisplayTimestampsFailClosedWithMissingFieldSource(): void
+    {
+        require_once __DIR__ . '/../../lib/weather/weather-locality.php';
+
+        $freshMetarTimestamp = time() - 60;
+        $weatherData = [
+            'obs_time_metar' => $freshMetarTimestamp,
+            'last_updated_metar' => $freshMetarTimestamp,
+            'last_updated' => $freshMetarTimestamp,
+            '_field_obs_time_map' => ['wind_speed' => $freshMetarTimestamp],
+            '_field_source_map' => ['temperature' => 'tempest'],
+        ];
+
+        anchorSupplementalOutageDisplayTimestamps($weatherData);
+
+        $this->assertArrayNotHasKey('wind_speed', $weatherData['_field_obs_time_map']);
+        $this->assertNull($weatherData['last_updated']);
+    }
+
+    /**
      * KSPB-shaped: co-located METAR is local; supplemental fail-closed must not apply.
      */
     public function testCoLocatedMetarFieldsNotHiddenForSupplementalFailClosed(): void

--- a/tests/js/weather-timestamp-utils.test.js
+++ b/tests/js/weather-timestamp-utils.test.js
@@ -308,6 +308,48 @@ function runTests() {
         assertNull(payload.last_updated_metar, 'metar fetch stripped');
     });
 
+    test('stripSupplementalMetarTimestampMetadata fail-closed when _field_source_map is missing', () => {
+        const supplemental = 1_700_000_900;
+        const payload = {
+            obs_time_metar: supplemental,
+            last_updated_metar: supplemental,
+            _field_obs_time_map: { wind_speed: supplemental },
+        };
+        stripSupplementalMetarTimestampMetadata(payload);
+        assertStrictEqual(
+            Object.keys(payload._field_obs_time_map).length,
+            0,
+            'per-field map cleared when sources unknown'
+        );
+        assertNull(payload.obs_time_metar, 'metar obs stripped');
+        assertStrictEqual(
+            pickObservationUnixTimestamp(payload),
+            null,
+            'scrubbed payload must not use supplemental per-field time'
+        );
+    });
+
+    test('stripSupplementalMetarTimestampMetadata drops fields with missing source attribution', () => {
+        const supplemental = 1_700_000_900;
+        const onField = 1_700_000_000;
+        const payload = {
+            obs_time_primary: onField,
+            _field_obs_time_map: { wind_speed: supplemental, temperature: onField },
+            _field_source_map: { temperature: 'tempest' },
+        };
+        stripSupplementalMetarTimestampMetadata(payload);
+        assertStrictEqual(
+            pickOnFieldObservationUnixTimestamp(payload),
+            onField,
+            'only attributed on-field entries remain'
+        );
+        assertStrictEqual(
+            Object.keys(payload._field_obs_time_map).length,
+            1,
+            'unattributed field removed'
+        );
+    });
+
     test('pickObservationUnixTimestamp uses on-field time when supplemental METAR metadata is scrubbed', () => {
         const onField = 1_700_000_000;
         const supplemental = 1_700_000_900;

--- a/tests/js/weather-timestamp-utils.test.js
+++ b/tests/js/weather-timestamp-utils.test.js
@@ -12,7 +12,9 @@
 const {
     pickFetchUnixTimestamp,
     pickObservationUnixTimestamp,
+    pickOnFieldObservationUnixTimestamp,
     pickWeatherUnixTimestamp,
+    stripSupplementalMetarTimestampMetadata,
     lastUpdatedDateFromWeather
 } = require('../../public/js/weather-timestamp-utils.js');
 
@@ -283,6 +285,55 @@ function runTests() {
         if (d === null || typeof d.getTime !== 'function' || !Number.isFinite(d.getTime())) {
             throw new Error('expected finite Date');
         }
+    });
+
+    test('pickOnFieldObservationUnixTimestamp ignores supplemental METAR metadata', () => {
+        const onField = 1_700_000_000;
+        const supplemental = 1_700_000_900;
+        const payload = {
+            obs_time_primary: onField,
+            last_updated_primary: onField,
+            obs_time_metar: supplemental,
+            last_updated_metar: supplemental,
+            _field_obs_time_map: { wind_speed: supplemental, temperature: onField },
+            _field_source_map: { wind_speed: 'metar', temperature: 'tempest' },
+        };
+        stripSupplementalMetarTimestampMetadata(payload);
+        assertStrictEqual(
+            pickOnFieldObservationUnixTimestamp(payload),
+            onField,
+            'max on-field after strip'
+        );
+        assertNull(payload.obs_time_metar, 'metar obs stripped');
+        assertNull(payload.last_updated_metar, 'metar fetch stripped');
+    });
+
+    test('pickObservationUnixTimestamp uses on-field time when supplemental METAR metadata is scrubbed', () => {
+        const onField = 1_700_000_000;
+        const supplemental = 1_700_000_900;
+        assertStrictEqual(
+            pickObservationUnixTimestamp({
+                obs_time_primary: onField,
+                last_updated_primary: onField,
+                last_updated: onField,
+                obs_time_metar: null,
+                last_updated_metar: null,
+                _field_obs_time_map: {},
+            }),
+            onField,
+            'on-field only after supplemental scrub'
+        );
+        assertStrictEqual(
+            pickObservationUnixTimestamp({
+                obs_time_primary: onField,
+                last_updated_primary: onField,
+                obs_time_metar: supplemental,
+                _field_obs_time_map: { wind_speed: supplemental },
+                _field_source_map: { wind_speed: 'metar' },
+            }),
+            supplemental,
+            'unscrubbed still prefers supplemental obs'
+        );
     });
 
     console.log('\n' + '='.repeat(50));

--- a/tests/js/wind-calm-policy.test.js
+++ b/tests/js/wind-calm-policy.test.js
@@ -1,0 +1,59 @@
+/**
+ * Wind calm vs unavailable (safety-critical display)
+ *
+ * Null/missing wind must not render as CALM on the compass. Matches embed card policy.
+ *
+ * Run with: node tests/js/wind-calm-policy.test.js
+ */
+
+const { isCalmWindSpeed, CALM_WIND_THRESHOLD } = require('../../public/js/wind-visual.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`  ✓ ${name}`);
+        passed++;
+    } catch (e) {
+        console.error(`  ✗ ${name}`);
+        console.error(`    ${e.message}`);
+        failed++;
+    }
+}
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+console.log('\nWind calm policy (safety-critical)\n' + '='.repeat(50));
+
+test('null wind speed is not calm', () => {
+    assert(!isCalmWindSpeed(null), 'null must not be calm');
+});
+
+test('undefined wind speed is not calm', () => {
+    assert(!isCalmWindSpeed(undefined), 'undefined must not be calm');
+});
+
+test('zero knots is calm when present', () => {
+    assert(isCalmWindSpeed(0), '0 kts is calm');
+});
+
+test('below threshold is calm', () => {
+    assert(isCalmWindSpeed(CALM_WIND_THRESHOLD - 0.1), '2.9 kts is calm');
+});
+
+test('at or above threshold is not calm', () => {
+    assert(!isCalmWindSpeed(CALM_WIND_THRESHOLD), '3 kts is not calm');
+    assert(!isCalmWindSpeed(10), '10 kts is not calm');
+});
+
+console.log('\n' + '='.repeat(50));
+console.log(`Results: ${passed} passed, ${failed} failed\n`);
+if (failed > 0) {
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Fixes follow-up to #182: during supplemental remote outage fail-closed, **Last updated** now reflects on-field sensor time, not fresh remote METAR metadata.
- Production case: 7S9 showed `--` for weather and the outage banner, but Last updated could still look recent from KUAO obs/fetch timestamps in cache.
- Strips supplemental METAR timestamp metadata and anchors `last_updated` to primary/backup on-field times on PHP serve and dashboard client paths.

Closes #183

## Technical changes

| Area | Change |
|------|--------|
| `lib/weather/weather-locality.php` | `anchorSupplementalOutageDisplayTimestamps()` called from supplemental fail-closed hide |
| `public/js/weather-timestamp-utils.js` | `stripSupplementalMetarTimestampMetadata()`, `pickOnFieldObservationUnixTimestamp()` |
| `public/js/airport-dashboard.js` | Client anchor + `refreshWeatherLastUpdatedFromCurrentData()` after outage hide |
| `docs/DATA_FLOW.md` | Policy point 3 under Last updated section |
| `docs/SAFETY_CRITICAL_CALCULATIONS.md` | Implementation reference updated |

## Tests

- `testSupplementalMetarAllFieldsHiddenWhenFreshMetarFillsLocalFieldsDuringOutage` - asserts `last_updated` anchors to stale primary, METAR obs stripped
- `testSupplementalOutageDisplayTimestampsFailClosedWithoutOnFieldMetadata` - no on-field metadata clears aggregate `last_updated`
- JS tests for strip + `pickOnFieldObservationUnixTimestamp`

## Test plan

- [x] `FailClosedStalenessTest` and `weather-timestamp-utils.test.js` pass locally
- [x] Deploy and verify 7S9 Last updated shows stale on-field age during outage (not ~30 min from KUAO)
- [x] KSPB co-located METAR unchanged