### PR TITLE
Derive DyaconLive today's peak gust from wind_gust series

### DIFF
--- a/api/weather.php
+++ b/api/weather.php
@@ -645,7 +645,10 @@ function generateMockWeatherData($airportId, $airport) {
     $obsTimestamp = $weatherData['obs_time_primary'] ?? $weatherData['last_updated_primary'] ?? time();
     // Only update if we have a valid gust value (> 0)
     if ($currentGust > 0) {
-        updatePeakGust($airportId, $currentGust, $airport, $obsTimestamp);
+        $gustObsTimestamp = isset($weatherData['peak_gust_obs_time']) && is_numeric($weatherData['peak_gust_obs_time'])
+            ? (int) $weatherData['peak_gust_obs_time']
+            : $obsTimestamp;
+        updatePeakGust($airportId, $currentGust, $airport, $gustObsTimestamp);
     }
     $peakGustInfo = getPeakGust($airportId, $currentGust, $airport);
     if (is_array($peakGustInfo)) {

--- a/api/weather.php
+++ b/api/weather.php
@@ -658,12 +658,12 @@ function generateMockWeatherData($airportId, $airport) {
     );
     $peakGustInfo = getPeakGust($airportId, $trackingSeed, $airport);
     if (is_array($peakGustInfo)) {
-    $weatherData['peak_gust_today'] = $peakGustInfo['value'] ?? $trackingSeed;
-    $weatherData['peak_gust_time'] = $peakGustInfo['ts'] ?? null; // UNIX timestamp (UTC)
+        $weatherData['peak_gust_today'] = $peakGustInfo['value'] ?? $trackingSeed;
+        $weatherData['peak_gust_time'] = $peakGustInfo['ts'] ?? null; // UNIX timestamp (UTC)
     } else {
-    // Backward compatibility with older scalar cache files
-    $weatherData['peak_gust_today'] = $peakGustInfo;
-    $weatherData['peak_gust_time'] = null;
+        // Backward compatibility with older scalar cache files
+        $weatherData['peak_gust_today'] = $peakGustInfo;
+        $weatherData['peak_gust_time'] = null;
     }
 
     // Track and update today's high and low temperatures

--- a/api/weather.php
+++ b/api/weather.php
@@ -636,23 +636,29 @@ function generateMockWeatherData($airportId, $airport) {
 
     // Daily tracking (side effects - updates cache files)
     // Track and update today's peak gust (store value and timestamp)
-    // Use peak_gust field if available (set by adapters), otherwise gust_speed, otherwise 0
-    // peak_gust is set by adapters and might survive merge better than gust_speed
     $currentGust = $weatherData['peak_gust'] ?? $weatherData['gust_speed'] ?? 0;
-    // Use explicit observation time from primary source (when weather was actually observed)
-    // This is critical for pilot safety - must show accurate observation times
-    // Prefer obs_time_primary (explicit observation time from API), fall back to last_updated_primary (fetch time), then current time
     $obsTimestamp = $weatherData['obs_time_primary'] ?? $weatherData['last_updated_primary'] ?? time();
-    // Only update if we have a valid gust value (> 0)
-    if ($currentGust > 0) {
-        $gustObsTimestamp = isset($weatherData['peak_gust_obs_time']) && is_numeric($weatherData['peak_gust_obs_time'])
-            ? (int) $weatherData['peak_gust_obs_time']
-            : $obsTimestamp;
-        updatePeakGust($airportId, $currentGust, $airport, $gustObsTimestamp);
+
+    if (is_numeric($currentGust) && (float) $currentGust > 0) {
+        updatePeakGust($airportId, (float) $currentGust, $airport, $obsTimestamp);
     }
-    $peakGustInfo = getPeakGust($airportId, $currentGust, $airport);
+
+    $historicalPeak = $weatherData['peak_gust_historical'] ?? null;
+    if (is_numeric($historicalPeak) && (float) $historicalPeak > 0) {
+        $historicalObs = isset($weatherData['peak_gust_historical_obs_time'])
+            && is_numeric($weatherData['peak_gust_historical_obs_time'])
+            ? (int) $weatherData['peak_gust_historical_obs_time']
+            : $obsTimestamp;
+        updatePeakGust($airportId, (float) $historicalPeak, $airport, $historicalObs);
+    }
+
+    $trackingSeed = max(
+        is_numeric($currentGust) ? (float) $currentGust : 0.0,
+        is_numeric($historicalPeak) ? (float) $historicalPeak : 0.0
+    );
+    $peakGustInfo = getPeakGust($airportId, $trackingSeed, $airport);
     if (is_array($peakGustInfo)) {
-    $weatherData['peak_gust_today'] = $peakGustInfo['value'] ?? $currentGust;
+    $weatherData['peak_gust_today'] = $peakGustInfo['value'] ?? $trackingSeed;
     $weatherData['peak_gust_time'] = $peakGustInfo['ts'] ?? null; // UNIX timestamp (UTC)
     } else {
     // Backward compatibility with older scalar cache files

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -167,7 +167,7 @@ function fetchWeatherUnified(array $airport, string $airportId): array {
 }
 
 /**
- * Set peak_gust from Dyacon wind_gust history when the latest bucket is calm.
+ * Set peak_gust_historical from Dyacon wind_gust history when the latest bucket is calm.
  *
  * @param array<string, mixed> $result Aggregated weather (mutated)
  * @param array<string, array<string, mixed>> $sources Source list from buildSourceList()
@@ -196,8 +196,8 @@ function applyDyaconLivePeakGustFromResponses(
             continue;
         }
 
-        $result['peak_gust'] = (float) $peak['value'];
-        $result['peak_gust_obs_time'] = (int) $peak['obs_time'];
+        $result['peak_gust_historical'] = (float) $peak['value'];
+        $result['peak_gust_historical_obs_time'] = (int) $peak['obs_time'];
         return;
     }
 }

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -167,7 +167,7 @@ function fetchWeatherUnified(array $airport, string $airportId): array {
 }
 
 /**
- * Set peak_gust_historical from Dyacon wind_gust history when the latest bucket is calm.
+ * Set peak_gust_historical from the Dyacon wind_gust series for the local calendar day.
  *
  * @param array<string, mixed> $result Aggregated weather (mutated)
  * @param array<string, array<string, mixed>> $sources Source list from buildSourceList()

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -196,7 +196,15 @@ function applyDyaconLivePeakGustFromResponses(
             continue;
         }
 
-        $result['peak_gust_historical'] = (float) $peak['value'];
+        $peakValue = (float) $peak['value'];
+        $validation = validateWeatherField('peak_gust', $peakValue, null, [
+            'wind_speed' => $result['wind_speed'] ?? null,
+        ]);
+        if (!($validation['valid'] ?? false)) {
+            continue;
+        }
+
+        $result['peak_gust_historical'] = $peakValue;
         $result['peak_gust_historical_obs_time'] = (int) $peak['obs_time'];
         return;
     }

--- a/lib/weather/UnifiedFetcher.php
+++ b/lib/weather/UnifiedFetcher.php
@@ -150,7 +150,9 @@ function fetchWeatherUnified(array $airport, string $airportId): array {
     // Validate all weather fields against climate bounds
     // This catches unit conversion errors, API format changes, and sensor malfunctions
     $result = validateWeatherData($result, $airportId);
-    
+
+    applyDyaconLivePeakGustFromResponses($result, $sources, $responses, $airport);
+
     // Add calculated fields
     $result = addCalculatedFields($result, $airport);
     
@@ -162,6 +164,42 @@ function fetchWeatherUnified(array $airport, string $airportId): array {
     $result['_sources_succeeded'] = count($snapshots);
     
     return $result;
+}
+
+/**
+ * Set peak_gust from Dyacon wind_gust history when the latest bucket is calm.
+ *
+ * @param array<string, mixed> $result Aggregated weather (mutated)
+ * @param array<string, array<string, mixed>> $sources Source list from buildSourceList()
+ * @param array<string, string|null> $responses Raw HTTP bodies by source key
+ * @param array<string, mixed> $airport Airport configuration
+ */
+function applyDyaconLivePeakGustFromResponses(
+    array &$result,
+    array $sources,
+    array $responses,
+    array $airport
+): void {
+    foreach ($sources as $sourceKey => $source) {
+        if (($source['type'] ?? '') !== 'dyaconlive') {
+            continue;
+        }
+
+        $body = $responses[$sourceKey] ?? null;
+        if (!is_string($body) || $body === '') {
+            continue;
+        }
+
+        $timezone = dyaconliveResolveTimezone($source, $airport);
+        $peak = dyaconlivePeakGustTodayFromResponse($body, $timezone);
+        if ($peak === null || !isset($peak['value'], $peak['obs_time']) || (float) $peak['value'] <= 0) {
+            continue;
+        }
+
+        $result['peak_gust'] = (float) $peak['value'];
+        $result['peak_gust_obs_time'] = (int) $peak['obs_time'];
+        return;
+    }
 }
 
 /**

--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -434,7 +434,7 @@ function dyaconlivePeakGustTodayFromResponse(
         }
 
         try {
-            $bucketLocal = new DateTimeImmutable($iso, new DateTimeZone($seriesTimezone));
+            $bucketLocal = new DateTimeImmutable($iso, $tzObj);
         } catch (Exception $e) {
             continue;
         }

--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -376,7 +376,11 @@ function dyaconliveSeriesValueAtBucket(?array $series, int $anchorIndex, ?string
  *
  * @return array{value: float, obs_time: int}|null Peak in knots and bucket obs time, or null
  */
-function dyaconlivePeakGustTodayFromResponse(string $response, string $timezone): ?array
+function dyaconlivePeakGustTodayFromResponse(
+    string $response,
+    string $timezone,
+    ?DateTimeImmutable $now = null
+): ?array
 {
     if ($response === '') {
         return null;
@@ -410,10 +414,13 @@ function dyaconlivePeakGustTodayFromResponse(string $response, string $timezone)
         : $timezone;
 
     try {
-        $todayKey = (new DateTimeImmutable('now', new DateTimeZone($seriesTimezone)))->format('Y-m-d');
+        $tzObj = new DateTimeZone($seriesTimezone);
     } catch (Exception $e) {
         return null;
     }
+
+    $reference = ($now ?? new DateTimeImmutable('now', $tzObj))->setTimezone($tzObj);
+    $todayKey = $reference->format('Y-m-d');
 
     $peakMph = null;
     $peakObsTime = null;

--- a/lib/weather/adapter/dyaconlive-v1.php
+++ b/lib/weather/adapter/dyaconlive-v1.php
@@ -370,3 +370,89 @@ function dyaconliveSeriesValueAtBucket(?array $series, int $anchorIndex, ?string
 
     return null;
 }
+
+/**
+ * Daily peak gust from wind_gust series for the station local calendar day.
+ *
+ * @return array{value: float, obs_time: int}|null Peak in knots and bucket obs time, or null
+ */
+function dyaconlivePeakGustTodayFromResponse(string $response, string $timezone): ?array
+{
+    if ($response === '') {
+        return null;
+    }
+
+    $seriesList = json_decode($response, true);
+    if (!is_array($seriesList)) {
+        return null;
+    }
+
+    $gustSeries = null;
+    foreach ($seriesList as $series) {
+        if (is_array($series) && ($series['variable_name'] ?? '') === 'wind_gust') {
+            $gustSeries = $series;
+            break;
+        }
+    }
+
+    if (!is_array($gustSeries)) {
+        return null;
+    }
+
+    $datetimes = $gustSeries['datetimes'] ?? [];
+    $values = $gustSeries['values'] ?? [];
+    if (!is_array($datetimes) || !is_array($values) || count($values) === 0) {
+        return null;
+    }
+
+    $seriesTimezone = is_string($gustSeries['timezone'] ?? null) && $gustSeries['timezone'] !== ''
+        ? $gustSeries['timezone']
+        : $timezone;
+
+    try {
+        $todayKey = (new DateTimeImmutable('now', new DateTimeZone($seriesTimezone)))->format('Y-m-d');
+    } catch (Exception $e) {
+        return null;
+    }
+
+    $peakMph = null;
+    $peakObsTime = null;
+    $count = min(count($datetimes), count($values));
+
+    for ($i = 0; $i < $count; $i++) {
+        $iso = $datetimes[$i] ?? null;
+        $rawValue = $values[$i] ?? null;
+        if (!is_string($iso) || !is_numeric($rawValue)) {
+            continue;
+        }
+
+        try {
+            $bucketLocal = new DateTimeImmutable($iso, new DateTimeZone($seriesTimezone));
+        } catch (Exception $e) {
+            continue;
+        }
+
+        if ($bucketLocal->format('Y-m-d') !== $todayKey) {
+            continue;
+        }
+
+        $mph = (float) $rawValue;
+        if ($mph <= 0) {
+            continue;
+        }
+
+        if ($peakMph === null || $mph > $peakMph) {
+            $peakMph = $mph;
+            $peakObsTime = dyaconliveParseBucketIsoToUnix($iso, $seriesTimezone);
+        }
+    }
+
+    if ($peakMph === null || $peakObsTime === null || $peakObsTime <= 0) {
+        return null;
+    }
+
+    return [
+        'value' => (float) round(mphToKnots($peakMph), 0),
+        'obs_time' => $peakObsTime,
+    ];
+}

--- a/tests/Unit/DyaconLiveAdapterTest.php
+++ b/tests/Unit/DyaconLiveAdapterTest.php
@@ -257,8 +257,9 @@ class DyaconLiveAdapterTest extends TestCase
     public function testDyaconlivePeakGustTodayFromResponse_ReturnsLocalDayMax(): void
     {
         $tz = 'America/Boise';
-        $today = (new DateTimeImmutable('now', new DateTimeZone($tz)))->format('Y-m-d');
-        $yesterday = (new DateTimeImmutable('now', new DateTimeZone($tz)))->modify('-1 day')->format('Y-m-d');
+        $today = '2026-07-07';
+        $yesterday = '2026-07-06';
+        $reference = new DateTimeImmutable($today . 'T12:00:00', new DateTimeZone($tz));
         $response = json_encode([
             [
                 'variable_name' => 'wind_gust',
@@ -273,7 +274,7 @@ class DyaconLiveAdapterTest extends TestCase
             ],
         ], JSON_THROW_ON_ERROR);
 
-        $peak = dyaconlivePeakGustTodayFromResponse($response, $tz);
+        $peak = dyaconlivePeakGustTodayFromResponse($response, $tz, $reference);
         $this->assertNotNull($peak);
         $this->assertSame(25.0, $peak['value']);
         $this->assertSame(
@@ -300,7 +301,8 @@ class DyaconLiveAdapterTest extends TestCase
     public function testDyaconlivePeakGustTodayFromResponse_OnlyZeroToday_ReturnsNull(): void
     {
         $tz = 'America/Boise';
-        $today = (new DateTimeImmutable('now', new DateTimeZone($tz)))->format('Y-m-d');
+        $today = '2026-07-07';
+        $reference = new DateTimeImmutable($today . 'T12:00:00', new DateTimeZone($tz));
         $response = json_encode([
             [
                 'variable_name' => 'wind_gust',
@@ -311,6 +313,6 @@ class DyaconLiveAdapterTest extends TestCase
             ],
         ], JSON_THROW_ON_ERROR);
 
-        $this->assertNull(dyaconlivePeakGustTodayFromResponse($response, $tz));
+        $this->assertNull(dyaconlivePeakGustTodayFromResponse($response, $tz, $reference));
     }
 }

--- a/tests/Unit/DyaconLiveAdapterTest.php
+++ b/tests/Unit/DyaconLiveAdapterTest.php
@@ -253,4 +253,64 @@ class DyaconLiveAdapterTest extends TestCase
         $this->assertTrue($snapshot->isValid);
         $this->assertFalse($snapshot->humidity->hasValue());
     }
+
+    public function testDyaconlivePeakGustTodayFromResponse_ReturnsLocalDayMax(): void
+    {
+        $tz = 'America/Boise';
+        $today = (new DateTimeImmutable('now', new DateTimeZone($tz)))->format('Y-m-d');
+        $yesterday = (new DateTimeImmutable('now', new DateTimeZone($tz)))->modify('-1 day')->format('Y-m-d');
+        $response = json_encode([
+            [
+                'variable_name' => 'wind_gust',
+                'units' => 'mph',
+                'datetimes' => [
+                    $yesterday . 'T23:50:00',
+                    $today . 'T10:00:00',
+                    $today . 'T10:10:00',
+                ],
+                'values' => [40.0, 0.0, 28.6336],
+                'timezone' => $tz,
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $peak = dyaconlivePeakGustTodayFromResponse($response, $tz);
+        $this->assertNotNull($peak);
+        $this->assertSame(25.0, $peak['value']);
+        $this->assertSame(
+            dyaconliveParseBucketIsoToUnix($today . 'T10:10:00', $tz),
+            $peak['obs_time']
+        );
+    }
+
+    public function testDyaconlivePeakGustTodayFromResponse_EmptySeries_ReturnsNull(): void
+    {
+        $response = json_encode([
+            [
+                'variable_name' => 'wind_gust',
+                'units' => 'mph',
+                'datetimes' => [],
+                'values' => [],
+                'timezone' => 'America/Boise',
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $this->assertNull(dyaconlivePeakGustTodayFromResponse($response, 'America/Boise'));
+    }
+
+    public function testDyaconlivePeakGustTodayFromResponse_OnlyZeroToday_ReturnsNull(): void
+    {
+        $tz = 'America/Boise';
+        $today = (new DateTimeImmutable('now', new DateTimeZone($tz)))->format('Y-m-d');
+        $response = json_encode([
+            [
+                'variable_name' => 'wind_gust',
+                'units' => 'mph',
+                'datetimes' => [$today . 'T09:00:00', $today . 'T09:10:00'],
+                'values' => [0.0, 0.0],
+                'timezone' => $tz,
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $this->assertNull(dyaconlivePeakGustTodayFromResponse($response, $tz));
+    }
 }

--- a/tests/Unit/DyaconLiveAdapterTest.php
+++ b/tests/Unit/DyaconLiveAdapterTest.php
@@ -254,7 +254,7 @@ class DyaconLiveAdapterTest extends TestCase
         $this->assertFalse($snapshot->humidity->hasValue());
     }
 
-    public function testDyaconlivePeakGustTodayFromResponse_ReturnsLocalDayMax(): void
+    public function testDyaconLivePeakGustTodayFromResponse_ReturnsLocalDayMax(): void
     {
         $tz = 'America/Boise';
         $today = '2026-07-07';
@@ -283,7 +283,7 @@ class DyaconLiveAdapterTest extends TestCase
         );
     }
 
-    public function testDyaconlivePeakGustTodayFromResponse_EmptySeries_ReturnsNull(): void
+    public function testDyaconLivePeakGustTodayFromResponse_EmptySeries_ReturnsNull(): void
     {
         $response = json_encode([
             [
@@ -298,7 +298,7 @@ class DyaconLiveAdapterTest extends TestCase
         $this->assertNull(dyaconlivePeakGustTodayFromResponse($response, 'America/Boise'));
     }
 
-    public function testDyaconlivePeakGustTodayFromResponse_OnlyZeroToday_ReturnsNull(): void
+    public function testDyaconLivePeakGustTodayFromResponse_OnlyZeroToday_ReturnsNull(): void
     {
         $tz = 'America/Boise';
         $today = '2026-07-07';


### PR DESCRIPTION
## Summary

Follow-up to #176. DyaconLive returns a full `wind_gust` time series in each data fetch, but we only read the latest bucket. When the current bucket is calm, today's peak gust was lost. This scans the series for the local-day maximum and feeds daily tracking with the correct bucket timestamp.

## Changes

- `dyaconlivePeakGustTodayFromResponse()` in the DyaconLive adapter
- `applyDyaconLivePeakGustFromResponses()` in the unified fetcher (writes `peak_gust_historical` / `peak_gust_historical_obs_time`)
- `api/weather.php` tracks instantaneous gust with `obs_time_primary` and Dyacon series peak with `peak_gust_historical_obs_time`
- Unit tests for local-day max, empty series, and all-zero today

## Test plan

- [x] `phpunit tests/Unit/DyaconLiveAdapterTest.php`
- [x] KAOC shows a non-zero today's peak gust after a gusty period even when current gust is calm

Refs #176