### PR TITLE
DA performance: operational departure end selection

### DIFF
--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -1070,6 +1070,32 @@
                 "type": "number",
                 "description": "Best departure-end summed profile risk (0-3) when full model used"
               },
+              "scored_end_risk": {
+                "type": "number",
+                "description": "Summed profile risk (0-3) for the operational departure end used for tier when selection_basis is window_mean_wind or asymmetric_heuristic"
+              },
+              "operational_end_id": {
+                "type": "string",
+                "description": "Runway end ident scored for tier (e.g. 14, 32L); omitted when selection_basis is both_ends",
+                "nullable": true
+              },
+              "selection_basis": {
+                "type": "string",
+                "enum": ["window_mean_wind", "asymmetric_heuristic", "both_ends"],
+                "description": "How the operational departure end was chosen for tier scoring"
+              },
+              "wind_basis": {
+                "type": "object",
+                "description": "Window mean wind used when selection_basis is window_mean_wind",
+                "nullable": true,
+                "properties": {
+                  "direction_magnetic": { "type": "number" },
+                  "speed_kts": { "type": "number" },
+                  "observation_count": { "type": "integer" },
+                  "window_hours": { "type": "integer" },
+                  "dispersion_ratio": { "type": "number" }
+                }
+              },
               "fallback": {
                 "type": "boolean",
                 "description": "True when runway data unavailable and elevation-banded thresholds used"

--- a/api/v1/weather-bulk.php
+++ b/api/v1/weather-bulk.php
@@ -104,7 +104,7 @@ function handleGetWeatherBulk(array $params, array $context): void
         metrics_track_weather_request($airportId);
         
         // Format weather response
-        $weatherData[$airportId] = formatWeatherResponse($weather, $airport);
+        $weatherData[$airportId] = formatWeatherResponse($weather, $airport, $airportId);
         $returned++;
     }
     

--- a/api/v1/weather.php
+++ b/api/v1/weather.php
@@ -71,7 +71,7 @@ function handleGetWeather(array $params, array $context): void
     }
     
     // Format weather for response
-    $formatted = formatWeatherResponse($weatherData, $airport);
+    $formatted = formatWeatherResponse($weatherData, $airport, $airportId);
     
     // Build metadata
     $meta = [

--- a/api/weather.php
+++ b/api/weather.php
@@ -39,9 +39,10 @@ require_once __DIR__ . '/../lib/weather/density-altitude-performance.php';
  *
  * @param array $weather Raw weather from cache
  * @param array|null $airport Airport config for density_altitude_performance enrichment
+ * @param string|null $airportId Config airport id for weather history lookup
  * @return array Weather with wind_direction object and last_hour_wind object (sectors, reference, unit, period_label)
  */
-function formatInternalApiWeatherResponse(array $weather, ?array $airport = null): array
+function formatInternalApiWeatherResponse(array $weather, ?array $airport = null, ?string $airportId = null): array
 {
     $out = $weather;
     unset($out['wind_direction_magnetic'], $out['wind_direction_text']);
@@ -59,7 +60,7 @@ function formatInternalApiWeatherResponse(array $weather, ?array $airport = null
     }
 
     if ($airport !== null) {
-        $out = attachDensityAltitudePerformance($out, $airport);
+        $out = attachDensityAltitudePerformance($out, $airport, $airportId);
     }
 
     return $out;
@@ -301,7 +302,7 @@ function generateMockWeatherData($airportId, $airport) {
         addWindDirectionMagneticToWeather($mockWeather, $airport);
 
         // Format and build response
-        $payload = ['success' => true, 'weather' => formatInternalApiWeatherResponse($mockWeather, $airport)];
+        $payload = ['success' => true, 'weather' => formatInternalApiWeatherResponse($mockWeather, $airport, $airportId)];
         $body = json_encode($payload);
         $etag = 'W/"' . sha1($body) . '"';
         
@@ -383,7 +384,7 @@ function generateMockWeatherData($airportId, $airport) {
             }
             addWindDirectionMagneticToWeather($cached, $airport);
 
-            $payload = ['success' => true, 'weather' => formatInternalApiWeatherResponse($cached, $airport)];
+            $payload = ['success' => true, 'weather' => formatInternalApiWeatherResponse($cached, $airport, $airportId)];
             
             // Add debug info if debug mode is enabled
             if ($debugMode) {
@@ -444,7 +445,7 @@ function generateMockWeatherData($airportId, $airport) {
             }
             addWindDirectionMagneticToWeather($staleData, $airport);
 
-            $payload = ['success' => true, 'weather' => formatInternalApiWeatherResponse($staleData, $airport), 'stale' => true];
+            $payload = ['success' => true, 'weather' => formatInternalApiWeatherResponse($staleData, $airport, $airportId), 'stale' => true];
             
             // Add debug info if debug mode is enabled
             if ($debugMode) {
@@ -776,7 +777,7 @@ function generateMockWeatherData($airportId, $airport) {
         exit;
     }
 
-    $responseWeather = formatInternalApiWeatherResponse($weatherData, $airport);
+    $responseWeather = formatInternalApiWeatherResponse($weatherData, $airport, $airportId);
 
     // Build ETag for response based on content
     $payload = ['success' => true, 'weather' => $responseWeather];

--- a/docs/API.md
+++ b/docs/API.md
@@ -69,6 +69,16 @@ Returns weather data for the specified airport.
       "risk_factor": 1.85,
       "worst_end_risk": 1.85,
       "best_end_risk": 0.92,
+      "scored_end_risk": 1.85,
+      "operational_end_id": "26",
+      "selection_basis": "window_mean_wind",
+      "wind_basis": {
+        "direction_magnetic": 260.0,
+        "speed_kts": 8.5,
+        "observation_count": 4,
+        "window_hours": 1,
+        "dispersion_ratio": 1.12
+      },
       "fallback": false,
       "reason": "reference_models",
       "reference": "Cessna 152/172/182 AFM max gross, 0 kt wind (neutral conservative case); longest NASR runway"

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -644,7 +644,24 @@ Pressure Altitude = Station Elevation + [(29.92 - Altimeter Setting) × 1000]
 
 **SAFETY CRITICAL**: This cue reminds pilots to verify AFM performance numbers when density altitude and runway context suggest extra planning. It is **not** a go/no-go judgment.
 
-**When it runs**: On each weather API response (Internal API, Public API, embeds) after density altitude is present and not fail-closed null. Computation is server-side at format time so NASR cache updates apply without re-fetching weather.
+**When it runs**: On each weather API response (Internal API, Public API, embeds) after density altitude is present and not fail-closed null. `attachDensityAltitudePerformance()` calls `buildDensityAltitudePerformance()` at format time so NASR cache updates apply without re-fetching weather.
+
+**Suppression** (no `density_altitude_performance` field in the response):
+
+- Density altitude missing or fail-closed null
+- Full model unavailable (missing pressure altitude or temperature) and fallback tier is `normal`
+- Full model or fallback yields tier `normal`
+
+**Pipeline**:
+
+1. Resolve runway context (config override, NASR, OurAirports, or weather-only fallback).
+2. Score **every** departure end on the selected runway (C152/C172/C182 reference models).
+3. Choose operational departure end and scoring basis (window mean wind, asymmetric heuristic, or both ends).
+4. Map risk to tier (`caution` / `warning`) from the scored end or worst/best pair.
+5. Cap tier at `caution` when obstruction data is absent (config override or OurAirports).
+6. Omit the field when tier is `normal`.
+
+Formulas, stress ratios, and tier thresholds are in [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md#density-altitude-performance).
 
 **Data inputs**:
 
@@ -657,6 +674,7 @@ Pressure Altitude = Station Elevation + [(29.92 - Altimeter Setting) × 1000]
 | Runway length, surface (no obstructions) | OurAirports `runways.csv` cache | When NASR has no row; longest non-closed land runway (exclude water surfaces). Same POH length/surface stress as config override; per-end displaced thresholds when published; no departure obstructions. See [OurAirports runway model](#ourairports-runway-model) below. |
 | Operator runway override | `airports.json` `runway_length_ft` / `runway_surface` | Replaces NASR and OurAirports selection; obstructions dropped |
 | AFM takeoff tables | `data/poh/*.json` | C152M, C172N, C182T short-field charts |
+| Wind history (operational end) | Weather history cache | Required for Path A; see [Operational departure end selection](#operational-departure-end-selection) |
 
 **Runway context precedence** (first match wins):
 
@@ -684,16 +702,46 @@ OurAirports is community-maintained; length and surface can disagree with nation
 **Full model** (runway data available):
 
 1. Select **longest** active land runway (exclude `WATER`, exclude `COND=FAILED`). Shorter runways at the same airport are not evaluated, to avoid over-alerting when the longest strip is available; pilots choosing a shorter runway must apply their own ADM.
-2. For each runway end, lookup AFM takeoff distance to clear 50 ft for C152/C172/C182 at max gross (**0 kt wind** - neutral conservative case; no headwind/tailwind adjustment).
+2. Score each departure end: AFM takeoff distance to clear 50 ft for C152/C172/C182 at max gross (**0 kt wind** - neutral conservative case; no headwind/tailwind adjustment).
 3. Apply POH note 4 on non-paved surfaces: `total = chart_total + 0.15 × ground_roll`.
 4. Use per-end effective departure length from NASR (`TKOF_DIST_AVBL`, displaced threshold) when published.
 5. Obstruction clearance: AFM chart total is distance to clear a **50 ft** obstacle. For NASR departure obstacles within runway length, scale required distance **linearly** by `obst_hgt / 50` (including above 50 ft). When `OBSTN_CLNC_SLOPE` is published, obstacles on or below the NASR clearance surface at that distance add no obstacle stress; penetrating obstacles use full height. Compare clearance stress `required / obst_dist` against runway stress `chart_total / effective_departure_length`; use the higher stress per model.
-6. Per-end total risk: unweighted sum `r152 + r172 + r182` (0-3) for each departure end.
-7. Operational end selection: window mean wind (primary), asymmetric spread heuristic, or both-ends fallback (see [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md#density-altitude-performance)).
-8. Tier mapping: single-end scoring uses scored end risk; both-ends uses worst/best asymmetric rules.
-9. Omit `density_altitude_performance` when tier is `normal` (reference-model margin is adequate).
+6. Per-end total risk: unweighted sum `r152 + r172 + r182` (0-3) for each departure end. Track worst and best ends across the runway.
+7. [Operational departure end selection](#operational-departure-end-selection) chooses which end drives the tier.
+8. Tier mapping applies single-end or both-ends rules (see below).
+9. Omit `density_altitude_performance` when tier is `normal`.
 
-**Config `runway_length_ft`**: Operator override replaces NASR runway length (optional `runway_surface`) with synthetic runway `config` and **empty ends**. NASR departure obstructions, displaced thresholds, and `TKOF_DIST_AVBL` are not applied. Use when NASR length is wrong; can under-alert if obstacles matter. See `docs/CONFIGURATION.md` (Density altitude performance overrides).
+#### Operational departure end selection
+
+After both ends are scored, `resolveDensityAltitudePerformanceEndSelection()` picks the departure end that drives the alert. Evaluation order is fixed; the first matching path wins.
+
+**Path A - window mean wind** (`selection_basis: window_mean_wind`):
+
+- Requires `config.public_api.weather_history_enabled`, resolvable magnetic headings for at least one runway end, and a config airport id for history lookup.
+- `computeWindowMeanWind()` reads observations in `wind_rose_window_hours` (default 1 hour), same rolling window as the wind rose. Non-calm observations only (`wind_speed ≥ CALM_WIND_THRESHOLD_KTS`, 3 kt). Vector mean direction and speed must pass quality gates (minimum observation count, mean speed, dispersion ratio). See [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md#density-altitude-performance).
+- `pickDepartureEndByWindFromMagnetic()` selects the runway end whose magnetic heading is closest to the mean wind **from** direction (into-wind departure).
+- Tier maps from **scored end risk** on that end only. Response includes `operational_end_id`, `scored_end_risk`, and `wind_basis`.
+
+**Path B - asymmetric spread heuristic** (`selection_basis: asymmetric_heuristic`):
+
+- Applies when Path A does not (light/variable wind, insufficient history, or unresolvable headings).
+- When `worst_end_risk - best_end_risk ≥ DA_PERF_ASYMMETRIC_SPREAD` (1.5), tier from the **best** (most favorable) end only. Covers one-way strips where one direction has departure obstructions and the other does not.
+- Tier maps from **scored end risk** on the best end. Response includes `operational_end_id` and `scored_end_risk`; `wind_basis` is null.
+
+**Path C - both ends** (`selection_basis: both_ends`):
+
+- Fallback when spread is below the asymmetric threshold, or when runway ends/headings are unavailable.
+- Config `runway_length_ft` override (synthetic runway with empty ends) always uses this path.
+- Tier uses worst/best asymmetric rules: **warning** when best end sum ≥ 2.40; **caution** when worst end sum ≥ 1.20 (and not warning). `risk_factor` uses best-end sum for warning, worst-end sum for caution. `operational_end_id` and `scored_end_risk` are omitted.
+
+**Tier mapping summary**:
+
+| `selection_basis` | Caution | Warning | `risk_factor` source |
+|-------------------|---------|---------|----------------------|
+| `window_mean_wind`, `asymmetric_heuristic` | Scored end ≥ 1.20 | Scored end ≥ 2.40 | Scored end sum |
+| `both_ends` | Worst end ≥ 1.20 | Best end ≥ 2.40 | Worst (caution) or best (warning) |
+
+**Config `runway_length_ft`**: Operator override replaces NASR runway length (optional `runway_surface`) with synthetic runway `config` and **empty ends**. NASR departure obstructions, displaced thresholds, and `TKOF_DIST_AVBL` are not applied. Wind-based and asymmetric end selection are skipped (Path C only). Use when NASR length is wrong; can under-alert if obstacles matter. See `docs/CONFIGURATION.md` (Density altitude performance overrides).
 
 **Fallback model** (no runway data from config, NASR, or OurAirports): Elevation-banded density-altitude thresholds only. Returns `tier` and `fallback: true`; `risk_factor` is **null** (no numeric score). UI copy must state that runway context was unavailable.
 
@@ -721,11 +769,23 @@ OurAirports is community-maintained; length and surface can disagree with nation
 }
 ```
 
-**Display**: ⚠️ (caution) or 🚩 (warning) adjacent to the density altitude value; warning tier uses amber styling. Tooltips use AFM wording.
+**Display**: ⚠️ (caution) or 🚩 (warning) adjacent to the density altitude value; warning tier uses amber styling. Tooltips use AFM wording and, when present, name the scored departure end (`operational_end_id`) and selection basis.
 
-**Implementation**: `lib/weather/density-altitude-performance.php`, `lib/nasr/*`, `lib/weather/poh-takeoff.php`
+**Implementation**:
 
-**Tests**: `tests/Unit/DensityAltitudePerformanceTest.php`, `tests/Unit/PohTakeoffTest.php`, `tests/Unit/NasrParseTest.php`
+| Component | File | Role |
+|-----------|------|------|
+| Assessment and API payload | `lib/weather/density-altitude-performance.php` | `buildDensityAltitudePerformance()`, tier mapping, attach at format time |
+| Operational end selection | `lib/weather/density-altitude-performance.php` | `resolveDensityAltitudePerformanceEndSelection()` |
+| Runway end headings and wind pick | `lib/weather/da-performance-runway-end.php` | `resolveRunwayEndMagneticHeading()`, `pickDepartureEndByWindFromMagnetic()` |
+| Window mean wind | `lib/weather/history.php` | `computeWindowMeanWind()` |
+| AFM table lookup | `lib/weather/poh-takeoff.php` | Chart distance and obstruction stress |
+| NASR runway selection | `lib/nasr/*` | Longest runway, effective departure length, obstructions |
+| Display helpers | `lib/density-altitude-performance-display.php` | Tooltip copy |
+
+**Tests**: `tests/Unit/DensityAltitudePerformanceTest.php`, `tests/Unit/DensityAltitudePerformanceReferenceScenarioTest.php`, `tests/Unit/WindowMeanWindTest.php`, `tests/Unit/PohTakeoffTest.php`, `tests/Unit/NasrParseTest.php`
+
+**Fleet validation**: `scripts/fleet-da-constants-audit.php` compares policy variants against live weather for configured airports (requires production `CONFIG_PATH`).
 
 **See also**: [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md#density-altitude-performance)
 
@@ -1096,6 +1156,8 @@ When new data is fetched but some fields are missing:
 **API Access**: Available via Public API endpoint `/v1/airports/{id}/weather/history` with optional time filtering and resolution downsampling (all, hourly, 15min).
 
 **Wind Rose Petals**: `computeWindRose()` derives 16-sector wind distribution from observations in a configurable rolling window. Window size is set by `config.public_api.wind_rose_window_hours` (default 1). Observations with wind speed below `CALM_WIND_THRESHOLD_KTS` (3 knots) are excluded. Requires at least 2 valid observations. Result is added to weather cache as `last_hour_wind` when `config.public_api.weather_history_enabled` is true. Petals extend in direction wind is FROM (meteorological convention). Arrow shows direction wind is blowing TOWARD (windsock convention).
+
+**Window mean wind** (density altitude performance): `computeWindowMeanWind()` uses the same history window and non-calm filter to derive a vector mean wind for operational departure end selection. Quality gates (`DA_PERF_WIND_MIN_OBS`, `DA_PERF_WIND_MIN_MEAN_KTS`, `DA_PERF_VARIABLE_WIND_RATIO`) are stricter than the wind rose minimum. See [Operational departure end selection](#operational-departure-end-selection) and [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md#density-altitude-performance).
 
 **API Format**: The Internal and Public APIs return `last_hour_wind` as an object: `{ sectors: number[16], sector_labels: string[16], reference: "magnetic_north", unit: "knots", period_label: string }`. Sectors are ordered N, NNE, NE, ENE, E, ESE, SE, SSE, S, SSW, SW, WSW, W, WNW, NW, NNW. `period_label` is derived from `wind_rose_window_hours` (e.g. "last hour", "last 3 hours") or overridden by `wind_rose_period_label`. Null when insufficient observations.
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -689,8 +689,9 @@ OurAirports is community-maintained; length and surface can disagree with nation
 4. Use per-end effective departure length from NASR (`TKOF_DIST_AVBL`, displaced threshold) when published.
 5. Obstruction clearance: AFM chart total is distance to clear a **50 ft** obstacle. For NASR departure obstacles within runway length, scale required distance **linearly** by `obst_hgt / 50` (including above 50 ft). When `OBSTN_CLNC_SLOPE` is published, obstacles on or below the NASR clearance surface at that distance add no obstacle stress; penetrating obstacles use full height. Compare clearance stress `required / obst_dist` against runway stress `chart_total / effective_departure_length`; use the higher stress per model.
 6. Per-end total risk: unweighted sum `r152 + r172 + r182` (0-3) for each departure end.
-7. Asymmetric tiers: **normal** when neither threshold applies (field omitted); **warning** when best end sum ≥ 2.40; **caution** when worst end sum ≥ 1.20 (and not warning). `risk_factor` uses best-end sum for warning, worst-end sum for caution.
-8. Omit `density_altitude_performance` when tier is `normal` (reference-model margin is adequate).
+7. Operational end selection: window mean wind (primary), asymmetric spread heuristic, or both-ends fallback (see [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md#density-altitude-performance)).
+8. Tier mapping: single-end scoring uses scored end risk; both-ends uses worst/best asymmetric rules.
+9. Omit `density_altitude_performance` when tier is `normal` (reference-model margin is adequate).
 
 **Config `runway_length_ft`**: Operator override replaces NASR runway length (optional `runway_surface`) with synthetic runway `config` and **empty ends**. NASR departure obstructions, displaced thresholds, and `TKOF_DIST_AVBL` are not applied. Use when NASR length is wrong; can under-alert if obstacles matter. See `docs/CONFIGURATION.md` (Density altitude performance overrides).
 
@@ -704,6 +705,16 @@ OurAirports is community-maintained; length and surface can disagree with nation
   "risk_factor": 1.85,
   "worst_end_risk": 1.85,
   "best_end_risk": 0.92,
+  "scored_end_risk": 1.85,
+  "operational_end_id": "26",
+  "selection_basis": "window_mean_wind",
+  "wind_basis": {
+    "direction_magnetic": 260.0,
+    "speed_kts": 8.5,
+    "observation_count": 4,
+    "window_hours": 1,
+    "dispersion_ratio": 1.12
+  },
   "fallback": false,
   "reason": "reference_models",
   "reference": "Cessna 152/172/182 AFM max gross, 0 kt wind (neutral conservative case); longest NASR runway"

--- a/docs/SAFETY_CRITICAL_CALCULATIONS.md
+++ b/docs/SAFETY_CRITICAL_CALCULATIONS.md
@@ -148,12 +148,18 @@ No obstruction stress when obstacle is beyond runway length or height/distance a
 
 **Per-end total risk**: Unweighted sum `r152 + r172 + r182` (range 0-3) for each departure end.
 
-**Asymmetric tiers** (evaluate best and worst ends on the selected runway):
+**Operational departure end selection** (before tier mapping):
 
-- **Normal** when neither threshold applies (`density_altitude_performance` omitted from API).
-- **Warning** when **best** end sum ≥ 2.40 (optimistic: favorable departure direction still constrained).
-- **Caution** when **worst** end sum ≥ 1.20 and warning did not apply (conservative: at least one direction warrants verification).
-- `risk_factor`: best-end sum for warning; worst-end sum for caution.
+1. **Window mean wind** (primary): Vector mean from weather history over `wind_rose_window_hours` (default 1 hour). Same non-calm rules as the wind rose. Requires at least `DA_PERF_WIND_MIN_OBS` (3) observations, mean speed ≥ `DA_PERF_WIND_MIN_MEAN_KTS` (5 kt), and dispersion ratio ≤ `DA_PERF_VARIABLE_WIND_RATIO` (2.0). Score only the into-wind departure end (magnetic).
+2. **Asymmetric spread heuristic**: When wind is light, variable, or history is insufficient: if `worst_end_risk - best_end_risk ≥ DA_PERF_ASYMMETRIC_SPREAD` (1.5) and `best_end_risk < 1.20`, tier from the **best** end only.
+3. **Both ends** (fallback): When both directions are similarly constrained, use worst/best asymmetric tier rules below. Config `runway_length_ft` override (empty ends), missing headings, or insufficient data also use this path (fail-closed).
+
+**Tier mapping**:
+
+- **Single-end** (`window_mean_wind` or `asymmetric_heuristic`): **warning** when scored end sum ≥ 2.40; **caution** when scored end sum ≥ 1.20; **normal** otherwise. `risk_factor` and `scored_end_risk` use the scored end sum.
+- **Both ends** (`both_ends`): **warning** when **best** end sum ≥ 2.40; **caution** when **worst** end sum ≥ 1.20 (and not warning). `risk_factor` uses best-end sum for warning, worst-end sum for caution.
+
+**Normal** tier omits `density_altitude_performance` from API responses.
 
 ### OurAirports runway model (when NASR unavailable)
 

--- a/docs/SAFETY_CRITICAL_CALCULATIONS.md
+++ b/docs/SAFETY_CRITICAL_CALCULATIONS.md
@@ -151,7 +151,7 @@ No obstruction stress when obstacle is beyond runway length or height/distance a
 **Operational departure end selection** (before tier mapping):
 
 1. **Window mean wind** (primary): Vector mean from weather history over `wind_rose_window_hours` (default 1 hour). Same non-calm rules as the wind rose. Requires at least `DA_PERF_WIND_MIN_OBS` (3) observations, mean speed ≥ `DA_PERF_WIND_MIN_MEAN_KTS` (5 kt), and dispersion ratio ≤ `DA_PERF_VARIABLE_WIND_RATIO` (2.0). Score only the into-wind departure end (magnetic).
-2. **Asymmetric spread heuristic**: When wind is light, variable, or history is insufficient: if `worst_end_risk - best_end_risk ≥ DA_PERF_ASYMMETRIC_SPREAD` (1.5) and `best_end_risk < 1.20`, tier from the **best** end only.
+2. **Asymmetric spread heuristic**: When wind is light, variable, or history is insufficient: if `worst_end_risk - best_end_risk ≥ DA_PERF_ASYMMETRIC_SPREAD` (1.5), tier from the **best** end only (one-way strip geometry).
 3. **Both ends** (fallback): When both directions are similarly constrained, use worst/best asymmetric tier rules below. Config `runway_length_ft` override (empty ends), missing headings, or insufficient data also use this path (fail-closed).
 
 **Tier mapping**:

--- a/docs/SAFETY_CRITICAL_CALCULATIONS.md
+++ b/docs/SAFETY_CRITICAL_CALCULATIONS.md
@@ -2,7 +2,7 @@
 
 This document provides a comprehensive reference for all safety-critical weather calculations in AviationWX. These calculations directly affect flight safety decisions and must be verified against official FAA and ICAO sources.
 
-**Last Updated**: 2026-02-14  
+**Last Updated**: 2026-07-15  
 **Verification Status**: ✅ All formulas verified against FAA sources
 
 ---
@@ -124,7 +124,9 @@ All safety-critical calculations use TDD methodology:
 
 **Purpose**: Provide a server-computed cue when density altitude and runway context suggest verifying AFM takeoff performance. This is **not** a go/no-go decision.
 
-**When suppressed**: Missing or fail-closed null density altitude; missing pressure altitude or temperature for full model; asymmetric tier `normal` (no cue shown).
+**When suppressed**: Missing or fail-closed null density altitude; missing pressure altitude or temperature for full model; tier `normal` (no cue shown).
+
+Pipeline and operational end selection order are documented in [DATA_FLOW.md](DATA_FLOW.md#density-altitude-performance).
 
 ### Full model (reference AFM tables + NASR runway)
 
@@ -144,20 +146,82 @@ No obstruction stress when obstacle is beyond runway length or height/distance a
 
 **Effective departure length** (per runway end): `min(runway_length - displaced_thr_len, tkof_dist_avbl)` when NASR publishes those fields; otherwise published runway length.
 
-**Profile risk**: `stress = max(runway_stress, obstruction_stress)`; `risk = clamp((stress - 0.67) / 0.66, 0, 1)`.
+**Profile risk**:
+
+```
+stress = max(runway_stress, obstruction_stress)
+risk   = clamp((stress - 0.67) / 0.66, 0, 1)
+```
+
+Constants `PERFORMANCE_STRESS_LOW` (0.67) and `PERFORMANCE_STRESS_HIGH` (1.33) are defined in `lib/constants.php`.
 
 **Per-end total risk**: Unweighted sum `r152 + r172 + r182` (range 0-3) for each departure end.
 
-**Operational departure end selection** (before tier mapping):
+### Operational departure end selection
 
-1. **Window mean wind** (primary): Vector mean from weather history over `wind_rose_window_hours` (default 1 hour). Same non-calm rules as the wind rose. Requires at least `DA_PERF_WIND_MIN_OBS` (3) observations, mean speed ≥ `DA_PERF_WIND_MIN_MEAN_KTS` (5 kt), and dispersion ratio ≤ `DA_PERF_VARIABLE_WIND_RATIO` (2.0). Score only the into-wind departure end (magnetic).
-2. **Asymmetric spread heuristic**: When wind is light, variable, or history is insufficient: if `worst_end_risk - best_end_risk ≥ DA_PERF_ASYMMETRIC_SPREAD` (1.5), tier from the **best** end only (one-way strip geometry).
-3. **Both ends** (fallback): When both directions are similarly constrained, use worst/best asymmetric tier rules below. Config `runway_length_ft` override (empty ends), missing headings, or insufficient data also use this path (fail-closed).
+After both ends are scored, one of three paths selects the end that drives tier mapping.
 
-**Tier mapping**:
+**Path A - window mean wind** (`selection_basis: window_mean_wind`):
 
-- **Single-end** (`window_mean_wind` or `asymmetric_heuristic`): **warning** when scored end sum ≥ 2.40; **caution** when scored end sum ≥ 1.20; **normal** otherwise. `risk_factor` and `scored_end_risk` use the scored end sum.
-- **Both ends** (`both_ends`): **warning** when **best** end sum ≥ 2.40; **caution** when **worst** end sum ≥ 1.20 (and not warning). `risk_factor` uses best-end sum for warning, worst-end sum for caution.
+Vector mean wind from weather history over `wind_rose_window_hours` (default 1 hour). Same observation window and non-calm filter as the wind rose (`CALM_WIND_THRESHOLD_KTS` = 3 kt). Each qualifying observation contributes u/v components from magnetic wind direction (meteorological FROM) and speed:
+
+```
+u += -speed × sin(dir_mag)
+v += -speed × cos(dir_mag)
+vector_speed = sqrt(u_mean² + v_mean²)
+direction_mag = atan2(-u_mean, -v_mean)  // degrees 0-360
+scalar_mean = mean(observed speeds)
+dispersion_ratio = scalar_mean / vector_speed
+```
+
+**Quality gates** (all required; otherwise Path A is skipped):
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `DA_PERF_WIND_MIN_OBS` | 3 | Minimum non-calm observations in window |
+| `DA_PERF_WIND_MIN_MEAN_KTS` | 5.0 | Minimum vector mean speed |
+| `DA_PERF_VARIABLE_WIND_RATIO` | 2.0 | Maximum `scalar_mean / vector_speed` (reject highly variable wind) |
+
+`pickDepartureEndByWindFromMagnetic()` selects the runway end whose magnetic heading has the smallest angular difference from mean wind FROM (into-wind departure). Tier maps from that end's total risk only.
+
+**Path B - asymmetric spread heuristic** (`selection_basis: asymmetric_heuristic`):
+
+When Path A does not apply:
+
+```
+spread = worst_end_risk - best_end_risk
+if spread >= DA_PERF_ASYMMETRIC_SPREAD (1.5):
+    tier from best end only
+```
+
+Covers one-way strip geometry where one departure direction has obstructions and the other does not. Tier maps from the best end's total risk even when that risk is at or above the caution threshold.
+
+**Path C - both ends** (`selection_basis: both_ends`):
+
+When spread is below 1.5, runway ends are empty, headings are unresolvable, or config `runway_length_ft` override is in use. Tier uses worst/best asymmetric rules below.
+
+### Tier mapping
+
+**Thresholds** (`lib/constants.php`):
+
+| Constant | Value |
+|----------|-------|
+| `DENSITY_ALTITUDE_PERFORMANCE_TIER_CAUTION` | 1.20 |
+| `DENSITY_ALTITUDE_PERFORMANCE_TIER_WARNING` | 2.40 |
+
+**Single-end** (`window_mean_wind` or `asymmetric_heuristic`):
+
+- **warning** when scored end sum ≥ 2.40
+- **caution** when scored end sum ≥ 1.20 (and not warning)
+- **normal** otherwise
+- `risk_factor` and `scored_end_risk` use the scored end sum
+
+**Both ends** (`both_ends`):
+
+- **warning** when **best** end sum ≥ 2.40
+- **caution** when **worst** end sum ≥ 1.20 (and not warning)
+- **normal** otherwise
+- `risk_factor` uses best-end sum for warning, worst-end sum for caution
 
 **Normal** tier omits `density_altitude_performance` from API responses.
 
@@ -177,17 +241,26 @@ When no runway data: elevation-banded thresholds on density altitude and delta (
 
 ### Implementation
 
-- `lib/weather/density-altitude-performance.php` - assessment and API payload
-- `lib/weather/poh-takeoff.php` - AFM table lookup and obstruction stress
-- `lib/nasr/*` - NASR cache and runway selection
-- `scripts/fetch-nasr-apt.php` - NASR ingest
+| Function | File |
+|----------|------|
+| `buildDensityAltitudePerformance()` | `lib/weather/density-altitude-performance.php` |
+| `attachDensityAltitudePerformance()` | `lib/weather/density-altitude-performance.php` |
+| `resolveDensityAltitudePerformanceEndSelection()` | `lib/weather/density-altitude-performance.php` |
+| `evaluateRunwayEndPerformanceRange()`, `evaluateSingleRunwayEndPerformance()` | `lib/weather/density-altitude-performance.php` |
+| `densityAltitudePerformanceTierFromScoredEnd()`, `densityAltitudePerformanceTierFromEndRisks()` | `lib/weather/density-altitude-performance.php` |
+| `resolveRunwayEndMagneticHeading()`, `pickDepartureEndByWindFromMagnetic()` | `lib/weather/da-performance-runway-end.php` |
+| `computeWindowMeanWind()` | `lib/weather/history.php` |
+| `pohComputeDepartureEndStress()` | `lib/weather/poh-takeoff.php` |
+| NASR runway selection and effective length | `lib/nasr/runway-selection.php`, `lib/nasr/cache.php` |
+| NASR ingest | `scripts/fetch-nasr-apt.php` |
 
 ### Tests
 
-- `tests/Unit/DensityAltitudePerformanceTest.php`
+- `tests/Unit/DensityAltitudePerformanceTest.php` - tier mapping, end selection paths, OR81/KPFC-style strips
 - `tests/Unit/DensityAltitudePerformanceReferenceScenarioTest.php` - locked real-airport reference tiers
-- `tests/Unit/PohTakeoffTest.php`
-- `tests/Unit/NasrParseTest.php`
+- `tests/Unit/WindowMeanWindTest.php` - vector mean wind quality gates
+- `tests/Unit/PohTakeoffTest.php` - AFM lookup and obstruction stress
+- `tests/Unit/NasrParseTest.php` - NASR runway and obstruction fields
 
 ### Reference scenario locks (CI)
 
@@ -202,6 +275,10 @@ Real airports with fixed weather inputs are locked in `tests/Fixtures/density-al
 Recompute tiers locally (same NASR fixture build as the test `setUp()`), update the JSON expected `tier`, `expected_risk_factor`, `expected_worst_end_risk`, and `expected_best_end_risk`, and document the reason in the pull request. Do not change tier thresholds and scenario locks in the same change unless both are intentional.
 
 **Out of scope for scenario locks**: browser UI regression tests for tier display, live FAA weather (fixtures use pinned PA, temperature, and DA only).
+
+### Fleet validation
+
+`scripts/fleet-da-constants-audit.php` evaluates DA performance policy variants against live weather for all configured airports. Requires production `CONFIG_PATH` and `weather_history_enabled`. Use to compare alert counts and per-airport basis before changing `DA_PERF_*` constants.
 
 ---
 

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -460,6 +460,18 @@ if (!defined('DENSITY_ALTITUDE_PERFORMANCE_FALLBACK_TOOLTIP')) {
         . 'Verify all performance calculations using your AFM.'
     );
 }
+if (!defined('DA_PERF_WIND_MIN_OBS')) {
+    define('DA_PERF_WIND_MIN_OBS', 3);
+}
+if (!defined('DA_PERF_WIND_MIN_MEAN_KTS')) {
+    define('DA_PERF_WIND_MIN_MEAN_KTS', 5.0);
+}
+if (!defined('DA_PERF_VARIABLE_WIND_RATIO')) {
+    define('DA_PERF_VARIABLE_WIND_RATIO', 2.0);
+}
+if (!defined('DA_PERF_ASYMMETRIC_SPREAD')) {
+    define('DA_PERF_ASYMMETRIC_SPREAD', 1.5);
+}
 
 // Airport country resolution (geometry aggregate under CACHE_BASE_DIR; see scripts/refresh-airport-country-resolution.php)
 if (!defined('COUNTRY_RESOLUTION_AGGREGATE_SCHEMA_VERSION')) {

--- a/lib/density-altitude-performance-display.php
+++ b/lib/density-altitude-performance-display.php
@@ -19,11 +19,45 @@ function densityAltitudePerformanceTooltip(string $tier, ?array $performance = n
 
     if ($tier === 'warning') {
         return 'Density altitude is dangerously high for average GA aircraft. '
-            . 'Verify performance numbers before flight.';
+            . 'Verify performance numbers before flight.'
+            . densityAltitudePerformanceSelectionBasisNote($performance);
     }
     if ($tier === 'caution') {
-        return 'Density altitude is higher than normal. Verify performance numbers before flight.';
+        return 'Density altitude is higher than normal. Verify performance numbers before flight.'
+            . densityAltitudePerformanceSelectionBasisNote($performance);
     }
+    return '';
+}
+
+/**
+ * Tooltip suffix explaining which departure direction was scored.
+ *
+ * @param array<string, mixed>|null $performance Optional API payload with selection_basis
+ */
+function densityAltitudePerformanceSelectionBasisNote(?array $performance): string
+{
+    if (!is_array($performance) || empty($performance['selection_basis'])) {
+        return '';
+    }
+
+    $basis = (string) $performance['selection_basis'];
+    $endId = isset($performance['operational_end_id'])
+        ? trim((string) $performance['operational_end_id'])
+        : '';
+
+    if ($basis === 'window_mean_wind') {
+        $end = $endId !== '' ? 'RWY ' . $endId : 'the wind-aligned runway end';
+        return ' Cue reflects reference takeoff performance for ' . $end . ' using recent mean wind.';
+    }
+    if ($basis === 'asymmetric_heuristic') {
+        $end = $endId !== '' ? 'RWY ' . $endId : 'the less-constrained runway end';
+        return ' Cue reflects reference takeoff performance for ' . $end
+            . '; the opposite direction is more constrained.';
+    }
+    if ($basis === 'both_ends') {
+        return ' Cue reflects reference takeoff performance for both departure directions on the longest runway.';
+    }
+
     return '';
 }
 
@@ -78,10 +112,12 @@ function densityAltitudePerformanceAriaLabel(
             . 'Verify all performance calculations using your AFM.';
     }
     if ($tier === 'warning') {
-        return $base . '. Warning: dangerously high for average GA aircraft; verify performance numbers before flight.';
+        return $base . '. Warning: dangerously high for average GA aircraft; verify performance numbers before flight.'
+            . densityAltitudePerformanceSelectionBasisNote($performance);
     }
     if ($tier === 'caution') {
-        return $base . '. Caution: higher than normal; verify performance numbers before flight.';
+        return $base . '. Caution: higher than normal; verify performance numbers before flight.'
+            . densityAltitudePerformanceSelectionBasisNote($performance);
     }
     return $base;
 }

--- a/lib/embed-diff.php
+++ b/lib/embed-diff.php
@@ -48,7 +48,7 @@ function buildEmbedPayloadByTopic(string $airportId, ?array $weatherData, array 
 {
     $weatherDataMerged = [];
     if ($weatherData !== null && !empty($weatherData)) {
-        $weatherDataMerged = formatWeatherResponse($weatherData, $airport);
+        $weatherDataMerged = formatWeatherResponse($weatherData, $airport, $airportId);
     }
     $fullModeOptions = buildWindCompassFullModeOptions($airportId, $airport, $weatherDataMerged);
     $hasFullMode = ($fullModeOptions['runwaySegments'] ?? []) !== []

--- a/lib/public-api/weather-format.php
+++ b/lib/public-api/weather-format.php
@@ -103,6 +103,7 @@ function formatWindDirectionForApi(array $weather): array
  *
  * @param array $weather Raw weather data from cache
  * @param array $airport Airport configuration
+ * @param string|null $airportId Config airport id for weather history (enables window-mean-wind DA end selection)
  * @return array Formatted weather data
  */
 function formatWeatherResponse(array $weather, array $airport, ?string $airportId = null): array

--- a/lib/public-api/weather-format.php
+++ b/lib/public-api/weather-format.php
@@ -105,7 +105,7 @@ function formatWindDirectionForApi(array $weather): array
  * @param array $airport Airport configuration
  * @return array Formatted weather data
  */
-function formatWeatherResponse(array $weather, array $airport): array
+function formatWeatherResponse(array $weather, array $airport, ?string $airportId = null): array
 {
     $formatted = [
         'flight_category' => $weather['flight_category'] ?? null,
@@ -156,7 +156,7 @@ function formatWeatherResponse(array $weather, array $airport): array
         'metar_ceiling_reported' => $weather['metar_ceiling_reported'] ?? null,
     ];
 
-    $withPerformance = attachDensityAltitudePerformance($weather, $airport);
+    $withPerformance = attachDensityAltitudePerformance($weather, $airport, $airportId);
     if (isset($withPerformance['density_altitude_performance'])) {
         $formatted['density_altitude_performance'] = $withPerformance['density_altitude_performance'];
     }

--- a/lib/weather/da-performance-runway-end.php
+++ b/lib/weather/da-performance-runway-end.php
@@ -18,6 +18,27 @@ function angularDifference(float $headingA, float $headingB): float
 }
 
 /**
+ * Parse a runway end ident into magnetic heading degrees.
+ *
+ * Returns null when the ident is not a valid runway number (1-36, optional L/C/R).
+ * Unlike parseIdentHeading(), does not treat invalid idents as 360° north.
+ */
+function parseRunwayEndIdentMagneticHeading(string $endId): ?float
+{
+    $trimmed = trim($endId);
+    if ($trimmed === '' || !preg_match('/^(\d{1,2})([LCR])?$/i', $trimmed, $matches)) {
+        return null;
+    }
+
+    $num = (int) $matches[1];
+    if ($num < 1 || $num > 36) {
+        return null;
+    }
+
+    return (float) ($num * 10);
+}
+
+/**
  * Resolve magnetic departure heading for a runway end.
  *
  * Precedence: NASR true_alignment (converted to magnetic), config runway headings,
@@ -52,12 +73,12 @@ function resolveRunwayEndMagneticHeading(array $end, array $runway, array $airpo
         }
     }
 
-    $parsed = parseIdentHeading($endId);
-    if ($parsed < 1 || $parsed > 360) {
+    $parsed = parseRunwayEndIdentMagneticHeading($endId);
+    if ($parsed === null) {
         return null;
     }
 
-    return (float) $parsed;
+    return $parsed;
 }
 
 /**

--- a/lib/weather/da-performance-runway-end.php
+++ b/lib/weather/da-performance-runway-end.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Runway end heading resolution and wind-based departure end selection for DA performance.
+ */
+
+require_once __DIR__ . '/../constants.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../heading-conversion.php';
+require_once __DIR__ . '/../runways.php';
+
+/**
+ * Smallest angular difference between two headings (degrees 0-360).
+ */
+function angularDifference(float $headingA, float $headingB): float
+{
+    $diff = fmod(abs($headingA - $headingB), 360.0);
+    return $diff > 180.0 ? 360.0 - $diff : $diff;
+}
+
+/**
+ * Resolve magnetic departure heading for a runway end.
+ *
+ * Precedence: NASR true_alignment (converted to magnetic), config runway headings,
+ * then runway end ident parsing.
+ *
+ * @param array $end Runway end row
+ * @param array $runway Selected runway (may include config heading fields)
+ * @param array $airport Airport configuration
+ * @return float|null Magnetic heading 0-360, or null when unavailable
+ */
+function resolveRunwayEndMagneticHeading(array $end, array $runway, array $airport): ?float
+{
+    if (isset($end['true_alignment']) && is_numeric($end['true_alignment'])) {
+        return convertTrueToMagnetic((float) $end['true_alignment'], getMagneticDeclination($airport));
+    }
+
+    $endId = isset($end['end_id']) ? trim((string) $end['end_id']) : '';
+    if ($endId === '') {
+        return null;
+    }
+
+    $rwyId = (string) ($runway['rwy_id'] ?? '');
+    if ($rwyId !== '' && isset($runway['heading_1'], $runway['heading_2'])) {
+        $idents = explode('/', $rwyId, 2);
+        $leIdent = $idents[0] ?? '';
+        $heIdent = $idents[1] ?? $leIdent;
+        if (strcasecmp($endId, $leIdent) === 0 && is_numeric($runway['heading_1'])) {
+            return (float) $runway['heading_1'];
+        }
+        if (strcasecmp($endId, $heIdent) === 0 && is_numeric($runway['heading_2'])) {
+            return (float) $runway['heading_2'];
+        }
+    }
+
+    $parsed = parseIdentHeading($endId);
+    if ($parsed < 1 || $parsed > 360) {
+        return null;
+    }
+
+    return (float) $parsed;
+}
+
+/**
+ * Pick the departure runway end aligned with mean wind (into-wind takeoff).
+ *
+ * @param array $runway Selected runway with ends[]
+ * @param array $airport Airport configuration
+ * @param float $windFromMagDeg Mean wind direction (magnetic, meteorological FROM)
+ * @return array|null Matched end row with magnetic_heading, or null when no end resolves
+ */
+function pickDepartureEndByWindFromMagnetic(array $runway, array $airport, float $windFromMagDeg): ?array
+{
+    $ends = $runway['ends'] ?? [];
+    if ($ends === []) {
+        return null;
+    }
+
+    $bestEnd = null;
+    $bestDiff = null;
+
+    foreach ($ends as $end) {
+        if (!is_array($end)) {
+            continue;
+        }
+        $heading = resolveRunwayEndMagneticHeading($end, $runway, $airport);
+        if ($heading === null) {
+            continue;
+        }
+        $diff = angularDifference($heading, $windFromMagDeg);
+        if ($bestDiff === null || $diff < $bestDiff) {
+            $bestDiff = $diff;
+            $bestEnd = $end;
+            $bestEnd['magnetic_heading'] = $heading;
+        }
+    }
+
+    return $bestEnd;
+}

--- a/lib/weather/density-altitude-performance.php
+++ b/lib/weather/density-altitude-performance.php
@@ -216,8 +216,7 @@ function resolveDensityAltitudePerformanceEndSelection(
     }
 
     $spread = $worst['total_risk'] - $best['total_risk'];
-    if ($spread >= DA_PERF_ASYMMETRIC_SPREAD
-        && $best['total_risk'] < DENSITY_ALTITUDE_PERFORMANCE_TIER_CAUTION) {
+    if ($spread >= DA_PERF_ASYMMETRIC_SPREAD) {
         return [
             'selection_basis' => 'asymmetric_heuristic',
             'operational_end_id' => $best['end_id'],

--- a/lib/weather/density-altitude-performance.php
+++ b/lib/weather/density-altitude-performance.php
@@ -499,18 +499,23 @@ function buildDensityAltitudePerformance(array $weather, array $airport, ?string
 
     if ($selection['selection_basis'] === 'both_ends') {
         $tier = densityAltitudePerformanceTierFromEndRisks($worstTotalRisk, $bestTotalRisk);
-        $riskFactor = densityAltitudePerformanceRiskFactorForTier($tier, $worstTotalRisk, $bestTotalRisk);
     } else {
         $scoredRisk = (float) ($selection['scored_end']['total_risk'] ?? 0.0);
         $tier = densityAltitudePerformanceTierFromScoredEnd($scoredRisk);
+    }
+
+    if ($runwaySource === 'config' || $runwaySource === 'ourairports') {
+        $tier = densityAltitudePerformanceCapTierWithoutObstructions($tier);
+    }
+
+    if ($selection['selection_basis'] === 'both_ends') {
+        $riskFactor = densityAltitudePerformanceRiskFactorForTier($tier, $worstTotalRisk, $bestTotalRisk);
+    } else {
         $riskFactor = $scoredRisk;
     }
 
     $reason = 'reference_models';
     $reference = DENSITY_ALTITUDE_PERFORMANCE_REFERENCE;
-    if ($runwaySource === 'config' || $runwaySource === 'ourairports') {
-        $tier = densityAltitudePerformanceCapTierWithoutObstructions($tier);
-    }
     if ($runwaySource === 'config') {
         $reference = DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_CONFIG;
     } elseif ($runwaySource === 'ourairports') {

--- a/lib/weather/density-altitude-performance.php
+++ b/lib/weather/density-altitude-performance.php
@@ -7,6 +7,8 @@ require_once __DIR__ . '/../constants.php';
 require_once __DIR__ . '/../nasr/cache.php';
 require_once __DIR__ . '/../nasr/runway-selection.php';
 require_once __DIR__ . '/../runways.php';
+require_once __DIR__ . '/da-performance-runway-end.php';
+require_once __DIR__ . '/history.php';
 require_once __DIR__ . '/poh-takeoff.php';
 
 /** @var list<string> */
@@ -72,6 +74,159 @@ function densityAltitudePerformanceRiskFactorForTier(string $tier, float $worstT
     }
 
     return max($worstTotalRisk, $bestTotalRisk);
+}
+
+/**
+ * Map a single scored departure end risk to tier.
+ */
+function densityAltitudePerformanceTierFromScoredEnd(float $scoredRisk): string
+{
+    if ($scoredRisk >= DENSITY_ALTITUDE_PERFORMANCE_TIER_WARNING) {
+        return 'warning';
+    }
+    if ($scoredRisk >= DENSITY_ALTITUDE_PERFORMANCE_TIER_CAUTION) {
+        return 'caution';
+    }
+    return 'normal';
+}
+
+/**
+ * Look up or compute performance scoring for a specific runway end.
+ *
+ * @param array $evaluation Result from evaluateRunwayEndPerformanceRange()
+ * @param array $end Runway end row
+ * @param array $runway Selected runway
+ * @param array{c152: array, c172: array, c182: array} $tables
+ * @return array{total_risk: float, end_id: ?string, risk152: float, risk172: float, risk182: float}
+ */
+function lookupEvaluationForRunwayEnd(
+    array $evaluation,
+    array $end,
+    array $runway,
+    float $pressureAltitudeFt,
+    float $tempC,
+    array $tables
+): array {
+    $endId = $end['end_id'] ?? null;
+    if ($endId !== null) {
+        if (($evaluation['worst']['end_id'] ?? null) === $endId) {
+            return $evaluation['worst'];
+        }
+        if (($evaluation['best']['end_id'] ?? null) === $endId) {
+            return $evaluation['best'];
+        }
+    }
+
+    $runwayLengthFt = (int) ($runway['length_ft'] ?? 0);
+    $nonPaved = nasrIsNonPavedSurface((string) ($runway['surface'] ?? ''));
+    $availableFt = nasrEffectiveDepartureLengthFt($end, $runwayLengthFt);
+
+    return evaluateSingleRunwayEndPerformance(
+        $end,
+        $availableFt,
+        $nonPaved,
+        $pressureAltitudeFt,
+        $tempC,
+        $tables
+    );
+}
+
+/**
+ * Choose operational departure end and scoring basis for DA performance tier.
+ *
+ * @param array $evaluation Result from evaluateRunwayEndPerformanceRange()
+ * @param array $runway Selected runway with ends[]
+ * @param array $airport Airport configuration
+ * @param string|null $airportId Config airport id for weather history lookup
+ * @param float $pressureAltitudeFt Pressure altitude in feet
+ * @param float $tempC Temperature Celsius
+ * @param array{c152: array, c172: array, c182: array} $tables POH tables
+ * @param string $runwaySource nasr|ourairports|config
+ * @return array{
+ *     selection_basis: string,
+ *     operational_end_id: ?string,
+ *     scored_end: ?array,
+ *     wind_basis: ?array
+ * }
+ */
+function resolveDensityAltitudePerformanceEndSelection(
+    array $evaluation,
+    array $runway,
+    array $airport,
+    ?string $airportId,
+    float $pressureAltitudeFt,
+    float $tempC,
+    array $tables,
+    string $runwaySource
+): array {
+    $worst = $evaluation['worst'];
+    $best = $evaluation['best'];
+
+    $bothEndsResult = [
+        'selection_basis' => 'both_ends',
+        'operational_end_id' => null,
+        'scored_end' => null,
+        'wind_basis' => null,
+    ];
+
+    if ($runwaySource === 'config') {
+        return $bothEndsResult;
+    }
+
+    $ends = $runway['ends'] ?? [];
+    if ($ends === []) {
+        return $bothEndsResult;
+    }
+
+    $hasResolvableHeading = false;
+    foreach ($ends as $end) {
+        if (!is_array($end)) {
+            continue;
+        }
+        if (resolveRunwayEndMagneticHeading($end, $runway, $airport) !== null) {
+            $hasResolvableHeading = true;
+            break;
+        }
+    }
+
+    if ($airportId !== null && $airportId !== '' && $hasResolvableHeading) {
+        $windBasis = computeWindowMeanWind($airportId, $airport);
+        if ($windBasis !== null) {
+            $picked = pickDepartureEndByWindFromMagnetic(
+                $runway,
+                $airport,
+                (float) $windBasis['direction_magnetic']
+            );
+            if ($picked !== null) {
+                return [
+                    'selection_basis' => 'window_mean_wind',
+                    'operational_end_id' => $picked['end_id'] ?? null,
+                    'scored_end' => lookupEvaluationForRunwayEnd(
+                        $evaluation,
+                        $picked,
+                        $runway,
+                        $pressureAltitudeFt,
+                        $tempC,
+                        $tables
+                    ),
+                    'wind_basis' => $windBasis,
+                ];
+            }
+        }
+    }
+
+    $spread = $worst['total_risk'] - $best['total_risk'];
+    if ($spread >= DA_PERF_ASYMMETRIC_SPREAD
+        && $best['total_risk'] < DENSITY_ALTITUDE_PERFORMANCE_TIER_CAUTION) {
+        return [
+            'selection_basis' => 'asymmetric_heuristic',
+            'operational_end_id' => $best['end_id'],
+            'scored_end' => $best,
+            'wind_basis' => null,
+        ];
+    }
+
+    return $bothEndsResult;
 }
 
 /**
@@ -265,9 +420,10 @@ function assessFallbackDensityAltitudePerformance(?int $densityAltitudeFt, ?int 
  *
  * @param array $weather Cached weather row
  * @param array $airport Airport configuration
+ * @param string|null $airportId Optional config airport id for weather history (defaults to airport id/icao)
  * @return array<string, mixed>|null
  */
-function buildDensityAltitudePerformance(array $weather, array $airport): ?array
+function buildDensityAltitudePerformance(array $weather, array $airport, ?string $airportId = null): ?array
 {
     $densityAltitude = $weather['density_altitude'] ?? null;
     if (!is_numeric($densityAltitude)) {
@@ -296,8 +452,8 @@ function buildDensityAltitudePerformance(array $weather, array $airport): ?array
             $runwaySource = 'nasr';
         }
     } else {
-        $airportId = (string) ($airport['id'] ?? $airport['icao'] ?? '');
-        $selectedRunway = getOurAirportsPerformanceRunwayForAirport($airportId, $airport);
+        $ourAirportsId = (string) ($airport['id'] ?? $airport['icao'] ?? '');
+        $selectedRunway = getOurAirportsPerformanceRunwayForAirport($ourAirportsId, $airport);
         if ($selectedRunway !== null) {
             $runwaySource = 'ourairports';
         }
@@ -323,7 +479,31 @@ function buildDensityAltitudePerformance(array $weather, array $airport): ?array
 
     $worstTotalRisk = $evaluation['worst']['total_risk'];
     $bestTotalRisk = $evaluation['best']['total_risk'];
-    $tier = densityAltitudePerformanceTierFromEndRisks($worstTotalRisk, $bestTotalRisk);
+
+    $resolvedAirportId = $airportId ?? (string) ($airport['id'] ?? $airport['icao'] ?? '');
+    if ($resolvedAirportId === '') {
+        $resolvedAirportId = null;
+    }
+
+    $selection = resolveDensityAltitudePerformanceEndSelection(
+        $evaluation,
+        $selectedRunway,
+        $airport,
+        $resolvedAirportId,
+        (float) $pressureAltitude,
+        (float) $temperature,
+        $tables,
+        (string) $runwaySource
+    );
+
+    if ($selection['selection_basis'] === 'both_ends') {
+        $tier = densityAltitudePerformanceTierFromEndRisks($worstTotalRisk, $bestTotalRisk);
+        $riskFactor = densityAltitudePerformanceRiskFactorForTier($tier, $worstTotalRisk, $bestTotalRisk);
+    } else {
+        $scoredRisk = (float) ($selection['scored_end']['total_risk'] ?? 0.0);
+        $tier = densityAltitudePerformanceTierFromScoredEnd($scoredRisk);
+        $riskFactor = $scoredRisk;
+    }
 
     $reason = 'reference_models';
     $reference = DENSITY_ALTITUDE_PERFORMANCE_REFERENCE;
@@ -341,17 +521,28 @@ function buildDensityAltitudePerformance(array $weather, array $airport): ?array
         return null;
     }
 
-    $riskFactor = densityAltitudePerformanceRiskFactorForTier($tier, $worstTotalRisk, $bestTotalRisk);
-
-    return [
+    $payload = [
         'tier' => $tier,
         'risk_factor' => round($riskFactor, 3),
         'worst_end_risk' => round($worstTotalRisk, 3),
         'best_end_risk' => round($bestTotalRisk, 3),
+        'selection_basis' => $selection['selection_basis'],
         'fallback' => false,
         'reason' => $reason,
         'reference' => $reference,
     ];
+
+    if ($selection['operational_end_id'] !== null) {
+        $payload['operational_end_id'] = $selection['operational_end_id'];
+    }
+    if ($selection['scored_end'] !== null) {
+        $payload['scored_end_risk'] = round((float) $selection['scored_end']['total_risk'], 3);
+    }
+    if ($selection['wind_basis'] !== null) {
+        $payload['wind_basis'] = $selection['wind_basis'];
+    }
+
+    return $payload;
 }
 
 /**
@@ -359,11 +550,12 @@ function buildDensityAltitudePerformance(array $weather, array $airport): ?array
  *
  * @param array $weather Weather array (not modified)
  * @param array $airport Airport configuration
+ * @param string|null $airportId Optional config airport id for weather history lookup
  * @return array Weather array with optional density_altitude_performance
  */
-function attachDensityAltitudePerformance(array $weather, array $airport): array
+function attachDensityAltitudePerformance(array $weather, array $airport, ?string $airportId = null): array
 {
-    $performance = buildDensityAltitudePerformance($weather, $airport);
+    $performance = buildDensityAltitudePerformance($weather, $airport, $airportId);
     if ($performance !== null) {
         $weather['density_altitude_performance'] = $performance;
     } else {

--- a/lib/weather/density-altitude-performance.php
+++ b/lib/weather/density-altitude-performance.php
@@ -96,6 +96,8 @@ function densityAltitudePerformanceTierFromScoredEnd(float $scoredRisk): string
  * @param array $evaluation Result from evaluateRunwayEndPerformanceRange()
  * @param array $end Runway end row
  * @param array $runway Selected runway
+ * @param float $pressureAltitudeFt Pressure altitude in feet
+ * @param float $tempC Temperature Celsius
  * @param array{c152: array, c172: array, c182: array} $tables
  * @return array{total_risk: float, end_id: ?string, risk152: float, risk172: float, risk182: float}
  */

--- a/lib/weather/history.php
+++ b/lib/weather/history.php
@@ -377,6 +377,17 @@ function computeDailyExtremesFromHistory(string $airportId, string $dateKey, str
 }
 
 /**
+ * Whether a cached history observation is an array with a numeric obs_time in window.
+ */
+function weatherHistoryObservationInWindow($observation, int $cutoff): bool
+{
+    return is_array($observation)
+        && isset($observation['obs_time'])
+        && is_numeric($observation['obs_time'])
+        && (int) $observation['obs_time'] >= $cutoff;
+}
+
+/**
  * Compute wind rose data for petal visualization
  *
  * Returns 16 sectors (N, NNE, NE, ENE, E, ESE, SE, SSE, S, SSW, SW, WSW, W, WNW, NW, NNW)
@@ -404,8 +415,8 @@ function computeWindRose(string $airportId, ?array $airport = null): ?array
         return null;
     }
 
-    $windowObs = array_filter($observations, function ($obs) use ($cutoff) {
-        return isset($obs['obs_time']) && $obs['obs_time'] >= $cutoff;
+    $windowObs = array_filter($observations, static function ($obs) use ($cutoff) {
+        return weatherHistoryObservationInWindow($obs, $cutoff);
     });
     if (empty($windowObs)) {
         return null;
@@ -537,7 +548,7 @@ function computeWindowMeanWind(string $airportId, ?array $airport = null): ?arra
     }
 
     $windowObs = array_filter($observations, static function ($obs) use ($cutoff) {
-        return isset($obs['obs_time']) && $obs['obs_time'] >= $cutoff;
+        return weatherHistoryObservationInWindow($obs, $cutoff);
     });
     if ($windowObs === []) {
         return null;

--- a/lib/weather/history.php
+++ b/lib/weather/history.php
@@ -470,6 +470,139 @@ function computeWindRose(string $airportId, ?array $airport = null): ?array
 }
 
 /**
+ * Resolve magnetic wind direction (degrees) from a history observation.
+ *
+ * Prefers magnetic_north on a wind_direction object; otherwise converts stored true degrees.
+ *
+ * @param array $observation History observation row
+ * @param float $declinationDegrees Airport magnetic declination (positive = East)
+ * @return float|null Magnetic direction 0-360, or null when unavailable/variable
+ */
+function resolveHistoryObservationWindDirectionMagnetic(array $observation, float $declinationDegrees): ?float
+{
+    $dir = $observation['wind_direction'] ?? null;
+    if (is_array($dir)) {
+        if (!empty($dir['variable'])) {
+            return null;
+        }
+        $magnetic = $dir['magnetic_north'] ?? null;
+        if ($magnetic !== null && is_numeric($magnetic)) {
+            $normalized = fmod((float) $magnetic + 360.0, 360.0);
+            return $normalized < 0.0 ? $normalized + 360.0 : $normalized;
+        }
+        $trueNorth = $dir['true_north'] ?? null;
+        if ($trueNorth !== null && is_numeric($trueNorth)) {
+            return convertTrueToMagnetic((float) $trueNorth, $declinationDegrees);
+        }
+        return null;
+    }
+
+    if ($dir === null || !is_numeric($dir)) {
+        return null;
+    }
+
+    return convertTrueToMagnetic((float) $dir, $declinationDegrees);
+}
+
+/**
+ * Vector mean wind from weather history over the wind rose window.
+ *
+ * Uses the same window as {@see computeWindRose()}. Non-calm observations only.
+ * Returns null when history is disabled, observations are insufficient, mean speed
+ * is below DA_PERF_WIND_MIN_MEAN_KTS, or dispersion ratio exceeds DA_PERF_VARIABLE_WIND_RATIO.
+ *
+ * @param string $airportId Airport ID
+ * @param array|null $airport Airport config for magnetic declination; when null, declination 0 (tests)
+ * @return array{
+ *     direction_magnetic: float,
+ *     speed_kts: float,
+ *     observation_count: int,
+ *     window_hours: int,
+ *     dispersion_ratio: float
+ * }|null
+ */
+function computeWindowMeanWind(string $airportId, ?array $airport = null): ?array
+{
+    if (!isPublicApiWeatherHistoryEnabled()) {
+        return null;
+    }
+
+    $windowHours = getPublicApiWindRoseWindowHours();
+    $cutoff = time() - ($windowHours * 3600);
+
+    $history = loadWeatherHistory($airportId);
+    $observations = $history['observations'] ?? [];
+    if ($observations === []) {
+        return null;
+    }
+
+    $windowObs = array_filter($observations, static function ($obs) use ($cutoff) {
+        return isset($obs['obs_time']) && $obs['obs_time'] >= $cutoff;
+    });
+    if ($windowObs === []) {
+        return null;
+    }
+
+    $declination = ($airport !== null) ? getMagneticDeclination($airport) : 0.0;
+    $uSum = 0.0;
+    $vSum = 0.0;
+    $scalarSum = 0.0;
+    $count = 0;
+
+    foreach ($windowObs as $obs) {
+        $speed = $obs['wind_speed'] ?? null;
+        if ($speed === null || !is_numeric($speed)) {
+            continue;
+        }
+        $speed = (float) $speed;
+        if ($speed < CALM_WIND_THRESHOLD_KTS) {
+            continue;
+        }
+
+        $dirMag = resolveHistoryObservationWindDirectionMagnetic($obs, $declination);
+        if ($dirMag === null) {
+            continue;
+        }
+
+        $rad = deg2rad($dirMag);
+        $uSum += -$speed * sin($rad);
+        $vSum += -$speed * cos($rad);
+        $scalarSum += $speed;
+        $count++;
+    }
+
+    if ($count < DA_PERF_WIND_MIN_OBS) {
+        return null;
+    }
+
+    $uMean = $uSum / $count;
+    $vMean = $vSum / $count;
+    $vectorSpeed = sqrt(($uMean * $uMean) + ($vMean * $vMean));
+    if ($vectorSpeed < DA_PERF_WIND_MIN_MEAN_KTS) {
+        return null;
+    }
+
+    $scalarMean = $scalarSum / $count;
+    $dispersionRatio = $scalarMean / $vectorSpeed;
+    if ($dispersionRatio > DA_PERF_VARIABLE_WIND_RATIO) {
+        return null;
+    }
+
+    $direction = rad2deg(atan2(-$uMean, -$vMean));
+    if ($direction < 0.0) {
+        $direction += 360.0;
+    }
+
+    return [
+        'direction_magnetic' => round($direction, 1),
+        'speed_kts' => round($vectorSpeed, 1),
+        'observation_count' => $count,
+        'window_hours' => $windowHours,
+        'dispersion_ratio' => round($dispersionRatio, 2),
+    ];
+}
+
+/**
  * Prune old observations from weather history
  * 
  * @param string $airportId Airport ID

--- a/pages/airport.php
+++ b/pages/airport.php
@@ -1418,7 +1418,7 @@ const INITIAL_WEATHER_DATA = <?php
 
     if (is_array($initialWeatherData)) {
         require_once __DIR__ . '/../lib/weather/density-altitude-performance.php';
-        $initialWeatherData = attachDensityAltitudePerformance($initialWeatherData, $airport);
+        $initialWeatherData = attachDensityAltitudePerformance($initialWeatherData, $airport, $airportId);
     }
     
     // Defensive JSON encoding with error handling

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -795,11 +795,31 @@ function densityAltitudePerformanceTooltip(tier, performance) {
     if (performance && performance.fallback) {
         return 'Runway data unavailable. Indicator based on density altitude relative to field elevation only. Verify all performance calculations using your AFM.';
     }
+    const basisNote = densityAltitudePerformanceSelectionBasisNote(performance);
     if (tier === 'warning') {
-        return 'Density altitude is dangerously high for average GA aircraft. Verify performance numbers before flight.';
+        return 'Density altitude is dangerously high for average GA aircraft. Verify performance numbers before flight.' + basisNote;
     }
     if (tier === 'caution') {
-        return 'Density altitude is higher than normal. Verify performance numbers before flight.';
+        return 'Density altitude is higher than normal. Verify performance numbers before flight.' + basisNote;
+    }
+    return '';
+}
+
+function densityAltitudePerformanceSelectionBasisNote(performance) {
+    if (!performance || !performance.selection_basis) {
+        return '';
+    }
+    const endId = performance.operational_end_id ? String(performance.operational_end_id).trim() : '';
+    if (performance.selection_basis === 'window_mean_wind') {
+        const end = endId !== '' ? `RWY ${endId}` : 'the wind-aligned runway end';
+        return ` Cue reflects reference takeoff performance for ${end} using recent mean wind.`;
+    }
+    if (performance.selection_basis === 'asymmetric_heuristic') {
+        const end = endId !== '' ? `RWY ${endId}` : 'the less-constrained runway end';
+        return ` Cue reflects reference takeoff performance for ${end}; the opposite direction is more constrained.`;
+    }
+    if (performance.selection_basis === 'both_ends') {
+        return ' Cue reflects reference takeoff performance for both departure directions on the longest runway.';
     }
     return '';
 }
@@ -824,10 +844,10 @@ function densityAltitudePerformanceAriaLabel(densityAltitudeFt, tier, performanc
         return `${base}. Runway data unavailable; indicator based on density altitude relative to field elevation only. Verify all performance calculations using your AFM.`;
     }
     if (tier === 'warning') {
-        return `${base}. Warning: dangerously high for average GA aircraft; verify performance numbers before flight.`;
+        return `${base}. Warning: dangerously high for average GA aircraft; verify performance numbers before flight.${densityAltitudePerformanceSelectionBasisNote(performance)}`;
     }
     if (tier === 'caution') {
-        return `${base}. Caution: higher than normal; verify performance numbers before flight.`;
+        return `${base}. Caution: higher than normal; verify performance numbers before flight.${densityAltitudePerformanceSelectionBasisNote(performance)}`;
     }
     return base;
 }

--- a/public/js/embed-helpers.js
+++ b/public/js/embed-helpers.js
@@ -226,11 +226,31 @@
         if (performance && performance.fallback) {
             return 'Runway data unavailable. Indicator based on density altitude relative to field elevation only. Verify all performance calculations using your AFM.';
         }
+        const basisNote = densityAltitudePerformanceSelectionBasisNote(performance);
         if (tier === 'warning') {
-            return 'Density altitude is dangerously high for average GA aircraft. Verify performance numbers before flight.';
+            return 'Density altitude is dangerously high for average GA aircraft. Verify performance numbers before flight.' + basisNote;
         }
         if (tier === 'caution') {
-            return 'Density altitude is higher than normal. Verify performance numbers before flight.';
+            return 'Density altitude is higher than normal. Verify performance numbers before flight.' + basisNote;
+        }
+        return '';
+    }
+
+    function densityAltitudePerformanceSelectionBasisNote(performance) {
+        if (!performance || !performance.selection_basis) {
+            return '';
+        }
+        const endId = performance.operational_end_id ? String(performance.operational_end_id).trim() : '';
+        if (performance.selection_basis === 'window_mean_wind') {
+            const end = endId !== '' ? `RWY ${endId}` : 'the wind-aligned runway end';
+            return ` Cue reflects reference takeoff performance for ${end} using recent mean wind.`;
+        }
+        if (performance.selection_basis === 'asymmetric_heuristic') {
+            const end = endId !== '' ? `RWY ${endId}` : 'the less-constrained runway end';
+            return ` Cue reflects reference takeoff performance for ${end}; the opposite direction is more constrained.`;
+        }
+        if (performance.selection_basis === 'both_ends') {
+            return ' Cue reflects reference takeoff performance for both departure directions on the longest runway.';
         }
         return '';
     }
@@ -257,9 +277,9 @@
         if (performance && performance.fallback) {
             ariaLabel += '. Runway data unavailable; indicator based on density altitude relative to field elevation only. Verify all performance calculations using your AFM.';
         } else if (tier === 'warning') {
-            ariaLabel += '. Warning: dangerously high for average GA aircraft; verify performance numbers before flight.';
+            ariaLabel += '. Warning: dangerously high for average GA aircraft; verify performance numbers before flight.' + densityAltitudePerformanceSelectionBasisNote(performance);
         } else if (tier === 'caution') {
-            ariaLabel += '. Caution: higher than normal; verify performance numbers before flight.';
+            ariaLabel += '. Caution: higher than normal; verify performance numbers before flight.' + densityAltitudePerformanceSelectionBasisNote(performance);
         }
         return {
             text,

--- a/scripts/fleet-da-constants-audit.php
+++ b/scripts/fleet-da-constants-audit.php
@@ -5,7 +5,7 @@
  *
  * Usage:
  *   CONFIG_PATH=/path/to/airports.json php scripts/fleet-da-constants-audit.php
- *   php scripts/fleet-da-constants-audit.php --variant shipped|wind3|spread_best|both
+ *   php scripts/fleet-da-constants-audit.php --variant legacy|shipped|wind3|spread_best|both
  */
 
 declare(strict_types=1);
@@ -312,7 +312,7 @@ function fleetDaAuditBuildPerformance(
 $options = getopt('', ['variant:', 'help']);
 if (isset($options['help'])) {
     echo "Fleet DA constants audit\n\n";
-    echo "Usage: CONFIG_PATH=... php scripts/fleet-da-constants-audit.php [--variant shipped]\n";
+    echo "Usage: CONFIG_PATH=... php scripts/fleet-da-constants-audit.php [--variant legacy|shipped|wind3|spread_best|both]\n";
     exit(0);
 }
 

--- a/scripts/fleet-da-constants-audit.php
+++ b/scripts/fleet-da-constants-audit.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/../lib/heading-conversion.php';
 require_once __DIR__ . '/../lib/public-api/config.php';
 
 /**
- * @return array<string, array{min_mean_kts: float, asymmetric_best_always: bool, label: string}>
+ * @return array<string, array{min_mean_kts: float, asymmetric_best_always: bool, use_legacy_tier: bool, label: string}>
  */
 function fleetDaAuditVariants(): array
 {

--- a/scripts/fleet-da-constants-audit.php
+++ b/scripts/fleet-da-constants-audit.php
@@ -1,0 +1,448 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Fleet audit: DA performance tier under policy variants (production API weather + history).
+ *
+ * Usage:
+ *   CONFIG_PATH=/path/to/airports.json php scripts/fleet-da-constants-audit.php
+ *   php scripts/fleet-da-constants-audit.php --variant shipped|wind3|spread_best|both
+ */
+
+declare(strict_types=1);
+
+error_reporting(E_ALL & ~E_DEPRECATED);
+
+require_once __DIR__ . '/../lib/config.php';
+require_once __DIR__ . '/../lib/nasr/cache.php';
+require_once __DIR__ . '/../lib/nasr/runway-selection.php';
+require_once __DIR__ . '/../lib/weather/density-altitude-performance.php';
+require_once __DIR__ . '/../lib/weather/da-performance-runway-end.php';
+require_once __DIR__ . '/../lib/weather/history.php';
+require_once __DIR__ . '/../lib/heading-conversion.php';
+require_once __DIR__ . '/../lib/public-api/config.php';
+
+/**
+ * @return array<string, array{min_mean_kts: float, asymmetric_best_always: bool, label: string}>
+ */
+function fleetDaAuditVariants(): array
+{
+    return [
+        'legacy' => [
+            'label' => 'Pre-#213 worst-end tier',
+            'min_mean_kts' => DA_PERF_WIND_MIN_MEAN_KTS,
+            'asymmetric_best_always' => false,
+            'use_legacy_tier' => true,
+        ],
+        'shipped' => [
+            'label' => 'Shipped (#213)',
+            'min_mean_kts' => DA_PERF_WIND_MIN_MEAN_KTS,
+            'asymmetric_best_always' => false,
+            'use_legacy_tier' => false,
+        ],
+        'wind3' => [
+            'label' => 'MIN_MEAN_WIND 3 kt',
+            'min_mean_kts' => 3.0,
+            'asymmetric_best_always' => false,
+            'use_legacy_tier' => false,
+        ],
+        'spread_best' => [
+            'label' => 'Spread>=1.5 tier from best end (shipped after tweak)',
+            'min_mean_kts' => DA_PERF_WIND_MIN_MEAN_KTS,
+            'asymmetric_best_always' => true,
+            'use_legacy_tier' => false,
+        ],
+        'both' => [
+            'label' => 'Wind 3 kt + spread best',
+            'min_mean_kts' => 3.0,
+            'asymmetric_best_always' => true,
+            'use_legacy_tier' => false,
+        ],
+    ];
+}
+
+function fleetDaAuditApiGet(string $url): ?array
+{
+    $ctx = stream_context_create([
+        'http' => ['timeout' => 45, 'header' => "Accept: application/json\r\n"],
+    ]);
+    $raw = @file_get_contents($url, false, $ctx);
+    if ($raw === false) {
+        return null;
+    }
+    $decoded = json_decode($raw, true);
+
+    return is_array($decoded) ? $decoded : null;
+}
+
+/**
+ * @param list<array<string, mixed>> $observations API history observations
+ * @return array<string, mixed>|null
+ */
+function fleetDaAuditWindowMeanWind(array $observations, ?array $airport, float $minMeanKts): ?array
+{
+    $windowHours = getPublicApiWindRoseWindowHours();
+    $cutoff = time() - ($windowHours * 3600);
+    $declination = ($airport !== null) ? getMagneticDeclination($airport) : 0.0;
+    $uSum = 0.0;
+    $vSum = 0.0;
+    $scalarSum = 0.0;
+    $count = 0;
+
+    foreach ($observations as $obs) {
+        if (!is_array($obs)) {
+            continue;
+        }
+        $ts = $obs['obs_time'] ?? null;
+        if (!is_numeric($ts) || (int) $ts < $cutoff) {
+            $iso = $obs['obs_time_iso'] ?? null;
+            if (is_string($iso)) {
+                $parsed = strtotime($iso);
+                if ($parsed === false || $parsed < $cutoff) {
+                    continue;
+                }
+            } else {
+                continue;
+            }
+        }
+        $speed = $obs['wind_speed'] ?? null;
+        if ($speed === null || !is_numeric($speed) || (float) $speed < CALM_WIND_THRESHOLD_KTS) {
+            continue;
+        }
+        $speed = (float) $speed;
+        $dirMag = resolveHistoryObservationWindDirectionMagnetic($obs, $declination);
+        if ($dirMag === null) {
+            continue;
+        }
+        $rad = deg2rad($dirMag);
+        $uSum += -$speed * sin($rad);
+        $vSum += -$speed * cos($rad);
+        $scalarSum += $speed;
+        $count++;
+    }
+
+    if ($count < DA_PERF_WIND_MIN_OBS) {
+        return null;
+    }
+
+    $uMean = $uSum / $count;
+    $vMean = $vSum / $count;
+    $vectorSpeed = sqrt(($uMean * $uMean) + ($vMean * $vMean));
+    if ($vectorSpeed < $minMeanKts) {
+        return null;
+    }
+
+    $scalarMean = $scalarSum / $count;
+    $dispersionRatio = $scalarMean / max($vectorSpeed, 0.001);
+    if ($dispersionRatio > DA_PERF_VARIABLE_WIND_RATIO) {
+        return null;
+    }
+
+    $direction = rad2deg(atan2(-$uMean, -$vMean));
+    if ($direction < 0) {
+        $direction += 360.0;
+    }
+
+    return [
+        'direction_magnetic' => $direction,
+        'speed_kts' => $vectorSpeed,
+        'observation_count' => $count,
+        'window_hours' => $windowHours,
+        'dispersion_ratio' => $dispersionRatio,
+    ];
+}
+
+/**
+ * @param array<string, mixed> $variant
+ * @return array<string, mixed>|null
+ */
+function fleetDaAuditBuildPerformance(
+    array $weather,
+    array $airport,
+    string $airportId,
+    array $historyObs,
+    array $variant
+): ?array {
+    $densityAltitude = $weather['density_altitude'] ?? null;
+    if (!is_numeric($densityAltitude)) {
+        return null;
+    }
+    $densityAltitudeFt = (int) round((float) $densityAltitude);
+
+    $nasrRecord = getNasrAirportForConfig($airport);
+    $fieldElevationFt = getEffectiveFieldElevationFt($airport, $nasrRecord);
+
+    $configLength = getConfigRunwayLengthOverrideFt($airport);
+    $selectedRunway = null;
+    $runwaySource = null;
+
+    if ($configLength !== null) {
+        $selectedRunway = [
+            'rwy_id' => 'config',
+            'length_ft' => $configLength,
+            'surface' => getConfigRunwaySurfaceOverride($airport) ?? 'ASPH',
+            'ends' => [],
+        ];
+        $runwaySource = 'config';
+    } elseif ($nasrRecord !== null) {
+        $selectedRunway = nasrSelectLongestActiveLandRunway($nasrRecord);
+        if ($selectedRunway !== null) {
+            $runwaySource = 'nasr';
+        }
+    } else {
+        $selectedRunway = getOurAirportsPerformanceRunwayForAirport($airportId, $airport);
+        if ($selectedRunway !== null) {
+            $runwaySource = 'ourairports';
+        }
+    }
+
+    if ($selectedRunway === null) {
+        return assessFallbackDensityAltitudePerformance($densityAltitudeFt, $fieldElevationFt);
+    }
+
+    $pressureAltitude = $weather['pressure_altitude'] ?? null;
+    $temperature = $weather['temperature'] ?? null;
+    if (!is_numeric($pressureAltitude) || !is_numeric($temperature)) {
+        return assessFallbackDensityAltitudePerformance($densityAltitudeFt, $fieldElevationFt);
+    }
+
+    $tables = loadPohTakeoffTables();
+    $evaluation = evaluateRunwayEndPerformanceRange(
+        $selectedRunway,
+        (float) $pressureAltitude,
+        (float) $temperature,
+        $tables
+    );
+
+    $worstTotalRisk = $evaluation['worst']['total_risk'];
+    $bestTotalRisk = $evaluation['best']['total_risk'];
+
+    if (!empty($variant['use_legacy_tier'])) {
+        $tier = densityAltitudePerformanceTierFromEndRisks($worstTotalRisk, $bestTotalRisk);
+        if ($runwaySource === 'config' || $runwaySource === 'ourairports') {
+            $tier = densityAltitudePerformanceCapTierWithoutObstructions($tier);
+        }
+        if ($tier === 'normal') {
+            return null;
+        }
+
+        return [
+            'tier' => $tier,
+            'selection_basis' => 'both_ends',
+            'operational_end_id' => null,
+            'scored_end_risk' => null,
+            'worst_end_risk' => round($worstTotalRisk, 3),
+            'best_end_risk' => round($bestTotalRisk, 3),
+        ];
+    }
+
+    $selection = [
+        'selection_basis' => 'both_ends',
+        'operational_end_id' => null,
+        'scored_end' => null,
+        'wind_basis' => null,
+    ];
+
+    if ($runwaySource !== 'config' && ($selectedRunway['ends'] ?? []) !== []) {
+        $windBasis = fleetDaAuditWindowMeanWind($historyObs, $airport, (float) $variant['min_mean_kts']);
+        if ($windBasis !== null) {
+            $picked = pickDepartureEndByWindFromMagnetic(
+                $selectedRunway,
+                $airport,
+                (float) $windBasis['direction_magnetic']
+            );
+            if ($picked !== null) {
+                $selection = [
+                    'selection_basis' => 'window_mean_wind',
+                    'operational_end_id' => $picked['end_id'] ?? null,
+                    'scored_end' => lookupEvaluationForRunwayEnd(
+                        $evaluation,
+                        $picked,
+                        $selectedRunway,
+                        (float) $pressureAltitude,
+                        (float) $temperature,
+                        $tables
+                    ),
+                    'wind_basis' => $windBasis,
+                ];
+            }
+        }
+    }
+
+    if ($selection['selection_basis'] === 'both_ends') {
+        $spread = $worstTotalRisk - $bestTotalRisk;
+        $asymmetricOk = $spread >= DA_PERF_ASYMMETRIC_SPREAD
+            && ($variant['asymmetric_best_always'] || $bestTotalRisk < DENSITY_ALTITUDE_PERFORMANCE_TIER_CAUTION);
+        if ($asymmetricOk) {
+            $selection = [
+                'selection_basis' => 'asymmetric_heuristic',
+                'operational_end_id' => $evaluation['best']['end_id'],
+                'scored_end' => $evaluation['best'],
+                'wind_basis' => null,
+            ];
+        }
+    }
+
+    if ($selection['selection_basis'] === 'both_ends') {
+        $tier = densityAltitudePerformanceTierFromEndRisks($worstTotalRisk, $bestTotalRisk);
+        $scoredRisk = null;
+    } else {
+        $scoredRisk = (float) ($selection['scored_end']['total_risk'] ?? 0.0);
+        $tier = densityAltitudePerformanceTierFromScoredEnd($scoredRisk);
+    }
+
+    if ($runwaySource === 'config' || $runwaySource === 'ourairports') {
+        $tier = densityAltitudePerformanceCapTierWithoutObstructions($tier);
+    }
+
+    if ($tier === 'normal') {
+        return null;
+    }
+
+    return [
+        'tier' => $tier,
+        'selection_basis' => $selection['selection_basis'],
+        'operational_end_id' => $selection['operational_end_id'],
+        'scored_end_risk' => $scoredRisk !== null ? round($scoredRisk, 3) : null,
+        'worst_end_risk' => round($worstTotalRisk, 3),
+        'best_end_risk' => round($bestTotalRisk, 3),
+        'wind_speed_kts' => $selection['wind_basis']['speed_kts'] ?? null,
+    ];
+}
+
+$options = getopt('', ['variant:', 'help']);
+if (isset($options['help'])) {
+    echo "Fleet DA constants audit\n\n";
+    echo "Usage: CONFIG_PATH=... php scripts/fleet-da-constants-audit.php [--variant shipped]\n";
+    exit(0);
+}
+
+$config = loadConfig();
+$enabled = [];
+foreach ($config['airports'] ?? [] as $id => $ap) {
+    if ($ap['enabled'] ?? true) {
+        $enabled[$id] = $ap;
+    }
+}
+ksort($enabled);
+
+$variants = fleetDaAuditVariants();
+$onlyVariant = $options['variant'] ?? null;
+if ($onlyVariant !== null && !isset($variants[$onlyVariant])) {
+    fwrite(STDERR, "Unknown variant: $onlyVariant\n");
+    exit(1);
+}
+
+$ids = array_keys($enabled);
+$bulk = [];
+foreach (array_chunk($ids, 10) as $chunk) {
+    $url = 'https://api.aviationwx.org/v1/weather/bulk?airports=' . implode(',', $chunk);
+    $resp = fleetDaAuditApiGet($url);
+    if ($resp === null) {
+        continue;
+    }
+    foreach (($resp['weather'] ?? []) as $aid => $w) {
+        $bulk[$aid] = $w;
+    }
+    usleep(200000);
+}
+
+$runVariants = $onlyVariant !== null ? [$onlyVariant => $variants[$onlyVariant]] : $variants;
+$results = [];
+
+foreach ($ids as $airportId) {
+    $weather = $bulk[$airportId] ?? null;
+    if ($weather === null) {
+        continue;
+    }
+
+    $historyUrl = 'https://api.aviationwx.org/v1/airports/' . rawurlencode($airportId) . '/weather/history?hours=1';
+    $historyResp = fleetDaAuditApiGet($historyUrl);
+    $historyObs = $historyResp['observations'] ?? [];
+    usleep(100000);
+
+    $ap = $enabled[$airportId];
+    $ap['id'] = $airportId;
+    $row = [
+        'id' => $airportId,
+        'da' => $weather['density_altitude'] ?? null,
+        'pa' => $weather['pressure_altitude'] ?? null,
+    ];
+
+    foreach ($runVariants as $key => $variant) {
+        $perf = fleetDaAuditBuildPerformance($weather, $ap, $airportId, $historyObs, $variant);
+        $row[$key] = $perf['tier'] ?? 'normal';
+        $row[$key . '_basis'] = $perf['selection_basis'] ?? '-';
+        $row[$key . '_end'] = $perf['operational_end_id'] ?? '-';
+        $row[$key . '_scored'] = $perf['scored_end_risk'] ?? null;
+        $row[$key . '_worst'] = $perf['worst_end_risk'] ?? null;
+        $row[$key . '_best'] = $perf['best_end_risk'] ?? null;
+    }
+
+    $results[] = $row;
+}
+
+if ($onlyVariant === null) {
+    echo "FLEET DA POLICY COMPARISON\n";
+    echo str_repeat('=', 72) . "\n";
+    foreach (['legacy', 'shipped', 'wind3', 'spread_best', 'both'] as $vk) {
+        $alerts = count(array_filter($results, static fn ($r) => ($r[$vk] ?? 'normal') !== 'normal'));
+        echo sprintf("  %-14s %s: %d alerting\n", $vk, $variants[$vk]['label'], $alerts);
+    }
+    echo "\n";
+
+    $focus = ['or81', 'kpfc', '69v', '7s9', '05s', '12id', '1xs0', 'khio', 's81'];
+    echo "FOCUS AIRPORTS\n";
+    printf("%-12s %6s | %-7s %-7s %-7s %-7s %-7s\n", 'id', 'DA', 'legacy', 'shipped', 'wind3', 'spread', 'both');
+    foreach ($results as $r) {
+        if (!in_array($r['id'], $focus, true)) {
+            continue;
+        }
+        printf(
+            "%-12s %6s | %-7s %-7s %-7s %-7s %-7s\n",
+            $r['id'],
+            (string) ($r['da'] ?? '-'),
+            $r['legacy'] ?? '-',
+            $r['shipped'] ?? '-',
+            $r['wind3'] ?? '-',
+            $r['spread_best'] ?? '-',
+            $r['both'] ?? '-'
+        );
+        if (($r['shipped'] ?? 'normal') !== ($r['both'] ?? 'normal') || $r['id'] === 'or81') {
+            echo sprintf(
+                "    shipped: basis=%s end=%s scored=%s worst=%s best=%s\n",
+                $r['shipped_basis'] ?? '-',
+                $r['shipped_end'] ?? '-',
+                $r['shipped_scored'] ?? '-',
+                $r['shipped_worst'] ?? '-',
+                $r['shipped_best'] ?? '-'
+            );
+            echo sprintf(
+                "    both:    basis=%s end=%s scored=%s worst=%s best=%s\n",
+                $r['both_basis'] ?? '-',
+                $r['both_end'] ?? '-',
+                $r['both_scored'] ?? '-',
+                $r['both_worst'] ?? '-',
+                $r['both_best'] ?? '-'
+            );
+        }
+    }
+
+    echo "\nSHIPPED -> BOTH CHANGES\n";
+    foreach ($results as $r) {
+        if (($r['shipped'] ?? 'normal') === ($r['both'] ?? 'normal')) {
+            continue;
+        }
+        printf(
+            "  %-16s %s -> %s  (shipped %s/%s, both %s/%s)\n",
+            $r['id'],
+            $r['shipped'],
+            $r['both'],
+            $r['shipped_basis'],
+            $r['shipped_end'],
+            $r['both_basis'],
+            $r['both_end']
+        );
+    }
+} else {
+    echo json_encode($results, JSON_PRETTY_PRINT);
+}

--- a/tests/Fixtures/density-altitude-performance-scenarios.json
+++ b/tests/Fixtures/density-altitude-performance-scenarios.json
@@ -43,11 +43,8 @@
     "density_altitude_ft": 9399,
     "pressure_altitude_ft": 5673,
     "temperature_c": 34.7,
-    "expected_tier": "caution",
-    "expected_risk_factor": 3.0,
-    "expected_worst_end_risk": 3.0,
-    "expected_best_end_risk": 0.812,
-    "note": "Longest asphalt 08/26; hot high-elevation afternoon."
+    "expected_tier": "normal",
+    "note": "Asymmetric spread heuristic: best end below caution while worst is high."
   },
   {
     "airport_id": "56s",
@@ -66,11 +63,8 @@
     "density_altitude_ft": 12120,
     "pressure_altitude_ft": 9145,
     "temperature_c": 21.5,
-    "expected_tier": "caution",
-    "expected_risk_factor": 3.0,
-    "expected_worst_end_risk": 3.0,
-    "expected_best_end_risk": 0.908,
-    "note": "Extreme DA with close tree on 04; asymmetric tier caps at caution."
+    "expected_tier": "normal",
+    "note": "Asymmetric spread heuristic: favorable departure end below caution."
   },
   {
     "airport_id": "42b",
@@ -134,10 +128,7 @@
     "density_altitude_ft": 2000,
     "pressure_altitude_ft": 800,
     "temperature_c": 30,
-    "expected_tier": "caution",
-    "expected_risk_factor": 3.0,
-    "expected_worst_end_risk": 3.0,
-    "expected_best_end_risk": 1.076,
-    "note": "Synthetic hot afternoon; asymmetric ends (08 constrained, 26 moderate)."
+    "expected_tier": "normal",
+    "note": "Asymmetric spread heuristic: best end below caution threshold."
   }
 ]

--- a/tests/Unit/DaPerformanceRunwayEndTest.php
+++ b/tests/Unit/DaPerformanceRunwayEndTest.php
@@ -62,6 +62,13 @@ class DaPerformanceRunwayEndTest extends TestCase
         $this->assertSame(260.0, $heading);
     }
 
+    public function testResolveRunwayEndMagneticHeadingReturnsNullForMalformedIdent(): void
+    {
+        $end = ['end_id' => 'XX'];
+        $runway = ['rwy_id' => '08/26', 'length_ft' => 4000, 'surface' => 'ASPH'];
+        $this->assertNull(resolveRunwayEndMagneticHeading($end, $runway, []));
+    }
+
     public function testPickDepartureEndByWindFromMagneticSelectsIntoWindEnd(): void
     {
         $nasrRecord = getNasrAirportForConfig(['faa' => '69V']);

--- a/tests/Unit/DaPerformanceRunwayEndTest.php
+++ b/tests/Unit/DaPerformanceRunwayEndTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Runway end heading resolution and wind-based departure end selection.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Helpers/LoadsNasrAptFixtureCacheTrait.php';
+require_once __DIR__ . '/../../lib/weather/da-performance-runway-end.php';
+
+class DaPerformanceRunwayEndTest extends TestCase
+{
+    use LoadsNasrAptFixtureCacheTrait;
+
+    protected function setUp(): void
+    {
+        $this->loadNasrAptFixtureCache();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownNasrAptFixtureCache();
+    }
+
+    public function testAngularDifferenceWrapsAcrossNorth(): void
+    {
+        $this->assertEqualsWithDelta(20.0, angularDifference(350.0, 10.0), 0.001);
+        $this->assertEqualsWithDelta(0.0, angularDifference(90.0, 90.0), 0.001);
+    }
+
+    public function testResolveRunwayEndMagneticHeadingUsesNasrTrueAlignment(): void
+    {
+        $nasrRecord = getNasrAirportForConfig(['faa' => '69V']);
+        $this->assertNotNull($nasrRecord);
+        $runway = nasrSelectLongestActiveLandRunway($nasrRecord);
+        $this->assertNotNull($runway);
+
+        $end08 = null;
+        foreach ($runway['ends'] as $end) {
+            if (($end['end_id'] ?? '') === '08') {
+                $end08 = $end;
+                break;
+            }
+        }
+        $this->assertNotNull($end08);
+
+        $airport = ['faa' => '69V', 'magnetic_declination' => 14.0];
+        $heading = resolveRunwayEndMagneticHeading($end08, $runway, $airport);
+        $this->assertNotNull($heading);
+        $this->assertEqualsWithDelta(
+            convertTrueToMagnetic((float) $end08['true_alignment'], 14.0),
+            $heading,
+            0.5
+        );
+    }
+
+    public function testResolveRunwayEndMagneticHeadingFallsBackToEndIdent(): void
+    {
+        $end = ['end_id' => '26'];
+        $runway = ['rwy_id' => '08/26', 'length_ft' => 4000, 'surface' => 'ASPH'];
+        $heading = resolveRunwayEndMagneticHeading($end, $runway, []);
+        $this->assertSame(260.0, $heading);
+    }
+
+    public function testPickDepartureEndByWindFromMagneticSelectsIntoWindEnd(): void
+    {
+        $nasrRecord = getNasrAirportForConfig(['faa' => '69V']);
+        $this->assertNotNull($nasrRecord);
+        $runway = nasrSelectLongestActiveLandRunway($nasrRecord);
+        $this->assertNotNull($runway);
+
+        $airport = ['faa' => '69V', 'magnetic_declination' => 14.0];
+        $picked = pickDepartureEndByWindFromMagnetic($runway, $airport, 76.0);
+        $this->assertNotNull($picked);
+        $this->assertSame('08', $picked['end_id']);
+    }
+}

--- a/tests/Unit/DensityAltitudePerformanceTest.php
+++ b/tests/Unit/DensityAltitudePerformanceTest.php
@@ -231,6 +231,7 @@ class DensityAltitudePerformanceTest extends TestCase
         $this->assertSame('reference_models', $result['reason']);
         $this->assertSame(DENSITY_ALTITUDE_PERFORMANCE_REFERENCE_CONFIG, $result['reference']);
         $this->assertGreaterThanOrEqual(DENSITY_ALTITUDE_PERFORMANCE_TIER_WARNING, $result['worst_end_risk']);
+        $this->assertSame($result['worst_end_risk'], $result['risk_factor']);
     }
 
     public function testOurAirportsPathCapsWarningAtCaution(): void
@@ -249,6 +250,7 @@ class DensityAltitudePerformanceTest extends TestCase
         $this->assertSame('caution', $result['tier']);
         $this->assertSame('reference_models_ourairports', $result['reason']);
         $this->assertGreaterThanOrEqual(DENSITY_ALTITUDE_PERFORMANCE_TIER_WARNING, $result['worst_end_risk']);
+        $this->assertSame($result['worst_end_risk'], $result['risk_factor']);
     }
 
     public function testOurAirportsSelectsLongestNonWaterRunway(): void

--- a/tests/Unit/DensityAltitudePerformanceTest.php
+++ b/tests/Unit/DensityAltitudePerformanceTest.php
@@ -312,6 +312,96 @@ class DensityAltitudePerformanceTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testOr81WarmDayScoresFavorableEndWhenSpreadHigh(): void
+    {
+        resetNasrAptCacheMemo();
+        setNasrAptCacheForTesting([
+            'schema_version' => NASR_APT_SCHEMA_VERSION,
+            'airports' => [
+                'OR81' => [
+                    'runways' => [[
+                        'rwy_id' => '07/25',
+                        'length_ft' => 2000,
+                        'surface' => 'TURF-GRVL',
+                        'condition' => '',
+                        'ends' => [
+                            ['end_id' => '07', 'true_alignment' => 70, 'obstruction' => []],
+                            [
+                                'end_id' => '25',
+                                'true_alignment' => 250,
+                                'obstruction' => ['type' => 'TREES', 'hgt_ft' => 100.0, 'dist_ft' => 2000.0],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = buildDensityAltitudePerformance([
+            'density_altitude' => 1531,
+            'pressure_altitude' => 85,
+            'temperature' => 26.0,
+        ], [
+            'id' => 'or81',
+            'faa' => 'OR81',
+            'elevation_ft' => 185,
+            'magnetic_declination' => 13,
+            'runways' => [
+                ['name' => '07/25', 'heading_1' => 70, 'heading_2' => 250],
+            ],
+        ], 'or81');
+
+        $this->assertIsArray($result);
+        $this->assertSame('caution', $result['tier']);
+        $this->assertSame('asymmetric_heuristic', $result['selection_basis']);
+        $this->assertSame('07', $result['operational_end_id']);
+        $this->assertGreaterThanOrEqual(DENSITY_ALTITUDE_PERFORMANCE_TIER_CAUTION, $result['scored_end_risk']);
+        $this->assertLessThan(DENSITY_ALTITUDE_PERFORMANCE_TIER_WARNING, $result['scored_end_risk']);
+        $this->assertSame(3.0, $result['worst_end_risk']);
+    }
+
+    public function testOr81CoolDayNormalOnFavorableEnd(): void
+    {
+        resetNasrAptCacheMemo();
+        setNasrAptCacheForTesting([
+            'schema_version' => NASR_APT_SCHEMA_VERSION,
+            'airports' => [
+                'OR81' => [
+                    'runways' => [[
+                        'rwy_id' => '07/25',
+                        'length_ft' => 2000,
+                        'surface' => 'TURF-GRVL',
+                        'condition' => '',
+                        'ends' => [
+                            ['end_id' => '07', 'true_alignment' => 70, 'obstruction' => []],
+                            [
+                                'end_id' => '25',
+                                'true_alignment' => 250,
+                                'obstruction' => ['type' => 'TREES', 'hgt_ft' => 100.0, 'dist_ft' => 2000.0],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = buildDensityAltitudePerformance([
+            'density_altitude' => 126,
+            'pressure_altitude' => 75,
+            'temperature' => 15.0,
+        ], [
+            'id' => 'or81',
+            'faa' => 'OR81',
+            'elevation_ft' => 185,
+            'magnetic_declination' => 13,
+            'runways' => [
+                ['name' => '07/25', 'heading_1' => 70, 'heading_2' => 250],
+            ],
+        ], 'or81');
+
+        $this->assertNull($result);
+    }
+
     public function testKpfcLikeAsymmetricStripUsesBestEndHeuristic(): void
     {
         require_once __DIR__ . '/../../lib/nasr/cache.php';
@@ -374,10 +464,6 @@ class DensityAltitudePerformanceTest extends TestCase
         $this->assertSame('asymmetric_heuristic', $selection['selection_basis']);
         $this->assertSame('32', $selection['operational_end_id']);
         $this->assertLessThan(DENSITY_ALTITUDE_PERFORMANCE_TIER_CAUTION, $selection['scored_end']['total_risk']);
-        $this->assertGreaterThanOrEqual(
-            DA_PERF_ASYMMETRIC_SPREAD,
-            $evaluation['worst']['total_risk'] - $evaluation['best']['total_risk']
-        );
     }
 
     public function testSelectionBasisTooltipMentionsScoredDepartureEnd(): void

--- a/tests/Unit/DensityAltitudePerformanceTest.php
+++ b/tests/Unit/DensityAltitudePerformanceTest.php
@@ -290,6 +290,108 @@ class DensityAltitudePerformanceTest extends TestCase
         $this->assertStringContainsString('field elevation only', $aria);
     }
 
+    public function testDensityAltitudePerformanceTierFromScoredEndThresholds(): void
+    {
+        $this->assertSame('normal', densityAltitudePerformanceTierFromScoredEnd(1.19));
+        $this->assertSame('caution', densityAltitudePerformanceTierFromScoredEnd(1.20));
+        $this->assertSame('warning', densityAltitudePerformanceTierFromScoredEnd(2.40));
+    }
+
+    public function testAsymmetricHeuristicSuppressesFalsePositiveOn69v(): void
+    {
+        $result = buildDensityAltitudePerformance([
+            'density_altitude' => 9399,
+            'pressure_altitude' => 5673,
+            'temperature' => 34.7,
+        ], [
+            'id' => '69v',
+            'faa' => '69V',
+            'elevation_ft' => 5915,
+        ], '69v');
+
+        $this->assertNull($result);
+    }
+
+    public function testKpfcLikeAsymmetricStripUsesBestEndHeuristic(): void
+    {
+        require_once __DIR__ . '/../../lib/nasr/cache.php';
+        resetNasrAptCacheMemo();
+        setNasrAptCacheForTesting([
+            'schema_version' => NASR_APT_SCHEMA_VERSION,
+            'airports' => [
+                'PFC' => [
+                    'runways' => [[
+                        'rwy_id' => '14/32',
+                        'length_ft' => 5000,
+                        'surface' => 'ASPH',
+                        'condition' => 'GOOD',
+                        'ends' => [
+                            [
+                                'end_id' => '14',
+                                'true_alignment' => 140,
+                                'obstruction' => ['hgt_ft' => 200.0, 'dist_ft' => 500.0],
+                            ],
+                            [
+                                'end_id' => '32',
+                                'true_alignment' => 320,
+                                'obstruction' => [],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = buildDensityAltitudePerformance([
+            'density_altitude' => 500,
+            'pressure_altitude' => 100,
+            'temperature' => 15,
+        ], [
+            'id' => 'kpfc',
+            'faa' => 'PFC',
+            'icao' => 'KPFC',
+            'elevation_ft' => 10,
+        ], 'kpfc');
+
+        $this->assertNull($result);
+
+        $tables = loadPohTakeoffTables();
+        $nasrRecord = getNasrAirportForConfig(['faa' => 'PFC', 'icao' => 'KPFC']);
+        $this->assertNotNull($nasrRecord);
+        $runway = nasrSelectLongestActiveLandRunway($nasrRecord);
+        $evaluation = evaluateRunwayEndPerformanceRange($runway, 100.0, 15.0, $tables);
+        $selection = resolveDensityAltitudePerformanceEndSelection(
+            $evaluation,
+            $runway,
+            ['faa' => 'PFC', 'magnetic_declination' => 14.0],
+            null,
+            100.0,
+            15.0,
+            $tables,
+            'nasr'
+        );
+
+        $this->assertSame('asymmetric_heuristic', $selection['selection_basis']);
+        $this->assertSame('32', $selection['operational_end_id']);
+        $this->assertLessThan(DENSITY_ALTITUDE_PERFORMANCE_TIER_CAUTION, $selection['scored_end']['total_risk']);
+        $this->assertGreaterThanOrEqual(
+            DA_PERF_ASYMMETRIC_SPREAD,
+            $evaluation['worst']['total_risk'] - $evaluation['best']['total_risk']
+        );
+    }
+
+    public function testSelectionBasisTooltipMentionsScoredDepartureEnd(): void
+    {
+        $tooltip = densityAltitudePerformanceTooltip('caution', [
+            'tier' => 'caution',
+            'selection_basis' => 'asymmetric_heuristic',
+            'operational_end_id' => '32',
+        ]);
+
+        $this->assertStringContainsString('RWY 32', $tooltip);
+        $this->assertStringContainsString('reference takeoff performance', $tooltip);
+    }
+
     public function testCapTierWithoutObstructionsDowngradesWarning(): void
     {
         $this->assertSame('caution', densityAltitudePerformanceCapTierWithoutObstructions('warning'));

--- a/tests/Unit/WindowMeanWindTest.php
+++ b/tests/Unit/WindowMeanWindTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * SAFETY-CRITICAL: Window mean wind for density altitude operational end selection.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/weather/history.php';
+require_once __DIR__ . '/../../lib/config.php';
+
+class WindowMeanWindTest extends TestCase
+{
+    private $originalConfigPath;
+    private string $testConfigDir;
+    private string $testConfigFile;
+    private string $testAirportId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalConfigPath = getenv('CONFIG_PATH');
+        $this->testConfigDir = sys_get_temp_dir() . '/aviationwx_wmwind_' . uniqid();
+        mkdir($this->testConfigDir, 0755, true);
+        $this->testConfigFile = $this->testConfigDir . '/airports.json';
+        $this->testAirportId = 'wmw' . substr(uniqid(), -4);
+        $this->createTestConfig([
+            'config' => [
+                'public_api' => [
+                    'enabled' => true,
+                    'weather_history_enabled' => true,
+                    'weather_history_retention_hours' => 24,
+                    'wind_rose_window_hours' => 1,
+                ],
+            ],
+            'airports' => [],
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalConfigPath !== false) {
+            putenv('CONFIG_PATH=' . $this->originalConfigPath);
+        } else {
+            putenv('CONFIG_PATH');
+        }
+        $historyFile = getWeatherHistoryFilePath($this->testAirportId);
+        if (file_exists($historyFile)) {
+            @unlink($historyFile);
+        }
+        if (is_dir($this->testConfigDir)) {
+            @array_map('unlink', glob($this->testConfigDir . '/*'));
+            @rmdir($this->testConfigDir);
+        }
+        if (function_exists('apcu_clear_cache')) {
+            @apcu_clear_cache();
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function createTestConfig(array $config): void
+    {
+        file_put_contents($this->testConfigFile, json_encode($config));
+        putenv('CONFIG_PATH=' . $this->testConfigFile);
+        if (function_exists('apcu_clear_cache')) {
+            @apcu_clear_cache();
+        }
+    }
+
+    private function appendObs(int $obsTime, float $windSpeed, $windDirection): void
+    {
+        appendWeatherHistory($this->testAirportId, [
+            'obs_time_primary' => $obsTime,
+            'wind_speed' => $windSpeed,
+            'wind_direction' => $windDirection,
+        ]);
+    }
+
+    public function testReturnsNullWhenInsufficientObservations(): void
+    {
+        $baseTime = time();
+        $this->appendObs($baseTime - 600, 10.0, 270.0);
+        $this->appendObs($baseTime - 300, 10.0, 270.0);
+
+        $this->assertNull(computeWindowMeanWind($this->testAirportId));
+    }
+
+    public function testReturnsNullWhenMeanSpeedBelowMinimum(): void
+    {
+        $baseTime = time();
+        $this->appendObs($baseTime - 900, 4.0, 270.0);
+        $this->appendObs($baseTime - 600, 4.0, 270.0);
+        $this->appendObs($baseTime - 300, 4.0, 270.0);
+
+        $this->assertNull(computeWindowMeanWind($this->testAirportId));
+    }
+
+    public function testReturnsNullWhenWindHighlyVariable(): void
+    {
+        $baseTime = time();
+        $this->appendObs($baseTime - 900, 10.0, 0.0);
+        $this->appendObs($baseTime - 600, 10.0, 90.0);
+        $this->appendObs($baseTime - 300, 10.0, 180.0);
+
+        $this->assertNull(computeWindowMeanWind($this->testAirportId));
+    }
+
+    public function testConsistentWindReturnsVectorMean(): void
+    {
+        $baseTime = time();
+        $this->appendObs($baseTime - 900, 10.0, 270.0);
+        $this->appendObs($baseTime - 600, 12.0, 270.0);
+        $this->appendObs($baseTime - 300, 8.0, 270.0);
+
+        $result = computeWindowMeanWind($this->testAirportId);
+        $this->assertNotNull($result);
+        $this->assertSame(3, $result['observation_count']);
+        $this->assertEqualsWithDelta(270.0, $result['direction_magnetic'], 1.0);
+        $this->assertEqualsWithDelta(10.0, $result['speed_kts'], 0.5);
+        $this->assertLessThanOrEqual(DA_PERF_VARIABLE_WIND_RATIO, $result['dispersion_ratio']);
+    }
+
+    public function testPrefersMagneticNorthFromWindDirectionObject(): void
+    {
+        $baseTime = time();
+        $airport = ['magnetic_declination' => 14.0];
+        $this->appendObs($baseTime - 900, 10.0, [
+            'true_north' => 284,
+            'magnetic_north' => 270,
+            'variable' => false,
+        ]);
+        $this->appendObs($baseTime - 600, 10.0, [
+            'true_north' => 284,
+            'magnetic_north' => 270,
+            'variable' => false,
+        ]);
+        $this->appendObs($baseTime - 300, 10.0, [
+            'true_north' => 284,
+            'magnetic_north' => 270,
+            'variable' => false,
+        ]);
+
+        $result = computeWindowMeanWind($this->testAirportId, $airport);
+        $this->assertNotNull($result);
+        $this->assertEqualsWithDelta(270.0, $result['direction_magnetic'], 1.0);
+    }
+
+    public function testUsesObsTimeNotObservationTime(): void
+    {
+        $baseTime = time();
+        $history = loadWeatherHistory($this->testAirportId);
+        $history['observations'][] = [
+            'obs_time' => $baseTime - 300,
+            'observation_time' => $baseTime - 7200,
+            'wind_speed' => 10.0,
+            'wind_direction' => 270.0,
+        ];
+        $history['observations'][] = [
+            'obs_time' => $baseTime - 600,
+            'observation_time' => $baseTime - 7200,
+            'wind_speed' => 10.0,
+            'wind_direction' => 270.0,
+        ];
+        $history['observations'][] = [
+            'obs_time' => $baseTime - 900,
+            'observation_time' => $baseTime - 7200,
+            'wind_speed' => 10.0,
+            'wind_direction' => 270.0,
+        ];
+        saveWeatherHistory($this->testAirportId, $history);
+
+        $result = computeWindowMeanWind($this->testAirportId);
+        $this->assertNotNull($result);
+        $this->assertSame(3, $result['observation_count']);
+    }
+}

--- a/tests/Unit/WindowMeanWindTest.php
+++ b/tests/Unit/WindowMeanWindTest.php
@@ -175,4 +175,36 @@ class WindowMeanWindTest extends TestCase
         $this->assertNotNull($result);
         $this->assertSame(3, $result['observation_count']);
     }
+
+    public function testIgnoresMalformedHistoryObservations(): void
+    {
+        $baseTime = time();
+        $history = [
+            'airport_id' => $this->testAirportId,
+            'observations' => [
+                'not-an-array',
+                ['obs_time' => 'bad', 'wind_speed' => 10.0, 'wind_direction' => 270.0],
+                [
+                    'obs_time' => $baseTime - 900,
+                    'wind_speed' => 10.0,
+                    'wind_direction' => 270.0,
+                ],
+                [
+                    'obs_time' => $baseTime - 600,
+                    'wind_speed' => 10.0,
+                    'wind_direction' => 270.0,
+                ],
+                [
+                    'obs_time' => $baseTime - 300,
+                    'wind_speed' => 10.0,
+                    'wind_direction' => 270.0,
+                ],
+            ],
+        ];
+        saveWeatherHistory($this->testAirportId, $history);
+
+        $result = computeWindowMeanWind($this->testAirportId);
+        $this->assertNotNull($result);
+        $this->assertSame(3, $result['observation_count']);
+    }
 }


### PR DESCRIPTION
## Summary

Implements operational departure end selection for density altitude performance tier scoring (Closes #213).

- **`computeWindowMeanWind()`** in `lib/weather/history.php` - vector mean over `wind_rose_window_hours` with `DA_PERF_*` thresholds (min 3 obs, mean >= 5 kt, dispersion ratio <= 2.0).
- **Runway end resolution** in `lib/weather/da-performance-runway-end.php` - NASR `true_alignment`, config headings, end ident fallback; into-wind end pick via `pickDepartureEndByWindFromMagnetic()`.
- **End selection policy** in `resolveDensityAltitudePerformanceEndSelection()`:
  - Path A: window mean wind (primary)
  - Path B: asymmetric spread heuristic when `worst - best >= 1.5` — tier from **best end** (no `best < 1.20` ceiling; fleet-validated for one-way strips like OR81)
  - Path C: both-ends fallback
- **API fields**: `selection_basis`, `operational_end_id`, `scored_end_risk`, optional `wind_basis`.
- **Callers** pass airport id for weather history (`pages/airport.php`, `api/weather.php`, `lib/public-api/weather-format.php`, `lib/embed-diff.php`).
- **Fleet audit script**: `scripts/fleet-da-constants-audit.php`
- **Reference scenario locks** updated for 69v, s81, 03S (normal under asymmetric heuristic).

## Test plan

- [x] `make test-ci` passes locally
- [x] `WindowMeanWindTest` - vector mean, dispersion, magnetic preference
- [x] `DaPerformanceRunwayEndTest` - NASR 69V heading and wind pick; malformed ident returns null
- [x] `DensityAltitudePerformanceTest` - KPFC/OR81 asymmetric heuristic, 69v false positive suppression
- [x] `DensityAltitudePerformanceReferenceScenarioTest` - updated locks