### PR TITLE
Add DyaconLive weather source adapter

### DIFF
--- a/config/airports.json.example
+++ b/config/airports.json.example
@@ -204,6 +204,13 @@
           "api_key": "test_ambient_api_key_demo",
           "application_key": "test_ambient_app_key_demo",
           "backup": true
+        },
+        {
+          "type": "dyaconlive",
+          "station_id": 130114,
+          "username": "test_dyaconlive_user_demo",
+          "password": "test_dyaconlive_password_demo",
+          "_comment": "DyaconLive+ API credentials; station_id from GET /stations after token auth"
         }
       ],
       "webcams": [

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -526,6 +526,7 @@ All weather sources are configured in a unified `weather_sources` array. Sources
 | `swob_auto` | Nav Canada Weather (automated stations) | ~5 minutes |
 | `swob_man` | Nav Canada Weather (manned stations) | ~5 minutes |
 | `metar` | NOAA Aviation Weather METAR | ~60 minutes |
+| `dyaconlive` | Dyacon MS-100 advisory aviation station (DyaconLive+ API) | ~10 minutes |
 
 **Davis WeatherLink update intervals** (per [WeatherLink v2 Data Permissions](https://weatherlink.github.io/v2-api/data-permissions)): **Basic (free)** = most recent 15-minute record; **Pro (paid)** = most recent 5-minute record; **Pro+ (paid)** = most recent record (~1 minute). Historic data is only available on Pro/Pro+.
 
@@ -557,6 +558,36 @@ All weather sources are configured in a unified `weather_sources` array. Sources
 ```
 
 `mac_address` is optional and uses the first device if omitted.
+
+### DyaconLive
+
+[Dyacon](https://dyacon.com/) MS-100 series **advisory aviation** weather stations on [DyaconLive](https://dyacon.com/dyaconlive/). Product overview: [Dyacon aviation weather stations](https://dyacon.com/aviation-weather-station/). Requires **DyaconLive+** and API access from Dyacon (`support@dyacon.net`). Authentication uses your DyaconLive web login (no separate API key in the portal).
+
+Dyacon hardware measures wind, temperature, humidity, and barometric pressure (rain when a gauge is installed). DyaconLive Aviation Mode can display derived values such as estimated cloud base in the portal, but the API exposes sensor time series only. AviationWX does **not** populate ceiling or visibility from Dyacon. Pair with `metar` or another aviation source if you need those fields.
+
+```json
+"weather_sources": [
+  {
+    "type": "dyaconlive",
+    "station_id": 130114,
+    "username": "your-dyaconlive-email",
+    "password": "your-dyaconlive-password"
+  }
+]
+```
+
+| Field | Description |
+|-------|-------------|
+| `station_id` | Numeric station ID from `GET https://api.dyacon.net/stations` after token auth (not the public widget `pid`) |
+| `username` | DyaconLive login email |
+| `password` | DyaconLive password |
+| `timezone` | Optional IANA timezone for `/data` date boundaries (defaults to airport `timezone`) |
+
+**Pressure:** Dyacon reports station pressure at field elevation. The adapter converts to sea-level altimeter setting (inHg) using airport `elevation_ft`, matching METAR and other sources. If `elevation_ft` is missing on the airport, pressure is omitted.
+
+**Polling:** The global scheduler still runs every 60 seconds. The adapter skips upstream HTTP when the latest 10-minute bucket is already in local state, and fetches when behind or catching up after a miss. Wind uses 10-minute averages (`wind10m_*`).
+
+API docs: https://api.dyacon.net/docs
 
 ### Davis WeatherLink v2 (Newer Devices)
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -158,6 +158,22 @@ All weather sources are configured in a unified `weather_sources` array. Each so
   - Visibility: meters → statute miles (`SM = m / 1609.344`) if value > 10
 - **Note**: SynopticData provides access to over 170,000 weather stations worldwide. Typically used selectively on airports where other primary sources (Tempest, Ambient, WeatherLink, PWSWeather) aren't available. Supports async fetching. Pressure may be provided as altimeter (inHg, no conversion) or sea_level_pressure/pressure (mb/hPa, requires conversion).
 
+#### DyaconLive API (advisory aviation stations)
+- **Authentication**: `POST https://api.dyacon.net/token` (DyaconLive web login); bearer token on data endpoints. Requires DyaconLive+.
+- **Data endpoint**: `GET https://api.dyacon.net/data/{station_id}` with `startdate`, `enddate`, `timezone`, and repeated `variable` params. The adapter requests yesterday through today in station timezone so the latest bucket remains available across local midnight.
+- **Fetch path**: DyaconLive uses a dedicated fetcher (`lib/weather/dyaconlive-fetch.php`), not `curl_multi`, so token refresh on HTTP 401 can retry once after APCu cache invalidation.
+- **10-minute bucket schedule**: Dyacon publishes on clock-aligned 10-minute boundaries in station timezone. The global scheduler still runs every 60 seconds; per-source state under `cache/weather/dyaconlive/` stores the last ingested bucket and snapshot. When local state already has the expected latest bucket (90-second grace after each boundary), upstream HTTP is skipped and the cached snapshot is reused.
+- **Data provided** (sensor API fields only):
+  - Temperature (Fahrenheit, converted to Celsius)
+  - Humidity (%)
+  - Wind speed and direction (10-minute averages; mph to knots)
+  - Gust speed (mph to knots; zero treated as missing)
+  - Station pressure (inHg at field elevation, converted to sea-level altimeter using airport `elevation_ft`)
+  - Precipitation day cumulative (inches, when rain gauge equipped)
+  - Observation timestamp from the anchor bucket ISO datetime
+- **Not provided**: ceiling, visibility, or cloud cover (advisory Dyacon hardware is not METAR-class). Pair with `metar` or another aviation source when those fields are required.
+- **Parsing rule**: All sensor values are read at the anchor bucket timestamp (matched by ISO datetime across series), not by independent trailing array indices.
+
 #### METAR-Only Source
 - **Endpoint**: `https://aviationweather.gov/api/data/metar?ids={station}&format=json&taf=false&hours=0`
 - **Bulk cache (multi-airport only):** When **more than one airport** is enabled in config, the scheduler starts `scripts/refresh-metar-bulk.php` in the background on `METAR_BULK_REFRESH_INTERVAL_SECONDS` (see `lib/constants.php`); download, CSV ingest, and slice writes run inside that worker so the scheduler loop stays non-blocking. It downloads AWC `metars.cache.csv.gz`, maps each configured METAR `station_id` (plus `nearby_stations`) to a one-station JSON envelope under `cache/metar-bulk/stations/{ICAO}.json`, and `fetchMETARFromStation` prefers that file when its mtime is within `METAR_BULK_STATION_FILE_MAX_AGE_SECONDS`. Ingest **rejects the gzip** unless the CSV header row matches the canonical 44-column AWC layout in `lib/metar-bulk-csv-schema.php` (and `tests/Fixtures/metar-bulk-csv-header-line.txt`); a mismatch is logged with a short column diff summary and workers fall back to per-station HTTP. Rows shorter than 44 columns are skipped (`skipped_short_rows` in refresh logs). With **only one enabled airport**, bulk download and slice reads are skipped; per-station METAR HTTP is used. Stale or missing slices always fall back to the JSON endpoint above so METAR still serves when bulk ingest fails or a slice ages out.

--- a/guides/09-weather-station-configuration.md
+++ b/guides/09-weather-station-configuration.md
@@ -35,6 +35,7 @@ If you can't get good wind exposure, it is usually better to:
 - If you're installing **Tempest** → go to **Tempest setup**
 - If you're installing **Davis Vantage Pro2** → go to **Davis setup**
 - If you're installing **Ambient WS‑2902** → go to **Ambient setup**
+- If you have a **Dyacon** station on DyaconLive → go to **DyaconLive setup**
 - If you're integrating an existing station → go to **Existing station integration checklist**
 
 ---
@@ -92,6 +93,30 @@ You don't need to configure update cadence or push settings. We pull data from y
 - **That's it** - AviationWX handles polling automatically
 
 Davis installs tend to reward careful mounting and cable hygiene. If your airport or community is already familiar with Davis, lean into that expertise.
+
+---
+
+## DyaconLive setup (existing Dyacon stations)
+
+Good for airports that already operate a [Dyacon](https://dyacon.com/) MS-100 series station on [DyaconLive](https://dyacon.com/dyaconlive/). For how advisory Dyacon hardware compares to certified AWOS/ASOS, see [Guide 15](15-weather-sensor-standards-and-maintenance.md).
+
+### Why Dyacon fits some airports
+- common at small airports and remote strips when Dyacon is already installed
+- durable industrial sensors (wind, temperature, humidity, pressure; optional rain)
+- DyaconLive portal included with cellular or Wi-Fi equipped models
+
+### Install checklist (Dyacon)
+- ☐ Mount for unobstructed wind exposure (top of approved structure preferred; see Dyacon's MS-100 quick-start guide for airport siting)
+- ☐ Confirm the station reports consistently in DyaconLive
+- ☐ Confirm airport field elevation is documented (`elevation_ft` in airport config)
+- ☐ Validate "looks reasonable" readings for 24-72 hours
+
+### What you need to do
+- **Set up your station** following Dyacon's instructions and confirm DyaconLive+ with API access (`support@dyacon.net`)
+- **Provide AviationWX with your DyaconLive login and station ID** (see "DyaconLive - What We Need" below)
+- **That's it** - AviationWX handles polling automatically
+
+Dyacon updates about every 10 minutes. Ceiling and visibility are not available from the API; pair with METAR or another aviation source if pilots need those fields.
 
 ---
 
@@ -168,6 +193,7 @@ First, verify your station is working by checking its native app or website:
 - **Tempest**: Check the Tempest app or [tempestwx.com](https://tempestwx.com)
 - **Ambient**: Check [ambientweather.net](https://ambientweather.net)
 - **Davis WeatherLink**: Check [weatherlink.com](https://www.weatherlink.com)
+- **DyaconLive**: Check [dyacon.com/dyaconlive](https://dyacon.com/dyaconlive/)
 - **PWSWeather**: Check [pwsweather.com](https://www.pwsweather.com)
 
 If you can see valid, current data there, the station itself is working.
@@ -208,13 +234,14 @@ When you connect your station to AviationWX, your data doesn't just help pilots 
 
 ### Supported Weather Sources
 
-AviationWX supports six weather station platforms plus METAR-only configuration:
+AviationWX supports the weather station platforms below, plus METAR-only configuration:
 
 | Source | Best For | Update Speed | Cost |
 |--------|----------|--------------|------|
 | **Tempest** | New installs, community deployments | ~1 minute | Free API |
 | **Ambient Weather** | Budget stations, existing installs | ~1 minute | Free API |
 | **Davis WeatherLink** | Professional/long-term installs | 15 min (Basic/free), 5 min (Pro), ~1 min (Pro+) | Free API (Basic); paid for 5 min / 1 min |
+| **DyaconLive** | Existing Dyacon stations at small airports | ~10 minutes | DyaconLive+ required for API |
 | **PWSWeather** | Stations already uploading to PWSWeather.com | ~5 minutes | Free API via AerisWeather |
 | **SynopticData** | Backup source, aggregated networks | 5-10 minutes | Free tier available |
 | **AWOSnet** | Airports with AWOSnet-hosted AWOS | ~10 minutes | No API key needed |
@@ -442,6 +469,64 @@ The DID looks like: `001D0A12345678` (12-16 alphanumeric characters)
 
 - [WeatherLink v2 API Documentation](https://weatherlink.github.io/v2-api/)
 - [WeatherLink v1 API Documentation (PDF)](https://www.weatherlink.com/static/docs/APIdocumentation.pdf)
+
+---
+
+## DyaconLive - What We Need
+
+Good for airports with an existing [Dyacon](https://dyacon.com/) station on [DyaconLive](https://dyacon.com/dyaconlive/). Requires **DyaconLive+** and API access from Dyacon (`support@dyacon.net`).
+
+### Required Information
+
+| Field | Description | Where to Find It |
+|-------|-------------|------------------|
+| `station_id` | Numeric API station ID | `GET /stations` after token auth |
+| `username` | DyaconLive login email | Your DyaconLive account |
+| `password` | DyaconLive password | Your DyaconLive account |
+
+### How to Get Your Credentials
+
+1. **Confirm DyaconLive+ and API access** with Dyacon (`support@dyacon.net`) if you have not already
+2. **Log into DyaconLive** at [dyacon.com/dyaconlive](https://dyacon.com/dyaconlive/)
+3. **Use your DyaconLive email and password** - there is no separate API key in the portal
+
+> **Note**: DyaconLive (included with many stations) covers the web portal. **DyaconLive+** is required for API access to AviationWX.
+
+### How to Find Your Station ID
+
+The numeric `station_id` for the API is not the public widget `pid` used in embed URLs.
+
+1. Authenticate: `POST https://api.dyacon.net/token` with `username`, `password`, and `grant_type=password`
+2. List stations: `GET https://api.dyacon.net/stations` with the bearer token
+3. Note the numeric **`id`** for your station
+
+**Don't worry! We can look it up for you.** Provide your DyaconLive login when you submit your airport and we can discover the station ID.
+
+### Configuration Example
+
+```json
+"weather_source": {
+  "type": "dyaconlive",
+  "station_id": 130114,
+  "username": "your-dyaconlive-email",
+  "password": "your-dyaconlive-password"
+}
+```
+
+### How AviationWX reads DyaconLive data
+
+AviationWX pulls sensor fields from the DyaconLive API: temperature, humidity, wind (10-minute averages), station pressure, and rain when equipped. Station pressure is converted to sea-level altimeter using airport `elevation_ft`. **Ceiling and visibility are not available** from Dyacon sensor data. Details: [CONFIGURATION.md](../docs/CONFIGURATION.md#dyaconlive).
+
+### DyaconLive Limitations
+
+- Updates approximately every 10 minutes (not real-time like personal weather stations)
+- Advisory station data - not FAA-certified AWOS; no ceiling or visibility from the API
+- DyaconLive+ required for API access
+
+### API Documentation
+
+- [Dyacon aviation weather stations](https://dyacon.com/aviation-weather-station/)
+- [DyaconLive API](https://api.dyacon.net/docs)
 
 ---
 
@@ -697,7 +782,7 @@ Once you have gathered all the required information, send it to the AviationWX t
 1. **Email**: [Contact info in Guide 12]
 2. **Include**:
    - Airport identifier (ICAO, FAA, or IATA code)
-   - Weather source type (Tempest, Ambient, etc.)
+   - Weather source type (Tempest, Ambient, DyaconLive, etc.)
    - All required credentials for your source type
    - Station location description and mount details
    - Your contact information for maintenance coordination
@@ -713,6 +798,7 @@ We'll validate the connection, verify data quality, and add your airport to the 
 | **Tempest** | `station_id`, `api_key` |
 | **Ambient** | `api_key`, `application_key`,  `mac_address` |
 | **Davis WeatherLink** | `station_id`, `api_key`, `api_secret` |
+| **DyaconLive** | `station_id`, `username`, `password` (DyaconLive+ required) |
 | **PWSWeather** | `station_id`, `client_id`, `client_secret` |
 | **SynopticData** | `station_id` + permission (we have a central API key) |
 | **AWOSnet** | `station_id` (e.g., `ks40`) |

--- a/guides/12-submit-an-airport-to-aviationwx.md
+++ b/guides/12-submit-an-airport-to-aviationwx.md
@@ -142,6 +142,32 @@ For Canadian airports, AviationWX can use Nav Canada weather data via the SWOB-M
 
 Updates approximately every 5 minutes. See [Guide 09](09-weather-station-configuration.md#nav-canada-weather-canadian-airports) for details.
 
+### Option G - DyaconLive (Dyacon stations)
+If your airport has a [Dyacon](https://dyacon.com/) station on [DyaconLive](https://dyacon.com/dyaconlive/):
+
+Please send:
+- **DyaconLive login email** (`username`)
+- **DyaconLive password**
+- **Numeric station ID** (if you have it / can find it)
+
+How to find/create these:
+- **DyaconLive+** and API access are required (`support@dyacon.net`). There is no separate API key - we use your DyaconLive web login.
+- The API station ID is not the public widget `pid`. We can look up the station ID if you provide your login.
+- Airport **field elevation** (`elevation_ft`) is needed for altimeter conversion.
+
+Updates approximately every 10 minutes. Ceiling and visibility are not available from Dyacon - tell us if you also have METAR or AWOS to pair.
+
+See [Guide 09](09-weather-station-configuration.md#dyaconlive---what-we-need) for details.
+
+References:
+```text
+Dyacon aviation stations:
+https://dyacon.com/aviation-weather-station/
+
+DyaconLive API:
+https://api.dyacon.net/docs
+```
+
 ---
 
 ## Step 3 - Camera connection (choose one path)
@@ -221,8 +247,8 @@ Body:
 - Target update cadence:
 
 **Weather source**
-- Type: Tempest / Davis / Ambient / ASOS-AWOS / AWOSnet
-- Details (token/key/etc):
+- Type: Tempest / Davis / Ambient / DyaconLive / ASOS-AWOS / AWOSnet / Nav Canada SWOB
+- Details (token/key/login/etc):
 
 **Cameras**
 - Number of cameras:

--- a/guides/13-using-the-airport-dashboard.md
+++ b/guides/13-using-the-airport-dashboard.md
@@ -61,6 +61,7 @@ AviationWX combines multiple data sources to show you the **freshest, most compl
 |      |   Tempest    |      |  ASOS/AWOS   |      |   Density    |           |
 |      |   Davis      |      |   via FAA    |      |   Altitude   |           |
 |      |   Ambient    |      |              |      |   Crosswind  |           |
+|      |   DyaconLive |      |              |      |              |           |
 |      +------+-------+      +------+-------+      +------+-------+           |
 |             |                     |                     |                   |
 |             +---------------------+---------------------+                   |
@@ -77,10 +78,11 @@ AviationWX combines multiple data sources to show you the **freshest, most compl
 ```
 
 **What this means for you:**
-- Some airports have **on-site weather stations** (updated every 1-5 minutes)
+- Some airports have **on-site weather stations** (often every 1-5 minutes; Dyacon advisory stations on DyaconLive update about every 10 minutes)
 - Some airports use **official METAR data** from nearby ASOS/AWOS
 - Many airports show **both** - you get hyper-local conditions AND official aviation weather
 - Values like density altitude and crosswind components are calculated automatically
+- **DyaconLive** feeds are advisory surface weather; ceiling and visibility usually come from METAR or another official source when shown
 
 ### Flight Category Colors
 

--- a/guides/15-weather-sensor-standards-and-maintenance.md
+++ b/guides/15-weather-sensor-standards-and-maintenance.md
@@ -65,9 +65,21 @@ An NWS climate-focused overview notes that, for primary climate sensors, tempera
 
 ---
 
+## Industrial advisory aviation (Dyacon MS-100 series)
+
+[Dyacon](https://dyacon.com/) manufactures MS-100 series stations (MS-120 through MS-135) for commercial, industrial, and **advisory aviation** use. The [MS-130](https://dyacon.com/Ms-130/) is a common small-airport configuration: solar-powered, cellular upload to [DyaconLive](https://dyacon.com/dyaconlive/), optional SMS METAR-style text reports, and Modbus for local systems. Dyacon describes these as advisory stations - a practical middle ground between consumer hardware and FAA-certified AWOS, not a substitute for type-certified automated observing programs.
+
+Strengths: industrial build, documented [airport siting guidance](https://dyacon.com/wp-content/uploads/57-6040-DOC-Quick-start%20Guide-MS-100.pdf), autonomous remote operation, DyaconLive Aviation Mode for local flight planning (altimeter, density altitude, estimated cloud base in the portal).
+
+Limitations: **not** FAA-certified AWOS/ASOS; standard package measures wind, temperature, humidity, and barometric pressure (rain gauge optional). DyaconLive portal and SMS outputs may include **estimated** cloud base in METAR-style text, but there are no ceiling or visibility **instruments**. AviationWX's DyaconLive integration reads API sensor fields only - treat ceiling/visibility on the dashboard as coming from METAR or another source, not from Dyacon. Update cadence is about 10 minutes on clock-aligned buckets, slower than ASOS engineering streams.
+
+Calibration and care: follow Dyacon maintenance features in DyaconLive+ when enabled; inspect mount, cables, and rain funnel on the same quarterly rhythm as other field stations; compare wind and pressure trends to nearby official METAR during benign weather. Product hub: [Dyacon aviation weather stations](https://dyacon.com/aviation-weather-station/).
+
+---
+
 ## Consumer-grade examples (common, and especially limitation-heavy)
 
-Official AWOS/ASOS programs combine type-certified sensors, controlled siting, redundancy, and scheduled maintenance. Any field sensor you attach to AviationWX still inherits the same physics and exposure problems: wind shadow, radiation heating, wetting losses in precipitation, drift, and cabling faults. Higher-grade gear may add better shields, faster sampling, serviceable modules, or documented calibration procedures, but it is **never** a substitute for good siting, periodic checks, and honest labeling when a channel is weak. The Tempest, Davis, and Ambient examples below are common consumer or prosumer paths from this guide series, not an exhaustive list of supported hardware; we spell out vendor limits there most often because pilots can mistake a slick dashboard for AWOS-class data.
+Official AWOS/ASOS programs combine type-certified sensors, controlled siting, redundancy, and scheduled maintenance. Any field sensor you attach to AviationWX still inherits the same physics and exposure problems: wind shadow, radiation heating, wetting losses in precipitation, drift, and cabling faults. Higher-grade gear may add better shields, faster sampling, serviceable modules, or documented calibration procedures, but it is **never** a substitute for good siting, periodic checks, and honest labeling when a channel is weak. The Dyacon, Tempest, Davis, and Ambient examples below cover common supported paths; we spell out vendor limits most often where pilots can mistake a slick dashboard for AWOS-class data.
 
 Consumer and compact integrated stations usually optimize for cost, ease of install, and home use, with accuracy statements that assume controlled or ideal conditions and good siting. Expect wider real-world error than a national automated station when mounts are improvised.
 
@@ -155,6 +167,7 @@ If your country is not listed, a practical search pattern is: `"(your CAA name)"
 | Basic VFR weather minimums | [14 CFR 91.155 (eCFR)](https://www.ecfr.gov/current/title-14/chapter-I/subchapter-F/part-91/subpart-B/section-91.155) |
 | ICAO Annex 3 publication | [ICAO Annex 3 store listing](https://store.icao.int/en/annexes/annex-3) |
 | Tempest engineering specs | [Tempest spec sheet PDF](https://tempest.earth/wp-content/uploads/2016/05/Tempest_Spec-Sheet_220301-web-view.pdf) |
+| Dyacon advisory aviation stations | [Dyacon aviation weather stations](https://dyacon.com/aviation-weather-station/) |
 | WMO instruments guide (global) | [WMO-No. 8 hub](https://community.wmo.int/guide-instruments-and-methods-of-observation-wmo-no-8) |
 
 For EASA, UK CAA, and Canada starting points, see the international table above.

--- a/lib/config.php
+++ b/lib/config.php
@@ -4750,7 +4750,7 @@ function validateAirportsJsonStructure(array $config): array {
             if (!is_array($airport['weather_sources'])) {
                 $errors[] = "Airport '{$airportCode}' weather_sources must be an array";
             } else {
-                $validTypes = ['tempest', 'ambient', 'weatherlink_v2', 'weatherlink_v1', 'pwsweather', 'synopticdata', 'metar', 'nws', 'aviationwx_api', 'awosnet', 'swob_auto', 'swob_man'];
+                $validTypes = ['tempest', 'ambient', 'weatherlink_v2', 'weatherlink_v1', 'pwsweather', 'synopticdata', 'metar', 'nws', 'aviationwx_api', 'awosnet', 'swob_auto', 'swob_man', 'dyaconlive'];
                 foreach ($airport['weather_sources'] as $idx => $ws) {
                     $label = "weather_sources[{$idx}]";
                     if (!is_array($ws)) {
@@ -4835,6 +4835,23 @@ function validateAirportsJsonStructure(array $config): array {
                             $errors[] = "Airport '{$airportCode}' {$label} ({$wsType}) missing 'station_id'";
                         } elseif (!preg_match('/^[A-Za-z]{4}$/', trim($ws['station_id']))) {
                             $errors[] = "Airport '{$airportCode}' {$label} ({$wsType}) invalid 'station_id' format (4-letter ICAO code)";
+                        }
+                    } elseif ($wsType === 'dyaconlive') {
+                        if (!isset($ws['station_id']) || $ws['station_id'] === '') {
+                            $errors[] = "Airport '{$airportCode}' {$label} (dyaconlive) missing 'station_id'";
+                        } else {
+                            $stationId = $ws['station_id'];
+                            $validStationId = (is_int($stationId) && $stationId > 0)
+                                || (is_string($stationId) && ctype_digit(trim($stationId)) && (int) trim($stationId) > 0);
+                            if (!$validStationId) {
+                                $errors[] = "Airport '{$airportCode}' {$label} (dyaconlive) invalid 'station_id' (positive integer required)";
+                            }
+                        }
+                        if (!isset($ws['username']) || !is_string($ws['username']) || trim($ws['username']) === '') {
+                            $errors[] = "Airport '{$airportCode}' {$label} (dyaconlive) missing 'username'";
+                        }
+                        if (!isset($ws['password']) || !is_string($ws['password']) || $ws['password'] === '') {
+                            $errors[] = "Airport '{$airportCode}' {$label} (dyaconlive) missing 'password'";
                         }
                     }
                     // metar: station_id optional (nearby_stations can provide fallback)

--- a/lib/config.php
+++ b/lib/config.php
@@ -4853,6 +4853,9 @@ function validateAirportsJsonStructure(array $config): array {
                         if (!isset($ws['password']) || !is_string($ws['password']) || $ws['password'] === '') {
                             $errors[] = "Airport '{$airportCode}' {$label} (dyaconlive) missing 'password'";
                         }
+                        if (!isset($airport['elevation_ft']) || !is_numeric($airport['elevation_ft'])) {
+                            $warnings[] = "Airport '{$airportCode}' {$label} (dyaconlive): missing airport elevation_ft; pressure will be omitted";
+                        }
                     }
                     // metar: station_id optional (nearby_stations can provide fallback)
                 }

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -201,6 +201,21 @@ if (!defined('NOTAM_CACHE_TTL_DEFAULT')) {
 if (!defined('NOTAM_TOKEN_EXPIRY_BUFFER')) {
     define('NOTAM_TOKEN_EXPIRY_BUFFER', 60); // Refresh token 1 min before expiry
 }
+if (!defined('DYACONLIVE_API_BASE_URL')) {
+    define('DYACONLIVE_API_BASE_URL', 'https://api.dyacon.net');
+}
+if (!defined('DYACONLIVE_REPORT_INTERVAL_MINUTES')) {
+    define('DYACONLIVE_REPORT_INTERVAL_MINUTES', 10);
+}
+if (!defined('DYACONLIVE_BUCKET_GRACE_SECONDS')) {
+    define('DYACONLIVE_BUCKET_GRACE_SECONDS', 90);
+}
+if (!defined('DYACONLIVE_TOKEN_DEFAULT_TTL_SECONDS')) {
+    define('DYACONLIVE_TOKEN_DEFAULT_TTL_SECONDS', 1800);
+}
+if (!defined('DYACONLIVE_TOKEN_EXPIRY_BUFFER')) {
+    define('DYACONLIVE_TOKEN_EXPIRY_BUFFER', 60);
+}
 // NOTAM staleness thresholds (global only, 3-tier model)
 if (!defined('DEFAULT_NOTAM_STALE_WARNING_SECONDS')) {
     define('DEFAULT_NOTAM_STALE_WARNING_SECONDS', 900); // 15 minutes

--- a/lib/test-mocks.php
+++ b/lib/test-mocks.php
@@ -43,6 +43,19 @@ function getMockHttpResponse(string $url): ?string {
         require_once __DIR__ . '/../tests/mock-weather-responses.php';
         return getMockWeatherLinkResponse();
     }
+
+    if (strpos($url, 'api.dyacon.net') !== false) {
+        require_once __DIR__ . '/../tests/mock-weather-responses.php';
+        if (strpos($url, '/token') !== false) {
+            return json_encode([
+                'access_token' => 'test_dyaconlive_bearer_token',
+                'token_type' => 'bearer',
+            ]);
+        }
+        if (strpos($url, '/data/') !== false) {
+            return getMockDyaconLiveDataResponse();
+        }
+    }
     
     if (strpos($url, 'aviationweather.gov') !== false) {
         // METAR API (PHPUnit may disable via metarBulkTestSetSkipMetarHttpMock to exercise bulk slices)

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -27,6 +27,7 @@ function upstreamRateLimitCredentialFieldNames(string $provider): array
         'weatherlink_v1' => ['api_token'],
         'synopticdata' => ['api_token'],
         'aviationwx_api' => ['api_key'],
+        'dyaconlive' => ['username', 'password'],
         default => [],
     };
 }
@@ -41,6 +42,7 @@ function upstreamRateLimitIdentityFieldNames(string $provider): array
 {
     return match ($provider) {
         'metar', 'awosnet', 'swob_auto', 'swob_man', 'nws' => ['station_id'],
+        'dyaconlive' => ['station_id'],
         'aviationwx_api' => ['base_url', 'airport_id'],
         default => [],
     };
@@ -216,6 +218,10 @@ function upstreamRateLimitPolicyForProvider(string $provider): array
         'synopticdata' => [
             'rpm' => UPSTREAM_RATE_LIMIT_SYNOPTIC_RPM,
             'burst' => UPSTREAM_RATE_LIMIT_SYNOPTIC_BURST,
+        ],
+        'dyaconlive' => [
+            'rpm' => UPSTREAM_RATE_LIMIT_DEFAULT_RPM,
+            'burst' => 2,
         ],
         'metar' => [
             'rpm' => UPSTREAM_RATE_LIMIT_METAR_HTTP_RPM,

--- a/lib/upstream-rate-limit.php
+++ b/lib/upstream-rate-limit.php
@@ -72,10 +72,17 @@ function upstreamRateFingerprint(string $provider, array $sourceConfig): string
 {
     $material = [];
     foreach (upstreamRateLimitFingerprintFieldNames($provider) as $field) {
-        if (!isset($sourceConfig[$field]) || !is_string($sourceConfig[$field])) {
+        if (!array_key_exists($field, $sourceConfig)) {
             continue;
         }
-        $value = trim($sourceConfig[$field]);
+        $raw = $sourceConfig[$field];
+        if (is_int($raw) || is_float($raw)) {
+            $value = trim((string) $raw);
+        } elseif (is_string($raw)) {
+            $value = trim($raw);
+        } else {
+            continue;
+        }
         if ($value === '') {
             continue;
         }

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -217,8 +217,6 @@ function fetchAllSources(array $sources, string $airportId, array $airport = [])
             );
             if ($skipped !== null && $skipped->isValid) {
                 $skippedSnapshots[$sourceKey] = $skipped;
-                recordWeatherSuccess($airportId, $sourceType, $source);
-                weatherHealthTrackFetch($airportId, $sourceType, true, HTTP_STATUS_OK);
                 continue;
             }
 

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -250,9 +250,9 @@ function fetchAllSources(array $sources, string $airportId, array $airport = [])
                 recordWeatherFailure(
                     $airportId,
                     $sourceType,
-                    $httpCode === 401 ? 'auth' : 'transient',
+                    $httpCode === 401 ? 'permanent' : 'transient',
                     $httpCode,
-                    null,
+                    $httpCode === 401 ? 'DyaconLive authentication failed (HTTP 401)' : null,
                     $source,
                     $fetch['response_headers']
                 );

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -35,6 +35,9 @@ require_once __DIR__ . '/adapter/awosnet-v1.php';
 require_once __DIR__ . '/adapter/swob-helper.php';
 require_once __DIR__ . '/adapter/swob-auto-v1.php';
 require_once __DIR__ . '/adapter/swob-man-v1.php';
+require_once __DIR__ . '/adapter/dyaconlive-v1.php';
+require_once __DIR__ . '/dyaconlive-state.php';
+require_once __DIR__ . '/dyaconlive-fetch.php';
 require_once __DIR__ . '/wind-normalizer.php';
 require_once __DIR__ . '/metar-completeness-aggregate.php';
 require_once __DIR__ . '/calculator.php';
@@ -66,12 +69,24 @@ function fetchWeatherUnified(array $airport, string $airportId): array {
     }
     
     // Fetch all sources in parallel using curl_multi
-    $responses = fetchAllSources($sources, $airportId);
+    $fetchResult = fetchAllSources($sources, $airportId, $airport);
+    $responses = $fetchResult['responses'];
+    $skippedSnapshots = $fetchResult['skipped_snapshots'];
     
     // Parse responses into snapshots
     $snapshots = [];
     
     foreach ($sources as $sourceKey => $source) {
+        if (isset($skippedSnapshots[$sourceKey])) {
+            $snapshot = $skippedSnapshots[$sourceKey];
+            if ($snapshot->isValid) {
+                $sourceType = $source['type'] ?? '';
+                $snapshot = normalizeWindToTrueNorth($snapshot, $airport, $sourceType);
+                $snapshots[] = $snapshot;
+            }
+            continue;
+        }
+
         if (!isset($responses[$sourceKey]) || $responses[$sourceKey] === null) {
             continue;
         }
@@ -79,6 +94,24 @@ function fetchWeatherUnified(array $airport, string $airportId): array {
         $snapshot = parseSourceResponse($source, $responses[$sourceKey], $airport);
         if ($snapshot !== null && $snapshot->isValid) {
             $sourceType = $source['type'] ?? '';
+            if ($sourceType === 'dyaconlive') {
+                $sourceForParse = $source;
+                $sourceForParse['timezone'] = dyaconliveResolveTimezone($source, $airport);
+                $lastBucketIso = DyaconLiveAdapter::extractLastBucketIso(
+                    $responses[$sourceKey],
+                    $sourceForParse
+                );
+                if ($lastBucketIso !== null) {
+                    dyaconlivePersistSourceStateAfterParse(
+                        $airportId,
+                        $source,
+                        $airport,
+                        extractWeatherSourceIndexFromKey($sourceKey),
+                        $snapshot,
+                        $lastBucketIso
+                    );
+                }
+            }
             $snapshot = normalizeWindToTrueNorth($snapshot, $airport, $sourceType);
             $snapshots[] = $snapshot;
         }
@@ -162,16 +195,71 @@ function buildSourceList(array $airport): array {
  * 
  * @param array $sources Source configurations
  * @param string $airportId Airport ID for logging
- * @return array Responses keyed by source identifier
+ * @param array $airport Airport configuration (timezone for dyaconlive)
+ * @return array{responses: array<string, string|null>, skipped_snapshots: array<string, WeatherSnapshot>}
  */
-function fetchAllSources(array $sources, string $airportId): array {
+function fetchAllSources(array $sources, string $airportId, array $airport = []): array {
     $mh = curl_multi_init();
     $handles = [];
     $responseHeadersByKey = [];
     $responses = [];
+    $skippedSnapshots = [];
 
     foreach ($sources as $sourceKey => $source) {
         $sourceType = $source['type'];
+
+        if ($sourceType === 'dyaconlive') {
+            $skipped = dyaconliveResolveSkippedSnapshot(
+                $airportId,
+                $source,
+                $airport,
+                extractWeatherSourceIndexFromKey($sourceKey)
+            );
+            if ($skipped !== null && $skipped->isValid) {
+                $skippedSnapshots[$sourceKey] = $skipped;
+                recordWeatherSuccess($airportId, $sourceType, $source);
+                weatherHealthTrackFetch($airportId, $sourceType, true, HTTP_STATUS_OK);
+                continue;
+            }
+
+            $breakerResult = checkWeatherCircuitBreaker($airportId, $sourceType, $source);
+            if (is_array($breakerResult) && ($breakerResult['skip'] ?? false)) {
+                weatherHealthTrackCircuitOpen($airportId, $sourceType);
+                continue;
+            }
+
+            $rateLimit = upstreamRateLimitConsumeForSource($source);
+            if (!$rateLimit['allowed']) {
+                aviationwx_log('info', 'upstream rate limit skip', [
+                    'airport_id' => $airportId,
+                    'provider' => $sourceType,
+                    'fingerprint_prefix' => $rateLimit['fingerprint_prefix'],
+                ], 'app');
+                weatherHealthTrackUpstreamThrottleSkip($airportId, $sourceType);
+                continue;
+            }
+
+            $fetch = dyaconliveFetchDataResponse($source, $airport);
+            $httpCode = $fetch['http_code'];
+            if (is_int($httpCode) && $httpCode >= 200 && $httpCode < 300 && is_string($fetch['body'])) {
+                $responses[$sourceKey] = $fetch['body'];
+                recordWeatherSuccess($airportId, $sourceType, $source);
+                weatherHealthTrackFetch($airportId, $sourceType, true, $httpCode);
+            } else {
+                $responses[$sourceKey] = null;
+                recordWeatherFailure(
+                    $airportId,
+                    $sourceType,
+                    $httpCode === 401 ? 'auth' : 'transient',
+                    $httpCode,
+                    null,
+                    $source,
+                    $fetch['response_headers']
+                );
+                weatherHealthTrackFetch($airportId, $sourceType, false, $httpCode);
+            }
+            continue;
+        }
 
         // METAR: mock/bulk/HTTP via metarResolveStationResponse (no curl_multi; bulk before HTTP circuit)
         if ($sourceType === 'metar') {
@@ -222,7 +310,7 @@ function fetchAllSources(array $sources, string $airportId): array {
         }
 
         // Build URL
-        $url = buildSourceUrl($source);
+        $url = buildSourceUrl($source, $airport);
         if ($url === null) {
             continue;
         }
@@ -241,6 +329,16 @@ function fetchAllSources(array $sources, string $airportId): array {
         
         // Get headers for this source
         $headers = buildSourceHeaders($source);
+
+        if (function_exists('isTestMode') && isTestMode() && function_exists('getMockHttpResponse')) {
+            $mockBody = getMockHttpResponse($url);
+            if (is_string($mockBody) && $mockBody !== '') {
+                $responses[$sourceKey] = $mockBody;
+                recordWeatherSuccess($airportId, $sourceType, $source);
+                weatherHealthTrackFetch($airportId, $sourceType, true, HTTP_STATUS_OK);
+                continue;
+            }
+        }
         
         $responseHeadersByKey[$sourceKey] = [];
         $headerCollector = function ($ch, string $line) use (&$responseHeadersByKey, $sourceKey): int {
@@ -377,16 +475,32 @@ function fetchAllSources(array $sources, string $airportId): array {
         }
     }
     
-    return $responses;
+    return [
+        'responses' => $responses,
+        'skipped_snapshots' => $skippedSnapshots,
+    ];
+}
+
+/**
+ * Extract weather_sources array index from fetcher source key (source_0, backup_1, ...).
+ */
+function extractWeatherSourceIndexFromKey(string $sourceKey): int
+{
+    if (preg_match('/_(\d+)$/', $sourceKey, $matches)) {
+        return (int) $matches[1];
+    }
+
+    return 0;
 }
 
 /**
  * Build URL for a source
  * 
  * @param array $source Source configuration
+ * @param array $airport Airport configuration
  * @return string|null URL or null if invalid
  */
-function buildSourceUrl(array $source): ?string {
+function buildSourceUrl(array $source, array $airport = []): ?string {
     $type = $source['type'] ?? null;
     
     return match($type) {
@@ -402,6 +516,7 @@ function buildSourceUrl(array $source): ?string {
         'awosnet' => AwosnetAdapter::buildUrl($source),
         'swob_auto' => SwobAutoAdapter::buildUrl($source),
         'swob_man' => SwobManAdapter::buildUrl($source),
+        'dyaconlive' => DyaconLiveAdapter::buildUrl($source, dyaconliveResolveTimezone($source, $airport)),
         default => null,
     };
 }
@@ -448,6 +563,10 @@ function parseSourceResponse(array $source, string $response, array $airport): ?
         'awosnet' => AwosnetAdapter::parseToSnapshot($response, $source),
         'swob_auto' => SwobAutoAdapter::parseToSnapshot($response, $source),
         'swob_man' => SwobManAdapter::parseToSnapshot($response, $source),
+        'dyaconlive' => DyaconLiveAdapter::parseToSnapshot($response, array_merge($source, [
+            'timezone' => dyaconliveResolveTimezone($source, $airport),
+            'elevation_ft' => $airport['elevation_ft'] ?? null,
+        ])),
         default => null,
     };
 }

--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -1,0 +1,371 @@
+<?php
+/**
+ * DyaconLive API Adapter v1
+ *
+ * API documentation: https://api.dyacon.net/docs
+ *
+ * Authentication: OAuth2 password grant (DyaconLive web login); bearer on data endpoints.
+ * Required config: station_id (integer), username, password
+ *
+ * Reports align to 10-minute clock boundaries in station timezone. Upstream skip logic
+ * lives in dyaconlive-state.php (scheduler cadence unchanged).
+ */
+
+require_once __DIR__ . '/../../constants.php';
+require_once __DIR__ . '/../../test-mocks.php';
+require_once __DIR__ . '/../../logger.php';
+require_once __DIR__ . '/../dyaconlive-auth.php';
+require_once __DIR__ . '/../dyaconlive-bucket.php';
+require_once __DIR__ . '/../calculator.php';
+require_once __DIR__ . '/../data/WeatherReading.php';
+require_once __DIR__ . '/../data/WindGroup.php';
+require_once __DIR__ . '/../data/WeatherSnapshot.php';
+
+use AviationWX\Weather\Data\WeatherReading;
+use AviationWX\Weather\Data\WindGroup;
+use AviationWX\Weather\Data\WeatherSnapshot;
+
+class DyaconLiveAdapter
+{
+    /** Fields this adapter can provide */
+    public const FIELDS_PROVIDED = [
+        'temperature',
+        'humidity',
+        'pressure',
+        'wind_speed',
+        'wind_direction',
+        'gust_speed',
+        'precip_accum',
+    ];
+
+    public const UPDATE_FREQUENCY = 600;
+
+    public const MAX_ACCEPTABLE_AGE = 1200;
+
+    public const SOURCE_TYPE = 'dyaconlive';
+
+    /** API variable query params (unit overrides via pipe syntax) */
+    public const DATA_VARIABLES = [
+        'air_temp|F',
+        'humidity',
+        'air_pressure|inHg',
+        'wind10m_speed|mph',
+        'wind10m_direction',
+        'wind_gust|mph',
+        'rainday_cumul',
+    ];
+
+    public static function getFieldsProvided(): array
+    {
+        return self::FIELDS_PROVIDED;
+    }
+
+    public static function getTypicalUpdateFrequency(): int
+    {
+        return self::UPDATE_FREQUENCY;
+    }
+
+    public static function getMaxAcceptableAge(): int
+    {
+        return self::MAX_ACCEPTABLE_AGE;
+    }
+
+    public static function getSourceType(): string
+    {
+        return self::SOURCE_TYPE;
+    }
+
+    public static function providesField(string $fieldName): bool
+    {
+        return in_array($fieldName, self::FIELDS_PROVIDED, true);
+    }
+
+    /**
+     * @param array<string, mixed> $config Source configuration
+     */
+    public static function buildUrl(array $config, string $timezone = 'UTC'): ?string
+    {
+        $stationId = self::normalizeStationId($config['station_id'] ?? null);
+        if ($stationId === null) {
+            return null;
+        }
+        if (!isset($config['username'], $config['password'])
+            || !is_string($config['username'])
+            || !is_string($config['password'])
+            || trim($config['username']) === ''
+            || $config['password'] === ''
+        ) {
+            return null;
+        }
+
+        try {
+            $tz = new DateTimeZone($timezone);
+        } catch (Exception $e) {
+            $tz = new DateTimeZone('UTC');
+        }
+
+        $today = (new DateTimeImmutable('now', $tz))->format('Y-m-d');
+        $params = [
+            'startdate' => $today,
+            'enddate' => $today,
+            'timezone' => $timezone,
+        ];
+
+        $query = [];
+        foreach ($params as $key => $value) {
+            $query[] = rawurlencode($key) . '=' . rawurlencode($value);
+        }
+        foreach (self::DATA_VARIABLES as $variable) {
+            $query[] = 'variable=' . rawurlencode($variable);
+        }
+
+        $base = rtrim(DYACONLIVE_API_BASE_URL, '/');
+
+        return $base . '/data/' . $stationId . '?' . implode('&', $query);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return list<string>
+     */
+    public static function getHeaders(array $config): array
+    {
+        $username = isset($config['username']) && is_string($config['username']) ? trim($config['username']) : '';
+        $password = isset($config['password']) && is_string($config['password']) ? $config['password'] : '';
+        $token = dyaconliveGetBearerToken($username, $password);
+        if ($token === null) {
+            return ['Accept: application/json'];
+        }
+
+        return [
+            'Accept: application/json',
+            'Authorization: Bearer ' . $token,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public static function parseToSnapshot(string $response, array $config = []): ?WeatherSnapshot
+    {
+        $timezone = isset($config['timezone']) && is_string($config['timezone']) && $config['timezone'] !== ''
+            ? $config['timezone']
+            : 'UTC';
+        $stationId = self::normalizeStationId($config['station_id'] ?? null);
+
+        $parsed = parseDyaconLiveDataResponse($response, $timezone);
+        if ($parsed === null) {
+            return null;
+        }
+
+        if ($parsed['obs_time'] === null) {
+            return WeatherSnapshot::empty(self::SOURCE_TYPE);
+        }
+
+        $pressure = self::normalizeStationPressureToAltimeter(
+            $parsed['pressure'],
+            $config
+        );
+
+        $obsTime = $parsed['obs_time'];
+        $source = self::SOURCE_TYPE;
+        $hasWind = $parsed['wind_speed'] !== null && $parsed['wind_direction'] !== null;
+
+        return new WeatherSnapshot(
+            source: $source,
+            fetchTime: time(),
+            temperature: WeatherReading::celsius($parsed['temperature'], $source, $obsTime),
+            dewpoint: WeatherReading::null($source),
+            humidity: WeatherReading::percent($parsed['humidity'], $source, $obsTime),
+            pressure: WeatherReading::inHg($pressure, $source, $obsTime),
+            precipAccum: WeatherReading::inches($parsed['precip_accum'], $source, $obsTime),
+            wind: $hasWind
+                ? WindGroup::from(
+                    $parsed['wind_speed'],
+                    $parsed['wind_direction'],
+                    $parsed['gust_speed'],
+                    $source,
+                    $obsTime
+                )
+                : WindGroup::empty(),
+            visibility: WeatherReading::null($source),
+            ceiling: WeatherReading::null($source),
+            cloudCover: WeatherReading::null($source),
+            rawMetar: null,
+            isValid: true,
+            metarStationId: null,
+            stationId: $stationId !== null ? (string) $stationId : null,
+            metarFieldCompleteness: null
+        );
+    }
+
+    /**
+     * Last bucket ISO from parse (for state persistence).
+     *
+     * @param array<string, mixed> $config
+     */
+    public static function extractLastBucketIso(string $response, array $config = []): ?string
+    {
+        $timezone = isset($config['timezone']) && is_string($config['timezone']) && $config['timezone'] !== ''
+            ? $config['timezone']
+            : 'UTC';
+
+        $parsed = parseDyaconLiveDataResponse($response, $timezone);
+
+        return $parsed['last_bucket_iso'] ?? null;
+    }
+
+    public static function normalizeStationId(mixed $stationId): ?int
+    {
+        if (is_int($stationId)) {
+            return $stationId > 0 ? $stationId : null;
+        }
+        if (is_string($stationId) && ctype_digit(trim($stationId))) {
+            $id = (int) trim($stationId);
+            return $id > 0 ? $id : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Station pressure from Dyacon is reduced to sea-level altimeter for global pipeline.
+     *
+     * @param array<string, mixed> $config May include elevation_ft from airport config
+     */
+    private static function normalizeStationPressureToAltimeter(?float $stationPressureInHg, array $config): ?float
+    {
+        if ($stationPressureInHg === null) {
+            return null;
+        }
+
+        if (!isset($config['elevation_ft']) || !is_numeric($config['elevation_ft'])) {
+            aviationwx_log('warning', 'dyaconlive pressure skipped: missing elevation_ft for sea-level conversion', [
+                'station_id' => $config['station_id'] ?? null,
+            ], 'app');
+            return null;
+        }
+
+        return stationPressureToAltimeterSettingInHg($stationPressureInHg, (float) $config['elevation_ft']);
+    }
+}
+
+/**
+ * @return array{
+ *   temperature: float|null,
+ *   humidity: float|null,
+ *   pressure: float|null,
+ *   wind_speed: float|null,
+ *   wind_direction: float|int|null,
+ *   gust_speed: float|null,
+ *   precip_accum: float|null,
+ *   obs_time: int|null,
+ *   last_bucket_iso: string|null
+ * }|null
+ */
+function parseDyaconLiveDataResponse(string $response, string $timezone): ?array
+{
+    if (!is_string($response) || $response === '') {
+        return null;
+    }
+
+    $seriesList = json_decode($response, true);
+    if (!is_array($seriesList)) {
+        return null;
+    }
+
+    $byName = [];
+    foreach ($seriesList as $series) {
+        if (!is_array($series) || !isset($series['variable_name'])) {
+            continue;
+        }
+        $name = (string) $series['variable_name'];
+        $byName[$name] = $series;
+    }
+
+    $anchor = $byName['air_temp'] ?? $byName['wind10m_speed'] ?? null;
+    if (!is_array($anchor)) {
+        return [
+            'temperature' => null,
+            'humidity' => null,
+            'pressure' => null,
+            'wind_speed' => null,
+            'wind_direction' => null,
+            'gust_speed' => null,
+            'precip_accum' => null,
+            'obs_time' => null,
+            'last_bucket_iso' => null,
+        ];
+    }
+
+    $datetimes = $anchor['datetimes'] ?? [];
+    $values = $anchor['values'] ?? [];
+    if (!is_array($datetimes) || !is_array($values) || count($datetimes) === 0 || count($values) === 0) {
+        return [
+            'temperature' => null,
+            'humidity' => null,
+            'pressure' => null,
+            'wind_speed' => null,
+            'wind_direction' => null,
+            'gust_speed' => null,
+            'precip_accum' => null,
+            'obs_time' => null,
+            'last_bucket_iso' => null,
+        ];
+    }
+
+    $lastIndex = min(count($datetimes), count($values)) - 1;
+    $lastBucketIso = is_string($datetimes[$lastIndex] ?? null) ? $datetimes[$lastIndex] : null;
+    $seriesTimezone = is_string($anchor['timezone'] ?? null) && $anchor['timezone'] !== ''
+        ? $anchor['timezone']
+        : $timezone;
+    $obsTime = $lastBucketIso !== null
+        ? dyaconliveParseBucketIsoToUnix($lastBucketIso, $seriesTimezone)
+        : null;
+
+    $tempF = dyaconliveSeriesLastValue($byName['air_temp'] ?? null);
+    $temperature = $tempF !== null ? ((float) $tempF - 32.0) / 1.8 : null;
+    $humidity = dyaconliveSeriesLastValue($byName['humidity'] ?? null);
+    $pressure = dyaconliveSeriesLastValue($byName['air_pressure'] ?? null);
+    $windMph = dyaconliveSeriesLastValue($byName['wind10m_speed'] ?? null);
+    $windDir = dyaconliveSeriesLastValue($byName['wind10m_direction'] ?? null);
+    $gustMph = dyaconliveSeriesLastValue($byName['wind_gust'] ?? null);
+    $precip = dyaconliveSeriesLastValue($byName['rainday_cumul'] ?? null);
+
+    $windKt = $windMph !== null ? round((float) $windMph * 0.868976, 0) : null;
+    $gustKt = ($gustMph !== null && (float) $gustMph > 0)
+        ? round((float) $gustMph * 0.868976, 0)
+        : null;
+
+    return [
+        'temperature' => $temperature,
+        'humidity' => $humidity !== null ? (float) $humidity : null,
+        'pressure' => $pressure !== null ? (float) $pressure : null,
+        'wind_speed' => $windKt !== null ? (float) $windKt : null,
+        'wind_direction' => $windDir !== null ? round((float) $windDir) : null,
+        'gust_speed' => $gustKt,
+        'precip_accum' => $precip !== null ? (float) $precip : null,
+        'obs_time' => $obsTime,
+        'last_bucket_iso' => $lastBucketIso,
+    ];
+}
+
+/**
+ * @param array<string, mixed>|null $series
+ */
+function dyaconliveSeriesLastValue(?array $series): ?float
+{
+    if (!is_array($series)) {
+        return null;
+    }
+    $values = $series['values'] ?? null;
+    if (!is_array($values) || count($values) === 0) {
+        return null;
+    }
+    $last = $values[count($values) - 1];
+    if (!is_numeric($last)) {
+        return null;
+    }
+
+    return (float) $last;
+}

--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -97,10 +97,12 @@ class DyaconLiveAdapter
             return null;
         }
 
+        $resolvedTimezone = $timezone;
         try {
             $tz = new DateTimeZone($timezone);
         } catch (Exception $e) {
             $tz = new DateTimeZone('UTC');
+            $resolvedTimezone = 'UTC';
         }
 
         $today = new DateTimeImmutable('now', $tz);
@@ -109,7 +111,7 @@ class DyaconLiveAdapter
         $params = [
             'startdate' => $startDate,
             'enddate' => $endDate,
-            'timezone' => $timezone,
+            'timezone' => $resolvedTimezone,
         ];
 
         $query = [];

--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -323,14 +323,14 @@ function parseDyaconLiveDataResponse(string $response, string $timezone): ?array
         ? dyaconliveParseBucketIsoToUnix($lastBucketIso, $seriesTimezone)
         : null;
 
-    $tempF = dyaconliveSeriesLastValue($byName['air_temp'] ?? null);
+    $tempF = dyaconliveSeriesValueAtBucket($byName['air_temp'] ?? null, $lastIndex, $lastBucketIso);
     $temperature = $tempF !== null ? ((float) $tempF - 32.0) / 1.8 : null;
-    $humidity = dyaconliveSeriesLastValue($byName['humidity'] ?? null);
-    $pressure = dyaconliveSeriesLastValue($byName['air_pressure'] ?? null);
-    $windMph = dyaconliveSeriesLastValue($byName['wind10m_speed'] ?? null);
-    $windDir = dyaconliveSeriesLastValue($byName['wind10m_direction'] ?? null);
-    $gustMph = dyaconliveSeriesLastValue($byName['wind_gust'] ?? null);
-    $precip = dyaconliveSeriesLastValue($byName['rainday_cumul'] ?? null);
+    $humidity = dyaconliveSeriesValueAtBucket($byName['humidity'] ?? null, $lastIndex, $lastBucketIso);
+    $pressure = dyaconliveSeriesValueAtBucket($byName['air_pressure'] ?? null, $lastIndex, $lastBucketIso);
+    $windMph = dyaconliveSeriesValueAtBucket($byName['wind10m_speed'] ?? null, $lastIndex, $lastBucketIso);
+    $windDir = dyaconliveSeriesValueAtBucket($byName['wind10m_direction'] ?? null, $lastIndex, $lastBucketIso);
+    $gustMph = dyaconliveSeriesValueAtBucket($byName['wind_gust'] ?? null, $lastIndex, $lastBucketIso);
+    $precip = dyaconliveSeriesValueAtBucket($byName['rainday_cumul'] ?? null, $lastIndex, $lastBucketIso);
 
     $windKt = $windMph !== null ? round((float) $windMph * 0.868976, 0) : null;
     $gustKt = ($gustMph !== null && (float) $gustMph > 0)
@@ -351,21 +351,32 @@ function parseDyaconLiveDataResponse(string $response, string $timezone): ?array
 }
 
 /**
+ * Read a numeric value from a Dyacon series at the anchor bucket (ISO match, then index).
+ *
  * @param array<string, mixed>|null $series
  */
-function dyaconliveSeriesLastValue(?array $series): ?float
+function dyaconliveSeriesValueAtBucket(?array $series, int $anchorIndex, ?string $bucketIso): ?float
 {
     if (!is_array($series)) {
         return null;
     }
+
+    $datetimes = $series['datetimes'] ?? null;
     $values = $series['values'] ?? null;
-    if (!is_array($values) || count($values) === 0) {
-        return null;
-    }
-    $last = $values[count($values) - 1];
-    if (!is_numeric($last)) {
+    if (!is_array($datetimes) || !is_array($values) || count($values) === 0) {
         return null;
     }
 
-    return (float) $last;
+    if ($bucketIso !== null && $bucketIso !== '') {
+        $matchedIndex = array_search($bucketIso, $datetimes, true);
+        if ($matchedIndex !== false && isset($values[$matchedIndex]) && is_numeric($values[$matchedIndex])) {
+            return (float) $values[$matchedIndex];
+        }
+    }
+
+    if ($anchorIndex >= 0 && $anchorIndex < count($values) && is_numeric($values[$anchorIndex])) {
+        return (float) $values[$anchorIndex];
+    }
+
+    return null;
 }

--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -195,6 +195,9 @@ class DyaconLiveAdapter
             : 'UTC';
 
         $parsed = parseDyaconLiveDataResponse($response, $timezone);
+        if (!is_array($parsed)) {
+            return null;
+        }
 
         return $parsed['last_bucket_iso'] ?? null;
     }

--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -228,7 +228,7 @@ class DyaconLiveAdapter
         }
 
         if (!isset($config['elevation_ft']) || !is_numeric($config['elevation_ft'])) {
-            aviationwx_log('warning', 'dyaconlive pressure skipped: missing elevation_ft for sea-level conversion', [
+            aviationwx_log('debug', 'dyaconlive pressure skipped: missing elevation_ft for sea-level conversion', [
                 'station_id' => $config['station_id'] ?? null,
             ], 'app');
             return null;

--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -14,7 +14,6 @@
 require_once __DIR__ . '/../../constants.php';
 require_once __DIR__ . '/../../test-mocks.php';
 require_once __DIR__ . '/../../logger.php';
-require_once __DIR__ . '/../dyaconlive-auth.php';
 require_once __DIR__ . '/../dyaconlive-bucket.php';
 require_once __DIR__ . '/../calculator.php';
 require_once __DIR__ . '/../data/WeatherReading.php';
@@ -124,25 +123,6 @@ class DyaconLiveAdapter
         $base = rtrim(DYACONLIVE_API_BASE_URL, '/');
 
         return $base . '/data/' . $stationId . '?' . implode('&', $query);
-    }
-
-    /**
-     * @param array<string, mixed> $config
-     * @return list<string>
-     */
-    public static function getHeaders(array $config): array
-    {
-        $username = isset($config['username']) && is_string($config['username']) ? trim($config['username']) : '';
-        $password = isset($config['password']) && is_string($config['password']) ? $config['password'] : '';
-        $token = dyaconliveGetBearerToken($username, $password);
-        if ($token === null) {
-            return ['Accept: application/json'];
-        }
-
-        return [
-            'Accept: application/json',
-            'Authorization: Bearer ' . $token,
-        ];
     }
 
     /**

--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -104,10 +104,12 @@ class DyaconLiveAdapter
             $tz = new DateTimeZone('UTC');
         }
 
-        $today = (new DateTimeImmutable('now', $tz))->format('Y-m-d');
+        $today = new DateTimeImmutable('now', $tz);
+        $startDate = $today->modify('-1 day')->format('Y-m-d');
+        $endDate = $today->format('Y-m-d');
         $params = [
-            'startdate' => $today,
-            'enddate' => $today,
+            'startdate' => $startDate,
+            'enddate' => $endDate,
             'timezone' => $timezone,
         ];
 

--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -14,6 +14,7 @@
 require_once __DIR__ . '/../../constants.php';
 require_once __DIR__ . '/../../test-mocks.php';
 require_once __DIR__ . '/../../logger.php';
+require_once __DIR__ . '/../../units.php';
 require_once __DIR__ . '/../dyaconlive-bucket.php';
 require_once __DIR__ . '/../calculator.php';
 require_once __DIR__ . '/../data/WeatherReading.php';
@@ -311,7 +312,7 @@ function parseDyaconLiveDataResponse(string $response, string $timezone): ?array
         : null;
 
     $tempF = dyaconliveSeriesValueAtBucket($byName['air_temp'] ?? null, $lastIndex, $lastBucketIso);
-    $temperature = $tempF !== null ? ((float) $tempF - 32.0) / 1.8 : null;
+    $temperature = $tempF !== null ? fahrenheitToCelsius((float) $tempF) : null;
     $humidity = dyaconliveSeriesValueAtBucket($byName['humidity'] ?? null, $lastIndex, $lastBucketIso);
     $pressure = dyaconliveSeriesValueAtBucket($byName['air_pressure'] ?? null, $lastIndex, $lastBucketIso);
     $windMph = dyaconliveSeriesValueAtBucket($byName['wind10m_speed'] ?? null, $lastIndex, $lastBucketIso);
@@ -319,9 +320,9 @@ function parseDyaconLiveDataResponse(string $response, string $timezone): ?array
     $gustMph = dyaconliveSeriesValueAtBucket($byName['wind_gust'] ?? null, $lastIndex, $lastBucketIso);
     $precip = dyaconliveSeriesValueAtBucket($byName['rainday_cumul'] ?? null, $lastIndex, $lastBucketIso);
 
-    $windKt = $windMph !== null ? round((float) $windMph * 0.868976, 0) : null;
+    $windKt = $windMph !== null ? round(mphToKnots((float) $windMph), 0) : null;
     $gustKt = ($gustMph !== null && (float) $gustMph > 0)
-        ? round((float) $gustMph * 0.868976, 0)
+        ? round(mphToKnots((float) $gustMph), 0)
         : null;
 
     return [

--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -339,7 +339,7 @@ function parseDyaconLiveDataResponse(string $response, string $timezone): ?array
 }
 
 /**
- * Read a numeric value from a Dyacon series at the anchor bucket (ISO match, then index).
+ * Read a numeric value from a Dyacon series at the anchor bucket (ISO match only when bucket ISO is known).
  *
  * @param array<string, mixed>|null $series
  */
@@ -360,6 +360,8 @@ function dyaconliveSeriesValueAtBucket(?array $series, int $anchorIndex, ?string
         if ($matchedIndex !== false && isset($values[$matchedIndex]) && is_numeric($values[$matchedIndex])) {
             return (float) $values[$matchedIndex];
         }
+
+        return null;
     }
 
     if ($anchorIndex >= 0 && $anchorIndex < count($values) && is_numeric($values[$anchorIndex])) {

--- a/lib/weather/calculator.php
+++ b/lib/weather/calculator.php
@@ -123,6 +123,34 @@ function calculateHumidityFromDewpoint($tempC, $dewpointC) {
 }
 
 /**
+ * Convert station barometric pressure to sea-level altimeter setting (inHg).
+ *
+ * Sensors such as Dyacon report station pressure at field elevation. The aggregator,
+ * validation, and density-altitude math expect METAR-style altimeter setting (sea-level
+ * equivalent in inHg), per calculatePressureAltitude().
+ *
+ * Inverse of the US standard barometric reduction:
+ *   P_station = P_sea_level × (1 - 0.0000068753 × elevation_ft)^5.2559
+ *
+ * @param float $stationPressureInHg Measured pressure at field elevation (inHg)
+ * @param float $elevationFt Field elevation (feet MSL)
+ * @return float|null Altimeter setting in inHg, or null when inputs are invalid
+ */
+function stationPressureToAltimeterSettingInHg(float $stationPressureInHg, float $elevationFt): ?float
+{
+    if ($stationPressureInHg <= 0.0 || $elevationFt < 0.0) {
+        return null;
+    }
+
+    $factor = 1.0 - 0.0000068753 * $elevationFt;
+    if ($factor <= 0.0) {
+        return null;
+    }
+
+    return $stationPressureInHg / pow($factor, 5.2559);
+}
+
+/**
  * Calculate pressure altitude using FAA-approved formula
  * 
  * Calculates pressure altitude in feet based on station elevation and altimeter setting.

--- a/lib/weather/dyaconlive-auth.php
+++ b/lib/weather/dyaconlive-auth.php
@@ -122,7 +122,7 @@ function dyaconliveTokenExpiresInSeconds(string $accessToken, array $tokenBody):
 
     $parts = explode('.', $accessToken);
     if (count($parts) >= 2) {
-        $payloadJson = base64_decode(strtr($parts[1], '-_', '+/'), true);
+        $payloadJson = dyaconliveBase64UrlDecode($parts[1]);
         if (is_string($payloadJson)) {
             $payload = json_decode($payloadJson, true);
             if (is_array($payload) && isset($payload['exp']) && is_numeric($payload['exp'])) {
@@ -135,6 +135,22 @@ function dyaconliveTokenExpiresInSeconds(string $accessToken, array $tokenBody):
     }
 
     return DYACONLIVE_TOKEN_DEFAULT_TTL_SECONDS;
+}
+
+/**
+ * Decode a JWT base64url segment (adds padding for strict base64_decode).
+ */
+function dyaconliveBase64UrlDecode(string $segment): ?string
+{
+    $segment = strtr($segment, '-_', '+/');
+    $remainder = strlen($segment) % 4;
+    if ($remainder > 0) {
+        $segment .= str_repeat('=', 4 - $remainder);
+    }
+
+    $decoded = base64_decode($segment, true);
+
+    return is_string($decoded) ? $decoded : null;
 }
 
 /**

--- a/lib/weather/dyaconlive-auth.php
+++ b/lib/weather/dyaconlive-auth.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * DyaconLive API bearer token lifecycle (OAuth2 password grant).
+ */
+
+require_once __DIR__ . '/../constants.php';
+require_once __DIR__ . '/../logger.php';
+
+/**
+ * Obtain bearer token for DyaconLive API (APCu-cached per username).
+ *
+ * @param string $username DyaconLive login email
+ * @param string $password DyaconLive password
+ * @return string|null Bearer token or null on failure
+ */
+function dyaconliveGetBearerToken(string $username, string $password): ?string
+{
+    if (isset($GLOBALS['dyaconliveTestBearerToken'])
+        && is_string($GLOBALS['dyaconliveTestBearerToken'])
+        && $GLOBALS['dyaconliveTestBearerToken'] !== ''
+    ) {
+        return $GLOBALS['dyaconliveTestBearerToken'];
+    }
+
+    $username = trim($username);
+    if ($username === '' || $password === '') {
+        aviationwx_log('error', 'dyaconlive auth: missing credentials', [], 'app');
+        return null;
+    }
+
+    $cacheKey = 'dyaconlive_token_' . md5($username);
+    if (function_exists('apcu_fetch')) {
+        $cached = @apcu_fetch($cacheKey);
+        if ($cached !== false && is_array($cached)) {
+            $token = $cached['token'] ?? null;
+            $expiresAt = $cached['expires_at'] ?? 0;
+            if (is_string($token) && $token !== '' && $expiresAt > (time() + DYACONLIVE_TOKEN_EXPIRY_BUFFER)) {
+                return $token;
+            }
+        }
+    }
+
+    $url = rtrim(DYACONLIVE_API_BASE_URL, '/') . '/token';
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_POST => true,
+        CURLOPT_POSTFIELDS => http_build_query([
+            'username' => $username,
+            'password' => $password,
+            'grant_type' => 'password',
+        ]),
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT => 15,
+        CURLOPT_CONNECTTIMEOUT => 10,
+        CURLOPT_HTTPHEADER => [
+            'Content-Type: application/x-www-form-urlencoded',
+            'Accept: application/json',
+        ],
+    ]);
+
+    $response = curl_exec($ch);
+    $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $curlError = curl_error($ch);
+
+    if ($httpCode !== 200 || !is_string($response)) {
+        aviationwx_log('error', 'dyaconlive auth: token request failed', [
+            'http_code' => $httpCode,
+            'error' => $curlError !== '' ? $curlError : null,
+        ], 'app');
+        return null;
+    }
+
+    $data = json_decode($response, true);
+    if (!is_array($data) || empty($data['access_token']) || !is_string($data['access_token'])) {
+        aviationwx_log('error', 'dyaconlive auth: invalid token response', [
+            'http_code' => $httpCode,
+        ], 'app');
+        return null;
+    }
+
+    $token = $data['access_token'];
+    $expiresIn = dyaconliveTokenExpiresInSeconds($token, $data);
+    $expiresAt = time() + $expiresIn;
+
+    if (function_exists('apcu_store')) {
+        @apcu_store($cacheKey, [
+            'token' => $token,
+            'expires_at' => $expiresAt,
+        ], $expiresIn);
+    }
+
+    return $token;
+}
+
+/**
+ * @param array<string, mixed> $tokenBody Decoded /token JSON
+ */
+function dyaconliveTokenExpiresInSeconds(string $accessToken, array $tokenBody): int
+{
+    if (isset($tokenBody['expires_in']) && is_numeric($tokenBody['expires_in'])) {
+        return max(60, (int) $tokenBody['expires_in']);
+    }
+
+    $parts = explode('.', $accessToken);
+    if (count($parts) >= 2) {
+        $payloadJson = base64_decode(strtr($parts[1], '-_', '+/'), true);
+        if (is_string($payloadJson)) {
+            $payload = json_decode($payloadJson, true);
+            if (is_array($payload) && isset($payload['exp']) && is_numeric($payload['exp'])) {
+                $ttl = (int) $payload['exp'] - time();
+                if ($ttl > 60) {
+                    return $ttl;
+                }
+            }
+        }
+    }
+
+    return DYACONLIVE_TOKEN_DEFAULT_TTL_SECONDS;
+}
+
+/**
+ * Drop cached bearer token so the next request fetches a new one (e.g. after HTTP 401).
+ */
+function dyaconliveInvalidateBearerTokenCache(string $username): void
+{
+    $username = trim($username);
+    if ($username === '') {
+        return;
+    }
+
+    $cacheKey = 'dyaconlive_token_' . md5($username);
+    if (function_exists('apcu_delete')) {
+        @apcu_delete($cacheKey);
+    }
+}
+
+/**
+ * Cache key fingerprint for tests.
+ */
+function dyaconliveBearerTokenCacheKey(string $username): string
+{
+    return 'dyaconlive_token_' . md5(trim($username));
+}

--- a/lib/weather/dyaconlive-auth.php
+++ b/lib/weather/dyaconlive-auth.php
@@ -55,6 +55,11 @@ function dyaconliveGetBearerToken(string $username, string $password): ?string
     }
 
     $ch = curl_init($url);
+    if ($ch === false) {
+        aviationwx_log('error', 'dyaconlive auth: curl_init failed', [], 'app');
+        return null;
+    }
+
     curl_setopt_array($ch, [
         CURLOPT_POST => true,
         CURLOPT_POSTFIELDS => http_build_query([
@@ -74,6 +79,7 @@ function dyaconliveGetBearerToken(string $username, string $password): ?string
     $response = curl_exec($ch);
     $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
     $curlError = curl_error($ch);
+    curl_close($ch);
 
     if ($httpCode !== 200 || !is_string($response)) {
         aviationwx_log('error', 'dyaconlive auth: token request failed', [

--- a/lib/weather/dyaconlive-auth.php
+++ b/lib/weather/dyaconlive-auth.php
@@ -42,7 +42,7 @@ function dyaconliveGetBearerToken(string $username, string $password): ?string
         }
     }
 
-    $cacheKey = 'dyaconlive_token_' . md5($username);
+    $cacheKey = dyaconliveBearerTokenCacheKey($username);
     if (function_exists('apcu_fetch')) {
         $cached = @apcu_fetch($cacheKey);
         if ($cached !== false && is_array($cached)) {
@@ -54,7 +54,6 @@ function dyaconliveGetBearerToken(string $username, string $password): ?string
         }
     }
 
-    $url = rtrim(DYACONLIVE_API_BASE_URL, '/') . '/token';
     $ch = curl_init($url);
     curl_setopt_array($ch, [
         CURLOPT_POST => true,
@@ -142,14 +141,14 @@ function dyaconliveInvalidateBearerTokenCache(string $username): void
         return;
     }
 
-    $cacheKey = 'dyaconlive_token_' . md5($username);
+    $cacheKey = dyaconliveBearerTokenCacheKey($username);
     if (function_exists('apcu_delete')) {
         @apcu_delete($cacheKey);
     }
 }
 
 /**
- * Cache key fingerprint for tests.
+ * APCu cache key for a DyaconLive username.
  */
 function dyaconliveBearerTokenCacheKey(string $username): string
 {

--- a/lib/weather/dyaconlive-auth.php
+++ b/lib/weather/dyaconlive-auth.php
@@ -5,6 +5,7 @@
 
 require_once __DIR__ . '/../constants.php';
 require_once __DIR__ . '/../logger.php';
+require_once __DIR__ . '/../test-mocks.php';
 
 /**
  * Obtain bearer token for DyaconLive API (APCu-cached per username).
@@ -26,6 +27,19 @@ function dyaconliveGetBearerToken(string $username, string $password): ?string
     if ($username === '' || $password === '') {
         aviationwx_log('error', 'dyaconlive auth: missing credentials', [], 'app');
         return null;
+    }
+
+    $url = rtrim(DYACONLIVE_API_BASE_URL, '/') . '/token';
+    if (function_exists('isTestMode') && isTestMode() && function_exists('getMockHttpResponse')
+        && !isset($GLOBALS['dyaconliveTestBearerToken'])
+    ) {
+        $mockBody = getMockHttpResponse($url);
+        if (is_string($mockBody) && $mockBody !== '') {
+            $data = json_decode($mockBody, true);
+            if (is_array($data) && !empty($data['access_token']) && is_string($data['access_token'])) {
+                return $data['access_token'];
+            }
+        }
     }
 
     $cacheKey = 'dyaconlive_token_' . md5($username);

--- a/lib/weather/dyaconlive-bucket.php
+++ b/lib/weather/dyaconlive-bucket.php
@@ -15,8 +15,11 @@ require_once __DIR__ . '/../constants.php';
  * @param int $intervalMinutes Report interval (default 10)
  * @return int Bucket start as Unix timestamp (UTC)
  */
-function dyaconliveFloorToBucketUnix(int $nowUnix, string $timezone, int $intervalMinutes = 10): int
-{
+function dyaconliveFloorToBucketUnix(
+    int $nowUnix,
+    string $timezone,
+    int $intervalMinutes = DYACONLIVE_REPORT_INTERVAL_MINUTES
+): int {
     $intervalMinutes = max(1, $intervalMinutes);
     try {
         $dt = (new DateTimeImmutable('@' . $nowUnix))->setTimezone(new DateTimeZone($timezone));
@@ -43,7 +46,7 @@ function dyaconliveFloorToBucketUnix(int $nowUnix, string $timezone, int $interv
 function dyaconliveExpectedLatestBucketUnix(
     int $nowUnix,
     string $timezone,
-    int $intervalMinutes = 10,
+    int $intervalMinutes = DYACONLIVE_REPORT_INTERVAL_MINUTES,
     int $graceSeconds = DYACONLIVE_BUCKET_GRACE_SECONDS
 ): int {
     $intervalSeconds = max(60, $intervalMinutes * 60);

--- a/lib/weather/dyaconlive-bucket.php
+++ b/lib/weather/dyaconlive-bucket.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * DyaconLive 10-minute bucket schedule helpers.
+ *
+ * KAOC probing confirmed reports align to wall-clock :00/:10/... boundaries in station timezone.
+ */
+
+require_once __DIR__ . '/../constants.php';
+
+/**
+ * Floor a Unix timestamp to the start of its 10-minute bucket in the given timezone.
+ *
+ * @param int $nowUnix Current time (UTC unix)
+ * @param string $timezone IANA timezone (e.g. America/Boise)
+ * @param int $intervalMinutes Report interval (default 10)
+ * @return int Bucket start as Unix timestamp (UTC)
+ */
+function dyaconliveFloorToBucketUnix(int $nowUnix, string $timezone, int $intervalMinutes = 10): int
+{
+    $intervalMinutes = max(1, $intervalMinutes);
+    try {
+        $dt = (new DateTimeImmutable('@' . $nowUnix))->setTimezone(new DateTimeZone($timezone));
+    } catch (Exception $e) {
+        $dt = new DateTimeImmutable('@' . $nowUnix);
+    }
+
+    $minute = (int) $dt->format('i');
+    $flooredMinute = (int) (floor($minute / $intervalMinutes) * $intervalMinutes);
+    $bucketLocal = $dt->setTime((int) $dt->format('H'), $flooredMinute, 0);
+
+    return $bucketLocal->getTimestamp();
+}
+
+/**
+ * Latest bucket we expect DyaconLive to have published by now (grace after boundary).
+ *
+ * @param int $nowUnix Current time (UTC unix)
+ * @param string $timezone IANA timezone
+ * @param int $intervalMinutes Report interval minutes
+ * @param int $graceSeconds Wait after bucket boundary before expecting that bucket
+ * @return int Expected latest complete bucket Unix timestamp
+ */
+function dyaconliveExpectedLatestBucketUnix(
+    int $nowUnix,
+    string $timezone,
+    int $intervalMinutes = 10,
+    int $graceSeconds = DYACONLIVE_BUCKET_GRACE_SECONDS
+): int {
+    $intervalSeconds = max(60, $intervalMinutes * 60);
+    $currentBoundary = dyaconliveFloorToBucketUnix($nowUnix, $timezone, $intervalMinutes);
+    if ($nowUnix < $currentBoundary + $graceSeconds) {
+        return $currentBoundary - $intervalSeconds;
+    }
+
+    return $currentBoundary;
+}
+
+/**
+ * Whether upstream HTTP can be skipped (local state already has expected bucket).
+ *
+ * @param int|null $lastBucketUnix Last ingested bucket from state file
+ * @param int $nowUnix Current time
+ * @param string $timezone Station timezone
+ * @return bool True when cached state is current enough
+ */
+function dyaconliveShouldSkipUpstreamFetch(?int $lastBucketUnix, int $nowUnix, string $timezone): bool
+{
+    if ($lastBucketUnix === null || $lastBucketUnix <= 0) {
+        return false;
+    }
+
+    $expected = dyaconliveExpectedLatestBucketUnix($nowUnix, $timezone);
+
+    return $lastBucketUnix >= $expected;
+}
+
+/**
+ * Parse Dyacon API datetime string (no offset) in station timezone to Unix UTC.
+ *
+ * @param string $iso Local datetime from API (e.g. 2026-07-07T09:40:00)
+ * @param string $timezone IANA timezone
+ * @return int|null Unix timestamp or null on parse failure
+ */
+function dyaconliveParseBucketIsoToUnix(string $iso, string $timezone): ?int
+{
+    $iso = trim($iso);
+    if ($iso === '') {
+        return null;
+    }
+
+    try {
+        $dt = new DateTimeImmutable($iso, new DateTimeZone($timezone));
+    } catch (Exception $e) {
+        return null;
+    }
+
+    return $dt->getTimestamp();
+}

--- a/lib/weather/dyaconlive-fetch.php
+++ b/lib/weather/dyaconlive-fetch.php
@@ -78,14 +78,20 @@ function dyaconliveHttpGet(string $url, string $token): array
     };
 
     $ch = curl_init($url);
+    if ($ch === false) {
+        return [
+            'body' => null,
+            'http_code' => null,
+            'response_headers' => [],
+        ];
+    }
+
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT => defined('CURL_TIMEOUT') ? CURL_TIMEOUT : 30,
         CURLOPT_CONNECTTIMEOUT => 10,
         CURLOPT_USERAGENT => 'AviationWX/2.0',
         CURLOPT_FAILONERROR => false,
-        CURLOPT_FOLLOWLOCATION => true,
-        CURLOPT_MAXREDIRS => 3,
         CURLOPT_HTTPHEADER => [
             'Accept: application/json',
             'Authorization: Bearer ' . $token,
@@ -95,6 +101,7 @@ function dyaconliveHttpGet(string $url, string $token): array
 
     $body = curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
 
     return [
         'body' => is_string($body) ? $body : null,

--- a/lib/weather/dyaconlive-fetch.php
+++ b/lib/weather/dyaconlive-fetch.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * DyaconLive HTTP fetch (token auth, 401 refresh-and-retry).
+ */
+
+require_once __DIR__ . '/../constants.php';
+require_once __DIR__ . '/../circuit-breaker.php';
+require_once __DIR__ . '/../logger.php';
+require_once __DIR__ . '/../test-mocks.php';
+require_once __DIR__ . '/adapter/dyaconlive-v1.php';
+require_once __DIR__ . '/dyaconlive-auth.php';
+require_once __DIR__ . '/dyaconlive-state.php';
+
+/**
+ * Fetch DyaconLive /data response body for a configured source.
+ *
+ * @param array<string, mixed> $source weather_sources entry
+ * @param array<string, mixed> $airport Airport config
+ * @return array{body: string|null, http_code: int|null, response_headers: array<string, string>}
+ */
+function dyaconliveFetchDataResponse(array $source, array $airport): array
+{
+    $url = DyaconLiveAdapter::buildUrl($source, dyaconliveResolveTimezone($source, $airport));
+    if ($url === null) {
+        return ['body' => null, 'http_code' => null, 'response_headers' => []];
+    }
+
+    if (function_exists('isTestMode') && isTestMode() && function_exists('getMockHttpResponse')
+        && !isset($GLOBALS['dyaconliveTestHttpGetCallback'])
+    ) {
+        $mockBody = getMockHttpResponse($url);
+        if (is_string($mockBody) && $mockBody !== '') {
+            return ['body' => $mockBody, 'http_code' => 200, 'response_headers' => []];
+        }
+    }
+
+    $username = isset($source['username']) && is_string($source['username']) ? trim($source['username']) : '';
+    $password = isset($source['password']) && is_string($source['password']) ? $source['password'] : '';
+    if ($username === '' || $password === '') {
+        return ['body' => null, 'http_code' => null, 'response_headers' => []];
+    }
+
+    for ($attempt = 0; $attempt < 2; $attempt++) {
+        $token = dyaconliveGetBearerToken($username, $password);
+        if ($token === null) {
+            return ['body' => null, 'http_code' => null, 'response_headers' => []];
+        }
+
+        $result = dyaconliveHttpGet($url, $token);
+        $httpCode = $result['http_code'];
+        if ($httpCode !== 401 || $attempt === 1) {
+            return $result;
+        }
+
+        aviationwx_log('info', 'dyaconlive data 401: refreshing token and retrying', [
+            'station_id' => $source['station_id'] ?? null,
+        ], 'app');
+        dyaconliveInvalidateBearerTokenCache($username);
+    }
+
+    return ['body' => null, 'http_code' => null, 'response_headers' => []];
+}
+
+/**
+ * @return array{body: string|false|null, http_code: int|null, response_headers: array<string, string>}
+ */
+function dyaconliveHttpGet(string $url, string $token): array
+{
+    if (isset($GLOBALS['dyaconliveTestHttpGetCallback'])
+        && is_callable($GLOBALS['dyaconliveTestHttpGetCallback'])
+    ) {
+        return $GLOBALS['dyaconliveTestHttpGetCallback']($url, $token);
+    }
+
+    $responseHeaders = [];
+    $headerCollector = function ($ch, string $line) use (&$responseHeaders): int {
+        return circuitBreakerCollectCurlHeaderLine($responseHeaders, $line);
+    };
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT => defined('CURL_TIMEOUT') ? CURL_TIMEOUT : 30,
+        CURLOPT_CONNECTTIMEOUT => 10,
+        CURLOPT_USERAGENT => 'AviationWX/2.0',
+        CURLOPT_FAILONERROR => false,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_MAXREDIRS => 3,
+        CURLOPT_HTTPHEADER => [
+            'Accept: application/json',
+            'Authorization: Bearer ' . $token,
+        ],
+        CURLOPT_HEADERFUNCTION => $headerCollector,
+    ]);
+
+    $body = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+    return [
+        'body' => is_string($body) ? $body : null,
+        'http_code' => is_int($httpCode) ? $httpCode : null,
+        'response_headers' => $responseHeaders,
+    ];
+}

--- a/lib/weather/dyaconlive-state.php
+++ b/lib/weather/dyaconlive-state.php
@@ -135,9 +135,13 @@ function dyaconliveSnapshotFromStateArray(array $data): ?WeatherSnapshot
     $source = DyaconLiveAdapter::SOURCE_TYPE;
     $obsTime = isset($data['obs_time']) ? (int) $data['obs_time'] : time();
     $fetchTime = isset($data['fetch_time']) ? (int) $data['fetch_time'] : time();
-    $hasWind = isset($data['wind_speed_kt'], $data['wind_direction'])
-        && $data['wind_speed_kt'] !== null
-        && $data['wind_direction'] !== null;
+    $windSpeedKt = isset($data['wind_speed_kt']) && is_numeric($data['wind_speed_kt'])
+        ? (float) $data['wind_speed_kt']
+        : null;
+    $windDirection = isset($data['wind_direction']) && is_numeric($data['wind_direction'])
+        ? (float) $data['wind_direction']
+        : null;
+    $hasWind = $windSpeedKt !== null && $windDirection !== null;
 
     return new WeatherSnapshot(
         source: $source,
@@ -165,9 +169,11 @@ function dyaconliveSnapshotFromStateArray(array $data): ?WeatherSnapshot
         ),
         wind: $hasWind
             ? WindGroup::from(
-                (float) $data['wind_speed_kt'],
-                $data['wind_direction'],
-                isset($data['gust_speed_kt']) ? (float) $data['gust_speed_kt'] : null,
+                $windSpeedKt,
+                $windDirection,
+                isset($data['gust_speed_kt']) && is_numeric($data['gust_speed_kt'])
+                    ? (float) $data['gust_speed_kt']
+                    : null,
                 $source,
                 $obsTime
             )

--- a/lib/weather/dyaconlive-state.php
+++ b/lib/weather/dyaconlive-state.php
@@ -78,7 +78,17 @@ function dyaconliveWriteSourceState(
         'written_at' => time(),
     ];
 
-    $json = json_encode($payload, JSON_THROW_ON_ERROR);
+    try {
+        $json = json_encode($payload, JSON_THROW_ON_ERROR);
+    } catch (JsonException $e) {
+        aviationwx_log('error', 'dyaconlive state encode failed', [
+            'path' => $path,
+            'error' => $e->getMessage(),
+        ], 'app');
+
+        return false;
+    }
+
     $tmp = $path . '.tmp.' . getmypid();
     if (@file_put_contents($tmp, $json, LOCK_EX) === false) {
         return false;

--- a/lib/weather/dyaconlive-state.php
+++ b/lib/weather/dyaconlive-state.php
@@ -91,6 +91,7 @@ function dyaconliveWriteSourceState(
 
     $tmp = $path . '.tmp.' . getmypid();
     if (@file_put_contents($tmp, $json, LOCK_EX) === false) {
+        @unlink($tmp);
         return false;
     }
 

--- a/lib/weather/dyaconlive-state.php
+++ b/lib/weather/dyaconlive-state.php
@@ -5,6 +5,7 @@
 
 require_once __DIR__ . '/../cache-paths.php';
 require_once __DIR__ . '/../logger.php';
+require_once __DIR__ . '/utils.php';
 require_once __DIR__ . '/data/WeatherReading.php';
 require_once __DIR__ . '/data/WindGroup.php';
 require_once __DIR__ . '/data/WeatherSnapshot.php';
@@ -205,7 +206,6 @@ function dyaconliveResolveSkippedSnapshot(
     int $sourceIndex
 ): ?WeatherSnapshot {
     require_once __DIR__ . '/dyaconlive-bucket.php';
-    require_once __DIR__ . '/../config.php';
 
     $timezone = dyaconliveResolveTimezone($source, $airport);
     $statePath = getDyaconLiveSourceStatePath($airportId, $sourceIndex);

--- a/lib/weather/dyaconlive-state.php
+++ b/lib/weather/dyaconlive-state.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * DyaconLive per-source state (last ingested bucket + cached snapshot for skip path).
+ */
+
+require_once __DIR__ . '/../cache-paths.php';
+require_once __DIR__ . '/../logger.php';
+require_once __DIR__ . '/data/WeatherReading.php';
+require_once __DIR__ . '/data/WindGroup.php';
+require_once __DIR__ . '/data/WeatherSnapshot.php';
+require_once __DIR__ . '/adapter/dyaconlive-v1.php';
+
+use AviationWX\Weather\Data\WeatherReading;
+use AviationWX\Weather\Data\WindGroup;
+use AviationWX\Weather\Data\WeatherSnapshot;
+
+/**
+ * Default state file path for an airport weather_sources index.
+ *
+ * @param string $airportId Airport identifier
+ * @param int $sourceIndex Index in weather_sources[]
+ * @return string Absolute path
+ */
+function getDyaconLiveSourceStatePath(string $airportId, int $sourceIndex): string
+{
+    if (isset($GLOBALS['dyaconliveTestStateDir'])
+        && is_string($GLOBALS['dyaconliveTestStateDir'])
+        && $GLOBALS['dyaconliveTestStateDir'] !== ''
+    ) {
+        return rtrim($GLOBALS['dyaconliveTestStateDir'], '/') . '/'
+            . strtolower($airportId) . '_' . $sourceIndex . '.json';
+    }
+
+    return CACHE_WEATHER_DIR . '/dyaconlive/' . strtolower($airportId) . '_' . $sourceIndex . '.json';
+}
+
+/**
+ * @return array{last_bucket_unix: int, last_bucket_iso: string, snapshot: array<string, mixed>}|null
+ */
+function dyaconliveReadSourceState(string $path): ?array
+{
+    if (!is_file($path)) {
+        return null;
+    }
+
+    $raw = @file_get_contents($path);
+    if ($raw === false || $raw === '') {
+        return null;
+    }
+
+    $data = json_decode($raw, true);
+    if (!is_array($data) || !isset($data['last_bucket_unix'], $data['snapshot']) || !is_array($data['snapshot'])) {
+        return null;
+    }
+
+    return $data;
+}
+
+/**
+ * @param WeatherSnapshot $snapshot Parsed snapshot to cache for skip reuse
+ */
+function dyaconliveWriteSourceState(
+    string $path,
+    int $lastBucketUnix,
+    string $lastBucketIso,
+    WeatherSnapshot $snapshot
+): bool {
+    $dir = dirname($path);
+    if (!is_dir($dir) && !@mkdir($dir, 0755, true) && !is_dir($dir)) {
+        aviationwx_log('error', 'dyaconlive state mkdir failed', ['dir' => $dir], 'app');
+        return false;
+    }
+
+    $payload = [
+        'last_bucket_unix' => $lastBucketUnix,
+        'last_bucket_iso' => $lastBucketIso,
+        'snapshot' => dyaconliveSnapshotToStateArray($snapshot),
+        'written_at' => time(),
+    ];
+
+    $json = json_encode($payload, JSON_THROW_ON_ERROR);
+    $tmp = $path . '.tmp.' . getmypid();
+    if (@file_put_contents($tmp, $json, LOCK_EX) === false) {
+        return false;
+    }
+
+    if (!@rename($tmp, $path)) {
+        @unlink($tmp);
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function dyaconliveSnapshotToStateArray(WeatherSnapshot $snapshot): array
+{
+    $obsTime = $snapshot->getFieldObservationTime('temperature')
+        ?? $snapshot->getFieldObservationTime('wind_speed')
+        ?? time();
+
+    return [
+        'is_valid' => $snapshot->isValid,
+        'obs_time' => $obsTime,
+        'fetch_time' => $snapshot->fetchTime,
+        'temperature_c' => $snapshot->temperature->value,
+        'humidity' => $snapshot->humidity->value,
+        'pressure_inhg' => $snapshot->pressure->value,
+        'precip_accum_in' => $snapshot->precipAccum->value,
+        'wind_speed_kt' => $snapshot->wind->speed->value,
+        'wind_direction' => $snapshot->wind->direction->value,
+        'gust_speed_kt' => $snapshot->wind->gust->value,
+        'station_id' => $snapshot->stationId,
+    ];
+}
+
+function dyaconliveSnapshotFromStateArray(array $data): ?WeatherSnapshot
+{
+    if (empty($data['is_valid'])) {
+        return WeatherSnapshot::empty(DyaconLiveAdapter::SOURCE_TYPE);
+    }
+
+    $source = DyaconLiveAdapter::SOURCE_TYPE;
+    $obsTime = isset($data['obs_time']) ? (int) $data['obs_time'] : time();
+    $fetchTime = isset($data['fetch_time']) ? (int) $data['fetch_time'] : time();
+    $hasWind = isset($data['wind_speed_kt'], $data['wind_direction'])
+        && $data['wind_speed_kt'] !== null
+        && $data['wind_direction'] !== null;
+
+    return new WeatherSnapshot(
+        source: $source,
+        fetchTime: $fetchTime,
+        temperature: WeatherReading::celsius(
+            isset($data['temperature_c']) ? (float) $data['temperature_c'] : null,
+            $source,
+            $obsTime
+        ),
+        dewpoint: WeatherReading::null($source),
+        humidity: WeatherReading::percent(
+            isset($data['humidity']) ? (float) $data['humidity'] : null,
+            $source,
+            $obsTime
+        ),
+        pressure: WeatherReading::inHg(
+            isset($data['pressure_inhg']) ? (float) $data['pressure_inhg'] : null,
+            $source,
+            $obsTime
+        ),
+        precipAccum: WeatherReading::inches(
+            isset($data['precip_accum_in']) ? (float) $data['precip_accum_in'] : null,
+            $source,
+            $obsTime
+        ),
+        wind: $hasWind
+            ? WindGroup::from(
+                (float) $data['wind_speed_kt'],
+                $data['wind_direction'],
+                isset($data['gust_speed_kt']) ? (float) $data['gust_speed_kt'] : null,
+                $source,
+                $obsTime
+            )
+            : WindGroup::empty(),
+        visibility: WeatherReading::null($source),
+        ceiling: WeatherReading::null($source),
+        cloudCover: WeatherReading::null($source),
+        rawMetar: null,
+        isValid: true,
+        metarStationId: null,
+        stationId: isset($data['station_id']) ? (string) $data['station_id'] : null,
+        metarFieldCompleteness: null
+    );
+}
+
+/**
+ * Resolve cached snapshot for skip path, if state is current.
+ *
+ * @param array<string, mixed> $source weather_sources entry
+ * @param array<string, mixed> $airport Airport config
+ * @param int $sourceIndex Index in weather_sources
+ * @return WeatherSnapshot|null Snapshot to reuse, or null when fetch is required
+ */
+function dyaconliveResolveSkippedSnapshot(
+    string $airportId,
+    array $source,
+    array $airport,
+    int $sourceIndex
+): ?WeatherSnapshot {
+    require_once __DIR__ . '/dyaconlive-bucket.php';
+    require_once __DIR__ . '/../config.php';
+
+    $timezone = dyaconliveResolveTimezone($source, $airport);
+    $statePath = getDyaconLiveSourceStatePath($airportId, $sourceIndex);
+    $state = dyaconliveReadSourceState($statePath);
+    if ($state === null) {
+        return null;
+    }
+
+    $nowUnix = dyaconliveCurrentUnixTime();
+    $lastBucket = isset($state['last_bucket_unix']) ? (int) $state['last_bucket_unix'] : null;
+    if (!dyaconliveShouldSkipUpstreamFetch($lastBucket, $nowUnix, $timezone)) {
+        return null;
+    }
+
+    $snapshot = dyaconliveSnapshotFromStateArray($state['snapshot']);
+    if ($snapshot === null || !$snapshot->isValid) {
+        return null;
+    }
+
+    aviationwx_log('info', 'dyaconlive upstream skip', [
+        'airport_id' => $airportId,
+        'last_bucket_iso' => $state['last_bucket_iso'] ?? null,
+        'station_id' => $source['station_id'] ?? null,
+    ], 'app');
+
+    return $snapshot;
+}
+
+/**
+ * @param array<string, mixed> $source
+ * @param array<string, mixed> $airport
+ */
+function dyaconliveResolveTimezone(array $source, array $airport): string
+{
+    if (isset($source['timezone']) && is_string($source['timezone']) && trim($source['timezone']) !== '') {
+        return trim($source['timezone']);
+    }
+
+    return getAirportTimezone($airport);
+}
+
+/**
+ * Persist state after a successful fetch/parse.
+ *
+ * @param array<string, mixed> $source
+ * @param array<string, mixed> $airport
+ */
+function dyaconlivePersistSourceStateAfterParse(
+    string $airportId,
+    array $source,
+    array $airport,
+    int $sourceIndex,
+    WeatherSnapshot $snapshot,
+    string $lastBucketIso
+): void {
+    $timezone = dyaconliveResolveTimezone($source, $airport);
+    $bucketUnix = dyaconliveParseBucketIsoToUnix($lastBucketIso, $timezone);
+    if ($bucketUnix === null || !$snapshot->isValid) {
+        return;
+    }
+
+    dyaconliveWriteSourceState(
+        getDyaconLiveSourceStatePath($airportId, $sourceIndex),
+        $bucketUnix,
+        $lastBucketIso,
+        $snapshot
+    );
+}
+
+/**
+ * Current Unix time (override in tests via $GLOBALS['dyaconliveTestNowUnix']).
+ */
+function dyaconliveCurrentUnixTime(): int
+{
+    if (isset($GLOBALS['dyaconliveTestNowUnix']) && is_int($GLOBALS['dyaconliveTestNowUnix'])) {
+        return $GLOBALS['dyaconliveTestNowUnix'];
+    }
+
+    return time();
+}

--- a/lib/weather/dyaconlive-state.php
+++ b/lib/weather/dyaconlive-state.php
@@ -218,7 +218,7 @@ function dyaconliveResolveSkippedSnapshot(
         return null;
     }
 
-    aviationwx_log('info', 'dyaconlive upstream skip', [
+    aviationwx_log('debug', 'dyaconlive upstream skip', [
         'airport_id' => $airportId,
         'last_bucket_iso' => $state['last_bucket_iso'] ?? null,
         'station_id' => $source['station_id'] ?? null,

--- a/lib/weather/utils.php
+++ b/lib/weather/utils.php
@@ -408,6 +408,11 @@ function getWeatherSourceInfo(string $sourceType): ?array {
                 'name' => 'Nav Canada Weather',
                 'url' => 'https://www.navcanada.ca/'
             ];
+        case 'dyaconlive':
+            return [
+                'name' => 'DyaconLive',
+                'url' => 'https://dyacon.net/'
+            ];
         default:
             return null;
     }

--- a/tests/Fixtures/airports.json.test
+++ b/tests/Fixtures/airports.json.test
@@ -294,6 +294,29 @@
           "station_id": "KSPFX"
         }
       ]
+    },
+    "kaoc": {
+      "name": "Afton Municipal Airport",
+      "enabled": true,
+      "maintenance": false,
+      "icao": "KAOC",
+      "iata": null,
+      "faa": "AOC",
+      "address": "Afton, Wyoming",
+      "lat": 42.7111,
+      "lon": -110.9422,
+      "elevation_ft": 5335,
+      "timezone": "America/Boise",
+      "access_type": "public",
+      "tower_status": "non_towered",
+      "weather_sources": [
+        {
+          "type": "dyaconlive",
+          "station_id": 130114,
+          "username": "test_dyaconlive_user_demo",
+          "password": "test_dyaconlive_password_demo"
+        }
+      ]
     }
   }
 }

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -2066,6 +2066,32 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('invalid \'station_id\'', implode(' ', $result['errors']));
     }
 
+    public function testWeatherSource_DyaconliveMissingElevationFt_WarnsButRemainsValid()
+    {
+        $config = [
+            'airports' => [
+                'kaoc' => [
+                    'name' => 'Test Airport',
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'weather_sources' => [[
+                        'type' => 'dyaconlive',
+                        'station_id' => 130114,
+                        'username' => 'user@example.com',
+                        'password' => 'secret',
+                    ]]
+                ]
+            ]
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid']);
+        $this->assertNotEmpty($result['warnings'] ?? []);
+        $this->assertStringContainsString('elevation_ft', implode(' ', $result['warnings']));
+    }
+
     public function testWeatherSource_ValidMetar()
     {
         $config = [

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -1993,6 +1993,79 @@ class ConfigValidationTest extends TestCase
         $this->assertTrue($result['valid'], 'Valid pwsweather weather source should pass validation');
     }
 
+    public function testWeatherSource_ValidDyaconlive()
+    {
+        $config = [
+            'airports' => [
+                'kaoc' => [
+                    'name' => 'Test Airport',
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'weather_sources' => [[
+                        'type' => 'dyaconlive',
+                        'station_id' => 130114,
+                        'username' => 'user@example.com',
+                        'password' => 'secret',
+                    ]]
+                ]
+            ]
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], 'Valid dyaconlive weather source should pass validation');
+    }
+
+    public function testWeatherSource_DyaconliveMissingPassword_Invalid()
+    {
+        $config = [
+            'airports' => [
+                'kaoc' => [
+                    'name' => 'Test Airport',
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'weather_sources' => [[
+                        'type' => 'dyaconlive',
+                        'station_id' => 130114,
+                        'username' => 'user@example.com',
+                    ]]
+                ]
+            ]
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString("dyaconlive) missing 'password'", implode(' ', $result['errors']));
+    }
+
+    public function testWeatherSource_DyaconliveInvalidStationId_Invalid()
+    {
+        $config = [
+            'airports' => [
+                'kaoc' => [
+                    'name' => 'Test Airport',
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'weather_sources' => [[
+                        'type' => 'dyaconlive',
+                        'station_id' => 'not-numeric',
+                        'username' => 'user@example.com',
+                        'password' => 'secret',
+                    ]]
+                ]
+            ]
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('invalid \'station_id\'', implode(' ', $result['errors']));
+    }
+
     public function testWeatherSource_ValidMetar()
     {
         $config = [

--- a/tests/Unit/DyaconLiveAdapterTest.php
+++ b/tests/Unit/DyaconLiveAdapterTest.php
@@ -45,6 +45,21 @@ class DyaconLiveAdapterTest extends TestCase
         $this->assertStringContainsString('variable=wind10m_speed%7Cmph', $url);
     }
 
+    public function testBuildUrl_ValidConfig_IncludesYesterdayAndTodayDateRange(): void
+    {
+        $url = DyaconLiveAdapter::buildUrl([
+            'station_id' => 130114,
+            'username' => 'user',
+            'password' => 'pass',
+        ], 'America/Boise');
+        $this->assertNotNull($url);
+        $tz = new DateTimeZone('America/Boise');
+        $today = (new DateTimeImmutable('now', $tz))->format('Y-m-d');
+        $yesterday = (new DateTimeImmutable('now', $tz))->modify('-1 day')->format('Y-m-d');
+        $this->assertStringContainsString('startdate=' . rawurlencode($yesterday), $url);
+        $this->assertStringContainsString('enddate=' . rawurlencode($today), $url);
+    }
+
     public function testParseToSnapshot_MockResponse_MapsFieldsAndObservationTime(): void
     {
         $response = getMockDyaconLiveDataResponse();

--- a/tests/Unit/DyaconLiveAdapterTest.php
+++ b/tests/Unit/DyaconLiveAdapterTest.php
@@ -121,6 +121,13 @@ class DyaconLiveAdapterTest extends TestCase
         $this->assertFalse($snapshot->isValid);
     }
 
+    public function testExtractLastBucketIso_InvalidJson_ReturnsNull(): void
+    {
+        $this->assertNull(DyaconLiveAdapter::extractLastBucketIso('not-json', [
+            'timezone' => 'America/Boise',
+        ]));
+    }
+
     public function testParseToSnapshot_InvalidJson_ReturnsNull(): void
     {
         $this->assertNull(DyaconLiveAdapter::parseToSnapshot('not-json', ['station_id' => 1]));

--- a/tests/Unit/DyaconLiveAdapterTest.php
+++ b/tests/Unit/DyaconLiveAdapterTest.php
@@ -135,4 +135,46 @@ class DyaconLiveAdapterTest extends TestCase
         $this->assertNotNull($snapshot);
         $this->assertFalse($snapshot->wind->gust->hasValue());
     }
+
+    public function testParseToSnapshot_MisalignedSeries_UsesAnchorBucketNotTrailingIndex(): void
+    {
+        $response = json_encode([
+            [
+                'variable_name' => 'air_temp',
+                'units' => 'F',
+                'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00'],
+                'values' => [71.0, 72.0],
+                'timezone' => 'America/Boise',
+            ],
+            [
+                'variable_name' => 'humidity',
+                'units' => '%',
+                'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00', '2026-07-07T09:50:00'],
+                'values' => [52.0, 48.0, 99.0],
+                'timezone' => 'America/Boise',
+            ],
+            [
+                'variable_name' => 'wind10m_speed',
+                'units' => 'mph',
+                'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00'],
+                'values' => [3.0, 4.0],
+                'timezone' => 'America/Boise',
+            ],
+            [
+                'variable_name' => 'wind10m_direction',
+                'units' => 'degrees',
+                'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00'],
+                'values' => [180.0, 190.0],
+                'timezone' => 'America/Boise',
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $snapshot = DyaconLiveAdapter::parseToSnapshot($response, [
+            'timezone' => 'America/Boise',
+            'elevation_ft' => 100,
+        ]);
+        $this->assertNotNull($snapshot);
+        $this->assertTrue($snapshot->isValid);
+        $this->assertEqualsWithDelta(48.0, $snapshot->humidity->value, 0.1);
+    }
 }

--- a/tests/Unit/DyaconLiveAdapterTest.php
+++ b/tests/Unit/DyaconLiveAdapterTest.php
@@ -45,6 +45,18 @@ class DyaconLiveAdapterTest extends TestCase
         $this->assertStringContainsString('variable=wind10m_speed%7Cmph', $url);
     }
 
+    public function testBuildUrl_InvalidTimezone_FallsBackToUtcInQueryParam(): void
+    {
+        $url = DyaconLiveAdapter::buildUrl([
+            'station_id' => 130114,
+            'username' => 'user',
+            'password' => 'pass',
+        ], 'Not/A_Real_Timezone');
+        $this->assertNotNull($url);
+        $this->assertStringContainsString('timezone=UTC', $url);
+        $this->assertStringNotContainsString('Not%2FA_Real_Timezone', $url);
+    }
+
     public function testBuildUrl_ValidConfig_IncludesYesterdayAndTodayDateRange(): void
     {
         $url = DyaconLiveAdapter::buildUrl([

--- a/tests/Unit/DyaconLiveAdapterTest.php
+++ b/tests/Unit/DyaconLiveAdapterTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * DyaconLive API adapter tests (safety-critical parsing path).
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/weather/adapter/dyaconlive-v1.php';
+require_once __DIR__ . '/../mock-weather-responses.php';
+
+class DyaconLiveAdapterTest extends TestCase
+{
+    public function testBuildUrl_MissingCredentials_ReturnsNull(): void
+    {
+        $this->assertNull(DyaconLiveAdapter::buildUrl(['station_id' => 130114], 'America/Boise'));
+        $this->assertNull(DyaconLiveAdapter::buildUrl([
+            'username' => 'user',
+            'password' => 'pass',
+        ], 'America/Boise'));
+    }
+
+    public function testBuildUrl_InvalidStationId_ReturnsNull(): void
+    {
+        $config = [
+            'station_id' => 'evil/130114',
+            'username' => 'user',
+            'password' => 'pass',
+        ];
+        $this->assertNull(DyaconLiveAdapter::buildUrl($config, 'America/Boise'));
+    }
+
+    public function testBuildUrl_ValidConfig_ContainsDataEndpointAndVariables(): void
+    {
+        $url = DyaconLiveAdapter::buildUrl([
+            'station_id' => 130114,
+            'username' => 'user',
+            'password' => 'pass',
+        ], 'America/Boise');
+        $this->assertNotNull($url);
+        $this->assertStringContainsString('https://api.dyacon.net/data/130114', $url);
+        $this->assertStringContainsString('timezone=America%2FBoise', $url);
+        $this->assertStringContainsString('variable=air_temp%7CF', $url);
+        $this->assertStringContainsString('variable=wind10m_speed%7Cmph', $url);
+    }
+
+    public function testParseToSnapshot_MockResponse_MapsFieldsAndObservationTime(): void
+    {
+        $response = getMockDyaconLiveDataResponse();
+        $snapshot = DyaconLiveAdapter::parseToSnapshot($response, [
+            'station_id' => 130114,
+            'timezone' => 'America/Boise',
+            'elevation_ft' => 5335,
+        ]);
+        $this->assertNotNull($snapshot);
+        $this->assertTrue($snapshot->isValid);
+        $this->assertTrue($snapshot->temperature->hasValue());
+        $this->assertEqualsWithDelta(22.42, $snapshot->temperature->value, 0.05);
+        $this->assertTrue($snapshot->humidity->hasValue());
+        $this->assertEqualsWithDelta(50.9, $snapshot->humidity->value, 0.1);
+        $this->assertTrue($snapshot->pressure->hasValue());
+        $this->assertGreaterThan(29.5, $snapshot->pressure->value);
+        $this->assertLessThan(30.5, $snapshot->pressure->value);
+        $this->assertTrue($snapshot->wind->speed->hasValue());
+        $this->assertTrue($snapshot->wind->direction->hasValue());
+        $this->assertFalse($snapshot->ceiling->hasValue());
+        $this->assertFalse($snapshot->visibility->hasValue());
+        $obs = $snapshot->getFieldObservationTime('temperature');
+        $this->assertIsInt($obs);
+        $dt = (new DateTimeImmutable('@' . $obs))->setTimezone(new DateTimeZone('America/Boise'));
+        $this->assertSame('2026-07-07 09:40:00', $dt->format('Y-m-d H:i:s'));
+    }
+
+    public function testParseToSnapshot_MissingElevation_PressureNull(): void
+    {
+        $response = getMockDyaconLiveDataResponse();
+        $snapshot = DyaconLiveAdapter::parseToSnapshot($response, [
+            'station_id' => 130114,
+            'timezone' => 'America/Boise',
+        ]);
+        $this->assertNotNull($snapshot);
+        $this->assertTrue($snapshot->isValid);
+        $this->assertFalse($snapshot->pressure->hasValue());
+    }
+
+    public function testParseToSnapshot_EmptySeries_ReturnsInvalidSnapshot(): void
+    {
+        $response = json_encode([
+            ['variable_name' => 'air_temp', 'units' => 'F', 'datetimes' => [], 'values' => [], 'timezone' => 'UTC'],
+        ], JSON_THROW_ON_ERROR);
+        $snapshot = DyaconLiveAdapter::parseToSnapshot($response, ['station_id' => 1]);
+        $this->assertNotNull($snapshot);
+        $this->assertFalse($snapshot->isValid);
+    }
+
+    public function testParseToSnapshot_InvalidJson_ReturnsNull(): void
+    {
+        $this->assertNull(DyaconLiveAdapter::parseToSnapshot('not-json', ['station_id' => 1]));
+    }
+
+    public function testParseToSnapshot_ZeroGust_TreatedAsMissing(): void
+    {
+        $response = json_encode([
+            [
+                'variable_name' => 'air_temp',
+                'units' => 'F',
+                'datetimes' => ['2026-07-07T09:40:00'],
+                'values' => [72.0],
+                'timezone' => 'America/Boise',
+            ],
+            [
+                'variable_name' => 'wind10m_speed',
+                'units' => 'mph',
+                'datetimes' => ['2026-07-07T09:40:00'],
+                'values' => [5.0],
+                'timezone' => 'America/Boise',
+            ],
+            [
+                'variable_name' => 'wind10m_direction',
+                'units' => 'degrees',
+                'datetimes' => ['2026-07-07T09:40:00'],
+                'values' => [180.0],
+                'timezone' => 'America/Boise',
+            ],
+            [
+                'variable_name' => 'wind_gust',
+                'units' => 'mph',
+                'datetimes' => ['2026-07-07T09:40:00'],
+                'values' => [0.0],
+                'timezone' => 'America/Boise',
+            ],
+        ], JSON_THROW_ON_ERROR);
+        $snapshot = DyaconLiveAdapter::parseToSnapshot($response, ['timezone' => 'America/Boise', 'elevation_ft' => 100]);
+        $this->assertNotNull($snapshot);
+        $this->assertFalse($snapshot->wind->gust->hasValue());
+    }
+}

--- a/tests/Unit/DyaconLiveAdapterTest.php
+++ b/tests/Unit/DyaconLiveAdapterTest.php
@@ -211,4 +211,46 @@ class DyaconLiveAdapterTest extends TestCase
         $this->assertTrue($snapshot->isValid);
         $this->assertEqualsWithDelta(48.0, $snapshot->humidity->value, 0.1);
     }
+
+    public function testParseToSnapshot_MissingAnchorBucketInSeries_ReturnsNullForField(): void
+    {
+        $response = json_encode([
+            [
+                'variable_name' => 'air_temp',
+                'units' => 'F',
+                'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00'],
+                'values' => [71.0, 72.0],
+                'timezone' => 'America/Boise',
+            ],
+            [
+                'variable_name' => 'humidity',
+                'units' => '%',
+                'datetimes' => ['2026-07-07T09:20:00', '2026-07-07T09:30:00', '2026-07-07T09:50:00'],
+                'values' => [40.0, 52.0, 99.0],
+                'timezone' => 'America/Boise',
+            ],
+            [
+                'variable_name' => 'wind10m_speed',
+                'units' => 'mph',
+                'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00'],
+                'values' => [3.0, 4.0],
+                'timezone' => 'America/Boise',
+            ],
+            [
+                'variable_name' => 'wind10m_direction',
+                'units' => 'degrees',
+                'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00'],
+                'values' => [180.0, 190.0],
+                'timezone' => 'America/Boise',
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $snapshot = DyaconLiveAdapter::parseToSnapshot($response, [
+            'timezone' => 'America/Boise',
+            'elevation_ft' => 100,
+        ]);
+        $this->assertNotNull($snapshot);
+        $this->assertTrue($snapshot->isValid);
+        $this->assertFalse($snapshot->humidity->hasValue());
+    }
 }

--- a/tests/Unit/DyaconLiveAuthTest.php
+++ b/tests/Unit/DyaconLiveAuthTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * DyaconLive bearer token lifecycle tests.
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/weather/dyaconlive-auth.php';
+
+class DyaconLiveAuthTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['dyaconliveTestBearerToken']);
+        parent::tearDown();
+    }
+
+    public function testTokenExpiresInSeconds_UsesExpiresInWhenPresent(): void
+    {
+        $ttl = dyaconliveTokenExpiresInSeconds('token', ['expires_in' => 900]);
+        $this->assertSame(900, $ttl);
+    }
+
+    public function testTokenExpiresInSeconds_ParsesJwtExp(): void
+    {
+        $exp = time() + 1800;
+        $payload = base64_encode(json_encode(['exp' => $exp], JSON_THROW_ON_ERROR));
+        $token = 'hdr.' . rtrim(strtr($payload, '+/', '-_'), '=') . '.sig';
+        $ttl = dyaconliveTokenExpiresInSeconds($token, []);
+        $this->assertGreaterThan(1700, $ttl);
+        $this->assertLessThanOrEqual(1800, $ttl);
+    }
+
+    public function testTokenExpiresInSeconds_FallsBackToDefault(): void
+    {
+        $ttl = dyaconliveTokenExpiresInSeconds('not-a-jwt', []);
+        $this->assertSame(DYACONLIVE_TOKEN_DEFAULT_TTL_SECONDS, $ttl);
+    }
+
+    public function testGetBearerToken_TestOverride_ReturnsInjectedToken(): void
+    {
+        $GLOBALS['dyaconliveTestBearerToken'] = 'injected-test-token';
+        $this->assertSame('injected-test-token', dyaconliveGetBearerToken('user@example.com', 'secret'));
+    }
+
+    public function testGetBearerToken_MissingCredentials_ReturnsNull(): void
+    {
+        $this->assertNull(dyaconliveGetBearerToken('', 'secret'));
+        $this->assertNull(dyaconliveGetBearerToken('user@example.com', ''));
+    }
+
+    public function testBearerTokenCacheKey_IsStablePerUsername(): void
+    {
+        $this->assertSame(
+            dyaconliveBearerTokenCacheKey('user@example.com'),
+            dyaconliveBearerTokenCacheKey('user@example.com')
+        );
+        $this->assertNotSame(
+            dyaconliveBearerTokenCacheKey('a@example.com'),
+            dyaconliveBearerTokenCacheKey('b@example.com')
+        );
+    }
+}

--- a/tests/Unit/DyaconLiveAuthTest.php
+++ b/tests/Unit/DyaconLiveAuthTest.php
@@ -51,6 +51,12 @@ class DyaconLiveAuthTest extends TestCase
         $this->assertNull(dyaconliveGetBearerToken('user@example.com', ''));
     }
 
+    public function testGetBearerToken_TestMode_UsesMockTokenEndpoint(): void
+    {
+        unset($GLOBALS['dyaconliveTestBearerToken']);
+        $this->assertSame('test_dyaconlive_bearer_token', dyaconliveGetBearerToken('user@example.com', 'secret'));
+    }
+
     public function testBearerTokenCacheKey_IsStablePerUsername(): void
     {
         $this->assertSame(

--- a/tests/Unit/DyaconLiveBucketTest.php
+++ b/tests/Unit/DyaconLiveBucketTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * DyaconLive 10-minute bucket schedule tests (safety-critical staleness path).
+ *
+ * KAOC probing confirmed clock-aligned :00/:10/... reports in station timezone.
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/weather/dyaconlive-bucket.php';
+
+class DyaconLiveBucketTest extends TestCase
+{
+    private const TZ = 'America/Boise';
+
+    /**
+     * @param string $localDateTime Y-m-d H:i:s in America/Boise
+     */
+    private function localUnix(string $localDateTime): int
+    {
+        $dt = new DateTimeImmutable($localDateTime, new DateTimeZone(self::TZ));
+        return $dt->getTimestamp();
+    }
+
+    public function testFloorToBucketUnix_AlignsToTenMinuteBoundary(): void
+    {
+        $now = $this->localUnix('2026-07-07 09:47:15');
+        $bucket = dyaconliveFloorToBucketUnix($now, self::TZ);
+        $dt = (new DateTimeImmutable('@' . $bucket))->setTimezone(new DateTimeZone(self::TZ));
+        $this->assertSame('2026-07-07 09:40:00', $dt->format('Y-m-d H:i:s'));
+    }
+
+    public function testExpectedLatestBucket_At0947_Returns0940(): void
+    {
+        $now = $this->localUnix('2026-07-07 09:47:00');
+        $expected = dyaconliveExpectedLatestBucketUnix($now, self::TZ);
+        $dt = (new DateTimeImmutable('@' . $expected))->setTimezone(new DateTimeZone(self::TZ));
+        $this->assertSame('2026-07-07 09:40:00', $dt->format('Y-m-d H:i:s'));
+    }
+
+    public function testExpectedLatestBucket_At0941BeforeGrace_Returns0930(): void
+    {
+        $now = $this->localUnix('2026-07-07 09:41:00');
+        $expected = dyaconliveExpectedLatestBucketUnix($now, self::TZ, 10, 90);
+        $dt = (new DateTimeImmutable('@' . $expected))->setTimezone(new DateTimeZone(self::TZ));
+        $this->assertSame('2026-07-07 09:30:00', $dt->format('Y-m-d H:i:s'));
+    }
+
+    public function testExpectedLatestBucket_At094135AfterGrace_Returns0940(): void
+    {
+        $now = $this->localUnix('2026-07-07 09:41:35');
+        $expected = dyaconliveExpectedLatestBucketUnix($now, self::TZ, 10, 90);
+        $dt = (new DateTimeImmutable('@' . $expected))->setTimezone(new DateTimeZone(self::TZ));
+        $this->assertSame('2026-07-07 09:40:00', $dt->format('Y-m-d H:i:s'));
+    }
+
+    public function testShouldSkipUpstream_NoState_NeverSkips(): void
+    {
+        $now = $this->localUnix('2026-07-07 09:47:00');
+        $this->assertFalse(dyaconliveShouldSkipUpstreamFetch(null, $now, self::TZ));
+    }
+
+    public function testShouldSkipUpstream_HasCurrentBucket_Skips(): void
+    {
+        $now = $this->localUnix('2026-07-07 09:47:00');
+        $last = $this->localUnix('2026-07-07 09:40:00');
+        $this->assertTrue(dyaconliveShouldSkipUpstreamFetch($last, $now, self::TZ));
+    }
+
+    public function testShouldSkipUpstream_BehindExpected_DoesNotSkip(): void
+    {
+        $now = $this->localUnix('2026-07-07 09:47:00');
+        $last = $this->localUnix('2026-07-07 09:30:00');
+        $this->assertFalse(dyaconliveShouldSkipUpstreamFetch($last, $now, self::TZ));
+    }
+
+    public function testParseBucketIsoToUnix_Invalid_ReturnsNull(): void
+    {
+        $this->assertNull(dyaconliveParseBucketIsoToUnix('not-a-date', self::TZ));
+    }
+
+    public function testParseBucketIsoToUnix_Valid_ReturnsUnix(): void
+    {
+        $unix = dyaconliveParseBucketIsoToUnix('2026-07-07T09:40:00', self::TZ);
+        $this->assertIsInt($unix);
+        $dt = (new DateTimeImmutable('@' . $unix))->setTimezone(new DateTimeZone(self::TZ));
+        $this->assertSame('2026-07-07 09:40:00', $dt->format('Y-m-d H:i:s'));
+    }
+}

--- a/tests/Unit/DyaconLiveFetchSkipTest.php
+++ b/tests/Unit/DyaconLiveFetchSkipTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * DyaconLive upstream skip and UnifiedFetcher integration tests.
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/config.php';
+require_once __DIR__ . '/../../lib/weather/UnifiedFetcher.php';
+require_once __DIR__ . '/../../lib/weather/dyaconlive-state.php';
+require_once __DIR__ . '/../../lib/weather/adapter/dyaconlive-v1.php';
+require_once __DIR__ . '/../mock-weather-responses.php';
+
+class DyaconLiveFetchSkipTest extends TestCase
+{
+    private ?string $stateDir = null;
+
+    protected function setUp(): void
+    {
+        $this->stateDir = sys_get_temp_dir() . '/dyaconlive-fetch-' . getmypid();
+        mkdir($this->stateDir, 0755, true);
+        $GLOBALS['dyaconliveTestStateDir'] = $this->stateDir;
+        $GLOBALS['dyaconliveTestBearerToken'] = 'test_dyaconlive_bearer_token';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['dyaconliveTestStateDir'], $GLOBALS['dyaconliveTestBearerToken'], $GLOBALS['dyaconliveTestNowUnix']);
+        if ($this->stateDir !== null && is_dir($this->stateDir)) {
+            foreach (glob($this->stateDir . '/*') ?: [] as $file) {
+                @unlink($file);
+            }
+            @rmdir($this->stateDir);
+        }
+    }
+
+    public function testFetchAllSources_WithCurrentBucketState_SkipsHttpResponse(): void
+    {
+        $airport = [
+            'icao' => 'KAOC',
+            'timezone' => 'America/Boise',
+            'weather_sources' => [
+                [
+                    'type' => 'dyaconlive',
+                    'station_id' => 130114,
+                    'username' => 'test@example.com',
+                    'password' => 'secret',
+                ],
+            ],
+        ];
+        $source = $airport['weather_sources'][0];
+        $response = getMockDyaconLiveDataResponse();
+        $snapshot = DyaconLiveAdapter::parseToSnapshot($response, [
+            'station_id' => 130114,
+            'timezone' => 'America/Boise',
+        ]);
+        $this->assertNotNull($snapshot);
+        $lastIso = DyaconLiveAdapter::extractLastBucketIso($response, [
+            'timezone' => 'America/Boise',
+        ]);
+        $this->assertNotNull($lastIso);
+        $bucketUnix = dyaconliveParseBucketIsoToUnix($lastIso, 'America/Boise');
+        $this->assertNotNull($bucketUnix);
+
+        dyaconliveWriteSourceState(
+            getDyaconLiveSourceStatePath('kaoc', 0),
+            $bucketUnix,
+            $lastIso,
+            $snapshot
+        );
+
+        $GLOBALS['dyaconliveTestNowUnix'] = dyaconliveParseBucketIsoToUnix('2026-07-07T09:47:00', 'America/Boise');
+
+        $sources = ['source_0' => $source];
+        $result = fetchAllSources($sources, 'kaoc', $airport);
+        $this->assertArrayHasKey('source_0', $result['skipped_snapshots']);
+        $this->assertArrayNotHasKey('source_0', $result['responses']);
+        $this->assertTrue($result['skipped_snapshots']['source_0']->isValid);
+    }
+
+    public function testFetchAllSources_WithoutState_FetchesMockResponse(): void
+    {
+        $airport = [
+            'icao' => 'KAOC',
+            'timezone' => 'America/Boise',
+        ];
+        $source = [
+            'type' => 'dyaconlive',
+            'station_id' => 130114,
+            'username' => 'test@example.com',
+            'password' => 'secret',
+        ];
+        $sources = ['source_0' => $source];
+        $result = fetchAllSources($sources, 'kaoc', $airport);
+        $this->assertArrayHasKey('source_0', $result['responses']);
+        $this->assertIsString($result['responses']['source_0']);
+        $this->assertStringContainsString('air_temp', $result['responses']['source_0']);
+    }
+
+    public function testFetchWeatherUnified_DyaconSource_ProducesTemperature(): void
+    {
+        $airport = [
+            'icao' => 'KAOC',
+            'timezone' => 'America/Boise',
+            'elevation_ft' => 5335,
+            'lat' => 43.6035278,
+            'lon' => -113.33425,
+            'weather_sources' => [
+                [
+                    'type' => 'dyaconlive',
+                    'station_id' => 130114,
+                    'username' => 'test@example.com',
+                    'password' => 'secret',
+                ],
+            ],
+        ];
+        $result = fetchWeatherUnified($airport, 'kaoc');
+        $this->assertNotNull($result['temperature'] ?? null);
+        $this->assertGreaterThanOrEqual(1, $result['_sources_succeeded'] ?? 0);
+    }
+}

--- a/tests/Unit/DyaconLiveFetchTest.php
+++ b/tests/Unit/DyaconLiveFetchTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * DyaconLive HTTP fetch tests (401 retry, auth failures).
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/weather/dyaconlive-fetch.php';
+require_once __DIR__ . '/../../lib/weather/dyaconlive-auth.php';
+require_once __DIR__ . '/../mock-weather-responses.php';
+
+class DyaconLiveFetchTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['dyaconliveTestHttpGetCallback'], $GLOBALS['dyaconliveTestBearerToken']);
+        parent::tearDown();
+    }
+
+    public function testFetchDataResponse_401Then200_RetriesOnce(): void
+    {
+        $calls = 0;
+        $GLOBALS['dyaconliveTestBearerToken'] = 'test-token';
+        $GLOBALS['dyaconliveTestHttpGetCallback'] = static function (string $url, string $token) use (&$calls) {
+            $calls++;
+            if ($calls === 1) {
+                return ['body' => null, 'http_code' => 401, 'response_headers' => []];
+            }
+
+            return [
+                'body' => getMockDyaconLiveDataResponse(),
+                'http_code' => 200,
+                'response_headers' => [],
+            ];
+        };
+
+        $source = [
+            'type' => 'dyaconlive',
+            'station_id' => 130114,
+            'username' => 'user@example.com',
+            'password' => 'secret',
+        ];
+        $airport = ['timezone' => 'America/Boise', 'elevation_ft' => 5335];
+
+        $result = dyaconliveFetchDataResponse($source, $airport);
+        $this->assertSame(2, $calls);
+        $this->assertSame(200, $result['http_code']);
+        $this->assertStringContainsString('air_temp', (string) $result['body']);
+    }
+
+    public function testFetchDataResponse_Persistent401_ReturnsFailure(): void
+    {
+        $calls = 0;
+        $GLOBALS['dyaconliveTestBearerToken'] = 'test-token';
+        $GLOBALS['dyaconliveTestHttpGetCallback'] = static function () use (&$calls) {
+            $calls++;
+            return ['body' => null, 'http_code' => 401, 'response_headers' => []];
+        };
+
+        $source = [
+            'type' => 'dyaconlive',
+            'station_id' => 130114,
+            'username' => 'user@example.com',
+            'password' => 'secret',
+        ];
+        $airport = ['timezone' => 'America/Boise'];
+
+        $result = dyaconliveFetchDataResponse($source, $airport);
+        $this->assertSame(2, $calls);
+        $this->assertSame(401, $result['http_code']);
+        $this->assertNull($result['body']);
+    }
+
+    public function testFetchDataResponse_InvalidConfig_ReturnsNullBody(): void
+    {
+        $result = dyaconliveFetchDataResponse(
+            ['type' => 'dyaconlive', 'username' => 'u', 'password' => 'p'],
+            ['timezone' => 'America/Boise']
+        );
+        $this->assertNull($result['body']);
+        $this->assertNull($result['http_code']);
+    }
+}

--- a/tests/Unit/DyaconLiveStateTest.php
+++ b/tests/Unit/DyaconLiveStateTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * DyaconLive per-source state and upstream skip reuse tests.
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/config.php';
+require_once __DIR__ . '/../../lib/weather/dyaconlive-state.php';
+require_once __DIR__ . '/../../lib/weather/adapter/dyaconlive-v1.php';
+require_once __DIR__ . '/../mock-weather-responses.php';
+
+class DyaconLiveStateTest extends TestCase
+{
+    private string $stateDir;
+
+    protected function setUp(): void
+    {
+        $this->stateDir = sys_get_temp_dir() . '/dyaconlive-state-test-' . getmypid();
+        mkdir($this->stateDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $files = glob($this->stateDir . '/*') ?: [];
+        foreach ($files as $file) {
+            @unlink($file);
+        }
+        @rmdir($this->stateDir);
+    }
+
+    public function testStateRoundTrip_PersistsBucketAndSnapshot(): void
+    {
+        $path = $this->stateDir . '/kaoc_0.json';
+        $response = getMockDyaconLiveDataResponse();
+        $snapshot = DyaconLiveAdapter::parseToSnapshot($response, [
+            'timezone' => 'America/Boise',
+            'elevation_ft' => 5335,
+        ]);
+        $this->assertNotNull($snapshot);
+
+        dyaconliveWriteSourceState($path, 1720364400, '2026-07-07T09:40:00', $snapshot);
+        $loaded = dyaconliveReadSourceState($path);
+        $this->assertIsArray($loaded);
+        $this->assertSame(1720364400, $loaded['last_bucket_unix']);
+        $this->assertSame('2026-07-07T09:40:00', $loaded['last_bucket_iso']);
+        $this->assertIsArray($loaded['snapshot']);
+        $rebuilt = dyaconliveSnapshotFromStateArray($loaded['snapshot']);
+        $this->assertNotNull($rebuilt);
+        $this->assertTrue($rebuilt->isValid);
+        $this->assertEqualsWithDelta(
+            $snapshot->temperature->value,
+            $rebuilt->temperature->value,
+            0.001
+        );
+    }
+
+    public function testReadSourceState_MissingFile_ReturnsNull(): void
+    {
+        $this->assertNull(dyaconliveReadSourceState($this->stateDir . '/missing.json'));
+    }
+
+    public function testReadSourceState_CorruptJson_ReturnsNull(): void
+    {
+        $path = $this->stateDir . '/bad.json';
+        file_put_contents($path, '{not json');
+        $this->assertNull(dyaconliveReadSourceState($path));
+    }
+}

--- a/tests/Unit/DyaconLiveStateTest.php
+++ b/tests/Unit/DyaconLiveStateTest.php
@@ -62,6 +62,23 @@ class DyaconLiveStateTest extends TestCase
         $this->assertNull(dyaconliveReadSourceState($this->stateDir . '/missing.json'));
     }
 
+    public function testSnapshotFromStateArray_InvalidWindDirection_UsesEmptyWind(): void
+    {
+        $response = getMockDyaconLiveDataResponse();
+        $snapshot = DyaconLiveAdapter::parseToSnapshot($response, [
+            'timezone' => 'America/Boise',
+            'elevation_ft' => 5335,
+        ]);
+        $this->assertNotNull($snapshot);
+        $state = dyaconliveSnapshotToStateArray($snapshot);
+        $state['wind_direction'] = 'not-a-number';
+
+        $rebuilt = dyaconliveSnapshotFromStateArray($state);
+        $this->assertNotNull($rebuilt);
+        $this->assertFalse($rebuilt->wind->speed->hasValue());
+        $this->assertFalse($rebuilt->wind->direction->hasValue());
+    }
+
     public function testReadSourceState_CorruptJson_ReturnsNull(): void
     {
         $path = $this->stateDir . '/bad.json';

--- a/tests/Unit/FetchAllSourcesMetarBulkTest.php
+++ b/tests/Unit/FetchAllSourcesMetarBulkTest.php
@@ -74,9 +74,9 @@ final class FetchAllSourcesMetarBulkTest extends TestCase
         $responses = fetchAllSources($sources, 'kzzz');
         @unlink($path);
 
-        $this->assertArrayHasKey('source_0', $responses);
-        $this->assertIsString($responses['source_0']);
-        $this->assertStringContainsString('"temp":42', $responses['source_0']);
+        $this->assertArrayHasKey('source_0', $responses['responses']);
+        $this->assertIsString($responses['responses']['source_0']);
+        $this->assertStringContainsString('"temp":42', $responses['responses']['source_0']);
     }
 
     public function testFetchAllSources_MetarThrottled_DoesNotRecordCircuitFailure(): void
@@ -121,7 +121,7 @@ final class FetchAllSourcesMetarBulkTest extends TestCase
 
         $responses = fetchAllSources($sources, 'kthr');
 
-        $this->assertArrayNotHasKey('source_0', $responses);
+        $this->assertArrayNotHasKey('source_0', $responses['responses']);
         if (is_file(CACHE_BACKOFF_FILE)) {
             $data = json_decode((string) file_get_contents(CACHE_BACKOFF_FILE), true);
             $this->assertIsArray($data);

--- a/tests/Unit/UpstreamRateLimitTest.php
+++ b/tests/Unit/UpstreamRateLimitTest.php
@@ -90,6 +90,36 @@ final class UpstreamRateLimitTest extends TestCase
         $this->assertSame($a, $b);
     }
 
+    public function testFingerprint_Dyaconlive_UsesUsernamePasswordAndStationId(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+
+        $base = [
+            'username' => 'user@example.com',
+            'password' => 'secret',
+            'station_id' => 130114,
+        ];
+        $a = upstreamRateFingerprint('dyaconlive', $base);
+        $b = upstreamRateFingerprint('dyaconlive', $base);
+        $this->assertSame($a, $b);
+
+        $differentStation = upstreamRateFingerprint('dyaconlive', array_merge($base, ['station_id' => 130115]));
+        $this->assertNotSame($a, $differentStation);
+
+        $differentPassword = upstreamRateFingerprint('dyaconlive', array_merge($base, ['password' => 'other']));
+        $this->assertNotSame($a, $differentPassword);
+    }
+
+    public function testRateLimitPolicy_Dyaconlive_UsesDefaultRpmAndSmallBurst(): void
+    {
+        require_once __DIR__ . '/../../lib/upstream-rate-limit.php';
+        require_once __DIR__ . '/../../lib/constants.php';
+
+        $policy = upstreamRateLimitPolicyForProvider('dyaconlive');
+        $this->assertSame(UPSTREAM_RATE_LIMIT_DEFAULT_RPM, $policy['rpm']);
+        $this->assertSame(2, $policy['burst']);
+    }
+
     public function testTokenBucketCompute_AllowsBurstThenDenies(): void
     {
         require_once __DIR__ . '/../../lib/upstream-rate-limit.php';

--- a/tests/Unit/WeatherCalculationsTest.php
+++ b/tests/Unit/WeatherCalculationsTest.php
@@ -341,6 +341,21 @@ class WeatherCalculationsTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testStationPressureToAltimeterSetting_KaocFixture_WithinAviationRange(): void
+    {
+        require_once __DIR__ . '/../../lib/weather/calculator.php';
+        $altimeter = stationPressureToAltimeterSettingInHg(24.75586096108245, 5335.0);
+        $this->assertNotNull($altimeter);
+        $this->assertEqualsWithDelta(30.1285, $altimeter, 0.01);
+    }
+
+    public function testStationPressureToAltimeterSetting_InvalidInput_ReturnsNull(): void
+    {
+        require_once __DIR__ . '/../../lib/weather/calculator.php';
+        $this->assertNull(stationPressureToAltimeterSettingInHg(0.0, 1000.0));
+        $this->assertNull(stationPressureToAltimeterSettingInHg(29.92, -1.0));
+    }
+
     /**
      * Ensures pressure altitude is calculated correctly for altimeter settings
      */

--- a/tests/Unit/WeatherSourceNormalizationTest.php
+++ b/tests/Unit/WeatherSourceNormalizationTest.php
@@ -136,7 +136,7 @@ class WeatherSourceNormalizationTest extends TestCase
      */
     public function testHasWeatherSources_AllSourceTypes_ReturnsTrue()
     {
-        $sourceTypes = ['tempest', 'ambient', 'weatherlink_v2', 'weatherlink_v1', 'pwsweather', 'metar', 'nws', 'synopticdata'];
+        $sourceTypes = ['tempest', 'ambient', 'weatherlink_v2', 'weatherlink_v1', 'pwsweather', 'metar', 'nws', 'synopticdata', 'dyaconlive'];
         
         foreach ($sourceTypes as $type) {
             $airport = createTestAirport([

--- a/tests/mock-weather-responses.php
+++ b/tests/mock-weather-responses.php
@@ -218,6 +218,64 @@ function getMockWeatherLinkResponse() {
 }
 
 /**
+ * Mock DyaconLive GET /data/{stationid} response (KAOC-shaped fixture).
+ */
+function getMockDyaconLiveDataResponse(): string
+{
+    return json_encode([
+        [
+            'variable_name' => 'air_temp',
+            'units' => 'F',
+            'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00'],
+            'values' => [71.0, 72.356],
+            'timezone' => 'America/Boise',
+        ],
+        [
+            'variable_name' => 'humidity',
+            'units' => '%',
+            'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00'],
+            'values' => [52.0, 50.9],
+            'timezone' => 'America/Boise',
+        ],
+        [
+            'variable_name' => 'air_pressure',
+            'units' => 'inHg',
+            'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00'],
+            'values' => [24.74, 24.75586096108245],
+            'timezone' => 'America/Boise',
+        ],
+        [
+            'variable_name' => 'wind10m_speed',
+            'units' => 'mph',
+            'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00'],
+            'values' => [3.5, 3.8029],
+            'timezone' => 'America/Boise',
+        ],
+        [
+            'variable_name' => 'wind10m_direction',
+            'units' => 'degrees',
+            'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00'],
+            'values' => [185.0, 187.7],
+            'timezone' => 'America/Boise',
+        ],
+        [
+            'variable_name' => 'wind_gust',
+            'units' => 'mph',
+            'datetimes' => ['2026-07-07T09:30:00', '2026-07-07T09:40:00'],
+            'values' => [0.0, 0.0],
+            'timezone' => 'America/Boise',
+        ],
+        [
+            'variable_name' => 'rainday_cumul',
+            'units' => 'in',
+            'datetimes' => [],
+            'values' => [],
+            'timezone' => 'America/Boise',
+        ],
+    ], JSON_THROW_ON_ERROR);
+}
+
+/**
  * Get a mock AerisWeather API response (for PWSWeather.com stations)
  * Based on actual API structure: { "success": true, "response": { "id": "...", "ob": { ... } } }
  * 


### PR DESCRIPTION
Closes #176

## Summary

Adds `dyaconlive` as a modular weather source for Dyacon MS-100 advisory stations on DyaconLive+. Fetches sensor time series from `api.dyacon.net`, converts station pressure to sea-level altimeter using airport `elevation_ft`, and respects Dyacon's 10-minute bucket schedule with local skip state so we do not hammer upstream on every 60s scheduler tick.

Dyacon is not METAR-class: ceiling and visibility stay null unless paired with `metar` or another aviation source.

## Implementation

- **Adapter:** `lib/weather/adapter/dyaconlive-v1.php` - parse `/data` time series, map temp/humidity/wind/pressure/rain
- **Auth:** `lib/weather/dyaconlive-auth.php` - OAuth password grant, APCu token cache, 401 invalidate
- **Fetch:** `lib/weather/dyaconlive-fetch.php` - dedicated path (not curl_multi) with one retry on 401
- **Bucket skip:** `lib/weather/dyaconlive-bucket.php` + `lib/weather/dyaconlive-state.php` - per-source state under `cache/weather/dyaconlive/`
- **Pressure:** `stationPressureToAltimeterSettingInHg()` in `lib/weather/calculator.php`
- **UnifiedFetcher:** dyacon branch in `fetchAllSources()`, state persist after parse
- **Config:** validation for `station_id`, `username`, `password`; warning when `elevation_ft` missing
- **Docs:** `docs/CONFIGURATION.md`, `docs/DATA_FLOW.md`, guides 09/12/13/15

## Hardening (separate commits)

1. Align parser values to anchor bucket ISO across series
2. Widen `/data` date window (yesterday-today) for midnight catch-up
3. Config warning for missing `elevation_ft`
4. Mock `/token` in test mode
5. DRY bearer token cache key; remove unused `getHeaders()`
6. DATA_FLOW policy for bucket skip
7. Upstream rate-limit tests; fingerprint numeric `station_id`

## Config example

```json
{
  "type": "dyaconlive",
  "station_id": 130114,
  "username": "your-dyaconlive-email",
  "password": "your-dyaconlive-password"
}
```

Requires DyaconLive+ and API access from `support@dyacon.net`.

## Test plan

- [x] `make test-ci`
- [x] Unit tests: adapter, auth, bucket, state, fetch, skip integration, config validation, pressure conversion, upstream fingerprint
- [x] Manual: KAOC credentials in secrets config; confirm DyaconLive portal matches dashboard fields (no ceiling/visibility from Dyacon alone)