### PR TITLE
Fail-closed airportIsMetarOnly for malformed weather source types

### DIFF
--- a/lib/weather/utils.php
+++ b/lib/weather/utils.php
@@ -303,7 +303,7 @@ function airportIsMetarOnly(array $airport): bool
     }
 
     foreach ($airport['weather_sources'] as $source) {
-        if (!empty($source['type']) && $source['type'] !== 'metar') {
+        if (($source['type'] ?? '') !== 'metar') {
             return false;
         }
     }

--- a/tests/Unit/WeatherLocalityTest.php
+++ b/tests/Unit/WeatherLocalityTest.php
@@ -116,7 +116,7 @@ class WeatherLocalityTest extends TestCase
         $this->assertSame(2500, newestOnFieldOutageTimestamp($sources, $sourceTimestamps));
     }
 
-    public function testGetSupplementalOutageClientConfig_7S9Shaped(): void
+    public function testGetSupplementalOutageClientConfig_7S9SupplementalMetar_ReturnsExpectedBootstrap(): void
     {
         $airport = [
             'faa' => '7S9',

--- a/tests/Unit/WeatherUtilsTest.php
+++ b/tests/Unit/WeatherUtilsTest.php
@@ -176,5 +176,17 @@ class WeatherUtilsTest extends TestCase
 
         $this->assertFalse(airportIsMetarOnly($airport));
     }
+
+    public function testAirportIsMetarOnly_MalformedSourceType_ReturnsFalse(): void
+    {
+        $airport = [
+            'weather_sources' => [
+                ['type' => 'metar', 'station_id' => 'KUAO'],
+                ['type' => ''],
+            ],
+        ];
+
+        $this->assertFalse(airportIsMetarOnly($airport));
+    }
 }
 

--- a/tests/Unit/WeatherUtilsTest.php
+++ b/tests/Unit/WeatherUtilsTest.php
@@ -188,5 +188,17 @@ class WeatherUtilsTest extends TestCase
 
         $this->assertFalse(airportIsMetarOnly($airport));
     }
+
+    public function testAirportIsMetarOnly_MissingSourceType_ReturnsFalse(): void
+    {
+        $airport = [
+            'weather_sources' => [
+                ['type' => 'metar', 'station_id' => 'KUAO'],
+                ['station_id' => 'orphan'],
+            ],
+        ];
+
+        $this->assertFalse(airportIsMetarOnly($airport));
+    }
 }
 


### PR DESCRIPTION
## Summary
- Require explicit `type === 'metar'` for every configured source in `airportIsMetarOnly()` (malformed/missing type is not METAR-only)
- Add regression tests for empty and missing `type` entries
- Rename supplemental outage config unit test to match CODE_STYLE naming

Follow-up to #190 Copilot review feedback that landed after merge.

## Test plan
- [x] `./vendor/bin/phpunit tests/Unit/WeatherUtilsTest.php --filter AirportIsMetarOnly`
- [x] `make test-ci`