### PR TITLE
Fix site nav overflow at mid-width viewports

### DIFF
--- a/public/css/navigation.css
+++ b/public/css/navigation.css
@@ -335,13 +335,29 @@
    Responsive Styles
    ============================================ */
 
-@media (max-width: 900px) {
+/* Full inline nav needs ~1050px; switch to hamburger before links overflow */
+@media (max-width: 1050px) {
     .site-nav-links {
         display: none;
     }
     
     .site-nav-hamburger {
         display: block;
+    }
+
+    .site-nav-logo-text {
+        display: none;
+    }
+
+    .site-nav-search-wrapper {
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+
+    .site-nav-search-input {
+        width: 100%;
+        max-width: 350px;
+        min-width: 120px;
     }
 }
 


### PR DESCRIPTION
## Summary

- Raise the site nav hamburger breakpoint from `900px` to `1050px` so inline links collapse before they overflow
- In compact mode, hide logo text and let the airport search field flex instead of staying fixed at `350px`
- Closes #237

## Problem

On content pages (homepage, guides, airports directory, status, API docs), the top-right inline nav links could extend past the viewport between roughly 900px and 1050px. The hamburger menu existed but appeared too late - the full desktop link bar needs more horizontal space than the old breakpoint allowed.

## Changes

`public/css/navigation.css` only:

- `@media (max-width: 1050px)` - hide `.site-nav-links`, show hamburger
- Hide `.site-nav-logo-text` in compact mode to free space
- Make `.site-nav-search-wrapper` flexible (`flex: 1 1 auto; min-width: 0`) with search input capped at 350px
- Existing `640px` mobile rules unchanged

No PHP or JS changes. Airport dashboard nav is a separate component and untouched.

## Test plan

- [x] `make test-ci` passes
- [x] Local Docker: resize homepage between 1200px and 800px - hamburger appears at 1050px, no right-edge overflow
- [x] Hamburger drawer opens and all nav items are reachable
- [x] Maintainer visual sign-off on production-like viewport sizes