### PR TITLE
Document reference-data classification and observability ontology

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -634,6 +634,93 @@ See [LOCAL_SETUP.md](docs/LOCAL_SETUP.md) for testing instructions.
 - **Rate Limiting**: Prevents resource exhaustion
 - **Background Processing**: Stale-while-revalidate reduces blocking
 
+## Data classification and observability
+
+AviationWX ingests many external catalogs and live feeds. New sources (NASR tables, OurAirports CSVs, computed slices) should land in predictable places for **health checks**, the **status page**, and **safety review** without another taxonomy debate.
+
+Organize by **what breaks for whom**, not by vendor, filename, or fetch script. The status page layout may change; this vocabulary should stay stable.
+
+### Planes (top level)
+
+| Plane | Question | Typical cadence | Primary observability |
+|-------|----------|-----------------|------------------------|
+| **Platform** | Is the node healthy enough to work? | Continuous | System Status (flat rows: config, cache, scheduler, logging, …) |
+| **Live observations** | Is fresh operational data arriving? | Seconds to hours | System Status (expandable providers) and **Site Status** per airport |
+| **Reference catalogs** | Is slow-changing airfield context still trustworthy? | Days to weeks | System Status under **Reference data** (expandable consumer features) |
+| **Derived context** | Are computed joins and config slices still valid? | Varies | Report under the catalog or feature they serve |
+
+**Site Status** (per configured airport) is a separate dimension: live observation health only. Do not mix bulk-catalog age into per-airport cards.
+
+### Consumer features (reference catalogs)
+
+These map to product and safety domains. UI groups are views over this list; groups may merge or split without renaming consumers.
+
+| Consumer | Serves | Example sources |
+|----------|--------|-----------------|
+| `runway_geometry` | Wind compass, map runway labels | FAA NGDA, OurAirports `runways.csv` |
+| `runway_performance` | Density-altitude runway model | NASR APT, OurAirports runway fields, `airports.json` overrides; **uses** NOTAM cache for active closures |
+| `airport_identity` | Validation, joins, slugs | OurAirports `airports.csv`, config |
+| `airport_comms` | Dashboard and API frequencies | NASR FRQ, OurAirports `airport-frequencies.csv`, config |
+| `airport_location` | Country and region context | Country-resolution aggregate (computed) |
+| `geomagnetism` | Magnetic wind direction | WMM (bundled with deploy) |
+
+Runway geometry and runway performance may share fetch jobs but are **distinct consumers**: they fail independently and follow different precedence (see [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md) and [DATA_FLOW.md](DATA_FLOW.md)).
+
+Live observations use the same leaf pattern under their plane, for example `weather_obs` (METAR HTTP, METAR bulk, PWS, …), `restrictions` (NOTAM), and `imagery` (webcams, variants).
+
+### Source leaves (grows freely)
+
+Each cache artifact or ingest path is one **leaf** with metadata in a consistent shape:
+
+| Field | Purpose |
+|-------|---------|
+| `consumer` | Slug from the tables above (for example `runway_geometry`, `airport_comms`) |
+| `source` | Human label and upstream URL |
+| `kind` | `bulk`, `computed`, `bundled`, or `config` |
+| `cadence` | Probe interval, fetch interval, hard max age |
+| `dependencies` | Other leaves this consumer reads (links only, not duplicate health rows) |
+
+**Kind** sets ops expectations:
+
+- **bulk** - external dump; conditional HTTP probes (ETag / `Last-Modified`) apply when supported
+- **computed** - rebuilt from config and geometry (country resolution)
+- **bundled** - ships with deploy (WMM)
+- **config** - operator truth in `airports.json` (overrides, manual runways, frequencies)
+
+### Dependencies (edges, not duplicate rows)
+
+Record consumption once; reference elsewhere in copy:
+
+- Runway geometry **uses** `airports.csv` for centers and FAA→ICAO mapping
+- Runway performance **uses** NOTAM cache for active runway and aerodrome closures
+- NASR configured slices **use** full NASR cache plus config SHA
+- Density-altitude performance **uses** runway performance and weather (weather stays in the live plane)
+
+On the status page, show dependencies as a short note under the consumer (for example “NOTAM: see Live observations”), not a second health row under Reference data.
+
+### Rollup and health-check rules
+
+Regardless of how many expandable blocks the status page renders:
+
+1. **Parent status = worst child** in that subtree
+2. **Auto-expand** when degraded or down
+3. **One health check per cache artifact** - shared files (for example `airports.csv`) appear once under `airport_identity`, referenced from other consumers
+4. **Staleness is explicit** per leaf: local cache age, upstream probe result, hard max age
+
+Implement health checks in `lib/status-checks.php` using this model (`sources[]` under consumer features, parallel to weather `providers[]`). See [OPERATIONS.md](OPERATIONS.md#status-page) for how operators interpret the page today.
+
+### Where new work goes
+
+| When adding… | Ontology action |
+|--------------|-----------------|
+| OurAirports or NASR bulk ingest | New or updated leaf under the matching consumer; `kind: bulk` |
+| New NASR table for runway performance | Same `runway_performance` consumer, richer leaf details |
+| New OurAirports CSV for a new product surface | New consumer only if it is a first-class feature; otherwise extend an existing consumer |
+| Computed aggregate | `kind: computed` under the consumer it serves |
+| Live feed | Live plane, existing provider pattern |
+
+Pipeline specifics (merge order, staleness nulling, DA precedence) remain in [DATA_FLOW.md](DATA_FLOW.md) and [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md). This section is the **map**; those documents are the **rules** for each pipeline.
+
 ## Monitoring
 
 - **Logging**: Comprehensive file-based logging via `lib/logger.php` (writes to `/var/log/aviationwx/`, persisted on host at `/var/aviationwx/logs`)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -634,17 +634,17 @@ See [LOCAL_SETUP.md](docs/LOCAL_SETUP.md) for testing instructions.
 - **Rate Limiting**: Prevents resource exhaustion
 - **Background Processing**: Stale-while-revalidate reduces blocking
 
-## Data classification and observability
+## Data Classification and Observability
 
-AviationWX ingests many external catalogs and live feeds. New sources (NASR tables, OurAirports CSVs, computed slices) should land in predictable places for **health checks**, the **status page**, and **safety review** without another taxonomy debate.
+AviationWX ingests many external catalogs and live feeds. New sources (NASR tables, OurAirports CSVs, computed slices) land in predictable places for **health checks**, the **status page**, and **safety review**.
 
-Organize by **what breaks for whom**, not by vendor, filename, or fetch script. The status page layout may change; this vocabulary should stay stable.
+Organize by **what breaks for whom**, not by vendor, filename, or fetch script. Expandable status-page groups are views over this vocabulary; consumer slugs stay stable when groups merge or split.
 
 ### Planes (top level)
 
 | Plane | Question | Typical cadence | Primary observability |
 |-------|----------|-----------------|------------------------|
-| **Platform** | Is the node healthy enough to work? | Continuous | System Status (flat rows: config, cache, scheduler, logging, …) |
+| **Platform** | Is the node healthy enough to work? | Continuous | System Status (flat rows: config, cache, scheduler, logging, ...) |
 | **Live observations** | Is fresh operational data arriving? | Seconds to hours | System Status (expandable providers) and **Site Status** per airport |
 | **Reference catalogs** | Is slow-changing airfield context still trustworthy? | Days to weeks | System Status under **Reference data** (expandable consumer features) |
 | **Derived context** | Are computed joins and config slices still valid? | Varies | Report under the catalog or feature they serve |
@@ -666,7 +666,7 @@ These map to product and safety domains. UI groups are views over this list; gro
 
 Runway geometry and runway performance may share fetch jobs but are **distinct consumers**: they fail independently and follow different precedence (see [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md) and [DATA_FLOW.md](DATA_FLOW.md)).
 
-Live observations use the same leaf pattern under their plane, for example `weather_obs` (METAR HTTP, METAR bulk, PWS, …), `restrictions` (NOTAM), and `imagery` (webcams, variants).
+Live observations use the same leaf pattern under their plane, for example `weather_obs` (METAR HTTP, METAR bulk, PWS, ...), `restrictions` (NOTAM), and `imagery` (webcams, variants).
 
 ### Source leaves (grows freely)
 
@@ -696,7 +696,7 @@ Record consumption once; reference elsewhere in copy:
 - NASR configured slices **use** full NASR cache plus config SHA
 - Density-altitude performance **uses** runway performance and weather (weather stays in the live plane)
 
-On the status page, show dependencies as a short note under the consumer (for example “NOTAM: see Live observations”), not a second health row under Reference data.
+On the status page, show dependencies as a short note under the consumer (for example "NOTAM: see Live observations"), not a second health row under Reference data.
 
 ### Rollup and health-check rules
 
@@ -707,11 +707,11 @@ Regardless of how many expandable blocks the status page renders:
 3. **One health check per cache artifact** - shared files (for example `airports.csv`) appear once under `airport_identity`, referenced from other consumers
 4. **Staleness is explicit** per leaf: local cache age, upstream probe result, hard max age
 
-Implement health checks in `lib/status-checks.php` using this model (`sources[]` under consumer features, parallel to weather `providers[]`). See [OPERATIONS.md](OPERATIONS.md#status-page) for how operators interpret the page today.
+Health checks in `lib/status-checks.php` use this model (`sources[]` under consumer features, parallel to weather `providers[]`). See [OPERATIONS.md](OPERATIONS.md#status-page) for operator interpretation.
 
 ### Where new work goes
 
-| When adding… | Ontology action |
+| When adding... | Ontology action |
 |--------------|-----------------|
 | OurAirports or NASR bulk ingest | New or updated leaf under the matching consumer; `kind: bulk` |
 | New NASR table for runway performance | Same `runway_performance` consumer, richer leaf details |
@@ -723,12 +723,14 @@ Pipeline specifics (merge order, staleness nulling, DA precedence) remain in [DA
 
 ## Monitoring
 
+Reference-catalog classification, status-page grouping, and health-check rollup rules are in [Data Classification and Observability](#data-classification-and-observability) above. Platform endpoints and logs:
+
 - **Logging**: Comprehensive file-based logging via `lib/logger.php` (writes to `/var/log/aviationwx/`, persisted on host at `/var/aviationwx/logs`)
 - **Log Rotation**: Logrotate handles rotation (1 rotated file, 100MB max per file)
 - **Metrics**: `/metrics.php` endpoint for monitoring
 - **Health Checks**: `/health.php` for uptime monitoring
 - **Diagnostics**: `/diagnostics.php` for system information
-- **Status Page**: `/status.php` for system health overview
+- **Status Page**: `/status.php` for system and reference-catalog health (see [OPERATIONS.md](OPERATIONS.md#status-page))
 
 ## Future Improvements
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -4,6 +4,8 @@ This document describes how weather, webcam, and NOTAM data is fetched, processe
 
 **Document role:** Checked-in reference for **required pipeline logic** - what the system must do, in present tense. It is not a project plan, rollout tracker, or implementation status log. Delivery gaps belong in GitHub issues and pull requests (see `CODE_STYLE.md`). Use this document to understand system intent, then verify in code that behavior matches. Logic stated here can be audited against the implementation to find safety or functional gaps.
 
+For how external catalogs and live feeds are **classified** (planes, consumer features, health-check leaves), see [ARCHITECTURE.md - Data classification and observability](ARCHITECTURE.md#data-classification-and-observability). This document states **pipeline behavior** for each path; the architecture section is the stable map for new ingest and status-page work.
+
 ## Table of Contents
 
 1. [Weather Data Fetching](#weather-data-fetching)

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -4,7 +4,7 @@ This document describes how weather, webcam, and NOTAM data is fetched, processe
 
 **Document role:** Checked-in reference for **required pipeline logic** - what the system must do, in present tense. It is not a project plan, rollout tracker, or implementation status log. Delivery gaps belong in GitHub issues and pull requests (see `CODE_STYLE.md`). Use this document to understand system intent, then verify in code that behavior matches. Logic stated here can be audited against the implementation to find safety or functional gaps.
 
-For how external catalogs and live feeds are **classified** (planes, consumer features, health-check leaves), see [ARCHITECTURE.md - Data classification and observability](ARCHITECTURE.md#data-classification-and-observability). This document states **pipeline behavior** for each path; the architecture section is the stable map for new ingest and status-page work.
+For how external catalogs and live feeds are **classified** (planes, consumer features, health-check leaves), see [ARCHITECTURE.md - Data Classification and Observability](ARCHITECTURE.md#data-classification-and-observability). This document states **pipeline behavior** for each path; the architecture section is the stable map for ingest grouping and status-page health checks.
 
 ## Table of Contents
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -87,10 +87,11 @@ Shows:
 - Per-airport status (Weather API, Webcams)
 - Usage metrics (Views, API requests, Map tiles served)
 
-**Reference data on the status page (direction):** System Status will group slow-changing catalogs under **Reference data**, with expandable **consumer features** (runway geometry, runway performance, airport identity, comms, and related sources). Each source row should show cache age, upstream probe result when applicable, and hard max age. The stable vocabulary and rollup rules live in [ARCHITECTURE.md - Data classification and observability](ARCHITECTURE.md#data-classification-and-observability). Today several reference caches (identifier validation, frequencies, NASR FRQ) are not yet surfaced; implementation is tracked separately from this ops guide.
+**Reference data:** System Status groups slow-changing catalogs under **Reference data**, with expandable **consumer features** (runway geometry, runway performance, airport identity, comms, and related sources). Each source row shows local cache age, upstream probe result when applicable, and hard max age. Vocabulary and rollup rules: [ARCHITECTURE.md - Data Classification and Observability](ARCHITECTURE.md#data-classification-and-observability).
 
 **Interpreting signals**
 
+- **Reference data** (system row): rollup of reference-catalog consumers. Expand (▶) for per-source rows (FAA NGDA, OurAirports CSVs, NASR APT, NASR FRQ, identifier cache, and related leaves). Parent status is the worst child; the section auto-expands when degraded or down.
 - **Weather Data Fetching** (system row): aggregate **HTTP fetch success** for weather sources over the last hour. It is **not** a guarantee that every airport has fresh observations. Expand the row (▶) to see per-provider **HTTP 429** counts for the last hour (`cache/weather_health.json`).
 - **NOTAM Data Fetching** (system row): aggregate NMS API success over the last hour. Expand the row to see per-endpoint 429 counts (location query, geo query, auth token) from `cache/notam_health.json`. Fleet-wide NMS pauses after upstream **429**/**503** are stored in `cache/backoff.json` (`global_notam_*` keys); deferred queries during a pause do not add HTTP 429 counts.
 - **Per-airport weather**: based on observation timestamps in the weather cache (same family of values as the public API).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -87,6 +87,8 @@ Shows:
 - Per-airport status (Weather API, Webcams)
 - Usage metrics (Views, API requests, Map tiles served)
 
+**Reference data on the status page (direction):** System Status will group slow-changing catalogs under **Reference data**, with expandable **consumer features** (runway geometry, runway performance, airport identity, comms, and related sources). Each source row should show cache age, upstream probe result when applicable, and hard max age. The stable vocabulary and rollup rules live in [ARCHITECTURE.md - Data classification and observability](ARCHITECTURE.md#data-classification-and-observability). Today several reference caches (identifier validation, frequencies, NASR FRQ) are not yet surfaced; implementation is tracked separately from this ops guide.
+
 **Interpreting signals**
 
 - **Weather Data Fetching** (system row): aggregate **HTTP fetch success** for weather sources over the last hour. It is **not** a guarantee that every airport has fresh observations. Expand the row (▶) to see per-provider **HTTP 429** counts for the last hour (`cache/weather_health.json`).


### PR DESCRIPTION
## Summary

- Add **Data classification and observability** to `docs/ARCHITECTURE.md`: stable planes, consumer features, source-leaf metadata, dependencies, rollup rules, and guidance for where new ingest belongs.
- Cross-link from `docs/DATA_FLOW.md` (pipeline rules vs architectural map) and `docs/OPERATIONS.md` (status page direction).

Part of #223 (docs deliverable; implementation PRs to follow).

## Test plan

- [x] Docs only - review section anchors and cross-links render correctly on GitHub