### PR TITLE
Fix calculated dewpoint obs time for fail-closed display

### DIFF
--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -580,11 +580,17 @@ function parseSourceResponse(array $source, string $response, array $airport): ?
  * @return array<string, mixed> Weather data with calculated fields and normalized display timestamps
  */
 function addCalculatedFields(array $data, array $airport): array {
+    $dewpointDerivedFromRh = false;
+
     // Dewpoint from RH when sources omit Td but report humidity (e.g. some PWS JSON paths)
-    if (($data['dewpoint'] ?? null) === null && 
-        ($data['temperature'] ?? null) !== null && 
+    if (($data['dewpoint'] ?? null) === null &&
+        ($data['temperature'] ?? null) !== null &&
         ($data['humidity'] ?? null) !== null) {
-        $data['dewpoint'] = calculateDewpoint($data['temperature'], $data['humidity']);
+        $computedDewpoint = calculateDewpoint($data['temperature'], $data['humidity']);
+        if ($computedDewpoint !== null) {
+            $data['dewpoint'] = $computedDewpoint;
+            $dewpointDerivedFromRh = true;
+        }
     }
     
     // RH from dewpoint when humidity is omitted but Td is present
@@ -625,11 +631,45 @@ function addCalculatedFields(array $data, array $airport): array {
     // Sunrise/sunset times
     $data['sunrise'] = getSunriseTime($airport);
     $data['sunset'] = getSunsetTime($airport);
-    
+
+    assignCalculatedDewpointObsTime($data, $dewpointDerivedFromRh);
+
     // Same aggregate last_updated policy as WeatherAggregator; airport UI uses pickObservationUnixTimestamp (JS) for display.
     normalizeAggregateLastUpdatedTimes($data, time());
-    
+
     return $data;
+}
+
+/**
+ * Stalest input wins: derived dewpoint is only as fresh as the older of temp and humidity.
+ *
+ * @param array<string, mixed> $data Weather payload (mutated)
+ * @param bool $dewpointDerivedFromRh True when dewpoint was just computed from T/RH
+ */
+function assignCalculatedDewpointObsTime(array &$data, bool $dewpointDerivedFromRh): void
+{
+    if (!$dewpointDerivedFromRh || ($data['dewpoint'] ?? null) === null) {
+        return;
+    }
+
+    $obsMap = $data['_field_obs_time_map'] ?? null;
+    if (!is_array($obsMap) || isset($obsMap['dewpoint'])) {
+        return;
+    }
+
+    $tempObs = $obsMap['temperature'] ?? null;
+    $humObs = $obsMap['humidity'] ?? null;
+    if (!is_numeric($tempObs) || !is_numeric($humObs)) {
+        return;
+    }
+
+    $tempObs = (int) $tempObs;
+    $humObs = (int) $humObs;
+    if ($tempObs <= 0 || $humObs <= 0) {
+        return;
+    }
+
+    $data['_field_obs_time_map']['dewpoint'] = min($tempObs, $humObs);
 }
 
 /**

--- a/tests/Unit/WeatherAdapterUnitConversionTest.php
+++ b/tests/Unit/WeatherAdapterUnitConversionTest.php
@@ -278,11 +278,54 @@ class WeatherAdapterUnitConversionTest extends TestCase
             'last_updated' => time(),
             'last_updated_iso' => date('c'),
         ];
+        $tempObs = time() - 120;
+        $humObs = time() - 300;
+        $data['_field_obs_time_map'] = [
+            'temperature' => $tempObs,
+            'humidity' => $humObs,
+        ];
+
         $out = addCalculatedFields($data, $airport);
         $expectedTd = calculateDewpoint(20.0, 50.0);
         $this->assertNotNull($expectedTd, 'Fixture inputs must be valid for calculateDewpoint()');
         $this->assertNotNull($out['dewpoint'], 'addCalculatedFields should set dewpoint from humidity');
         $this->assertEqualsWithDelta($expectedTd, (float) $out['dewpoint'], 0.001);
+        $this->assertSame(
+            min($tempObs, $humObs),
+            $out['_field_obs_time_map']['dewpoint'] ?? null,
+            'Derived dewpoint obs time should use the stalest T/RH input'
+        );
+    }
+
+    /**
+     * Sensor-provided dewpoint keeps its existing obs time entry.
+     */
+    public function testAddCalculatedFields_SensorDewpoint_DoesNotOverwriteObsTimeMap(): void
+    {
+        $airport = createTestAirport(['elevation_ft' => 1000]);
+        $sensorObs = time() - 60;
+        $data = [
+            'temperature' => 20.0,
+            'humidity' => 50.0,
+            'dewpoint' => 10.0,
+            'pressure' => 29.92,
+            'wind_speed' => null,
+            'wind_direction' => null,
+            'visibility' => 10,
+            'ceiling' => null,
+            'cloud_cover' => null,
+            'gust_speed' => null,
+            'last_updated' => time(),
+            'last_updated_iso' => date('c'),
+            '_field_obs_time_map' => [
+                'temperature' => time() - 600,
+                'humidity' => time() - 600,
+                'dewpoint' => $sensorObs,
+            ],
+        ];
+
+        $out = addCalculatedFields($data, $airport);
+        $this->assertSame($sensorObs, $out['_field_obs_time_map']['dewpoint'] ?? null);
     }
 
     /**


### PR DESCRIPTION
## Summary

Follow-up to #176 (DyaconLive adapter). When dewpoint is derived from temperature and humidity, the API now sets `_field_obs_time_map['dewpoint']` using the older of the two input obs times. That stops the dashboard from hiding valid calculated dewpoint and spread as `--`.

## Changes

- `assignCalculatedDewpointObsTime()` in `lib/weather/UnifiedFetcher.php`
- Unit tests for derived vs sensor-provided dewpoint obs times

## Test plan

- [x] `phpunit tests/Unit/WeatherAdapterUnitConversionTest.php --filter AddCalculatedFields`
- [x] Confirm KAOC (or any Dyacon-only site) shows dewpoint after deploy

Refs #176