### PR TITLE
Reference data: show all precedence sources per consumer

### DIFF
--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -1641,7 +1641,7 @@
         "properties": {
           "slug": { "type": "string" },
           "name": { "type": "string" },
-          "kind": { "type": "string", "enum": ["bulk", "computed", "bundled"] },
+          "kind": { "type": "string", "enum": ["bulk", "computed", "bundled", "config"] },
           "status": { "type": "string", "enum": ["operational", "degraded", "down"] },
           "message": { "type": "string" },
           "local_age_seconds": { "type": ["integer", "null"] },

--- a/lib/reference-data-health.php
+++ b/lib/reference-data-health.php
@@ -196,18 +196,18 @@ function reference_data_health_build(?array $config, ?string $configSha256 = nul
             reference_data_ourairports_bulk_source_health('runways', 'ourairports_runways', 'OurAirports runways'),
         ], 'Uses OurAirports airports.csv for centers and FAA to ICAO mapping (see airport_identity).'),
         reference_data_build_consumer('runway_performance', 'Runway performance', [
+            $configSourceHealth,
             reference_data_nasr_apt_source_health(),
             reference_data_ourairports_bulk_source_health('runways', 'ourairports_runways', 'OurAirports runways'),
-            $configSourceHealth,
         ], 'Active runway closures: see NOTAM under Live observations.'),
         reference_data_build_consumer('airport_identity', 'Airport identity', [
-            reference_data_ourairports_identity_source_health(),
             $configSourceHealth,
+            reference_data_ourairports_identity_source_health(),
         ]),
         reference_data_build_consumer('airport_comms', 'Airport communications', [
+            $configSourceHealth,
             reference_data_nasr_frq_source_health(),
             reference_data_ourairports_frequencies_source_health(),
-            $configSourceHealth,
         ]),
         reference_data_build_consumer('airport_location', 'Airport location', [
             reference_data_country_resolution_source_health($config, $configSha256),

--- a/lib/reference-data-health.php
+++ b/lib/reference-data-health.php
@@ -187,6 +187,8 @@ function reference_data_build_consumer(
  */
 function reference_data_health_build(?array $config, ?string $configSha256 = null): array
 {
+    $configSourceHealth = reference_data_config_source_health($config, $configSha256);
+
     $consumers = [
         reference_data_build_consumer('runway_geometry', 'Runway geometry', [
             reference_data_runways_merged_source_health($config),
@@ -196,16 +198,16 @@ function reference_data_health_build(?array $config, ?string $configSha256 = nul
         reference_data_build_consumer('runway_performance', 'Runway performance', [
             reference_data_nasr_apt_source_health(),
             reference_data_ourairports_bulk_source_health('runways', 'ourairports_runways', 'OurAirports runways'),
-            reference_data_config_source_health($config, $configSha256),
+            $configSourceHealth,
         ], 'Active runway closures: see NOTAM under Live observations.'),
         reference_data_build_consumer('airport_identity', 'Airport identity', [
             reference_data_ourairports_identity_source_health(),
-            reference_data_config_source_health($config, $configSha256),
+            $configSourceHealth,
         ]),
         reference_data_build_consumer('airport_comms', 'Airport communications', [
             reference_data_nasr_frq_source_health(),
             reference_data_ourairports_frequencies_source_health(),
-            reference_data_config_source_health($config, $configSha256),
+            $configSourceHealth,
         ]),
         reference_data_build_consumer('airport_location', 'Airport location', [
             reference_data_country_resolution_source_health($config, $configSha256),

--- a/lib/reference-data-health.php
+++ b/lib/reference-data-health.php
@@ -195,13 +195,17 @@ function reference_data_health_build(?array $config, ?string $configSha256 = nul
         ], 'Uses OurAirports airports.csv for centers and FAA to ICAO mapping (see airport_identity).'),
         reference_data_build_consumer('runway_performance', 'Runway performance', [
             reference_data_nasr_apt_source_health(),
+            reference_data_ourairports_bulk_source_health('runways', 'ourairports_runways', 'OurAirports runways'),
+            reference_data_config_source_health($config, $configSha256),
         ], 'Active runway closures: see NOTAM under Live observations.'),
         reference_data_build_consumer('airport_identity', 'Airport identity', [
             reference_data_ourairports_identity_source_health(),
+            reference_data_config_source_health($config, $configSha256),
         ]),
         reference_data_build_consumer('airport_comms', 'Airport communications', [
             reference_data_nasr_frq_source_health(),
             reference_data_ourairports_frequencies_source_health(),
+            reference_data_config_source_health($config, $configSha256),
         ]),
         reference_data_build_consumer('airport_location', 'Airport location', [
             reference_data_country_resolution_source_health($config, $configSha256),

--- a/lib/reference-data-sources.php
+++ b/lib/reference-data-sources.php
@@ -174,12 +174,18 @@ function reference_data_config_source_health(?array $config, ?string $configSha2
     }
 
     $airportCount = count($airports);
-    $message = "{$airportCount} airports configured";
+    $message = $airportCount === 1
+        ? '1 airport configured'
+        : "{$airportCount} airports configured";
     if ($runwayOverrideCount > 0) {
-        $message .= " • {$runwayOverrideCount} runway overrides";
+        $message .= $runwayOverrideCount === 1
+            ? ' • 1 runway override'
+            : " • {$runwayOverrideCount} runway overrides";
     }
     if ($frequenciesOverrideCount > 0) {
-        $message .= " • {$frequenciesOverrideCount} frequency overrides";
+        $message .= $frequenciesOverrideCount === 1
+            ? ' • 1 frequency override'
+            : " • {$frequenciesOverrideCount} frequency overrides";
     }
 
     $configPath = function_exists('getConfigFilePath') ? getConfigFilePath() : null;

--- a/lib/reference-data-sources.php
+++ b/lib/reference-data-sources.php
@@ -133,6 +133,86 @@ function reference_data_ourairports_bulk_source_health(string $fileKey, string $
 /**
  * @return array<string, mixed>
  */
+function reference_data_config_source_health(?array $config, ?string $configSha256 = null): array
+{
+    $airports = is_array($config) ? ($config['airports'] ?? []) : [];
+    if (!is_array($airports) || $airports === []) {
+        return [
+            'slug' => 'airports_config',
+            'name' => 'airports.json',
+            'kind' => 'config',
+            'status' => 'down',
+            'message' => 'Configuration missing or empty',
+            'lastChanged' => 0,
+            'details' => [
+                'local_age_seconds' => null,
+                'last_probe_result' => null,
+                'upstream_last_modified' => null,
+                'needs_fetch' => false,
+                'last_fetch_error' => null,
+                'effective_date' => null,
+                'airport_count' => 0,
+                'runway_override_count' => 0,
+                'frequencies_override_count' => 0,
+                'config_sha256' => is_string($configSha256) && $configSha256 !== '' ? $configSha256 : null,
+            ],
+        ];
+    }
+
+    $runwayOverrideCount = 0;
+    $frequenciesOverrideCount = 0;
+    foreach ($airports as $airport) {
+        if (!is_array($airport)) {
+            continue;
+        }
+        if (isset($airport['runway_length_ft']) && is_numeric($airport['runway_length_ft'])) {
+            $runwayOverrideCount++;
+        }
+        if (isset($airport['frequencies']) && is_array($airport['frequencies']) && $airport['frequencies'] !== []) {
+            $frequenciesOverrideCount++;
+        }
+    }
+
+    $airportCount = count($airports);
+    $message = "{$airportCount} airports configured";
+    if ($runwayOverrideCount > 0) {
+        $message .= " • {$runwayOverrideCount} runway overrides";
+    }
+    if ($frequenciesOverrideCount > 0) {
+        $message .= " • {$frequenciesOverrideCount} frequency overrides";
+    }
+
+    $configPath = function_exists('getConfigFilePath') ? getConfigFilePath() : null;
+    $lastChanged = 0;
+    if (is_string($configPath) && $configPath !== '' && is_readable($configPath)) {
+        $lastChanged = (int) filemtime($configPath);
+    }
+
+    return [
+        'slug' => 'airports_config',
+        'name' => 'airports.json',
+        'kind' => 'config',
+        'status' => 'operational',
+        'message' => $message,
+        'lastChanged' => $lastChanged,
+        'details' => [
+            'local_age_seconds' => $lastChanged > 0 ? time() - $lastChanged : null,
+            'last_probe_result' => null,
+            'upstream_last_modified' => null,
+            'needs_fetch' => false,
+            'last_fetch_error' => null,
+            'effective_date' => null,
+            'airport_count' => $airportCount,
+            'runway_override_count' => $runwayOverrideCount,
+            'frequencies_override_count' => $frequenciesOverrideCount,
+            'config_sha256' => is_string($configSha256) && $configSha256 !== '' ? $configSha256 : null,
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function reference_data_faa_ngda_runways_source_health(): array
 {
     $path = CACHE_FAA_NGDA_RUNWAYS_CSV;
@@ -357,6 +437,15 @@ function reference_data_source_diagnostics_text(array $sourceRow): string
     }
     if (is_string($details['effective_date'] ?? null) && $details['effective_date'] !== '') {
         $parts[] = 'cycle: ' . $details['effective_date'];
+    }
+    if (isset($details['runway_override_count']) && (int) $details['runway_override_count'] > 0) {
+        $parts[] = 'runway overrides: ' . (int) $details['runway_override_count'];
+    }
+    if (isset($details['frequencies_override_count']) && (int) $details['frequencies_override_count'] > 0) {
+        $parts[] = 'frequency overrides: ' . (int) $details['frequencies_override_count'];
+    }
+    if (is_string($details['config_sha256'] ?? null) && $details['config_sha256'] !== '') {
+        $parts[] = 'config sha: ' . substr($details['config_sha256'], 0, 12);
     }
     if (isset($details['local_age_seconds']) && $details['local_age_seconds'] !== null) {
         $parts[] = 'age: ' . (int) $details['local_age_seconds'] . 's';

--- a/tests/Unit/ReferenceDataHealthTest.php
+++ b/tests/Unit/ReferenceDataHealthTest.php
@@ -58,6 +58,56 @@ class ReferenceDataHealthTest extends TestCase
         $this->assertContains('ourairports_runways', $slugs);
     }
 
+    public function testRunwayPerformanceConsumerIncludesAllPrecedenceSources(): void
+    {
+        $component = reference_data_health_build(null, null);
+        $consumer = null;
+        foreach ($component['consumers'] as $row) {
+            if (($row['slug'] ?? '') === 'runway_performance') {
+                $consumer = $row;
+                break;
+            }
+        }
+
+        $this->assertIsArray($consumer);
+        $slugs = array_column($consumer['sources'], 'slug');
+        $this->assertContains('nasr_apt', $slugs);
+        $this->assertContains('ourairports_runways', $slugs);
+        $this->assertContains('airports_config', $slugs);
+    }
+
+    public function testAirportIdentityAndCommsIncludeConfigSource(): void
+    {
+        $component = reference_data_health_build(null, null);
+        $bySlug = [];
+        foreach ($component['consumers'] as $consumer) {
+            $bySlug[$consumer['slug'] ?? ''] = $consumer;
+        }
+
+        $this->assertContains('airports_config', array_column($bySlug['airport_identity']['sources'], 'slug'));
+        $this->assertContains('airports_config', array_column($bySlug['airport_comms']['sources'], 'slug'));
+    }
+
+    public function testConfigSourceReportsOverrideCounts(): void
+    {
+        $config = [
+            'airports' => [
+                'ktest' => [
+                    'icao' => 'KTEST',
+                    'runway_length_ft' => 3200,
+                    'frequencies' => ['ctaf' => '122.8'],
+                ],
+            ],
+        ];
+
+        $leaf = reference_data_config_source_health($config, 'abc123');
+
+        $this->assertSame('config', $leaf['kind']);
+        $this->assertSame('operational', $leaf['status']);
+        $this->assertSame(1, $leaf['details']['runway_override_count'] ?? null);
+        $this->assertSame(1, $leaf['details']['frequencies_override_count'] ?? null);
+    }
+
     public function testMissingRunwaysMergedMarksConsumerDown(): void
     {
         $component = reference_data_health_build(null, null);

--- a/tests/Unit/ReferenceDataHealthTest.php
+++ b/tests/Unit/ReferenceDataHealthTest.php
@@ -71,6 +71,7 @@ class ReferenceDataHealthTest extends TestCase
 
         $this->assertIsArray($consumer);
         $slugs = array_column($consumer['sources'], 'slug');
+        $this->assertSame(['airports_config', 'nasr_apt', 'ourairports_runways'], $slugs);
         $this->assertContains('nasr_apt', $slugs);
         $this->assertContains('ourairports_runways', $slugs);
         $this->assertContains('airports_config', $slugs);
@@ -86,8 +87,14 @@ class ReferenceDataHealthTest extends TestCase
 
         $this->assertArrayHasKey('airport_identity', $bySlug);
         $this->assertArrayHasKey('airport_comms', $bySlug);
-        $this->assertContains('airports_config', array_column($bySlug['airport_identity']['sources'], 'slug'));
-        $this->assertContains('airports_config', array_column($bySlug['airport_comms']['sources'], 'slug'));
+        $this->assertSame(
+            ['airports_config', 'ourairports_airports'],
+            array_column($bySlug['airport_identity']['sources'], 'slug')
+        );
+        $this->assertSame(
+            ['airports_config', 'nasr_frq', 'ourairports_frequencies'],
+            array_column($bySlug['airport_comms']['sources'], 'slug')
+        );
     }
 
     public function testConfigSource_ReportsOverrideCounts(): void

--- a/tests/Unit/ReferenceDataHealthTest.php
+++ b/tests/Unit/ReferenceDataHealthTest.php
@@ -58,7 +58,7 @@ class ReferenceDataHealthTest extends TestCase
         $this->assertContains('ourairports_runways', $slugs);
     }
 
-    public function testRunwayPerformanceConsumerIncludesAllPrecedenceSources(): void
+    public function testRunwayPerformanceConsumer_IncludesAllPrecedenceSources(): void
     {
         $component = reference_data_health_build(null, null);
         $consumer = null;
@@ -76,7 +76,7 @@ class ReferenceDataHealthTest extends TestCase
         $this->assertContains('airports_config', $slugs);
     }
 
-    public function testAirportIdentityAndCommsIncludeConfigSource(): void
+    public function testAirportIdentityAndComms_IncludeConfigSource(): void
     {
         $component = reference_data_health_build(null, null);
         $bySlug = [];
@@ -84,11 +84,13 @@ class ReferenceDataHealthTest extends TestCase
             $bySlug[$consumer['slug'] ?? ''] = $consumer;
         }
 
+        $this->assertArrayHasKey('airport_identity', $bySlug);
+        $this->assertArrayHasKey('airport_comms', $bySlug);
         $this->assertContains('airports_config', array_column($bySlug['airport_identity']['sources'], 'slug'));
         $this->assertContains('airports_config', array_column($bySlug['airport_comms']['sources'], 'slug'));
     }
 
-    public function testConfigSourceReportsOverrideCounts(): void
+    public function testConfigSource_ReportsOverrideCounts(): void
     {
         $config = [
             'airports' => [

--- a/tests/Unit/ReferenceDataHealthTest.php
+++ b/tests/Unit/ReferenceDataHealthTest.php
@@ -108,6 +108,7 @@ class ReferenceDataHealthTest extends TestCase
         $this->assertSame('operational', $leaf['status']);
         $this->assertSame(1, $leaf['details']['runway_override_count'] ?? null);
         $this->assertSame(1, $leaf['details']['frequencies_override_count'] ?? null);
+        $this->assertSame('1 airport configured • 1 runway override • 1 frequency override', $leaf['message']);
     }
 
     public function testMissingRunwaysMergedMarksConsumerDown(): void


### PR DESCRIPTION
## Summary
- Add `airports.json` config leaf (`kind: config`) with override counts in diagnostics
- **Runway performance** now lists NASR APT, OurAirports runways, and config (matches DA precedence: config → NASR → OurAirports)
- **Airport identity** and **airport communications** include config alongside bulk catalogs

Aligns the status page consumer dropdown with `docs/ARCHITECTURE.md` product precedence without duplicating unrelated leaves under runway geometry.

## Test plan
- [x] `make test-ci` passes locally
- [x] `ReferenceDataHealthTest` covers new consumer source lists