### PR TITLE
Non-US DA performance: OurAirports runway fallback and honest fallback UI

### DIFF
--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -1076,7 +1076,7 @@
               },
               "reason": {
                 "type": "string",
-                "enum": ["reference_models", "density_altitude_only"]
+                "enum": ["reference_models", "reference_models_ourairports", "density_altitude_only"]
               },
               "reference": {
                 "type": "string",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -140,9 +140,18 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 
 ### Density altitude performance overrides
 
-The weather API `density_altitude_performance` cue compares AFM takeoff charts to runway context. By default it uses the **longest** active land runway from NASR with per-end departure obstructions and effective departure length.
+The weather API `density_altitude_performance` cue compares AFM takeoff charts to runway context.
 
-When `runway_length_ft` is set on an airport, that length replaces NASR runway selection. Optional `runway_surface` sets the surface code for POH grass correction (non-paved surfaces add 15% of ground roll to chart total).
+**Runway source precedence** (first match wins):
+
+1. `runway_length_ft` / `runway_surface` in `airports.json` (operator override)
+2. FAA NASR longest active land runway (US)
+3. OurAirports longest active land runway when NASR has no row (non-US and private strips without NASR)
+4. Weather-only elevation bands (`fallback: true`)
+
+By default, US airports with a NASR match use the **longest** active land runway from NASR with per-end departure obstructions and effective departure length.
+
+When `runway_length_ft` is set on an airport, that length replaces NASR and OurAirports runway selection. Optional `runway_surface` sets the surface code for POH grass correction (non-paved surfaces add 15% of ground roll to chart total).
 
 **Operator-provided length caveat:** The override builds a synthetic runway with **no departure-end data** (`ends` is empty). NASR departure obstructions (`OBSTN_HGT`, `DIST_FROM_THR`, `OBSTN_CLNC_SLOPE`), displaced thresholds, and `TKOF_DIST_AVBL` are **not** applied even when NASR lists them for the airport. Only runway-length stress is evaluated. Set this when NASR runway length is wrong or missing; the cue can **under-alert** when departure obstacles matter on that strip. Pilots remain responsible for obstacle clearance and runway selection.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -155,6 +155,8 @@ When `runway_length_ft` is set on an airport, that length replaces NASR and OurA
 
 **Operator-provided length caveat:** The override builds a synthetic runway with **no departure-end data** (`ends` is empty). NASR departure obstructions (`OBSTN_HGT`, `DIST_FROM_THR`, `OBSTN_CLNC_SLOPE`), displaced thresholds, and `TKOF_DIST_AVBL` are **not** applied even when NASR lists them for the airport. Only runway-length stress is evaluated. Set this when NASR runway length is wrong or missing; the cue can **under-alert** when departure obstacles matter on that strip. Pilots remain responsible for obstacle clearance and runway selection.
 
+**Tier cap without obstruction data:** Because the override has no departure-end obstructions, the indicator cannot emit **warning** (🚩); tier is capped at **caution** when length/surface stress alone would otherwise trigger warning. The same cap applies to OurAirports-only runway context.
+
 Policy detail: `docs/SAFETY_CRITICAL_CALCULATIONS.md` (Density Altitude Performance) and `docs/DATA_FLOW.md`.
 
 ### Radio frequencies

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -671,7 +671,7 @@ Pressure Altitude = Station Elevation + [(29.92 - Altimeter Setting) × 1000]
 - **Selection**: Longest non-closed land runway; exclude water surfaces using OurAirports surface codes.
 - **Stress**: Full POH reference model on runway length and surface (grass correction when non-paved). Per-end records apply displaced-threshold length when OurAirports publishes it; no departure obstructions or TODA from AIS.
 - **API**: `fallback: false`, `reason: reference_models_ourairports` when this path is used.
-- **Tier cap**: When obstruction data is absent, tier may be capped at **caution** (never **warning**) so the strongest alarm requires NASR-grade obstruction context or explicit maintainer config.
+- **Tier cap**: When obstruction data is absent (OurAirports or operator config override), tier is capped at **caution** (never **warning**). The strongest alarm requires NASR-grade departure-end obstruction context.
 
 OurAirports is community-maintained; length and surface can disagree with national AIS. NASR remains authoritative for US airports when both exist.
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -669,7 +669,7 @@ Pressure Altitude = Station Elevation + [(29.92 - Altimeter Setting) × 1000]
 
 - **Source**: `scripts/fetch-runways.php` downloads OurAirports `runways.csv` weekly for wind-compass geometry; DA performance consumes `length_ft`, `surface`, and displaced-threshold fields from the same cache slice (not lat/lon segments alone).
 - **Selection**: Longest non-closed land runway; exclude water/heli-only surfaces using OurAirports surface codes.
-- **Stress**: Full POH reference model on runway length and surface (grass correction when non-paved). Synthetic runway with **empty `ends`** (no departure obstructions, displaced threshold, or TODA from AIS).
+- **Stress**: Full POH reference model on runway length and surface (grass correction when non-paved). Per-end records apply displaced-threshold length when OurAirports publishes it; no departure obstructions or TODA from AIS.
 - **API**: `fallback: false`, `reason: reference_models_ourairports` when this path is used.
 - **Tier cap**: When obstruction data is absent, tier may be capped at **caution** (never **warning**) so the strongest alarm requires NASR-grade obstruction context or explicit maintainer config.
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -654,7 +654,7 @@ Pressure Altitude = Station Elevation + [(29.92 - Altimeter Setting) × 1000]
 | Density altitude | Weather cache | Required; null suppresses cue |
 | Field elevation | `airports.json` or NASR `APT_BASE` | Fallback path and delta |
 | Runway length, surface, departure obstructions | NASR `APT_RWY` / `APT_RWY_END` cache | US airports with a NASR match |
-| Runway length, surface (no obstructions) | OurAirports `runways.csv` cache | When NASR has no row; longest non-closed land runway (exclude water surfaces). Same POH length/surface stress as config override; `ends` empty. See [OurAirports runway model](#ourairports-runway-model) below. |
+| Runway length, surface (no obstructions) | OurAirports `runways.csv` cache | When NASR has no row; longest non-closed land runway (exclude water surfaces). Same POH length/surface stress as config override; per-end displaced thresholds when published; no departure obstructions. See [OurAirports runway model](#ourairports-runway-model) below. |
 | Operator runway override | `airports.json` `runway_length_ft` / `runway_surface` | Replaces NASR and OurAirports selection; obstructions dropped |
 | AFM takeoff tables | `data/poh/*.json` | C152M, C172N, C182T short-field charts |
 
@@ -668,7 +668,7 @@ Pressure Altitude = Station Elevation + [(29.92 - Altimeter Setting) × 1000]
 **OurAirports runway model** (when NASR is unavailable):
 
 - **Source**: `scripts/fetch-runways.php` downloads OurAirports `runways.csv` weekly for wind-compass geometry; DA performance consumes `length_ft`, `surface`, and displaced-threshold fields from the same cache slice (not lat/lon segments alone).
-- **Selection**: Longest non-closed land runway; exclude water/heli-only surfaces using OurAirports surface codes.
+- **Selection**: Longest non-closed land runway; exclude water surfaces using OurAirports surface codes.
 - **Stress**: Full POH reference model on runway length and surface (grass correction when non-paved). Per-end records apply displaced-threshold length when OurAirports publishes it; no departure obstructions or TODA from AIS.
 - **API**: `fallback: false`, `reason: reference_models_ourairports` when this path is used.
 - **Tier cap**: When obstruction data is absent, tier may be capped at **caution** (never **warning**) so the strongest alarm requires NASR-grade obstruction context or explicit maintainer config.

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -653,8 +653,27 @@ Pressure Altitude = Station Elevation + [(29.92 - Altimeter Setting) × 1000]
 | Pressure altitude, temperature | Weather cache | Required for full model |
 | Density altitude | Weather cache | Required; null suppresses cue |
 | Field elevation | `airports.json` or NASR `APT_BASE` | Fallback path and delta |
-| Runway length, surface, departure obstructions | NASR `APT_RWY` / `APT_RWY_END` cache | US airports; config `runway_length_ft` overrides length only (obstructions dropped) |
+| Runway length, surface, departure obstructions | NASR `APT_RWY` / `APT_RWY_END` cache | US airports with a NASR match |
+| Runway length, surface (no obstructions) | OurAirports `runways.csv` cache | When NASR has no row; longest non-closed land runway (exclude water surfaces). Same POH length/surface stress as config override; `ends` empty. See [OurAirports runway model](#ourairports-runway-model) below. |
+| Operator runway override | `airports.json` `runway_length_ft` / `runway_surface` | Replaces NASR and OurAirports selection; obstructions dropped |
 | AFM takeoff tables | `data/poh/*.json` | C152M, C172N, C182T short-field charts |
+
+**Runway context precedence** (first match wins):
+
+1. `runway_length_ft` in `airports.json` (optional `runway_surface`)
+2. NASR longest active land runway (US AIS)
+3. OurAirports longest active land runway when NASR has no row
+4. Weather-only fallback (elevation-banded DA thresholds; `fallback: true`)
+
+**OurAirports runway model** (when NASR is unavailable):
+
+- **Source**: `scripts/fetch-runways.php` downloads OurAirports `runways.csv` weekly for wind-compass geometry; DA performance consumes `length_ft`, `surface`, and displaced-threshold fields from the same cache slice (not lat/lon segments alone).
+- **Selection**: Longest non-closed land runway; exclude water/heli-only surfaces using OurAirports surface codes.
+- **Stress**: Full POH reference model on runway length and surface (grass correction when non-paved). Synthetic runway with **empty `ends`** (no departure obstructions, displaced threshold, or TODA from AIS).
+- **API**: `fallback: false`, `reason: reference_models_ourairports` when this path is used.
+- **Tier cap**: When obstruction data is absent, tier may be capped at **caution** (never **warning**) so the strongest alarm requires NASR-grade obstruction context or explicit maintainer config.
+
+OurAirports is community-maintained; length and surface can disagree with national AIS. NASR remains authoritative for US airports when both exist.
 
 **NASR ingest**: `scripts/fetch-nasr-apt.php` (scheduler weekly + startup when missing) writes `cache/nasr/nasr_apt.json`. Failed runway surface condition (`COND=FAILED`) and water surfaces are excluded from longest-runway selection.
 
@@ -675,7 +694,7 @@ Pressure Altitude = Station Elevation + [(29.92 - Altimeter Setting) × 1000]
 
 **Config `runway_length_ft`**: Operator override replaces NASR runway length (optional `runway_surface`) with synthetic runway `config` and **empty ends**. NASR departure obstructions, displaced thresholds, and `TKOF_DIST_AVBL` are not applied. Use when NASR length is wrong; can under-alert if obstacles matter. See `docs/CONFIGURATION.md` (Density altitude performance overrides).
 
-**Fallback model** (no runway data): Elevation-banded density-altitude thresholds only. Returns `tier` and `fallback: true`; `risk_factor` is **null** (no numeric score).
+**Fallback model** (no runway data from config, NASR, or OurAirports): Elevation-banded density-altitude thresholds only. Returns `tier` and `fallback: true`; `risk_factor` is **null** (no numeric score). UI copy must state that runway context was unavailable.
 
 **API field** `density_altitude_performance`:
 

--- a/docs/SAFETY_CRITICAL_CALCULATIONS.md
+++ b/docs/SAFETY_CRITICAL_CALCULATIONS.md
@@ -155,6 +155,16 @@ No obstruction stress when obstacle is beyond runway length or height/distance a
 - **Caution** when **worst** end sum ≥ 1.20 and warning did not apply (conservative: at least one direction warrants verification).
 - `risk_factor`: best-end sum for warning; worst-end sum for caution.
 
+### OurAirports runway model (when NASR unavailable)
+
+When FAA NASR has no airport row (typical for non-US fields such as Canadian ICAOs), select the **longest** active land runway from the OurAirports cache. Exclude closed runways and water surfaces.
+
+**Stress model**: Same POH reference tables and grass correction as the NASR full model, but the runway has **empty `ends`**. No departure obstructions, displaced thresholds, or `TKOF_DIST_AVBL` (OurAirports does not publish NASR-style per-end obstacle fields).
+
+**Tier policy without obstruction data**: Cap at **caution** when only OurAirports length/surface is available (do not emit **warning** without obstruction or NASR-grade departure-end context). This avoids the strongest alarm on incomplete AIS.
+
+**Precedence**: Operator `runway_length_ft` overrides OurAirports. When both NASR and OurAirports exist for a US airport, **NASR wins**.
+
 ### Fallback model (weather only)
 
 When no runway data: elevation-banded thresholds on density altitude and delta (DA minus field elevation). Returns tier only; `risk_factor` is **null**; `fallback: true`.

--- a/docs/SAFETY_CRITICAL_CALCULATIONS.md
+++ b/docs/SAFETY_CRITICAL_CALCULATIONS.md
@@ -159,7 +159,7 @@ No obstruction stress when obstacle is beyond runway length or height/distance a
 
 When FAA NASR has no airport row (typical for non-US fields such as Canadian ICAOs), select the **longest** active land runway from the OurAirports cache. Exclude closed runways and water surfaces.
 
-**Stress model**: Same POH reference tables and grass correction as the NASR full model, but the runway has **empty `ends`**. No departure obstructions, displaced thresholds, or `TKOF_DIST_AVBL` (OurAirports does not publish NASR-style per-end obstacle fields).
+**Stress model**: Same POH reference tables and grass correction as the NASR full model. Per-end records carry **displaced-threshold length** when OurAirports publishes it; there are **no departure obstructions** and no `TKOF_DIST_AVBL` (OurAirports does not publish NASR-style obstacle or TODA fields).
 
 **Tier policy without obstruction data**: Cap at **caution** when only OurAirports length/surface is available (do not emit **warning** without obstruction or NASR-grade departure-end context). This avoids the strongest alarm on incomplete AIS.
 

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -441,6 +441,18 @@ if (!defined('DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_OURAIRPORTS')) {
         'Cessna 152/172/182 AFM max gross, 0 kt wind (neutral conservative case); longest OurAirports runway (no obstruction data)'
     );
 }
+if (!defined('DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_CONFIG')) {
+    define(
+        'DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_CONFIG',
+        'Cessna 152/172/182 AFM max gross, 0 kt wind (neutral conservative case); operator runway_length_ft override (no obstruction data)'
+    );
+}
+if (!defined('DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_FALLBACK')) {
+    define(
+        'DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_FALLBACK',
+        'Elevation-banded density altitude thresholds; no runway data'
+    );
+}
 if (!defined('DENSITY_ALTITUDE_PERFORMANCE_FALLBACK_TOOLTIP')) {
     define(
         'DENSITY_ALTITUDE_PERFORMANCE_FALLBACK_TOOLTIP',

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -435,6 +435,19 @@ if (!defined('DENSITY_ALTITUDE_PERFORMANCE_REFERENCE')) {
         'Cessna 152/172/182 AFM max gross, 0 kt wind (neutral conservative case); longest NASR runway'
     );
 }
+if (!defined('DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_OURAIRPORTS')) {
+    define(
+        'DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_OURAIRPORTS',
+        'Cessna 152/172/182 AFM max gross, 0 kt wind (neutral conservative case); longest OurAirports runway (no obstruction data)'
+    );
+}
+if (!defined('DENSITY_ALTITUDE_PERFORMANCE_FALLBACK_TOOLTIP')) {
+    define(
+        'DENSITY_ALTITUDE_PERFORMANCE_FALLBACK_TOOLTIP',
+        'Runway data unavailable. Indicator based on density altitude relative to field elevation only. '
+        . 'Verify all performance calculations using your AFM.'
+    );
+}
 
 // Airport country resolution (geometry aggregate under CACHE_BASE_DIR; see scripts/refresh-airport-country-resolution.php)
 if (!defined('COUNTRY_RESOLUTION_AGGREGATE_SCHEMA_VERSION')) {

--- a/lib/density-altitude-performance-display.php
+++ b/lib/density-altitude-performance-display.php
@@ -61,7 +61,8 @@ function densityAltitudePerformanceAriaLabel(
     string $tier,
     string $distUnit = 'ft',
     ?array $performance = null
-): string {
+): string
+{
     if (!is_numeric($densityAltitudeFt)) {
         return 'Density altitude unavailable';
     }

--- a/lib/density-altitude-performance-display.php
+++ b/lib/density-altitude-performance-display.php
@@ -8,9 +8,15 @@ require_once __DIR__ . '/units.php';
 
 /**
  * Primary tooltip copy for density altitude performance tiers (pilot-facing uses AFM).
+ *
+ * @param array<string, mixed>|null $performance Optional API payload with fallback flag
  */
-function densityAltitudePerformanceTooltip(string $tier): string
+function densityAltitudePerformanceTooltip(string $tier, ?array $performance = null): string
 {
+    if (is_array($performance) && !empty($performance['fallback'])) {
+        return DENSITY_ALTITUDE_PERFORMANCE_FALLBACK_TOOLTIP;
+    }
+
     if ($tier === 'warning') {
         return 'Density altitude is dangerously high for average GA aircraft. '
             . 'Verify performance numbers before flight.';
@@ -48,9 +54,14 @@ function densityAltitudePerformanceValueClass(string $tier): string
  *
  * @param int|float|null $densityAltitudeFt
  * @param string $distUnit Embed distance unit (`ft` or `m`)
+ * @param array<string, mixed>|null $performance Optional API payload with fallback flag
  */
-function densityAltitudePerformanceAriaLabel($densityAltitudeFt, string $tier, string $distUnit = 'ft'): string
-{
+function densityAltitudePerformanceAriaLabel(
+    $densityAltitudeFt,
+    string $tier,
+    string $distUnit = 'ft',
+    ?array $performance = null
+): string {
     if (!is_numeric($densityAltitudeFt)) {
         return 'Density altitude unavailable';
     }
@@ -60,6 +71,10 @@ function densityAltitudePerformanceAriaLabel($densityAltitudeFt, string $tier, s
     } else {
         $feet = (int) round((float) $densityAltitudeFt);
         $base = 'Density altitude ' . number_format($feet) . ' feet';
+    }
+    if (is_array($performance) && !empty($performance['fallback'])) {
+        return $base . '. Runway data unavailable; indicator based on density altitude relative to field elevation only. '
+            . 'Verify all performance calculations using your AFM.';
     }
     if ($tier === 'warning') {
         return $base . '. Warning: dangerously high for average GA aircraft; verify performance numbers before flight.';
@@ -75,6 +90,7 @@ function densityAltitudePerformanceAriaLabel($densityAltitudeFt, string $tier, s
  *
  * @param int|float|null $densityAltitudeFt
  * @param string $formattedDistance Pre-formatted distance string (with unit if desired)
+ * @param array<string, mixed>|null $performance Optional API payload
  */
 function formatDensityAltitudePerformanceDisplay($densityAltitudeFt, string $formattedDistance, ?array $performance): string
 {

--- a/lib/embed-templates/full.php
+++ b/lib/embed-templates/full.php
@@ -199,8 +199,8 @@ function buildFullWidgetMetrics($weather, $options, $hasMetarData) {
         if ($daDisplay !== '--') {
             $tier = is_array($daPerformance) ? (string) ($daPerformance['tier'] ?? 'normal') : 'normal';
             $daClass = densityAltitudePerformanceValueClass($tier);
-            $daTooltip = densityAltitudePerformanceTooltip($tier);
-            $daAria = densityAltitudePerformanceAriaLabel($densityAltitude, $tier, $distUnit);
+            $daTooltip = densityAltitudePerformanceTooltip($tier, $daPerformance);
+            $daAria = densityAltitudePerformanceAriaLabel($densityAltitude, $tier, $distUnit, $daPerformance);
             $itemClasses = 'metric-item';
             if ($daClass !== '') {
                 $itemClasses .= ' ' . $daClass;

--- a/lib/embed-templates/shared.php
+++ b/lib/embed-templates/shared.php
@@ -724,8 +724,8 @@ function getCompactWidgetMetrics($weather, $options, $hasMetarData) {
         if ($daDisplay !== '--') {
             $tier = is_array($daPerformance) ? (string) ($daPerformance['tier'] ?? 'normal') : 'normal';
             $daClass = densityAltitudePerformanceValueClass($tier);
-            $daTooltip = densityAltitudePerformanceTooltip($tier);
-            $daAria = densityAltitudePerformanceAriaLabel($densityAltitude, $tier, $distUnit);
+            $daTooltip = densityAltitudePerformanceTooltip($tier, $daPerformance);
+            $daAria = densityAltitudePerformanceAriaLabel($densityAltitude, $tier, $distUnit, $daPerformance);
             $classSuffix = $daClass !== '' ? ' ' . htmlspecialchars($daClass, ENT_QUOTES, 'UTF-8') : '';
             $titleAttr = $daTooltip !== ''
                 ? ' title="' . htmlspecialchars($daTooltip, ENT_QUOTES, 'UTF-8') . '"'

--- a/lib/runways.php
+++ b/lib/runways.php
@@ -637,7 +637,7 @@ function loadOurAirportsPerformanceRunwaysFromFileCache(string $airportId, array
  *
  * @param string $airportId Airport identifier (config key or ICAO)
  * @param array $airport Airport configuration
- * @return array|null Selected runway with empty ends or null when unavailable
+ * @return array|null Selected runway with per-end displaced thresholds or null when unavailable
  */
 function getOurAirportsPerformanceRunwayForAirport(string $airportId, array $airport): ?array
 {

--- a/lib/runways.php
+++ b/lib/runways.php
@@ -345,6 +345,14 @@ function getRunwaySegmentsFromParsedCache(array $data, string $airportId, array 
  */
 function loadRunwaysCacheDataFromDisk(): ?array
 {
+    static $memoized = null;
+    static $resolved = false;
+
+    if ($resolved) {
+        return $memoized;
+    }
+
+    $resolved = true;
     $cachePath = CACHE_RUNWAYS_DATA_FILE;
     $fixturePath = dirname(__DIR__) . '/tests/Fixtures/runways_data.json';
 
@@ -365,7 +373,9 @@ function loadRunwaysCacheDataFromDisk(): ?array
         return null;
     }
 
-    return $data;
+    $memoized = $data;
+
+    return $memoized;
 }
 
 /**

--- a/lib/runways.php
+++ b/lib/runways.php
@@ -339,17 +339,15 @@ function getRunwaySegmentsFromParsedCache(array $data, string $airportId, array 
 }
 
 /**
- * Load runway segments from file cache for an airport
+ * Load parsed runway cache JSON from disk (live cache or test fixture).
  *
- * @param string $airportId Airport identifier
- * @param array $airport Airport config with lat, lon
- * @return array|null Segments or null if not found
+ * @return array<string, mixed>|null
  */
-function loadRunwaySegmentsFromFileCache(string $airportId, array $airport): ?array {
+function loadRunwaysCacheDataFromDisk(): ?array
+{
     $cachePath = CACHE_RUNWAYS_DATA_FILE;
     $fixturePath = dirname(__DIR__) . '/tests/Fixtures/runways_data.json';
 
-    // In test mode, prefer fixture for deterministic results
     if ((getenv('APP_ENV') === 'testing' || (defined('APP_ENV') && APP_ENV === 'testing'))
         && file_exists($fixturePath)) {
         $cachePath = $fixturePath;
@@ -357,7 +355,6 @@ function loadRunwaySegmentsFromFileCache(string $airportId, array $airport): ?ar
         return null;
     }
 
-    // @ suppresses read errors; we handle failure explicitly below
     $content = @file_get_contents($cachePath);
     if ($content === false) {
         return null;
@@ -365,6 +362,22 @@ function loadRunwaySegmentsFromFileCache(string $airportId, array $airport): ?ar
 
     $data = json_decode($content, true);
     if (!is_array($data) || !isset($data['airports'])) {
+        return null;
+    }
+
+    return $data;
+}
+
+/**
+ * Load runway segments from file cache for an airport
+ *
+ * @param string $airportId Airport identifier
+ * @param array $airport Airport config with lat, lon
+ * @return array|null Segments or null if not found
+ */
+function loadRunwaySegmentsFromFileCache(string $airportId, array $airport): ?array {
+    $data = loadRunwaysCacheDataFromDisk();
+    if ($data === null) {
         return null;
     }
 
@@ -381,25 +394,8 @@ function loadRunwaySegmentsFromFileCache(string $airportId, array $airport): ?ar
  * @return int Number of airports warmed
  */
 function warmRunwaysApcuCache(array $airports): int {
-    $cachePath = CACHE_RUNWAYS_DATA_FILE;
-    $fixturePath = dirname(__DIR__) . '/tests/Fixtures/runways_data.json';
-
-    // In test mode, prefer fixture for deterministic results
-    if ((getenv('APP_ENV') === 'testing' || (defined('APP_ENV') && APP_ENV === 'testing'))
-        && file_exists($fixturePath)) {
-        $cachePath = $fixturePath;
-    } elseif (!file_exists($cachePath)) {
-        return 0;
-    }
-
-    // @ suppresses read errors; we handle failure explicitly below
-    $content = @file_get_contents($cachePath);
-    if ($content === false) {
-        return 0;
-    }
-
-    $data = json_decode($content, true);
-    if (!is_array($data) || !isset($data['airports'])) {
+    $data = loadRunwaysCacheDataFromDisk();
+    if ($data === null) {
         return 0;
     }
 
@@ -433,4 +429,260 @@ function runwaysCacheNeedsRefresh(): bool {
     }
     $age = time() - filemtime($path);
     return $age >= RUNWAYS_CACHE_MAX_AGE;
+}
+
+/**
+ * Whether an OurAirports surface code represents water (excluded from DA runway selection).
+ */
+function ourAirportsIsWaterSurface(string $surface): bool
+{
+    return str_contains(strtoupper(trim($surface)), 'WATER');
+}
+
+/**
+ * Whether an OurAirports surface code is non-paved for POH grass correction.
+ */
+function ourAirportsIsNonPavedSurface(string $surface): bool
+{
+    $surface = strtoupper(trim($surface));
+    if ($surface === '') {
+        return false;
+    }
+
+    foreach (['TURF', 'GRS', 'GRE', 'GVL', 'GRASS', 'GRAVEL', 'GRVL', 'DIRT', 'SOD', 'CLAY', 'EARTH'] as $code) {
+        if (str_contains($surface, $code)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Normalize OurAirports surface text to NASR-style codes for POH lookup.
+ */
+function ourAirportsNormalizeSurfaceCode(string $surface): string
+{
+    $surface = strtoupper(trim($surface));
+    if ($surface === '' || ourAirportsIsWaterSurface($surface)) {
+        return $surface;
+    }
+    if (ourAirportsIsNonPavedSurface($surface)) {
+        return 'TURF';
+    }
+
+    return 'ASPH';
+}
+
+/**
+ * Build a runway id from OurAirports low/high end idents.
+ */
+function ourAirportsRunwayIdFromIdents(string $leIdent, string $heIdent): string
+{
+    $leIdent = trim($leIdent);
+    $heIdent = trim($heIdent);
+    if ($leIdent !== '' && $heIdent !== '') {
+        return $leIdent . '/' . $heIdent;
+    }
+    if ($leIdent !== '') {
+        return $leIdent;
+    }
+    if ($heIdent !== '') {
+        return $heIdent;
+    }
+
+    return 'unknown';
+}
+
+/**
+ * Whether a parsed OurAirports runway row is eligible for performance selection.
+ *
+ * @param array $runway Parsed runway with length_ft and surface
+ */
+function ourAirportsRunwayIsSelectable(array $runway): bool
+{
+    $lengthFt = (int) ($runway['length_ft'] ?? 0);
+    if ($lengthFt <= 0) {
+        return false;
+    }
+
+    $surface = (string) ($runway['surface'] ?? '');
+    if ($surface !== '' && ourAirportsIsWaterSurface($surface)) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Build NASR-shaped performance runway records from OurAirports parse rows.
+ *
+ * @param list<array> $runways Parsed OurAirports runway rows
+ * @return list<array>
+ */
+function buildOurAirportsPerformanceRunways(array $runways): array
+{
+    $performance = [];
+    foreach ($runways as $runway) {
+        if (!is_array($runway) || !ourAirportsRunwayIsSelectable($runway)) {
+            continue;
+        }
+
+        $performance[] = [
+            'rwy_id' => ourAirportsRunwayIdFromIdents(
+                (string) ($runway['le_ident'] ?? ''),
+                (string) ($runway['he_ident'] ?? '')
+            ),
+            'length_ft' => (int) $runway['length_ft'],
+            'surface' => ourAirportsNormalizeSurfaceCode((string) ($runway['surface'] ?? '')),
+            'ends' => [],
+            'le_displaced_threshold_ft' => isset($runway['le_displaced_threshold_ft'])
+                ? (int) $runway['le_displaced_threshold_ft']
+                : 0,
+            'he_displaced_threshold_ft' => isset($runway['he_displaced_threshold_ft'])
+                ? (int) $runway['he_displaced_threshold_ft']
+                : 0,
+        ];
+    }
+
+    return $performance;
+}
+
+/**
+ * Select the longest selectable OurAirports performance runway.
+ *
+ * @param list<array> $runways Performance runway records
+ * @return array|null Selected runway or null when none qualify
+ */
+function ourAirportsSelectLongestActiveLandRunway(array $runways): ?array
+{
+    $best = null;
+    $bestLen = 0;
+
+    foreach ($runways as $runway) {
+        if (!is_array($runway) || !ourAirportsRunwayIsSelectable($runway)) {
+            continue;
+        }
+        $len = (int) ($runway['length_ft'] ?? 0);
+        if ($len > $bestLen) {
+            $bestLen = $len;
+            $best = $runway;
+        }
+    }
+
+    return $best;
+}
+
+/**
+ * Extract performance runways for an airport from parsed runway cache data.
+ *
+ * @param array $data Parsed runways cache (must have 'airports' key)
+ * @param string $airportId Airport identifier
+ * @param array $airport Airport config with icao, faa (optional)
+ * @return list<array>|null Performance runways or null when not found
+ */
+function getOurAirportsPerformanceRunwaysFromParsedCache(array $data, string $airportId, array $airport): ?array
+{
+    if (!isset($data['airports']) || !is_array($data['airports'])) {
+        return null;
+    }
+    $airports = $data['airports'];
+    $identsToTry = array_filter([
+        strtoupper($airportId),
+        isset($airport['icao']) ? strtoupper((string) $airport['icao']) : null,
+        isset($airport['faa']) ? strtoupper((string) $airport['faa']) : null,
+    ]);
+    foreach ($identsToTry as $ident) {
+        if (!isset($airports[$ident]) || !is_array($airports[$ident])) {
+            continue;
+        }
+        $runways = $airports[$ident]['performance_runways'] ?? null;
+        if (is_array($runways) && $runways !== []) {
+            return $runways;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Load OurAirports performance runways from file cache for an airport.
+ *
+ * @param string $airportId Airport identifier
+ * @param array $airport Airport config
+ * @return list<array>|null Performance runways or null when not found
+ */
+function loadOurAirportsPerformanceRunwaysFromFileCache(string $airportId, array $airport): ?array
+{
+    $data = loadRunwaysCacheDataFromDisk();
+    if ($data === null) {
+        return null;
+    }
+
+    return getOurAirportsPerformanceRunwaysFromParsedCache($data, $airportId, $airport);
+}
+
+/**
+ * Select the longest OurAirports performance runway for density altitude performance.
+ *
+ * @param string $airportId Airport identifier (config key or ICAO)
+ * @param array $airport Airport configuration
+ * @return array|null Selected runway with empty ends or null when unavailable
+ */
+function getOurAirportsPerformanceRunwayForAirport(string $airportId, array $airport): ?array
+{
+    $runways = loadOurAirportsPerformanceRunwaysFromFileCache($airportId, $airport);
+    if ($runways === null) {
+        return null;
+    }
+
+    $selected = ourAirportsSelectLongestActiveLandRunway($runways);
+    if ($selected === null) {
+        return null;
+    }
+
+    return ourAirportsPerformanceRunwayForEvaluation($selected);
+}
+
+/**
+ * Build a runway record for POH evaluation from a cached OurAirports performance row.
+ *
+ * @param array $selected Performance runway from cache
+ * @return array Runway with ends for displaced-threshold roll limits
+ */
+function ourAirportsPerformanceRunwayForEvaluation(array $selected): array
+{
+    $rwyId = (string) ($selected['rwy_id'] ?? 'ourairports');
+    $idents = explode('/', $rwyId, 2);
+    $leIdent = $idents[0] ?? '';
+    $heIdent = $idents[1] ?? $leIdent;
+    $leDisplaced = isset($selected['le_displaced_threshold_ft'])
+        ? (int) $selected['le_displaced_threshold_ft']
+        : 0;
+    $heDisplaced = isset($selected['he_displaced_threshold_ft'])
+        ? (int) $selected['he_displaced_threshold_ft']
+        : 0;
+
+    $ends = [];
+    if ($leIdent !== '') {
+        $ends[] = [
+            'end_id' => $leIdent,
+            'displaced_thr_len' => $leDisplaced,
+            'obstruction' => [],
+        ];
+    }
+    if ($heIdent !== '' && $heIdent !== $leIdent) {
+        $ends[] = [
+            'end_id' => $heIdent,
+            'displaced_thr_len' => $heDisplaced,
+            'obstruction' => [],
+        ];
+    }
+
+    return [
+        'rwy_id' => $rwyId,
+        'length_ft' => (int) ($selected['length_ft'] ?? 0),
+        'surface' => (string) ($selected['surface'] ?? 'ASPH'),
+        'ends' => $ends,
+    ];
 }

--- a/lib/runways.php
+++ b/lib/runways.php
@@ -525,6 +525,32 @@ function ourAirportsRunwayIsSelectable(array $runway): bool
 }
 
 /**
+ * Resolve OurAirports parsed runway rows for a cache airport ident.
+ *
+ * Tries the ident directly, then a mapped ICAO when FAA LID aliases are known.
+ *
+ * @param array<string, list<array>> $ourairports Runways keyed by airport ident
+ * @param array<string, string> $faaToIcao FAA LID to ICAO mapping
+ * @return list<array>|null Parsed OurAirports rows or null when unavailable
+ */
+function resolveOurAirportsRunwaysForCacheIdent(string $ident, array $ourairports, array $faaToIcao = []): ?array
+{
+    $candidates = [strtoupper($ident)];
+    $icao = $faaToIcao[$candidates[0]] ?? null;
+    if (is_string($icao) && $icao !== '' && strtoupper($icao) !== $candidates[0]) {
+        $candidates[] = strtoupper($icao);
+    }
+
+    foreach ($candidates as $candidate) {
+        if (isset($ourairports[$candidate]) && !empty($ourairports[$candidate])) {
+            return $ourairports[$candidate];
+        }
+    }
+
+    return null;
+}
+
+/**
  * Build NASR-shaped performance runway records from OurAirports parse rows.
  *
  * @param list<array> $runways Parsed OurAirports runway rows

--- a/lib/weather/density-altitude-performance.php
+++ b/lib/weather/density-altitude-performance.php
@@ -259,7 +259,8 @@ function assessFallbackDensityAltitudePerformance(?int $densityAltitudeFt, ?int 
  * Runway selection precedence:
  * 1. `runway_length_ft` / `runway_surface` in airport config (synthetic runway, empty ends)
  * 2. NASR longest active land runway (full obstruction model)
- * 3. OurAirports longest land runway when NASR absent (length/surface only; empty ends)
+ * 3. OurAirports longest land runway when NASR absent (length/surface; per-end displaced
+ *    thresholds when published; no departure obstructions or TODA)
  * 4. Weather-only fallback (`assessFallbackDensityAltitudePerformance`)
  *
  * @param array $weather Cached weather row

--- a/lib/weather/density-altitude-performance.php
+++ b/lib/weather/density-altitude-performance.php
@@ -6,6 +6,7 @@
 require_once __DIR__ . '/../constants.php';
 require_once __DIR__ . '/../nasr/cache.php';
 require_once __DIR__ . '/../nasr/runway-selection.php';
+require_once __DIR__ . '/../runways.php';
 require_once __DIR__ . '/poh-takeoff.php';
 
 /** @var list<string> */
@@ -198,6 +199,18 @@ function evaluateRunwayEndPerformanceRange(
 }
 
 /**
+ * Cap tier when departure obstruction data is absent (OurAirports / config override).
+ */
+function densityAltitudePerformanceCapTierWithoutObstructions(string $tier): string
+{
+    if ($tier === 'warning') {
+        return 'caution';
+    }
+
+    return $tier;
+}
+
+/**
  * Weather-only fallback tier when runway data is unavailable.
  *
  * @return array{tier: string, risk_factor: null, fallback: true, reason: string, reference: string}|null
@@ -243,9 +256,11 @@ function assessFallbackDensityAltitudePerformance(?int $densityAltitudeFt, ?int 
  *
  * Returns null when DA is missing/stale-suppressed or tier is normal.
  *
- * Runway selection: longest NASR land runway unless `runway_length_ft` is set in
- * airport config. That override uses operator length only (empty ends); NASR
- * departure obstructions and per-end effective length are not applied.
+ * Runway selection precedence:
+ * 1. `runway_length_ft` / `runway_surface` in airport config (synthetic runway, empty ends)
+ * 2. NASR longest active land runway (full obstruction model)
+ * 3. OurAirports longest land runway when NASR absent (length/surface only; empty ends)
+ * 4. Weather-only fallback (`assessFallbackDensityAltitudePerformance`)
  *
  * @param array $weather Cached weather row
  * @param array $airport Airport configuration
@@ -264,6 +279,7 @@ function buildDensityAltitudePerformance(array $weather, array $airport): ?array
 
     $configLength = getConfigRunwayLengthOverrideFt($airport);
     $selectedRunway = null;
+    $runwaySource = null;
 
     if ($configLength !== null) {
         $selectedRunway = [
@@ -272,8 +288,18 @@ function buildDensityAltitudePerformance(array $weather, array $airport): ?array
             'surface' => getConfigRunwaySurfaceOverride($airport) ?? 'ASPH',
             'ends' => [],
         ];
+        $runwaySource = 'config';
     } elseif ($nasrRecord !== null) {
         $selectedRunway = nasrSelectLongestActiveLandRunway($nasrRecord);
+        if ($selectedRunway !== null) {
+            $runwaySource = 'nasr';
+        }
+    } else {
+        $airportId = (string) ($airport['id'] ?? $airport['icao'] ?? '');
+        $selectedRunway = getOurAirportsPerformanceRunwayForAirport($airportId, $airport);
+        if ($selectedRunway !== null) {
+            $runwaySource = 'ourairports';
+        }
     }
 
     if ($selectedRunway === null) {
@@ -297,6 +323,15 @@ function buildDensityAltitudePerformance(array $weather, array $airport): ?array
     $worstTotalRisk = $evaluation['worst']['total_risk'];
     $bestTotalRisk = $evaluation['best']['total_risk'];
     $tier = densityAltitudePerformanceTierFromEndRisks($worstTotalRisk, $bestTotalRisk);
+
+    $reason = 'reference_models';
+    $reference = DENSITY_ALTITUDE_PERFORMANCE_REFERENCE;
+    if ($runwaySource === 'ourairports') {
+        $tier = densityAltitudePerformanceCapTierWithoutObstructions($tier);
+        $reason = 'reference_models_ourairports';
+        $reference = DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_OURAIRPORTS;
+    }
+
     if ($tier === 'normal') {
         return null;
     }
@@ -309,8 +344,8 @@ function buildDensityAltitudePerformance(array $weather, array $airport): ?array
         'worst_end_risk' => round($worstTotalRisk, 3),
         'best_end_risk' => round($bestTotalRisk, 3),
         'fallback' => false,
-        'reason' => 'reference_models',
-        'reference' => DENSITY_ALTITUDE_PERFORMANCE_REFERENCE,
+        'reason' => $reason,
+        'reference' => $reference,
     ];
 }
 

--- a/lib/weather/density-altitude-performance.php
+++ b/lib/weather/density-altitude-performance.php
@@ -326,8 +326,10 @@ function buildDensityAltitudePerformance(array $weather, array $airport): ?array
 
     $reason = 'reference_models';
     $reference = DENSITY_ALTITUDE_PERFORMANCE_REFERENCE;
-    if ($runwaySource === 'ourairports') {
+    if ($runwaySource === 'config' || $runwaySource === 'ourairports') {
         $tier = densityAltitudePerformanceCapTierWithoutObstructions($tier);
+    }
+    if ($runwaySource === 'ourairports') {
         $reason = 'reference_models_ourairports';
         $reference = DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_OURAIRPORTS;
     }

--- a/lib/weather/density-altitude-performance.php
+++ b/lib/weather/density-altitude-performance.php
@@ -247,7 +247,7 @@ function assessFallbackDensityAltitudePerformance(?int $densityAltitudeFt, ?int 
         'risk_factor' => null,
         'fallback' => true,
         'reason' => 'density_altitude_only',
-        'reference' => DENSITY_ALTITUDE_PERFORMANCE_REFERENCE,
+        'reference' => DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_FALLBACK,
     ];
 }
 
@@ -330,7 +330,9 @@ function buildDensityAltitudePerformance(array $weather, array $airport): ?array
     if ($runwaySource === 'config' || $runwaySource === 'ourairports') {
         $tier = densityAltitudePerformanceCapTierWithoutObstructions($tier);
     }
-    if ($runwaySource === 'ourairports') {
+    if ($runwaySource === 'config') {
+        $reference = DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_CONFIG;
+    } elseif ($runwaySource === 'ourairports') {
         $reason = 'reference_models_ourairports';
         $reference = DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_OURAIRPORTS;
     }

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -791,7 +791,10 @@ function formatAltitude(ft) {
     return unit === 'm' ? ftToM(ft) : Math.round(ft);
 }
 
-function densityAltitudePerformanceTooltip(tier) {
+function densityAltitudePerformanceTooltip(tier, performance) {
+    if (performance && performance.fallback) {
+        return 'Runway data unavailable. Indicator based on density altitude relative to field elevation only. Verify all performance calculations using your AFM.';
+    }
     if (tier === 'warning') {
         return 'Density altitude is dangerously high for average GA aircraft. Verify performance numbers before flight.';
     }
@@ -807,7 +810,7 @@ function densityAltitudePerformanceEmoji(tier) {
     return '';
 }
 
-function densityAltitudePerformanceAriaLabel(densityAltitudeFt, tier) {
+function densityAltitudePerformanceAriaLabel(densityAltitudeFt, tier, performance) {
     if (densityAltitudeFt === null || densityAltitudeFt === undefined) {
         return 'Density altitude unavailable';
     }
@@ -817,6 +820,9 @@ function densityAltitudePerformanceAriaLabel(densityAltitudeFt, tier) {
         : Math.round(Number(densityAltitudeFt));
     const unitLabel = unit === 'm' ? 'meters' : 'feet';
     const base = `Density altitude ${value.toLocaleString()} ${unitLabel}`;
+    if (performance && performance.fallback) {
+        return `${base}. Runway data unavailable; indicator based on density altitude relative to field elevation only. Verify all performance calculations using your AFM.`;
+    }
     if (tier === 'warning') {
         return `${base}. Warning: dangerously high for average GA aircraft; verify performance numbers before flight.`;
     }
@@ -834,8 +840,8 @@ function formatDensityAltitudePerformanceDisplay(densityAltitudeFt, performance)
         value,
         emoji,
         className: (tier === 'caution' || tier === 'warning') ? 'density-altitude-warning' : '',
-        title: densityAltitudePerformanceTooltip(tier),
-        ariaLabel: densityAltitudePerformanceAriaLabel(densityAltitudeFt, tier),
+        title: densityAltitudePerformanceTooltip(tier, performance),
+        ariaLabel: densityAltitudePerformanceAriaLabel(densityAltitudeFt, tier, performance),
     };
 }
 

--- a/public/js/embed-helpers.js
+++ b/public/js/embed-helpers.js
@@ -222,7 +222,10 @@
         }
     }
     
-    function densityAltitudePerformanceTooltip(tier) {
+    function densityAltitudePerformanceTooltip(tier, performance) {
+        if (performance && performance.fallback) {
+            return 'Runway data unavailable. Indicator based on density altitude relative to field elevation only. Verify all performance calculations using your AFM.';
+        }
         if (tier === 'warning') {
             return 'Density altitude is dangerously high for average GA aircraft. Verify performance numbers before flight.';
         }
@@ -251,7 +254,9 @@
             : Math.round(Number(densityAltitudeFt));
         const unitLabel = distUnit === 'm' ? 'meters' : 'feet';
         let ariaLabel = `Density altitude ${ariaValue.toLocaleString()} ${unitLabel}`;
-        if (tier === 'warning') {
+        if (performance && performance.fallback) {
+            ariaLabel += '. Runway data unavailable; indicator based on density altitude relative to field elevation only. Verify all performance calculations using your AFM.';
+        } else if (tier === 'warning') {
             ariaLabel += '. Warning: dangerously high for average GA aircraft; verify performance numbers before flight.';
         } else if (tier === 'caution') {
             ariaLabel += '. Caution: higher than normal; verify performance numbers before flight.';
@@ -259,7 +264,7 @@
         return {
             text,
             className: (tier === 'caution' || tier === 'warning') ? 'density-altitude-warning' : '',
-            title: densityAltitudePerformanceTooltip(tier),
+            title: densityAltitudePerformanceTooltip(tier, performance),
             ariaLabel,
         };
     }

--- a/scripts/fetch-runways.php
+++ b/scripts/fetch-runways.php
@@ -322,11 +322,12 @@ function runwaysToSegments(array $runways, float $centerLat, float $centerLon): 
 }
 
 /**
- * Merge FAA and OurAirports; FAA-only for FAA airports, OurAirports for the rest
+ * Merge FAA and OurAirports; FAA segments for FAA airports, OurAirports for the rest
  *
- * For airports in the FAA dataset: use FAA data only, output under both FAA ID and ICAO
- * (when mapped via OurAirports airports.csv). For airports not in FAA: use OurAirports.
- * Never mix both sources for the same airport.
+ * For airports in the FAA dataset: segment geometry comes from FAA only, output under both
+ * FAA ID and ICAO (when mapped via OurAirports airports.csv). When OurAirports has matching
+ * runway rows, attach them as performance_runways for DA fallback without replacing FAA
+ * segments. For airports not in FAA: use OurAirports for both segments and performance_runways.
  *
  * @param array $faa Runways by airport from FAA (keyed by ARPT_ID e.g. HIO)
  * @param array $ourairports Runways by airport from OurAirports (keyed by airport_ident e.g. KHIO)

--- a/scripts/fetch-runways.php
+++ b/scripts/fetch-runways.php
@@ -113,6 +113,10 @@ function parseOurAirportsRunways(string $csv): array {
         $heLon = $idx['he_longitude_deg'] ?? null;
         $leIdent = $idx['le_ident'] ?? null;
         $heIdent = $idx['he_ident'] ?? null;
+        $lengthIdx = $idx['length_ft'] ?? null;
+        $surfaceIdx = $idx['surface'] ?? null;
+        $leDisplacedIdx = $idx['le_displaced_threshold_ft'] ?? null;
+        $heDisplacedIdx = $idx['he_displaced_threshold_ft'] ?? null;
 
         if ($ident === null) {
             continue;
@@ -122,6 +126,17 @@ function parseOurAirportsRunways(string $csv): array {
         if ($airportId === '') {
             continue;
         }
+
+        $lengthFt = $lengthIdx !== null && isset($row[$lengthIdx]) && is_numeric($row[$lengthIdx])
+            ? (int) round((float) $row[$lengthIdx])
+            : 0;
+        $surface = $surfaceIdx !== null ? trim((string) ($row[$surfaceIdx] ?? '')) : '';
+        $leDisplaced = $leDisplacedIdx !== null && isset($row[$leDisplacedIdx]) && is_numeric($row[$leDisplacedIdx])
+            ? (int) round((float) $row[$leDisplacedIdx])
+            : 0;
+        $heDisplaced = $heDisplacedIdx !== null && isset($row[$heDisplacedIdx]) && is_numeric($row[$heDisplacedIdx])
+            ? (int) round((float) $row[$heDisplacedIdx])
+            : 0;
 
         $lat1 = $leLat !== null && isset($row[$leLat]) && $row[$leLat] !== '' ? (float) $row[$leLat] : null;
         $lon1 = $leLon !== null && isset($row[$leLon]) && $row[$leLon] !== '' ? (float) $row[$leLon] : null;
@@ -142,6 +157,10 @@ function parseOurAirportsRunways(string $csv): array {
             'lon2' => $lon2,
             'le_ident' => $leIdent !== null ? trim($row[$leIdent] ?? '') : '',
             'he_ident' => $heIdent !== null ? trim($row[$heIdent] ?? '') : '',
+            'length_ft' => $lengthFt,
+            'surface' => $surface,
+            'le_displaced_threshold_ft' => $leDisplaced,
+            'he_displaced_threshold_ft' => $heDisplaced,
             'source' => 'ourairports',
         ];
     }
@@ -366,6 +385,7 @@ function mergeRunwaySources(array $faa, array $ourairports, array $airportCenter
             'segments' => $segments,
             'center_lat' => $center['lat'],
             'center_lon' => $center['lon'],
+            'performance_runways' => buildOurAirportsPerformanceRunways($runways),
         ];
     }
     return $result;

--- a/scripts/fetch-runways.php
+++ b/scripts/fetch-runways.php
@@ -358,6 +358,10 @@ function mergeRunwaySources(array $faa, array $ourairports, array $airportCenter
             'center_lat' => $center['lat'],
             'center_lon' => $center['lon'],
         ];
+        $oaRunways = resolveOurAirportsRunwaysForCacheIdent($faaId, $ourairports, $faaToIcao);
+        if ($oaRunways !== null) {
+            $entry['performance_runways'] = buildOurAirportsPerformanceRunways($oaRunways);
+        }
         $result[$faaId] = $entry;
         $coveredByIdent[$faaId] = true;
         if (isset($faaToIcao[$faaId])) {
@@ -392,9 +396,11 @@ function mergeRunwaySources(array $faa, array $ourairports, array $airportCenter
 }
 
 // CLI entry
-if (php_sapi_name() !== 'cli') {
-    exit(1);
-}
+if (php_sapi_name() === 'cli') {
+    $scriptName = $_SERVER['PHP_SELF'] ?? $_SERVER['SCRIPT_NAME'] ?? '';
+    if (basename($scriptName) !== basename(__FILE__) && $scriptName !== __FILE__) {
+        return;
+    }
 
 $fp = acquireRunwaysFetchLock();
 if ($fp === false) {
@@ -505,3 +511,4 @@ aviationwx_log('info', 'runways fetch: complete', [
 ], 'app');
 
 exit(0);
+}

--- a/scripts/fetch-runways.php
+++ b/scripts/fetch-runways.php
@@ -358,6 +358,8 @@ function mergeRunwaySources(array $faa, array $ourairports, array $airportCenter
             'center_lat' => $center['lat'],
             'center_lon' => $center['lon'],
         ];
+        // FAA segments stay authoritative for wind compass; attach OurAirports length/surface
+        // separately so DA performance can fall back when NASR has no airport row.
         $oaRunways = resolveOurAirportsRunwaysForCacheIdent($faaId, $ourairports, $faaToIcao);
         if ($oaRunways !== null) {
             $entry['performance_runways'] = buildOurAirportsPerformanceRunways($oaRunways);

--- a/scripts/fetch-runways.php
+++ b/scripts/fetch-runways.php
@@ -405,113 +405,113 @@ if (php_sapi_name() === 'cli') {
         return;
     }
 
-$fp = acquireRunwaysFetchLock();
-if ($fp === false) {
-    aviationwx_log('info', 'runways fetch: another instance running, skipping', [], 'app');
-    exit(0);
-}
+    $fp = acquireRunwaysFetchLock();
+    if ($fp === false) {
+        aviationwx_log('info', 'runways fetch: another instance running, skipping', [], 'app');
+        exit(0);
+    }
 
-if (!runwaysCacheNeedsRefresh()) {
-    flock($fp, LOCK_UN);
-    fclose($fp);
-    aviationwx_log('info', 'runways fetch: cache fresh, skipping', [], 'app');
-    exit(0);
-}
+    if (!runwaysCacheNeedsRefresh()) {
+        flock($fp, LOCK_UN);
+        fclose($fp);
+        aviationwx_log('info', 'runways fetch: cache fresh, skipping', [], 'app');
+        exit(0);
+    }
 
-aviationwx_log('info', 'runways fetch: starting download', [], 'app');
+    aviationwx_log('info', 'runways fetch: starting download', [], 'app');
 
-$ourairportsCsv = downloadUrl($OURAIRPORTS_RUNWAYS_URL);
-$faaCsv = downloadUrl($FAA_RUNWAYS_URL);
+    $ourairportsCsv = downloadUrl($OURAIRPORTS_RUNWAYS_URL);
+    $faaCsv = downloadUrl($FAA_RUNWAYS_URL);
 
-if ($ourairportsCsv === null && $faaCsv === null) {
-    aviationwx_log('error', 'runways fetch: both downloads failed', [], 'app', true);
-    flock($fp, LOCK_UN);
-    fclose($fp);
-    exit(1);
-}
+    if ($ourairportsCsv === null && $faaCsv === null) {
+        aviationwx_log('error', 'runways fetch: both downloads failed', [], 'app', true);
+        flock($fp, LOCK_UN);
+        fclose($fp);
+        exit(1);
+    }
 
-$ourairports = $ourairportsCsv !== null ? parseOurAirportsRunways($ourairportsCsv) : [];
-$faa = $faaCsv !== null ? parseFaaRunways($faaCsv) : [];
+    $ourairports = $ourairportsCsv !== null ? parseOurAirportsRunways($ourairportsCsv) : [];
+    $faa = $faaCsv !== null ? parseFaaRunways($faaCsv) : [];
 
-$airportCenters = [];
-$faaToIcao = [];
-if ($ourairportsCsv !== null) {
-    $airportsCsv = downloadUrl('https://davidmegginson.github.io/ourairports-data/airports.csv');
-    if ($airportsCsv !== null) {
-        $lines = str_getcsv($airportsCsv, "\n", '"', '\\');
-        $header = str_getcsv(array_shift($lines), ',', '"', '\\');
-        $idx = array_flip(array_map('trim', $header));
-        $identIdx = $idx['ident'] ?? null;
-        $latIdx = $idx['latitude_deg'] ?? null;
-        $lonIdx = $idx['longitude_deg'] ?? null;
-        $gpsIdx = $idx['gps_code'] ?? null;
-        $icaoIdx = $idx['icao_code'] ?? null;
-        $iataIdx = $idx['iata_code'] ?? null;
-        $localIdx = $idx['local_code'] ?? null;
-        $countryIdx = $idx['iso_country'] ?? null;
-        if ($identIdx !== null && $latIdx !== null && $lonIdx !== null) {
-            foreach ($lines as $line) {
-                $row = str_getcsv($line, ',', '"', '\\');
-                if (count($row) <= max($identIdx, $latIdx, $lonIdx)) {
-                    continue;
-                }
-                $id = strtoupper(trim($row[$identIdx] ?? ''));
-                $lat = $row[$latIdx] ?? '';
-                $lon = $row[$lonIdx] ?? '';
-                if ($id !== '' && $lat !== '' && $lon !== '') {
-                    $airportCenters[$id] = ['lat' => (float) $lat, 'lon' => (float) $lon];
-                }
-                if ($icaoIdx === null || $countryIdx === null || trim($row[$countryIdx] ?? '') !== 'US') {
-                    continue;
-                }
-                $icao = strtoupper(trim($row[$icaoIdx] ?? ''));
-                if ($icao === '') {
-                    continue;
-                }
-                foreach ([$gpsIdx, $iataIdx, $localIdx] as $altIdx) {
-                    if ($altIdx === null) {
+    $airportCenters = [];
+    $faaToIcao = [];
+    if ($ourairportsCsv !== null) {
+        $airportsCsv = downloadUrl('https://davidmegginson.github.io/ourairports-data/airports.csv');
+        if ($airportsCsv !== null) {
+            $lines = str_getcsv($airportsCsv, "\n", '"', '\\');
+            $header = str_getcsv(array_shift($lines), ',', '"', '\\');
+            $idx = array_flip(array_map('trim', $header));
+            $identIdx = $idx['ident'] ?? null;
+            $latIdx = $idx['latitude_deg'] ?? null;
+            $lonIdx = $idx['longitude_deg'] ?? null;
+            $gpsIdx = $idx['gps_code'] ?? null;
+            $icaoIdx = $idx['icao_code'] ?? null;
+            $iataIdx = $idx['iata_code'] ?? null;
+            $localIdx = $idx['local_code'] ?? null;
+            $countryIdx = $idx['iso_country'] ?? null;
+            if ($identIdx !== null && $latIdx !== null && $lonIdx !== null) {
+                foreach ($lines as $line) {
+                    $row = str_getcsv($line, ',', '"', '\\');
+                    if (count($row) <= max($identIdx, $latIdx, $lonIdx)) {
                         continue;
                     }
-                    $alt = strtoupper(trim($row[$altIdx] ?? ''));
-                    if ($alt !== '' && $alt !== $icao) {
-                        $faaToIcao[$alt] = $icao;
+                    $id = strtoupper(trim($row[$identIdx] ?? ''));
+                    $lat = $row[$latIdx] ?? '';
+                    $lon = $row[$lonIdx] ?? '';
+                    if ($id !== '' && $lat !== '' && $lon !== '') {
+                        $airportCenters[$id] = ['lat' => (float) $lat, 'lon' => (float) $lon];
+                    }
+                    if ($icaoIdx === null || $countryIdx === null || trim($row[$countryIdx] ?? '') !== 'US') {
+                        continue;
+                    }
+                    $icao = strtoupper(trim($row[$icaoIdx] ?? ''));
+                    if ($icao === '') {
+                        continue;
+                    }
+                    foreach ([$gpsIdx, $iataIdx, $localIdx] as $altIdx) {
+                        if ($altIdx === null) {
+                            continue;
+                        }
+                        $alt = strtoupper(trim($row[$altIdx] ?? ''));
+                        if ($alt !== '' && $alt !== $icao) {
+                            $faaToIcao[$alt] = $icao;
+                        }
                     }
                 }
             }
         }
     }
-}
 
-$merged = mergeRunwaySources($faa, $ourairports, $airportCenters, $faaToIcao);
+    $merged = mergeRunwaySources($faa, $ourairports, $airportCenters, $faaToIcao);
 
-$output = [
-    'fetched_at' => time(),
-    'airports' => $merged,
-];
+    $output = [
+        'fetched_at' => time(),
+        'airports' => $merged,
+    ];
 
-ensureCacheDir(CACHE_RUNWAYS_DIR);
-$tmpPath = CACHE_RUNWAYS_DATA_FILE . '.tmp.' . getmypid();
-$written = @file_put_contents($tmpPath, json_encode($output, JSON_UNESCAPED_SLASHES));
-if ($written === false || !@rename($tmpPath, CACHE_RUNWAYS_DATA_FILE)) {
-    @unlink($tmpPath);
-    aviationwx_log('error', 'runways fetch: failed to write cache', [], 'app', true);
+    ensureCacheDir(CACHE_RUNWAYS_DIR);
+    $tmpPath = CACHE_RUNWAYS_DATA_FILE . '.tmp.' . getmypid();
+    $written = @file_put_contents($tmpPath, json_encode($output, JSON_UNESCAPED_SLASHES));
+    if ($written === false || !@rename($tmpPath, CACHE_RUNWAYS_DATA_FILE)) {
+        @unlink($tmpPath);
+        aviationwx_log('error', 'runways fetch: failed to write cache', [], 'app', true);
+        flock($fp, LOCK_UN);
+        fclose($fp);
+        exit(1);
+    }
+
+    $config = loadConfig(false);
+    $airports = $config['airports'] ?? [];
+    $warmed = warmRunwaysApcuCache($airports);
+
     flock($fp, LOCK_UN);
     fclose($fp);
-    exit(1);
-}
+    @unlink(getRunwaysFetchLockPath());
 
-$config = loadConfig(false);
-$airports = $config['airports'] ?? [];
-$warmed = warmRunwaysApcuCache($airports);
+    aviationwx_log('info', 'runways fetch: complete', [
+        'airports' => count($merged),
+        'apcu_warmed' => $warmed,
+    ], 'app');
 
-flock($fp, LOCK_UN);
-fclose($fp);
-@unlink(getRunwaysFetchLockPath());
-
-aviationwx_log('info', 'runways fetch: complete', [
-    'airports' => count($merged),
-    'apcu_warmed' => $warmed,
-], 'app');
-
-exit(0);
+    exit(0);
 }

--- a/tests/Fixtures/runways_data.json
+++ b/tests/Fixtures/runways_data.json
@@ -1,1 +1,133 @@
-{"fetched_at":1700000000,"airports":{"03S":{"segments":[{"start":[-0.307,-0.851],"end":[0.307,0.851],"le_ident":"34","he_ident":"16","ident_at_start":"34","ident_at_end":"16","source":"programmatic"}],"center_lat":45.395,"center_lon":-122.261},"CYAV":{"segments":[{"start":[0,-0.9],"end":[0,0.9],"le_ident":"36","he_ident":"18L","ident_at_start":"36","ident_at_end":"18L","source":"programmatic"},{"start":[-0.766,0.643],"end":[0.766,-0.643],"le_ident":"13","he_ident":"31","ident_at_start":"13","ident_at_end":"31","source":"programmatic"},{"start":[0.643,0.766],"end":[-0.643,-0.766],"le_ident":"22","he_ident":"04","ident_at_start":"22","ident_at_end":"04","source":"programmatic"}],"center_lat":50.0564,"center_lon":-97.0325},"KPDX":{"segments":[{"start":[-0.94,-0.342],"end":[0.94,0.342],"le_ident":"10R","he_ident":"28L","ident_at_start":"10R","ident_at_end":"28L","source":"programmatic"},{"start":[-0.94,-0.342],"end":[0.94,0.342],"le_ident":"10L","he_ident":"28R","ident_at_start":"10L","ident_at_end":"28R","source":"programmatic"}],"center_lat":45.5897694,"center_lon":-122.5950944},"KSPB":{"segments":[{"start":[-0.469,-0.883],"end":[0.469,0.883],"le_ident":"33","he_ident":"15","ident_at_start":"33","ident_at_end":"15","source":"programmatic"}],"center_lat":45.7710278,"center_lon":-122.8618333}}}
+{
+  "fetched_at": 1700000000,
+  "airports": {
+    "03S": {
+      "segments": [
+        {
+          "start": [-0.307, -0.851],
+          "end": [0.307, 0.851],
+          "le_ident": "34",
+          "he_ident": "16",
+          "ident_at_start": "34",
+          "ident_at_end": "16",
+          "source": "programmatic"
+        }
+      ],
+      "center_lat": 45.395,
+      "center_lon": -122.261
+    },
+    "CYAV": {
+      "segments": [
+        {
+          "start": [0, -0.9],
+          "end": [0, 0.9],
+          "le_ident": "36",
+          "he_ident": "18L",
+          "ident_at_start": "36",
+          "ident_at_end": "18L",
+          "source": "programmatic"
+        },
+        {
+          "start": [-0.766, 0.643],
+          "end": [0.766, -0.643],
+          "le_ident": "13",
+          "he_ident": "31",
+          "ident_at_start": "13",
+          "ident_at_end": "31",
+          "source": "programmatic"
+        },
+        {
+          "start": [0.643, 0.766],
+          "end": [-0.643, -0.766],
+          "le_ident": "22",
+          "he_ident": "04",
+          "ident_at_start": "22",
+          "ident_at_end": "04",
+          "source": "programmatic"
+        }
+      ],
+      "center_lat": 50.0564,
+      "center_lon": -97.0325,
+      "performance_runways": [
+        {
+          "rwy_id": "04/22",
+          "length_ft": 2850,
+          "surface": "ASPH",
+          "ends": [],
+          "le_displaced_threshold_ft": 0,
+          "he_displaced_threshold_ft": 0
+        },
+        {
+          "rwy_id": "13/31",
+          "length_ft": 3000,
+          "surface": "ASPH",
+          "ends": [],
+          "le_displaced_threshold_ft": 0,
+          "he_displaced_threshold_ft": 0
+        },
+        {
+          "rwy_id": "18/36",
+          "length_ft": 3000,
+          "surface": "ASPH",
+          "ends": [],
+          "le_displaced_threshold_ft": 0,
+          "he_displaced_threshold_ft": 0
+        }
+      ]
+    },
+    "KPDX": {
+      "segments": [
+        {
+          "start": [-0.94, -0.342],
+          "end": [0.94, 0.342],
+          "le_ident": "10R",
+          "he_ident": "28L",
+          "ident_at_start": "10R",
+          "ident_at_end": "28L",
+          "source": "programmatic"
+        },
+        {
+          "start": [-0.94, -0.342],
+          "end": [0.94, 0.342],
+          "le_ident": "10L",
+          "he_ident": "28R",
+          "ident_at_start": "10L",
+          "ident_at_end": "28R",
+          "source": "programmatic"
+        }
+      ],
+      "center_lat": 45.5897694,
+      "center_lon": -122.5950944
+    },
+    "KSPB": {
+      "segments": [
+        {
+          "start": [-0.469, -0.883],
+          "end": [0.469, 0.883],
+          "le_ident": "33",
+          "he_ident": "15",
+          "ident_at_start": "33",
+          "ident_at_end": "15",
+          "source": "programmatic"
+        }
+      ],
+      "center_lat": 45.7710278,
+      "center_lon": -122.8618333
+    },
+    "ZZOA": {
+      "center_lat": 45.0,
+      "center_lon": -122.0,
+      "segments": [],
+      "performance_runways": [
+        {
+          "rwy_id": "N/S",
+          "length_ft": 2000,
+          "surface": "TURF",
+          "ends": [],
+          "le_displaced_threshold_ft": 0,
+          "he_displaced_threshold_ft": 0
+        }
+      ]
+    }
+  }
+}

--- a/tests/Unit/DensityAltitudePerformanceTest.php
+++ b/tests/Unit/DensityAltitudePerformanceTest.php
@@ -339,7 +339,7 @@ class DensityAltitudePerformanceTest extends TestCase
 
     public function testFallbackAriaLabelMentionsMissingRunwayData(): void
     {
-        $aria = densityAltitudePerformanceAriaLabel(9500, 'warning', [
+        $aria = densityAltitudePerformanceAriaLabel(9500, 'warning', 'ft', [
             'tier' => 'warning',
             'fallback' => true,
             'reason' => 'density_altitude_only',

--- a/tests/Unit/DensityAltitudePerformanceTest.php
+++ b/tests/Unit/DensityAltitudePerformanceTest.php
@@ -59,6 +59,7 @@ class DensityAltitudePerformanceTest extends TestCase
         $this->assertTrue($result['fallback']);
         $this->assertNull($result['risk_factor']);
         $this->assertSame('density_altitude_only', $result['reason']);
+        $this->assertSame(DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_FALLBACK, $result['reference']);
     }
 
     public function testFallbackRunsWhenRunwayMissingEvenWithoutPressureAltitude(): void
@@ -107,6 +108,7 @@ class DensityAltitudePerformanceTest extends TestCase
         $this->assertNotNull($result);
         $this->assertTrue($result['fallback']);
         $this->assertSame('density_altitude_only', $result['reason']);
+        $this->assertSame(DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_FALLBACK, $result['reference']);
         $this->assertNull($result['risk_factor']);
     }
 
@@ -289,6 +291,7 @@ class DensityAltitudePerformanceTest extends TestCase
         $this->assertNotNull($result);
         $this->assertSame('caution', $result['tier']);
         $this->assertSame('reference_models', $result['reason']);
+        $this->assertSame(DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_CONFIG, $result['reference']);
         $this->assertGreaterThanOrEqual(DENSITY_ALTITUDE_PERFORMANCE_TIER_WARNING, $result['worst_end_risk']);
     }
 

--- a/tests/Unit/DensityAltitudePerformanceTest.php
+++ b/tests/Unit/DensityAltitudePerformanceTest.php
@@ -272,6 +272,26 @@ class DensityAltitudePerformanceTest extends TestCase
         $this->assertSame(DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_OURAIRPORTS, $result['reference']);
     }
 
+    public function testConfigRunwayOverrideCapsWarningAtCaution(): void
+    {
+        $result = buildDensityAltitudePerformance([
+            'density_altitude' => 5000,
+            'pressure_altitude' => 3441,
+            'temperature' => 28.3,
+        ], [
+            'id' => 'zzcfg',
+            'icao' => 'ZZCFG',
+            'elevation_ft' => 3647,
+            'runway_length_ft' => 2000,
+            'runway_surface' => 'TURF',
+        ]);
+
+        $this->assertNotNull($result);
+        $this->assertSame('caution', $result['tier']);
+        $this->assertSame('reference_models', $result['reason']);
+        $this->assertGreaterThanOrEqual(DENSITY_ALTITUDE_PERFORMANCE_TIER_WARNING, $result['worst_end_risk']);
+    }
+
     public function testOurAirportsPathCapsWarningAtCaution(): void
     {
         $result = buildDensityAltitudePerformance([

--- a/tests/Unit/DensityAltitudePerformanceTest.php
+++ b/tests/Unit/DensityAltitudePerformanceTest.php
@@ -6,6 +6,8 @@
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../lib/nasr/cache.php';
+require_once __DIR__ . '/../../lib/runways.php';
+require_once __DIR__ . '/../../lib/density-altitude-performance-display.php';
 require_once __DIR__ . '/../../lib/weather/density-altitude-performance.php';
 
 class DensityAltitudePerformanceTest extends TestCase
@@ -249,5 +251,88 @@ class DensityAltitudePerformanceTest extends TestCase
         );
 
         $this->assertSame('warning', $tier);
+    }
+
+    public function testCyavUsesOurAirportsLongestRunwayWhenNasrAbsent(): void
+    {
+        $result = buildDensityAltitudePerformance([
+            'density_altitude' => 5000,
+            'pressure_altitude' => 4500,
+            'temperature' => 35,
+        ], [
+            'id' => 'cyav',
+            'icao' => 'CYAV',
+            'elevation_ft' => 759,
+        ]);
+
+        $this->assertNotNull($result);
+        $this->assertSame('caution', $result['tier']);
+        $this->assertFalse($result['fallback']);
+        $this->assertSame('reference_models_ourairports', $result['reason']);
+        $this->assertSame(DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_OURAIRPORTS, $result['reference']);
+    }
+
+    public function testOurAirportsPathCapsWarningAtCaution(): void
+    {
+        $result = buildDensityAltitudePerformance([
+            'density_altitude' => 5000,
+            'pressure_altitude' => 3441,
+            'temperature' => 28.3,
+        ], [
+            'id' => 'zzoa',
+            'icao' => 'ZZOA',
+            'elevation_ft' => 3647,
+        ]);
+
+        $this->assertNotNull($result);
+        $this->assertSame('caution', $result['tier']);
+        $this->assertSame('reference_models_ourairports', $result['reason']);
+        $this->assertGreaterThanOrEqual(DENSITY_ALTITUDE_PERFORMANCE_TIER_WARNING, $result['worst_end_risk']);
+    }
+
+    public function testOurAirportsSelectsLongestNonWaterRunway(): void
+    {
+        $runways = [
+            ['length_ft' => 2850, 'surface' => 'ASPH', 'le_ident' => '04', 'he_ident' => '22'],
+            ['length_ft' => 3000, 'surface' => 'ASPH', 'le_ident' => '13', 'he_ident' => '31'],
+            ['length_ft' => 4500, 'surface' => 'WATER', 'le_ident' => '01', 'he_ident' => '19'],
+        ];
+
+        $selected = ourAirportsSelectLongestActiveLandRunway(buildOurAirportsPerformanceRunways($runways));
+
+        $this->assertNotNull($selected);
+        $this->assertSame(3000, $selected['length_ft']);
+        $this->assertSame('13/31', $selected['rwy_id']);
+    }
+
+    public function testFallbackTooltipMentionsMissingRunwayData(): void
+    {
+        $tooltip = densityAltitudePerformanceTooltip('warning', [
+            'tier' => 'warning',
+            'fallback' => true,
+            'reason' => 'density_altitude_only',
+        ]);
+
+        $this->assertStringContainsString('Runway data unavailable', $tooltip);
+        $this->assertStringContainsString('field elevation only', $tooltip);
+    }
+
+    public function testFallbackAriaLabelMentionsMissingRunwayData(): void
+    {
+        $aria = densityAltitudePerformanceAriaLabel(9500, 'warning', [
+            'tier' => 'warning',
+            'fallback' => true,
+            'reason' => 'density_altitude_only',
+        ]);
+
+        $this->assertStringContainsString('Runway data unavailable', $aria);
+        $this->assertStringContainsString('field elevation only', $aria);
+    }
+
+    public function testCapTierWithoutObstructionsDowngradesWarning(): void
+    {
+        $this->assertSame('caution', densityAltitudePerformanceCapTierWithoutObstructions('warning'));
+        $this->assertSame('caution', densityAltitudePerformanceCapTierWithoutObstructions('caution'));
+        $this->assertSame('normal', densityAltitudePerformanceCapTierWithoutObstructions('normal'));
     }
 }

--- a/tests/Unit/FetchRunwaysTest.php
+++ b/tests/Unit/FetchRunwaysTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/runways.php';
+require_once __DIR__ . '/../../scripts/fetch-runways.php';
+
+class FetchRunwaysTest extends TestCase
+{
+    public function testResolveOurAirportsRunwaysForCacheIdent_UsesFaaToIcaoMapping(): void
+    {
+        $ourairports = [
+            'KHIO' => [
+                [
+                    'length_ft' => 6600,
+                    'surface' => 'ASPH',
+                    'le_ident' => '03',
+                    'he_ident' => '21',
+                ],
+            ],
+        ];
+
+        $resolved = resolveOurAirportsRunwaysForCacheIdent('HIO', $ourairports, ['HIO' => 'KHIO']);
+
+        $this->assertNotNull($resolved);
+        $this->assertSame(6600, $resolved[0]['length_ft']);
+    }
+
+    public function testMergeRunwaySources_AttachesPerformanceRunwaysForFaaCoveredAirport(): void
+    {
+        $faa = [
+            'HIO' => [
+                [
+                    'lat1' => 45.54,
+                    'lon1' => -122.95,
+                    'lat2' => 45.53,
+                    'lon2' => -122.94,
+                    'le_ident' => '03',
+                    'he_ident' => '21',
+                    'source' => 'faa',
+                ],
+            ],
+        ];
+        $ourairports = [
+            'KHIO' => [
+                [
+                    'lat1' => 45.54,
+                    'lon1' => -122.95,
+                    'lat2' => 45.53,
+                    'lon2' => -122.94,
+                    'le_ident' => '03',
+                    'he_ident' => '21',
+                    'length_ft' => 6600,
+                    'surface' => 'ASPH',
+                    'le_displaced_threshold_ft' => 0,
+                    'he_displaced_threshold_ft' => 0,
+                    'source' => 'ourairports',
+                ],
+            ],
+        ];
+        $centers = ['HIO' => ['lat' => 45.535, 'lon' => -122.945]];
+
+        $merged = mergeRunwaySources($faa, $ourairports, $centers, ['HIO' => 'KHIO']);
+
+        $this->assertArrayHasKey('performance_runways', $merged['HIO']);
+        $this->assertArrayHasKey('performance_runways', $merged['KHIO']);
+        $this->assertSame(6600, $merged['KHIO']['performance_runways'][0]['length_ft']);
+    }
+}


### PR DESCRIPTION
## Summary

Non-US fields (and anything without a NASR row) can now get a real runway-length DA performance cue from OurAirports instead of weather-only elevation bands. When we still have no runway context, dashboard and embed tooltips say so plainly.

Closes #210

## What changed

**OurAirports runway path**
- `fetch-runways.php` caches `length_ft`, surface, and displaced thresholds alongside compass geometry
- DA performance precedence: config override → NASR → OurAirports → weather-only fallback
- API returns `reason: reference_models_ourairports`, `fallback: false` on the OurAirports path
- Warning tier capped at **caution** when obstruction data is absent (no 🚩 without NASR-grade departure-end context)

**Honest fallback UI**
- When `fallback: true`, dashboard JS and embed PHP/JS tooltips and `aria-label` state runway data was unavailable

**Tests**
- CYAV longest-runway selection, water exclusion, warning→caution cap, fallback copy
- Restored KSPB/KPDX/03S segments in `runways_data.json` so wind-compass tests keep passing

## Breaking changes

None for existing US NASR airports. Non-US airports may start showing a caution/warning cue where they previously had none or only weather-only fallback.

## Migration / deploy notes

Runway cache must refresh after deploy (`scripts/fetch-runways.php` or wait for scheduler) so live `performance_runways` rows exist. Until then non-US airports keep the weather-only path.

**Depends on:** #197 (`feature/da-performance-attention`) - this PR stacks on that branch.

## Test plan

- [x] `make test-ci`
- [x] CYAV on a hot day - confirm OurAirports runway context (not `fallback: true`)
- [x] Airport with no NASR and no OurAirports runway - confirm fallback tooltip copy on dashboard and embed
- [x] US airport with NASR - unchanged NASR full model