### PR TITLE
Map OurAirports ident for private-strip DA runway joins

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -119,6 +119,8 @@ If `CONFIG_PATH` points at a missing path, it is skipped and the remaining candi
 | **Density altitude performance** |||
 | `runway_length_ft` | NASR longest runway | Optional override for the density altitude performance cue. See [Density altitude performance overrides](#density-altitude-performance-overrides). |
 | `runway_surface` | `ASPH` when length override is set | NASR-style surface code when `runway_length_ft` is set (e.g. `TURF`, `ASPH`). Drives POH grass correction on non-paved surfaces. |
+| `ourairports_ident` | - | OurAirports open-data ident for internal runway joins (e.g. `US-4027`, `CYAV`). Not shown as the pilot-facing airport code. See [Density altitude performance overrides](#density-altitude-performance-overrides). |
+| `ourairports_id` | - | Optional stable OurAirports integer id from `airports.csv` when set alongside `ourairports_ident`. |
 | **Data Sources** |||
 | `weather_sources` | `[]` | Array of weather source configurations (see Weather Sources section) |
 | `webcams` | `[]` | Array of webcam configurations |
@@ -146,8 +148,10 @@ The weather API `density_altitude_performance` cue compares AFM takeoff charts t
 
 1. `runway_length_ft` / `runway_surface` in `airports.json` (operator override)
 2. FAA NASR longest active land runway (US)
-3. OurAirports longest active land runway when NASR has no row (non-US and private strips without NASR)
+3. OurAirports longest active land runway when NASR has no row: match `ourairports_ident` first, then ICAO, FAA, or config slug against the runway cache
 4. Weather-only elevation bands (`fallback: true`)
+
+Set `ourairports_ident` when the strip has no FAA or ICAO code but a row exists on [OurAirports](https://ourairports.com/data/) (Public Domain). Example: 45 Ranch → `US-4027`. Optional `ourairports_id` (integer from `airports.csv`) documents the stable OurAirports primary key; runway lookup uses `ourairports_ident`. These fields are for internal data joins only; dashboard labels still use ICAO > IATA > FAA.
 
 By default, US airports with a NASR match use the **longest** active land runway from NASR with per-end departure obstructions and effective departure length.
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -671,7 +671,7 @@ Formulas, stress ratios, and tier thresholds are in [SAFETY_CRITICAL_CALCULATION
 | Density altitude | Weather cache | Required; null suppresses cue |
 | Field elevation | `airports.json` or NASR `APT_BASE` | Fallback path and delta |
 | Runway length, surface, departure obstructions | NASR `APT_RWY` / `APT_RWY_END` cache | US airports with a NASR match |
-| Runway length, surface (no obstructions) | OurAirports `runways.csv` cache | When NASR has no row; longest non-closed land runway (exclude water surfaces). Same POH length/surface stress as config override; per-end displaced thresholds when published; no departure obstructions. See [OurAirports runway model](#ourairports-runway-model) below. |
+| Runway length, surface (no obstructions) | OurAirports `runways.csv` cache | When NASR has no row; join via `ourairports_ident` when set, else ICAO/FAA/config slug. Longest non-closed land runway (exclude water surfaces). Same POH length/surface stress as config override; per-end displaced thresholds when published; no departure obstructions. See [OurAirports runway model](#ourairports-runway-model) below. |
 | Operator runway override | `airports.json` `runway_length_ft` / `runway_surface` | Replaces NASR and OurAirports selection; obstructions dropped |
 | AFM takeoff tables | `data/poh/*.json` | C152M, C172N, C182T short-field charts |
 | Wind history (operational end) | Weather history cache | Required for Path A; see [Operational departure end selection](#operational-departure-end-selection) |
@@ -680,12 +680,13 @@ Formulas, stress ratios, and tier thresholds are in [SAFETY_CRITICAL_CALCULATION
 
 1. `runway_length_ft` in `airports.json` (optional `runway_surface`)
 2. NASR longest active land runway (US AIS)
-3. OurAirports longest active land runway when NASR has no row
+3. OurAirports longest active land runway when NASR has no row (`ourairports_ident`, then ICAO/FAA/config slug)
 4. Weather-only fallback (elevation-banded DA thresholds; `fallback: true`)
 
 **OurAirports runway model** (when NASR is unavailable):
 
 - **Source**: `scripts/fetch-runways.php` downloads OurAirports `runways.csv` weekly for wind-compass geometry; DA performance consumes `length_ft`, `surface`, and displaced-threshold fields from the same cache slice (not lat/lon segments alone).
+- **Join**: Config `ourairports_ident` when set; otherwise match ICAO, FAA LID, or config airport slug to OurAirports `ident` in the cache.
 - **Selection**: Longest non-closed land runway; exclude water surfaces using OurAirports surface codes.
 - **Stress**: Full POH reference model on runway length and surface (grass correction when non-paved). Per-end records apply displaced-threshold length when OurAirports publishes it; no departure obstructions or TODA from AIS.
 - **API**: `fallback: false`, `reason: reference_models_ourairports` when this path is used.

--- a/lib/airport-ourairports.php
+++ b/lib/airport-ourairports.php
@@ -37,6 +37,9 @@ function getOurAirportsNumericIdFromAirportConfig(array $airport): ?int
     }
 
     $raw = $airport['ourairports_id'];
+    if (is_bool($raw)) {
+        return null;
+    }
     if (is_int($raw)) {
         return $raw > 0 ? $raw : null;
     }

--- a/lib/airport-ourairports.php
+++ b/lib/airport-ourairports.php
@@ -91,11 +91,14 @@ function ourAirportsCacheLookupIdentsForAirport(string $configAirportId, array $
     };
 
     $push(getOurAirportsIdentFromAirportConfig($airport));
-    if (isset($airport['icao']) && is_string($airport['icao'])) {
-        $push($airport['icao']);
-    }
-    if (isset($airport['faa']) && is_string($airport['faa'])) {
-        $push($airport['faa']);
+    foreach (['icao', 'faa'] as $field) {
+        if (!isset($airport[$field])) {
+            continue;
+        }
+        $value = $airport[$field];
+        if (is_string($value) || is_int($value) || is_float($value)) {
+            $push((string) $value);
+        }
     }
     $push($configAirportId);
 

--- a/lib/airport-ourairports.php
+++ b/lib/airport-ourairports.php
@@ -41,12 +41,12 @@ function getOurAirportsNumericIdFromAirportConfig(array $airport): ?int
         return $raw > 0 ? $raw : null;
     }
 
-    if (is_numeric($raw)) {
-        $id = (int) $raw;
-        return $id > 0 ? $id : null;
+    $validated = filter_var($raw, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+    if ($validated === false) {
+        return null;
     }
 
-    return null;
+    return (int) $validated;
 }
 
 /**
@@ -63,7 +63,7 @@ function isValidOurAirportsIdentFormat(string $ident): bool
         return false;
     }
 
-    return preg_match('/^[A-Z0-9][A-Z0-9-]*$/', $ident) === 1;
+    return preg_match('/^[A-Z0-9]([A-Z0-9-]*[A-Z0-9])?$/', $ident) === 1;
 }
 
 /**

--- a/lib/airport-ourairports.php
+++ b/lib/airport-ourairports.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * OurAirports identifier helpers for internal open-data joins.
+ *
+ * Pilot-facing labels use ICAO > IATA > FAA ({@see getBestIdentifierForLinks()}).
+ * These helpers resolve config airports to OurAirports cache keys only.
+ */
+
+/**
+ * Configured OurAirports text ident (e.g. US-4027, CYAV, ID35).
+ *
+ * @param array $airport Airport configuration
+ * @return string|null Uppercase ident or null when unset
+ */
+function getOurAirportsIdentFromAirportConfig(array $airport): ?string
+{
+    if (!isset($airport['ourairports_ident']) || !is_string($airport['ourairports_ident'])) {
+        return null;
+    }
+
+    $ident = strtoupper(trim($airport['ourairports_ident']));
+
+    return $ident !== '' ? $ident : null;
+}
+
+/**
+ * Optional stable OurAirports integer row id from airports.csv.
+ *
+ * @param array $airport Airport configuration
+ * @return int|null Positive integer or null when unset
+ */
+function getOurAirportsNumericIdFromAirportConfig(array $airport): ?int
+{
+    if (!isset($airport['ourairports_id'])) {
+        return null;
+    }
+
+    $raw = $airport['ourairports_id'];
+    if (is_int($raw)) {
+        return $raw > 0 ? $raw : null;
+    }
+
+    if (is_numeric($raw)) {
+        $id = (int) $raw;
+        return $id > 0 ? $id : null;
+    }
+
+    return null;
+}
+
+/**
+ * Whether a string is a valid OurAirports ident for config validation.
+ *
+ * @param string $ident Candidate ident
+ * @return bool
+ */
+function isValidOurAirportsIdentFormat(string $ident): bool
+{
+    $ident = strtoupper(trim($ident));
+
+    if ($ident === '' || strlen($ident) > 15) {
+        return false;
+    }
+
+    return preg_match('/^[A-Z0-9][A-Z0-9-]*$/', $ident) === 1;
+}
+
+/**
+ * Ordered OurAirports runway-cache keys to try (first match wins).
+ *
+ * Precedence: explicit ourairports_ident, ICAO, FAA, config slug.
+ *
+ * @param string $configAirportId Config key (e.g. 45ranch)
+ * @param array $airport Airport configuration
+ * @return list<string> Unique uppercase idents
+ */
+function ourAirportsCacheLookupIdentsForAirport(string $configAirportId, array $airport): array
+{
+    $candidates = [];
+
+    $push = static function (?string $ident) use (&$candidates): void {
+        if ($ident === null) {
+            return;
+        }
+        $upper = strtoupper(trim($ident));
+        if ($upper === '' || in_array($upper, $candidates, true)) {
+            return;
+        }
+        $candidates[] = $upper;
+    };
+
+    $push(getOurAirportsIdentFromAirportConfig($airport));
+    if (isset($airport['icao']) && is_string($airport['icao'])) {
+        $push($airport['icao']);
+    }
+    if (isset($airport['faa']) && is_string($airport['faa'])) {
+        $push($airport['faa']);
+    }
+    $push($configAirportId);
+
+    return $candidates;
+}

--- a/lib/config.php
+++ b/lib/config.php
@@ -4538,10 +4538,12 @@ function validateAirportsJsonStructure(array $config): array {
 
         if (array_key_exists('ourairports_ident', $airport)) {
             $oaIdent = $airport['ourairports_ident'];
-            if ($oaIdent === null || $oaIdent === '') {
+            if ($oaIdent === null) {
                 // Treat as unset
             } elseif (!is_string($oaIdent)) {
                 $errors[] = "Airport '{$airportCode}' ourairports_ident must be a string";
+            } elseif (trim($oaIdent) === '') {
+                $errors[] = "Airport '{$airportCode}' ourairports_ident must not be empty when set";
             } elseif (!isValidOurAirportsIdentFormat($oaIdent)) {
                 $errors[] = "Airport '{$airportCode}' has invalid ourairports_ident: '{$oaIdent}' "
                     . '(use OurAirports ident, e.g. US-4027, CYAV, ID35)';

--- a/lib/config.php
+++ b/lib/config.php
@@ -4554,6 +4554,8 @@ function validateAirportsJsonStructure(array $config): array {
             $oaId = $airport['ourairports_id'];
             if ($oaId === null) {
                 // Treat as unset
+            } elseif (is_bool($oaId)) {
+                $errors[] = "Airport '{$airportCode}' ourairports_id must be a positive integer";
             } elseif (filter_var($oaId, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) === false) {
                 $errors[] = "Airport '{$airportCode}' ourairports_id must be a positive integer";
             } else {

--- a/lib/config.php
+++ b/lib/config.php
@@ -4554,6 +4554,14 @@ function validateAirportsJsonStructure(array $config): array {
                 // Treat as unset
             } elseif (filter_var($oaId, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) === false) {
                 $errors[] = "Airport '{$airportCode}' ourairports_id must be a positive integer";
+            } else {
+                $oaIdent = $airport['ourairports_ident'] ?? null;
+                $hasValidIdent = is_string($oaIdent)
+                    && trim($oaIdent) !== ''
+                    && isValidOurAirportsIdentFormat($oaIdent);
+                if (!$hasValidIdent) {
+                    $errors[] = "Airport '{$airportCode}' ourairports_id requires ourairports_ident";
+                }
             }
         }
 

--- a/lib/config.php
+++ b/lib/config.php
@@ -8,6 +8,7 @@ define('AVIATIONWX_CONFIG_LOADED', true);
 require_once __DIR__ . '/logger.php';
 require_once __DIR__ . '/constants.php';
 require_once __DIR__ . '/airport-identifiers.php';
+require_once __DIR__ . '/airport-ourairports.php';
 require_once __DIR__ . '/country-resolution.php';
 require_once __DIR__ . '/aviation-region-links.php';
 
@@ -4532,6 +4533,27 @@ function validateAirportsJsonStructure(array $config): array {
                     $faaMap[$faaKey] = [];
                 }
                 $faaMap[$faaKey][] = $airportCode;
+            }
+        }
+
+        if (array_key_exists('ourairports_ident', $airport)) {
+            $oaIdent = $airport['ourairports_ident'];
+            if ($oaIdent === null || $oaIdent === '') {
+                // Treat as unset
+            } elseif (!is_string($oaIdent)) {
+                $errors[] = "Airport '{$airportCode}' ourairports_ident must be a string";
+            } elseif (!isValidOurAirportsIdentFormat($oaIdent)) {
+                $errors[] = "Airport '{$airportCode}' has invalid ourairports_ident: '{$oaIdent}' "
+                    . '(use OurAirports ident, e.g. US-4027, CYAV, ID35)';
+            }
+        }
+
+        if (array_key_exists('ourairports_id', $airport)) {
+            $oaId = $airport['ourairports_id'];
+            if ($oaId === null) {
+                // Treat as unset
+            } elseif (filter_var($oaId, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) === false) {
+                $errors[] = "Airport '{$airportCode}' ourairports_id must be a positive integer";
             }
         }
 

--- a/lib/runways.php
+++ b/lib/runways.php
@@ -8,6 +8,7 @@
  * Active runways only; combines both sources in APCu cache.
  */
 
+require_once __DIR__ . '/airport-ourairports.php';
 require_once __DIR__ . '/constants.php';
 require_once __DIR__ . '/cache-paths.php';
 require_once __DIR__ . '/heading-conversion.php';
@@ -614,7 +615,7 @@ function ourAirportsSelectLongestActiveLandRunway(array $runways): ?array
  *
  * @param array $data Parsed runways cache (must have 'airports' key)
  * @param string $airportId Airport identifier
- * @param array $airport Airport config with icao, faa (optional)
+ * @param array $airport Airport config with optional ourairports_ident, icao, faa
  * @return list<array>|null Performance runways or null when not found
  */
 function getOurAirportsPerformanceRunwaysFromParsedCache(array $data, string $airportId, array $airport): ?array
@@ -623,11 +624,7 @@ function getOurAirportsPerformanceRunwaysFromParsedCache(array $data, string $ai
         return null;
     }
     $airports = $data['airports'];
-    $identsToTry = array_filter([
-        strtoupper($airportId),
-        isset($airport['icao']) ? strtoupper((string) $airport['icao']) : null,
-        isset($airport['faa']) ? strtoupper((string) $airport['faa']) : null,
-    ]);
+    $identsToTry = ourAirportsCacheLookupIdentsForAirport($airportId, $airport);
     foreach ($identsToTry as $ident) {
         if (!isset($airports[$ident]) || !is_array($airports[$ident])) {
             continue;

--- a/lib/weather/density-altitude-performance.php
+++ b/lib/weather/density-altitude-performance.php
@@ -415,9 +415,9 @@ function assessFallbackDensityAltitudePerformance(?int $densityAltitudeFt, ?int 
  * Runway selection precedence:
  * 1. `runway_length_ft` / `runway_surface` in airport config (synthetic runway, empty ends)
  * 2. NASR longest active land runway (full obstruction model)
- * 3. OurAirports longest land runway when NASR absent (`ourairports_ident`, then ICAO/FAA/config
- *    slug against runway cache; length/surface; per-end displaced thresholds when published;
- *    no departure obstructions or TODA)
+ * 3. OurAirports longest land runway when NASR absent (`ourairports_ident`, then ICAO/FAA,
+ *    then the config airport key passed as `$airportId`; length/surface; per-end displaced
+ *    thresholds when published; no departure obstructions or TODA)
  * 4. Weather-only fallback (`assessFallbackDensityAltitudePerformance`)
  *
  * @param array $weather Cached weather row

--- a/lib/weather/density-altitude-performance.php
+++ b/lib/weather/density-altitude-performance.php
@@ -415,8 +415,9 @@ function assessFallbackDensityAltitudePerformance(?int $densityAltitudeFt, ?int 
  * Runway selection precedence:
  * 1. `runway_length_ft` / `runway_surface` in airport config (synthetic runway, empty ends)
  * 2. NASR longest active land runway (full obstruction model)
- * 3. OurAirports longest land runway when NASR absent (length/surface; per-end displaced
- *    thresholds when published; no departure obstructions or TODA)
+ * 3. OurAirports longest land runway when NASR absent (`ourairports_ident`, then ICAO/FAA/config
+ *    slug against runway cache; length/surface; per-end displaced thresholds when published;
+ *    no departure obstructions or TODA)
  * 4. Weather-only fallback (`assessFallbackDensityAltitudePerformance`)
  *
  * @param array $weather Cached weather row

--- a/lib/weather/density-altitude-performance.php
+++ b/lib/weather/density-altitude-performance.php
@@ -454,7 +454,7 @@ function buildDensityAltitudePerformance(array $weather, array $airport, ?string
             $runwaySource = 'nasr';
         }
     } else {
-        $ourAirportsId = (string) ($airport['id'] ?? $airport['icao'] ?? '');
+        $ourAirportsId = $airportId ?? (string) ($airport['id'] ?? $airport['icao'] ?? '');
         $selectedRunway = getOurAirportsPerformanceRunwayForAirport($ourAirportsId, $airport);
         if ($selectedRunway !== null) {
             $runwaySource = 'ourairports';

--- a/tests/Fixtures/runways_data.json
+++ b/tests/Fixtures/runways_data.json
@@ -128,6 +128,21 @@
           "he_displaced_threshold_ft": 0
         }
       ]
+    },
+    "US-4027": {
+      "center_lat": 42.173084,
+      "center_lon": -116.875378,
+      "segments": [],
+      "performance_runways": [
+        {
+          "rwy_id": "17/35",
+          "length_ft": 2700,
+          "surface": "GRS",
+          "ends": [],
+          "le_displaced_threshold_ft": 0,
+          "he_displaced_threshold_ft": 0
+        }
+      ]
     }
   }
 }

--- a/tests/Unit/AirportOurAirportsTest.php
+++ b/tests/Unit/AirportOurAirportsTest.php
@@ -33,6 +33,16 @@ class AirportOurAirportsTest extends TestCase
         $this->assertSame(['US-4027', 'ZZZZ', 'ZZZ1', '45RANCH'], $idents);
     }
 
+    public function testCacheLookupIdents_CastsScalarIcaoFaa(): void
+    {
+        $idents = ourAirportsCacheLookupIdentsForAirport('45ranch', [
+            'icao' => 1234,
+            'faa' => 5678,
+        ]);
+
+        $this->assertSame(['1234', '5678', '45RANCH'], $idents);
+    }
+
     public function testGetOurAirportsIdentFromAirportConfig_NormalizesCase(): void
     {
         $this->assertSame('US-4027', getOurAirportsIdentFromAirportConfig([

--- a/tests/Unit/AirportOurAirportsTest.php
+++ b/tests/Unit/AirportOurAirportsTest.php
@@ -18,6 +18,7 @@ class AirportOurAirportsTest extends TestCase
     {
         $this->assertFalse(isValidOurAirportsIdentFormat(''));
         $this->assertFalse(isValidOurAirportsIdentFormat('-US'));
+        $this->assertFalse(isValidOurAirportsIdentFormat('US-'));
         $this->assertFalse(isValidOurAirportsIdentFormat('bad ident'));
     }
 

--- a/tests/Unit/AirportOurAirportsTest.php
+++ b/tests/Unit/AirportOurAirportsTest.php
@@ -48,5 +48,11 @@ class AirportOurAirportsTest extends TestCase
         $this->assertNull(getOurAirportsNumericIdFromAirportConfig([
             'ourairports_id' => 0,
         ]));
+        $this->assertNull(getOurAirportsNumericIdFromAirportConfig([
+            'ourairports_id' => '1.2',
+        ]));
+        $this->assertNull(getOurAirportsNumericIdFromAirportConfig([
+            'ourairports_id' => '1e3',
+        ]));
     }
 }

--- a/tests/Unit/AirportOurAirportsTest.php
+++ b/tests/Unit/AirportOurAirportsTest.php
@@ -65,5 +65,8 @@ class AirportOurAirportsTest extends TestCase
         $this->assertNull(getOurAirportsNumericIdFromAirportConfig([
             'ourairports_id' => '1e3',
         ]));
+        $this->assertNull(getOurAirportsNumericIdFromAirportConfig([
+            'ourairports_id' => true,
+        ]));
     }
 }

--- a/tests/Unit/AirportOurAirportsTest.php
+++ b/tests/Unit/AirportOurAirportsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/airport-ourairports.php';
+
+class AirportOurAirportsTest extends TestCase
+{
+    public function testIsValidOurAirportsIdentFormat_AcceptsCommonPatterns(): void
+    {
+        $this->assertTrue(isValidOurAirportsIdentFormat('CYAV'));
+        $this->assertTrue(isValidOurAirportsIdentFormat('US-4027'));
+        $this->assertTrue(isValidOurAirportsIdentFormat('ID35'));
+        $this->assertTrue(isValidOurAirportsIdentFormat('03ID'));
+    }
+
+    public function testIsValidOurAirportsIdentFormat_RejectsInvalid(): void
+    {
+        $this->assertFalse(isValidOurAirportsIdentFormat(''));
+        $this->assertFalse(isValidOurAirportsIdentFormat('-US'));
+        $this->assertFalse(isValidOurAirportsIdentFormat('bad ident'));
+    }
+
+    public function testCacheLookupIdents_PrefersExplicitOurAirportsIdent(): void
+    {
+        $idents = ourAirportsCacheLookupIdentsForAirport('45ranch', [
+            'ourairports_ident' => 'US-4027',
+            'icao' => 'ZZZZ',
+            'faa' => 'ZZZ1',
+        ]);
+
+        $this->assertSame(['US-4027', 'ZZZZ', 'ZZZ1', '45RANCH'], $idents);
+    }
+
+    public function testGetOurAirportsIdentFromAirportConfig_NormalizesCase(): void
+    {
+        $this->assertSame('US-4027', getOurAirportsIdentFromAirportConfig([
+            'ourairports_ident' => ' us-4027 ',
+        ]));
+        $this->assertNull(getOurAirportsIdentFromAirportConfig([]));
+    }
+
+    public function testGetOurAirportsNumericIdFromAirportConfig(): void
+    {
+        $this->assertSame(344311, getOurAirportsNumericIdFromAirportConfig([
+            'ourairports_id' => 344311,
+        ]));
+        $this->assertNull(getOurAirportsNumericIdFromAirportConfig([
+            'ourairports_id' => 0,
+        ]));
+    }
+}

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -5460,6 +5460,25 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('ourairports_ident must not be empty', implode(' ', $result['errors']));
     }
 
+    public function testValidateAirportsJsonStructure_RejectsBooleanOurAirportsId(): void
+    {
+        $config = $this->createMinimalConfig();
+        $config['airports']['bad'] = [
+            'name' => 'Bad Strip',
+            'lat' => 42.0,
+            'lon' => -116.0,
+            'access_type' => 'public',
+            'tower_status' => 'non_towered',
+            'ourairports_ident' => 'US-4027',
+            'ourairports_id' => true,
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('ourairports_id must be a positive integer', implode(' ', $result['errors']));
+    }
+
     public function testValidateAirportsJsonStructure_RejectsOurAirportsIdWithoutIdent(): void
     {
         $config = $this->createMinimalConfig();

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -5442,6 +5442,24 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('ourairports_ident', implode(' ', $result['errors']));
     }
 
+    public function testValidateAirportsJsonStructure_RejectsEmptyOurAirportsIdent(): void
+    {
+        $config = $this->createMinimalConfig();
+        $config['airports']['bad'] = [
+            'name' => 'Bad Strip',
+            'lat' => 42.0,
+            'lon' => -116.0,
+            'access_type' => 'public',
+            'tower_status' => 'non_towered',
+            'ourairports_ident' => '',
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('ourairports_ident must not be empty', implode(' ', $result['errors']));
+    }
+
     public function testValidateAirportsJsonStructure_RejectsOurAirportsIdWithoutIdent(): void
     {
         $config = $this->createMinimalConfig();

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -5442,6 +5442,24 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('ourairports_ident', implode(' ', $result['errors']));
     }
 
+    public function testValidateAirportsJsonStructure_RejectsOurAirportsIdWithoutIdent(): void
+    {
+        $config = $this->createMinimalConfig();
+        $config['airports']['bad'] = [
+            'name' => 'Bad Strip',
+            'lat' => 42.0,
+            'lon' => -116.0,
+            'access_type' => 'public',
+            'tower_status' => 'non_towered',
+            'ourairports_id' => 344311,
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('ourairports_id requires ourairports_ident', implode(' ', $result['errors']));
+    }
+
     // =========================================================================
     // Helper Methods
     // =========================================================================

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -5406,6 +5406,42 @@ class ConfigValidationTest extends TestCase
         $this->assertGreaterThanOrEqual(60, $sec);
     }
 
+    public function testValidateAirportsJsonStructure_AcceptsOurAirportsIdentFields(): void
+    {
+        $config = $this->createMinimalConfig();
+        $config['airports']['45ranch'] = [
+            'name' => '45 Ranch Airport',
+            'lat' => 42.17,
+            'lon' => -116.87,
+            'access_type' => 'public',
+            'tower_status' => 'non_towered',
+            'ourairports_ident' => 'US-4027',
+            'ourairports_id' => 344311,
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+
+        $this->assertTrue($result['valid'], implode(' ', $result['errors']));
+    }
+
+    public function testValidateAirportsJsonStructure_RejectsInvalidOurAirportsIdent(): void
+    {
+        $config = $this->createMinimalConfig();
+        $config['airports']['bad'] = [
+            'name' => 'Bad Strip',
+            'lat' => 42.0,
+            'lon' => -116.0,
+            'access_type' => 'public',
+            'tower_status' => 'non_towered',
+            'ourairports_ident' => 'not valid',
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('ourairports_ident', implode(' ', $result['errors']));
+    }
+
     // =========================================================================
     // Helper Methods
     // =========================================================================

--- a/tests/Unit/DensityAltitudePerformanceTest.php
+++ b/tests/Unit/DensityAltitudePerformanceTest.php
@@ -253,6 +253,25 @@ class DensityAltitudePerformanceTest extends TestCase
         $this->assertSame($result['worst_end_risk'], $result['risk_factor']);
     }
 
+    public function testPrivateStripUsesOurAirportsIdentMapping(): void
+    {
+        $result = buildDensityAltitudePerformance([
+            'density_altitude' => 5200,
+            'pressure_altitude' => 4200,
+            'temperature' => 32,
+        ], [
+            'id' => '45ranch',
+            'elevation_ft' => 4300,
+            'ourairports_ident' => 'US-4027',
+            'ourairports_id' => 344311,
+        ], '45ranch');
+
+        $this->assertNotNull($result);
+        $this->assertFalse($result['fallback']);
+        $this->assertSame('reference_models_ourairports', $result['reason']);
+        $this->assertSame('caution', $result['tier']);
+    }
+
     public function testOurAirportsSelectsLongestNonWaterRunway(): void
     {
         $runways = [

--- a/tests/Unit/DensityAltitudePerformanceTest.php
+++ b/tests/Unit/DensityAltitudePerformanceTest.php
@@ -272,6 +272,23 @@ class DensityAltitudePerformanceTest extends TestCase
         $this->assertSame('caution', $result['tier']);
     }
 
+    public function testPrivateStripOurAirportsLookupUsesAirportIdParameter(): void
+    {
+        $result = buildDensityAltitudePerformance([
+            'density_altitude' => 5200,
+            'pressure_altitude' => 4200,
+            'temperature' => 32,
+        ], [
+            'elevation_ft' => 4300,
+            'ourairports_ident' => 'US-4027',
+            'ourairports_id' => 344311,
+        ], '45ranch');
+
+        $this->assertNotNull($result);
+        $this->assertFalse($result['fallback']);
+        $this->assertSame('reference_models_ourairports', $result['reason']);
+    }
+
     public function testOurAirportsSelectsLongestNonWaterRunway(): void
     {
         $runways = [

--- a/tests/Unit/FetchRunwaysTest.php
+++ b/tests/Unit/FetchRunwaysTest.php
@@ -26,6 +26,31 @@ class FetchRunwaysTest extends TestCase
         $this->assertSame(6600, $resolved[0]['length_ft']);
     }
 
+    public function testGetOurAirportsPerformanceRunwaysFromParsedCache_UsesOurAirportsIdent(): void
+    {
+        $data = [
+            'airports' => [
+                'US-4027' => [
+                    'performance_runways' => [
+                        [
+                            'rwy_id' => '17/35',
+                            'length_ft' => 2700,
+                            'surface' => 'GRS',
+                            'ends' => [],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $runways = getOurAirportsPerformanceRunwaysFromParsedCache($data, '45ranch', [
+            'ourairports_ident' => 'US-4027',
+        ]);
+
+        $this->assertNotNull($runways);
+        $this->assertSame(2700, $runways[0]['length_ft']);
+    }
+
     public function testMergeRunwaySources_AttachesPerformanceRunwaysForFaaCoveredAirport(): void
     {
         $faa = [


### PR DESCRIPTION
## Summary

- Add optional `ourairports_ident` and `ourairports_id` airport config fields for positive OurAirports open-data joins without changing pilot-facing ICAO > IATA > FAA labels.
- Resolve runway cache lookups via explicit OurAirports ident first, then ICAO, FAA, and config slug so strips like 45 Ranch can use `US-4027` when NASR has no row.
- Validate new fields in config-check and document precedence in `CONFIGURATION.md` and `DATA_FLOW.md`.

## Test plan

- [x] `make test-ci`
- [x] Unit tests for resolver, config validation, runway cache join, and DA performance on `US-4027` fixture
- [x] Set `ourairports_ident: US-4027` on 45 Ranch in secrets config once OurAirports publishes runway rows (or pair with `runway_length_ft` until then)

Closes #217