### PR TITLE
NASR ingest hardening: reject empty zip downloads

### DIFF
--- a/lib/nasr/csv-validation.php
+++ b/lib/nasr/csv-validation.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Pre-parse validation for NASR APT and FRQ CSV extracts.
+ * Pre-parse validation for NASR APT and FRQ downloads and CSV extracts.
  */
 
 /** @var array<string, string> */
@@ -10,6 +10,46 @@ const NASR_CSV_HEADER_PREFIX = [
     'APT_RWY_END' => '"EFF_DATE","SITE_NO","SITE_TYPE_CODE","STATE_CODE","ARPT_ID","CITY","COUNTRY_CODE","RWY_ID","RWY_END_ID"',
     'FRQ' => '"EFF_DATE","FACILITY"',
 ];
+
+/** Minimum bytes for a ZIP local file header (reject zero-byte HTTP bodies). */
+const NASR_ZIP_MIN_FILE_BYTES = 22;
+
+/**
+ * Whether a downloaded NASR subscription zip is non-empty and contains entries.
+ */
+function nasrDownloadedZipFileIsValid(string $path): bool
+{
+    if (!is_readable($path)) {
+        return false;
+    }
+
+    $size = @filesize($path);
+    if (!is_int($size) || $size < NASR_ZIP_MIN_FILE_BYTES) {
+        return false;
+    }
+
+    $handle = @fopen($path, 'rb');
+    if ($handle === false) {
+        return false;
+    }
+
+    $header = fread($handle, 2);
+    fclose($handle);
+
+    if ($header !== 'PK') {
+        return false;
+    }
+
+    $zip = new ZipArchive();
+    if ($zip->open($path) !== true) {
+        return false;
+    }
+
+    $valid = $zip->numFiles > 0;
+    $zip->close();
+
+    return $valid;
+}
 
 /**
  * Whether a NASR CSV file has a non-empty body and expected header prefix.

--- a/lib/nasr/csv-validation.php
+++ b/lib/nasr/csv-validation.php
@@ -11,7 +11,7 @@ const NASR_CSV_HEADER_PREFIX = [
     'FRQ' => '"EFF_DATE","FACILITY"',
 ];
 
-/** Minimum bytes for a ZIP local file header (reject zero-byte HTTP bodies). */
+/** Minimum bytes for an empty ZIP (End of Central Directory only; rejects zero-byte HTTP bodies). */
 const NASR_ZIP_MIN_FILE_BYTES = 22;
 
 /**

--- a/lib/nasr/csv-validation.php
+++ b/lib/nasr/csv-validation.php
@@ -15,7 +15,7 @@ const NASR_CSV_HEADER_PREFIX = [
 const NASR_ZIP_MIN_FILE_BYTES = 22;
 
 /**
- * Whether a downloaded NASR subscription zip is non-empty and contains entries.
+ * Whether a downloaded NASR subscription zip is non-empty and contains file entries.
  */
 function nasrDownloadedZipFileIsValid(string $path): bool
 {
@@ -45,7 +45,14 @@ function nasrDownloadedZipFileIsValid(string $path): bool
         return false;
     }
 
-    $valid = $zip->numFiles > 0;
+    $valid = false;
+    for ($i = 0; $i < $zip->numFiles; $i++) {
+        $name = $zip->getNameIndex($i);
+        if (is_string($name) && $name !== '' && !str_ends_with($name, '/')) {
+            $valid = true;
+            break;
+        }
+    }
     $zip->close();
 
     return $valid;

--- a/lib/nasr/csv-validation.php
+++ b/lib/nasr/csv-validation.php
@@ -23,6 +23,8 @@ function nasrDownloadedZipFileIsValid(string $path): bool
         return false;
     }
 
+    clearstatcache(true, $path);
+
     $size = @filesize($path);
     if (!is_int($size) || $size < NASR_ZIP_MIN_FILE_BYTES) {
         return false;

--- a/scripts/fetch-nasr-apt.php
+++ b/scripts/fetch-nasr-apt.php
@@ -54,6 +54,14 @@ function downloadNasrAptCsvDirectory(): ?array
             continue;
         }
 
+        if (!nasrDownloadedZipFileIsValid($zipPath)) {
+            aviationwx_log('warning', 'nasr_apt: rejected invalid zip download', [
+                'source_url' => $url,
+                'zip_bytes' => @filesize($zipPath),
+            ], 'app');
+            continue;
+        }
+
         $zip = new ZipArchive();
         if ($zip->open($zipPath) !== true) {
             continue;

--- a/scripts/fetch-nasr-frq.php
+++ b/scripts/fetch-nasr-frq.php
@@ -62,6 +62,15 @@ function downloadNasrFrqCsvDirectory(): ?array
         return null;
     }
 
+    if (!nasrDownloadedZipFileIsValid($zipPath)) {
+        aviationwx_log('warning', 'nasr_frq: rejected invalid zip download', [
+            'source_url' => $url,
+            'zip_bytes' => @filesize($zipPath),
+        ], 'app');
+        nasrCleanupDirectory($tmpRoot);
+        return null;
+    }
+
     $zip = new ZipArchive();
     if ($zip->open($zipPath) !== true) {
         nasrCleanupDirectory($tmpRoot);

--- a/tests/Unit/NasrCsvValidationTest.php
+++ b/tests/Unit/NasrCsvValidationTest.php
@@ -53,7 +53,7 @@ class NasrCsvValidationTest extends TestCase
     public function testNasrCsvFileRejectsZeroByteFile(): void
     {
         $path = sys_get_temp_dir() . '/nasr_zero_' . bin2hex(random_bytes(4)) . '.csv';
-        file_put_contents($path, '');
+        $this->assertNotFalse(file_put_contents($path, ''));
 
         try {
             $this->assertFalse(nasrFrqCsvFileIsValid($path));
@@ -65,7 +65,7 @@ class NasrCsvValidationTest extends TestCase
     public function testNasrDownloadedZipRejectsEmptyFile(): void
     {
         $path = sys_get_temp_dir() . '/nasr_empty_' . bin2hex(random_bytes(4)) . '.zip';
-        file_put_contents($path, '');
+        $this->assertNotFalse(file_put_contents($path, ''));
 
         try {
             $this->assertFalse(nasrDownloadedZipFileIsValid($path));
@@ -77,7 +77,7 @@ class NasrCsvValidationTest extends TestCase
     public function testNasrDownloadedZipRejectsNonZipMagic(): void
     {
         $path = sys_get_temp_dir() . '/nasr_badzip_' . bin2hex(random_bytes(4)) . '.zip';
-        file_put_contents($path, str_repeat('x', 64));
+        $this->assertNotFalse(file_put_contents($path, str_repeat('x', 64)));
 
         try {
             $this->assertFalse(nasrDownloadedZipFileIsValid($path));

--- a/tests/Unit/NasrCsvValidationTest.php
+++ b/tests/Unit/NasrCsvValidationTest.php
@@ -49,4 +49,69 @@ class NasrCsvValidationTest extends TestCase
             @unlink($path);
         }
     }
+
+    public function testNasrCsvFileRejectsZeroByteFile(): void
+    {
+        $path = sys_get_temp_dir() . '/nasr_zero_' . bin2hex(random_bytes(4)) . '.csv';
+        file_put_contents($path, '');
+
+        try {
+            $this->assertFalse(nasrFrqCsvFileIsValid($path));
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function testNasrDownloadedZipRejectsEmptyFile(): void
+    {
+        $path = sys_get_temp_dir() . '/nasr_empty_' . bin2hex(random_bytes(4)) . '.zip';
+        file_put_contents($path, '');
+
+        try {
+            $this->assertFalse(nasrDownloadedZipFileIsValid($path));
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function testNasrDownloadedZipRejectsNonZipMagic(): void
+    {
+        $path = sys_get_temp_dir() . '/nasr_badzip_' . bin2hex(random_bytes(4)) . '.zip';
+        file_put_contents($path, str_repeat('x', 64));
+
+        try {
+            $this->assertFalse(nasrDownloadedZipFileIsValid($path));
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function testNasrDownloadedZipRejectsZipWithNoEntries(): void
+    {
+        $path = sys_get_temp_dir() . '/nasr_emptyzip_' . bin2hex(random_bytes(4)) . '.zip';
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($path, ZipArchive::CREATE) === true);
+        $zip->close();
+
+        try {
+            $this->assertFalse(nasrDownloadedZipFileIsValid($path));
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function testNasrDownloadedZipAcceptsZipWithFrqFixture(): void
+    {
+        $path = sys_get_temp_dir() . '/nasr_goodzip_' . bin2hex(random_bytes(4)) . '.zip';
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($path, ZipArchive::CREATE) === true);
+        $zip->addFile($this->fixtureDir . '/FRQ.csv', 'FRQ.csv');
+        $zip->close();
+
+        try {
+            $this->assertTrue(nasrDownloadedZipFileIsValid($path));
+        } finally {
+            @unlink($path);
+        }
+    }
 }

--- a/tests/Unit/NasrCsvValidationTest.php
+++ b/tests/Unit/NasrCsvValidationTest.php
@@ -105,7 +105,7 @@ class NasrCsvValidationTest extends TestCase
         $path = sys_get_temp_dir() . '/nasr_goodzip_' . bin2hex(random_bytes(4)) . '.zip';
         $zip = new ZipArchive();
         $this->assertTrue($zip->open($path, ZipArchive::CREATE) === true);
-        $zip->addFile($this->fixtureDir . '/FRQ.csv', 'FRQ.csv');
+        $this->assertTrue($zip->addFile($this->fixtureDir . '/FRQ.csv', 'FRQ.csv'));
         $zip->close();
 
         try {

--- a/tests/Unit/NasrCsvValidationTest.php
+++ b/tests/Unit/NasrCsvValidationTest.php
@@ -100,6 +100,21 @@ class NasrCsvValidationTest extends TestCase
         }
     }
 
+    public function testNasrDownloadedZipRejectsDirectoryOnlyArchive(): void
+    {
+        $path = sys_get_temp_dir() . '/nasr_dironly_' . bin2hex(random_bytes(4)) . '.zip';
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($path, ZipArchive::CREATE) === true);
+        $this->assertTrue($zip->addEmptyDir('empty/'));
+        $zip->close();
+
+        try {
+            $this->assertFalse(nasrDownloadedZipFileIsValid($path));
+        } finally {
+            @unlink($path);
+        }
+    }
+
     public function testNasrDownloadedZipAcceptsZipWithFrqFixture(): void
     {
         $path = sys_get_temp_dir() . '/nasr_goodzip_' . bin2hex(random_bytes(4)) . '.zip';


### PR DESCRIPTION
## Summary
- Add `nasrDownloadedZipFileIsValid()` to reject zero-byte, non-ZIP, or entry-less subscription archives before extract
- Wire validation into APT and FRQ download paths with structured warning logs
- Extend `NasrCsvValidationTest` with zero-byte CSV and zip edge-case coverage

Closes #230.

Most #230 acceptance criteria shipped in #229 (worker timeouts, shared locks, meta lock, CSV header validation). This PR closes the remaining explicit gap: empty or invalid zip bodies after HTTP download.

## Test plan
- [x] `make test-ci` passes locally
- [x] `NasrCsvValidationTest` (9 tests) covers zip and zero-byte CSV rejection