### PR TITLE
Document OurAirports fallback data in airport guides

### DIFF
--- a/guides/12-submit-an-airport-to-aviationwx.md
+++ b/guides/12-submit-an-airport-to-aviationwx.md
@@ -62,6 +62,26 @@ In your email, include:
 Optional but helpful:
 - **Photos of the install site** (even cellphone photos are fine)
 - **A sample camera image** (one representative still)
+- **OurAirports status:** listed / needs update / not listed yet (include ident or link if you have it)
+
+---
+
+### Keep your OurAirports listing current
+
+AviationWX uses [OurAirports](https://ourairports.com/) open data to fill in **airport reference information** when a more official source is not available (for example FAA NASR data for U.S. fields).
+
+That can include:
+
+- **Runways** (used for the wind rose, runway labels, and density-altitude performance cues)
+- **Radio frequencies** and other published airport facts
+- **General airport information** (name, location, identifiers)
+
+Official sources take priority when we have them. For small private strips and fields not in national databases, OurAirports is often the main reference.
+
+**If you manage or sponsor the airport**, please keep the OurAirports entry accurate and up to date - especially runways and identifiers. Stale open data can mean wrong runway labels or incomplete performance cues on the dashboard.
+
+- **Already listed?** Review and update the airport page at [ourairports.com](https://ourairports.com/).
+- **Not listed yet?** Add the airport there when you can. If you know the OurAirports ident (for example `US-4027`), include it in your submission email.
 
 ---
 

--- a/guides/13-using-the-airport-dashboard.md
+++ b/guides/13-using-the-airport-dashboard.md
@@ -387,6 +387,14 @@ On mobile devices, you may also see a link that opens the airport in a supported
 
 ## Section 6: Airport Information
 
+### Where this information comes from
+
+The **Airport Information** section (elevation, runways, frequencies, fuel, and related details) combines maintainer-provided updates with open reference data. For runways and other airport facts, AviationWX uses official sources when available. When those are missing, we rely on [OurAirports](https://ourairports.com/) community-maintained data.
+
+That data also feeds the **runway wind** display and **density-altitude performance** cue when we do not have a more official runway record.
+
+If something looks wrong, contact the local airport steward or email `contact@aviationwx.org`. Airport owners and sponsors can also correct the listing on OurAirports, which helps pilots beyond AviationWX.
+
 ### Basic Info
 
 ```


### PR DESCRIPTION
## Summary

- Add steward-facing guidance in Guide 12 to keep OurAirports listings current when submitting an airport, including an optional checklist item for OurAirports status.
- Add pilot-facing context in Guide 13 explaining that airport reference data (runways, frequencies, and related details) uses official sources first and OurAirports when those are unavailable.

## Test plan

- [x] Proofread Guide 12 and Guide 13 copy for plain language and style consistency
- [x] Spot-check rendered guide pages after merge