### PR TITLE
Treat DyaconLive zero gust as calm, not missing

### DIFF
--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -321,9 +321,7 @@ function parseDyaconLiveDataResponse(string $response, string $timezone): ?array
     $precip = dyaconliveSeriesValueAtBucket($byName['rainday_cumul'] ?? null, $lastIndex, $lastBucketIso);
 
     $windKt = $windMph !== null ? round(mphToKnots((float) $windMph), 0) : null;
-    $gustKt = ($gustMph !== null && (float) $gustMph > 0)
-        ? round(mphToKnots((float) $gustMph), 0)
-        : null;
+    $gustKt = $gustMph !== null ? round(mphToKnots((float) $gustMph), 0) : null;
 
     return [
         'temperature' => $temperature,

--- a/tests/Unit/DyaconLiveAdapterTest.php
+++ b/tests/Unit/DyaconLiveAdapterTest.php
@@ -133,7 +133,7 @@ class DyaconLiveAdapterTest extends TestCase
         $this->assertNull(DyaconLiveAdapter::parseToSnapshot('not-json', ['station_id' => 1]));
     }
 
-    public function testParseToSnapshot_ZeroGust_TreatedAsMissing(): void
+    public function testParseToSnapshot_ZeroGust_TreatedAsCalm(): void
     {
         $response = json_encode([
             [
@@ -162,6 +162,44 @@ class DyaconLiveAdapterTest extends TestCase
                 'units' => 'mph',
                 'datetimes' => ['2026-07-07T09:40:00'],
                 'values' => [0.0],
+                'timezone' => 'America/Boise',
+            ],
+        ], JSON_THROW_ON_ERROR);
+        $snapshot = DyaconLiveAdapter::parseToSnapshot($response, ['timezone' => 'America/Boise', 'elevation_ft' => 100]);
+        $this->assertNotNull($snapshot);
+        $this->assertTrue($snapshot->wind->gust->hasValue());
+        $this->assertSame(0.0, $snapshot->wind->gust->value);
+    }
+
+    public function testParseToSnapshot_EmptyGustSeries_TreatedAsMissing(): void
+    {
+        $response = json_encode([
+            [
+                'variable_name' => 'air_temp',
+                'units' => 'F',
+                'datetimes' => ['2026-07-07T09:40:00'],
+                'values' => [72.0],
+                'timezone' => 'America/Boise',
+            ],
+            [
+                'variable_name' => 'wind10m_speed',
+                'units' => 'mph',
+                'datetimes' => ['2026-07-07T09:40:00'],
+                'values' => [5.0],
+                'timezone' => 'America/Boise',
+            ],
+            [
+                'variable_name' => 'wind10m_direction',
+                'units' => 'degrees',
+                'datetimes' => ['2026-07-07T09:40:00'],
+                'values' => [180.0],
+                'timezone' => 'America/Boise',
+            ],
+            [
+                'variable_name' => 'wind_gust',
+                'units' => 'mph',
+                'datetimes' => [],
+                'values' => [],
                 'timezone' => 'America/Boise',
             ],
         ], JSON_THROW_ON_ERROR);


### PR DESCRIPTION
## Summary

Follow-up to #176. DyaconLive sends `0` in `wind_gust` when the sensor is reporting calm air, and empty series when there is no gust data. The adapter now maps those cases correctly.

## Changes

- `gust_speed` is `0` kt when the aligned bucket value is zero
- `gust_speed` stays `null` when `wind_gust` has no series points
- Tests cover both paths

## Test plan

- [x] `phpunit tests/Unit/DyaconLiveAdapterTest.php`
- [x] KAOC API shows `gust_speed: 0` when Dyacon reports calm gusts

Refs #176