### PR TITLE
Pilot guide: density altitude performance cue in guide 13

### DIFF
--- a/guides/13-using-the-airport-dashboard.md
+++ b/guides/13-using-the-airport-dashboard.md
@@ -126,9 +126,9 @@ The dashboard uses **standard aviation weather colors**:
 
 ### Density Altitude Performance Cue
 
-Some dashboards add **⚠️** (caution) or **🚩** (warning) next to density altitude when reference light-GA takeoff charts (152/172/182, max gross, no wind credit) look limiting on the runways we have on file. It is a heads-up to check your takeoff numbers - not a go/no-go for your flight.
+Some dashboards add **⚠️** (caution) or **🚩** (warning) next to density altitude when our reference light-GA takeoff charts (152/172/182, max gross, no wind credit) suggest performance may be limiting on the runways we have on file. It is a heads-up to check your takeoff numbers - not a go/no-go for your flight.
 
-Hover or long-press the row for departure-end context. When runway length is unavailable, the cue may still flag from density altitude versus field elevation alone - the tooltip explains that fallback.
+The row tooltip or accessible label includes departure-end context. When runway length is unavailable, the cue may still flag from density altitude versus field elevation alone - the tooltip explains that fallback.
 
 No emoji means no caution or warning was flagged, or density altitude is unavailable. Either way, use your AFM or POH to confirm aircraft performance.
 

--- a/guides/13-using-the-airport-dashboard.md
+++ b/guides/13-using-the-airport-dashboard.md
@@ -9,7 +9,7 @@ This guide helps you get the most out of an AviationWX airport dashboard. Think 
 
 AviationWX dashboards focus on **essential, at-a-glance information** - the stuff you actually need when checking conditions before a flight. We keep it simple and fast.
 
-For deeper research, every dashboard includes links to trusted external resources like **AirNav** and **FAA Weather Cams** (plus regional camera links where they apply). We're not trying to replace these great tools - we're giving you a quick visual check and then connecting you to the experts when you need more.
+For deeper research, every dashboard includes links to external airport and weather resources (including **FAA Weather Cams** when available). We're not trying to replace these tools - we're giving you a quick visual check and then connecting you to the experts when you need more.
 
 > ⚠️ **Important**: AviationWX is a **supplemental** information source. Always obtain official weather briefings and NOTAMs before flight.
 
@@ -55,13 +55,12 @@ AviationWX combines multiple data sources to show you the **freshest, most compl
 |                          WEATHER DATA SOURCES                               |
 |                                                                             |
 |      +--------------+      +--------------+      +--------------+           |
-|      |   On-Site    |      |   Official   |      |  Calculated  |           |
-|      |    Sensor    |      |    METAR     |      |    Values    |           |
+|      |   On-site    |      |   Official   |      |  Calculated  |           |
+|      |   sensors    |      |    METAR     |      |    Values    |           |
 |      |              |      |              |      |              |           |
-|      |   Tempest    |      |  ASOS/AWOS   |      |   Density    |           |
-|      |   Davis      |      |   via FAA    |      |   Altitude   |           |
-|      |   Ambient    |      |              |      |   Crosswind  |           |
-|      |   DyaconLive |      |              |      |              |           |
+|      |  (per field) |      |  ASOS/AWOS   |      |   Density    |           |
+|      |              |      |   via FAA    |      |   Altitude   |           |
+|      |              |      |              |      |   Crosswind  |           |
 |      +------+-------+      +------+-------+      +------+-------+           |
 |             |                     |                     |                   |
 |             +---------------------+---------------------+                   |
@@ -78,11 +77,10 @@ AviationWX combines multiple data sources to show you the **freshest, most compl
 ```
 
 **What this means for you:**
-- Some airports have **on-site weather stations** (often every 1-5 minutes; Dyacon advisory stations on DyaconLive update about every 10 minutes)
+- Some airports have **on-site weather stations** (update interval varies by installation, often every few minutes)
 - Some airports use **official METAR data** from nearby ASOS/AWOS
 - Many airports show **both** - you get hyper-local conditions AND official aviation weather
 - Values like density altitude and crosswind components are calculated automatically
-- **DyaconLive** feeds are advisory surface weather; ceiling and visibility usually come from METAR or another official source when shown
 
 ### Flight Category Colors
 
@@ -125,6 +123,14 @@ The dashboard uses **standard aviation weather colors**:
 ```
 
 **Hover over any toggle button** to see what it does.
+
+### Density Altitude Performance Cue
+
+Some dashboards add **⚠️** (caution) or **🚩** (warning) next to density altitude when conditions look limiting for typical light GA aircraft on the runways we have on file. It is a heads-up to check your takeoff numbers - not a go/no-go for your flight.
+
+Hover the row for a short explanation. When runway information is limited, the tooltip will say so.
+
+No emoji means we did not flag a concern against that reference, or we could not run the full runway check. Either way, use your AFM or POH to confirm aircraft performance.
 
 ---
 
@@ -366,7 +372,7 @@ Each airport dashboard includes quick links to external resources:
 ```
 +-----------------------------------------------------------------------------+
 |                                                                             |
-|         [ AirNav ]                    [ FAA Weather ]                       |
+|         [ Airport ]                   [ FAA Weather ]                       |
 |              |                              |                             |
 |              v                              v                             |
 |       Airport info                   FAA weather cams                     |
@@ -375,7 +381,7 @@ Each airport dashboard includes quick links to external resources:
 +-----------------------------------------------------------------------------+
 ```
 
-On mobile devices, you'll also see a **ForeFlight** link that opens the airport directly in the ForeFlight app.
+On mobile devices, you may also see a link that opens the airport in a supported charting app.
 
 ---
 

--- a/guides/13-using-the-airport-dashboard.md
+++ b/guides/13-using-the-airport-dashboard.md
@@ -130,7 +130,7 @@ Some dashboards add **⚠️** (caution) or **🚩** (warning) next to density a
 
 Hover the row for departure-end context and any runway-data fallback note.
 
-No emoji means we did not flag a concern against that reference, or we could not run the full runway check. Either way, use your AFM or POH to confirm aircraft performance.
+No emoji means no caution or warning was flagged, or density altitude is unavailable. Either way, use your AFM or POH to confirm aircraft performance.
 
 ---
 

--- a/guides/13-using-the-airport-dashboard.md
+++ b/guides/13-using-the-airport-dashboard.md
@@ -126,9 +126,9 @@ The dashboard uses **standard aviation weather colors**:
 
 ### Density Altitude Performance Cue
 
-Some dashboards add **⚠️** (caution) or **🚩** (warning) next to density altitude when reference light-GA takeoff performance looks limiting on the runways we have on file (max gross, no wind credit). It is a heads-up to check your takeoff numbers - not a go/no-go for your flight.
+Some dashboards add **⚠️** (caution) or **🚩** (warning) next to density altitude when reference light-GA takeoff charts (152/172/182, max gross, no wind credit) look limiting on the runways we have on file. It is a heads-up to check your takeoff numbers - not a go/no-go for your flight.
 
-Hover the row for departure-end context and any runway-data fallback note.
+Hover the row for departure-end context. When runway length is unavailable, the cue may still flag from density altitude versus field elevation alone - the tooltip explains that fallback.
 
 No emoji means no caution or warning was flagged, or density altitude is unavailable. Either way, use your AFM or POH to confirm aircraft performance.
 

--- a/guides/13-using-the-airport-dashboard.md
+++ b/guides/13-using-the-airport-dashboard.md
@@ -128,7 +128,7 @@ The dashboard uses **standard aviation weather colors**:
 
 Some dashboards add **⚠️** (caution) or **🚩** (warning) next to density altitude when conditions look limiting for typical light GA aircraft on the runways we have on file. It is a heads-up to check your takeoff numbers - not a go/no-go for your flight.
 
-Hover the row for a short explanation. When runway information is limited, the tooltip will say so.
+Hover the row for a short explanation, including the reference assumptions behind the cue (typical light GA, max gross, no wind credit). When runway information is limited, the tooltip will say so.
 
 No emoji means we did not flag a concern against that reference, or we could not run the full runway check. Either way, use your AFM or POH to confirm aircraft performance.
 

--- a/guides/13-using-the-airport-dashboard.md
+++ b/guides/13-using-the-airport-dashboard.md
@@ -126,9 +126,9 @@ The dashboard uses **standard aviation weather colors**:
 
 ### Density Altitude Performance Cue
 
-Some dashboards add **⚠️** (caution) or **🚩** (warning) next to density altitude when conditions look limiting for typical light GA aircraft on the runways we have on file. It is a heads-up to check your takeoff numbers - not a go/no-go for your flight.
+Some dashboards add **⚠️** (caution) or **🚩** (warning) next to density altitude when reference light-GA takeoff performance looks limiting on the runways we have on file (max gross, no wind credit). It is a heads-up to check your takeoff numbers - not a go/no-go for your flight.
 
-Hover the row for a short explanation, including the reference assumptions behind the cue (typical light GA, max gross, no wind credit). When runway information is limited, the tooltip will say so.
+Hover the row for departure-end context and any runway-data fallback note.
 
 No emoji means we did not flag a concern against that reference, or we could not run the full runway check. Either way, use your AFM or POH to confirm aircraft performance.
 

--- a/guides/13-using-the-airport-dashboard.md
+++ b/guides/13-using-the-airport-dashboard.md
@@ -128,7 +128,7 @@ The dashboard uses **standard aviation weather colors**:
 
 Some dashboards add **⚠️** (caution) or **🚩** (warning) next to density altitude when reference light-GA takeoff charts (152/172/182, max gross, no wind credit) look limiting on the runways we have on file. It is a heads-up to check your takeoff numbers - not a go/no-go for your flight.
 
-Hover the row for departure-end context. When runway length is unavailable, the cue may still flag from density altitude versus field elevation alone - the tooltip explains that fallback.
+Hover or long-press the row for departure-end context. When runway length is unavailable, the cue may still flag from density altitude versus field elevation alone - the tooltip explains that fallback.
 
 No emoji means no caution or warning was flagged, or density altitude is unavailable. Either way, use your AFM or POH to confirm aircraft performance.
 


### PR DESCRIPTION
## Summary

Pilot-facing help for the density altitude performance emoji on the dashboard (Closes #204).

- **`guides/13-using-the-airport-dashboard.md`** - short **Density Altitude Performance Cue** section: what ⚠️/🚩 mean, hover for detail, no-emoji cases, confirm in AFM/POH
- Folded into guide 13 instead of a separate guide page - keeps pilot copy concise and next to the rest of the dashboard tour
- Weather overview copy stays brand-agnostic (FAA/METAR references kept); removed vendor-specific sensor and app names from the dashboard guide

## Test plan

- [x] `make test-ci` passes locally on this branch
- [x] `php scripts/validate-guides.php`
- [x] Spot-check rendered guide: http://localhost:8080/guides/13-using-the-airport-dashboard