### PR TITLE
Fix taxiway NOTAMs falsely marking adjacent runways closed

### DIFF
--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1732,7 +1732,7 @@ A NOTAM is classified as an aerodrome closure if (and not a cancellation). Scope
 
 - **Q-code path**: Code starts with `QMR` (runway) or `QFA` (aerodrome)
 - **FAA AIXM path**: `scenario` is `86` (`NOTAM_FAA_SCENARIO_RUNWAY_CLOSURE`) and/or `aixm_runway_event` is true (DOM runway closures often omit Q-code)
-- **Text fallback** (only when `code` is empty): Phrases such as `RWY ... CLSD`, `AD AP CLSD`, or `ARPT/AIRPORT ... CLSD`. Taxiway-only closures (`TWY`, `APRON`, `RAMP`) are excluded. Explicit `QMX`/`QMA`/`QMP` Q-codes are always excluded.
+- **Text fallback** (only when `code` is empty): Direct runway subject phrases (`RWY {designator} CLSD/CLOSED`), aerodrome phrases (`AD AP CLSD`, `ARPT/AIRPORT CLSD`). Taxiway-only closures (`TWY ... CLSD` where the runway is only a landmark) are excluded. Runway-affecting partial restrictions (`CLSD TO`, wingspan near `APCH END RWY`) are retained for the banner pipeline but do not mark runways fully closed. Explicit `QMX`/`QMA`/`QMP` Q-codes are always excluded; `QMR` is rejected when prose is taxiway-only.
 
 Additionally:
 - **Text indicates closure**: Contains `CLSD` or `CLOSED` (not hazard-only phrases such as `UNSAFE` or `HAZARD`)

--- a/lib/notam/banner.php
+++ b/lib/notam/banner.php
@@ -40,7 +40,8 @@ function notamBannerClassifyScope(array $notam, array $airport): ?string
     if ($notamType === 'tfr') {
         return 'airspace';
     }
-    if ($notamType === 'aerodrome_closure' && isAerodromeClosure($notam, $airport)) {
+    if ($notamType === 'aerodrome_closure'
+        && (isAerodromeClosure($notam, $airport) || isRunwayAffectingRestrictionNotam($notam, $airport))) {
         return notamBannerClosureScopeFromNotam($notam);
     }
 
@@ -62,11 +63,14 @@ function notamBannerClosureScopeFromNotam(array $notam): string
         return 'aerodrome';
     }
 
-    $upper = strtoupper((string) ($notam['text'] ?? ''));
-    if (preg_match('/\bAD\s+AP\b.*\b(CLSD|CLOSED)\b/', $upper) === 1) {
+    $upper = notamNormalizeProse((string) ($notam['text'] ?? ''));
+    if (preg_match('/\bAD\s+AP\s+(?:CLSD|CLOSED)\b/', $upper) === 1) {
         return 'aerodrome';
     }
-    if (preg_match('/\b(ARPT|AIRPORT)\b.*\b(CLSD|CLOSED)\b/', $upper) === 1) {
+    if (preg_match('/\b(?:ARPT|AIRPORT)\s+(?:CLSD|CLOSED)\b/', $upper) === 1) {
+        return 'aerodrome';
+    }
+    if (notamTextIndicatesAerodromeClosurePhrase((string) ($notam['text'] ?? ''))) {
         return 'aerodrome';
     }
 
@@ -100,21 +104,7 @@ function notamBannerClassifyCategory(string $scope, array $notam): string
  */
 function notamBannerTextIndicatesPartialRunwayRestriction(string $text): bool
 {
-    if ($text === '') {
-        return false;
-    }
-    $upper = strtoupper($text);
-    if (str_contains($upper, 'WINGSPAN')) {
-        return true;
-    }
-    if (preg_match('/\bCLSD\s+TO\b/', $upper) === 1) {
-        return true;
-    }
-    if (preg_match('/\bTO\s+ACFT\b/', $upper) === 1 && str_contains($upper, 'CLSD')) {
-        return true;
-    }
-
-    return false;
+    return notamTextIndicatesPartialRunwayRestriction($text);
 }
 
 /**
@@ -168,27 +158,12 @@ function notamBannerClassifyAirspaceCategory(string $text): string
  */
 function notamBannerExtractRunwayDesignator(string $text): ?string
 {
-    if ($text === '') {
-        return null;
-    }
-    if (preg_match(
-        '/\bRWY\s+(\d{1,2}[LRC]?\s*\/\s*\d{1,2}[LRC]?|\d{1,2}[LRC]?)\b/i',
-        $text,
-        $matches
-    ) !== 1) {
+    $raw = notamExtractRunwayDesignatorForDisplay($text);
+    if ($raw === null) {
         return null;
     }
 
-    $designator = strtoupper(preg_replace('/\s+/', '', $matches[1]) ?? $matches[1]);
-    if ($designator === '') {
-        return null;
-    }
-
-    if (str_contains($designator, '/')) {
-        return 'RWY ' . $designator;
-    }
-
-    return 'RWY ' . $designator;
+    return 'RWY ' . $raw;
 }
 
 /**

--- a/lib/notam/closure-parse.php
+++ b/lib/notam/closure-parse.php
@@ -80,14 +80,18 @@ function notamTextIndicatesTaxiwayOnlyClosure(string $text): bool
         return false;
     }
 
+    if (notamTextIndicatesAerodromeClosurePhrase($text)) {
+        return false;
+    }
+
     if (preg_match('/\bTWY\b/', $upper) !== 1) {
         return false;
     }
 
     return preg_match(
-        '/\bTWY\s+(?:[A-Z0-9]{1,3}\b|.+?\b(?:CLSD|CLOSED)\b)/',
+        '/\bTWY\s+[A-Z0-9]{1,3}\s+(?:CLSD|CLOSED)\b|\bTWY\s+.+?\s+(?:CLSD|CLOSED)\b/',
         $upper
-    ) === 1 && preg_match('/\b(?:CLSD|CLOSED)\b/', $upper) === 1;
+    ) === 1;
 }
 
 /**

--- a/lib/notam/closure-parse.php
+++ b/lib/notam/closure-parse.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Subject-aware parsing for runway, taxiway, and aerodrome closure phrases in NOTAM text.
+ */
+
+require_once __DIR__ . '/../runway-end-ident.php';
+
+const NOTAM_RWY_DESIGNATOR_CAPTURE = '(\d{1,2}[LRC]?(?:\s*\/\s*\d{1,2}[LRC]?)?)';
+
+/**
+ * Uppercase NOTAM prose with collapsed whitespace.
+ */
+function notamNormalizeProse(string $text): string
+{
+    return strtoupper(preg_replace('/\s+/', ' ', trim($text)) ?? '');
+}
+
+/**
+ * Whether prose contains a closure keyword.
+ */
+function notamProseHasClosureKeyword(string $upper): bool
+{
+    return str_contains($upper, 'CLSD') || str_contains($upper, 'CLOSED');
+}
+
+/**
+ * Regex matching RWY immediately followed by a designator and CLSD/CLOSED.
+ *
+ * @return string PCRE pattern with delimiters
+ */
+function notamDirectRunwayClosureRegex(): string
+{
+    return '/\bRWY\s+' . NOTAM_RWY_DESIGNATOR_CAPTURE . '\s+(?:CLSD|CLOSED)\b/';
+}
+
+/**
+ * Whether RWY {designator} is the closed subject (not a taxiway landmark).
+ */
+function notamTextIndicatesDirectRunwayClosure(string $text): bool
+{
+    $upper = notamNormalizeProse($text);
+    if ($upper === '' || !notamProseHasClosureKeyword($upper)) {
+        return false;
+    }
+
+    if (preg_match(notamDirectRunwayClosureRegex(), $upper, $matches, PREG_OFFSET_CAPTURE) !== 1) {
+        if (preg_match(
+            '/\bRWY\s+' . NOTAM_RWY_DESIGNATOR_CAPTURE . '\s+INTERSECTION\s+TWY\s+[A-Z0-9]{1,3}\s+(?:CLSD|CLOSED)\b/',
+            $upper
+        ) !== 1) {
+            return false;
+        }
+
+        return true;
+    }
+
+    $matchStart = $matches[0][1];
+    $prefix = substr($upper, 0, $matchStart);
+    if (preg_match('/\b(OBST|CRANE|HCRANE|HIRTA)\b/', $prefix) === 1) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Whether prose closes a taxiway segment without closing the runway itself.
+ */
+function notamTextIndicatesTaxiwayOnlyClosure(string $text): bool
+{
+    $upper = notamNormalizeProse($text);
+    if ($upper === '' || !notamProseHasClosureKeyword($upper)) {
+        return false;
+    }
+
+    if (notamTextIndicatesDirectRunwayClosure($text)) {
+        return false;
+    }
+
+    if (preg_match('/\bTWY\b/', $upper) !== 1) {
+        return false;
+    }
+
+    return preg_match(
+        '/\bTWY\s+(?:[A-Z0-9]{1,3}\b|.+?\b(?:CLSD|CLOSED)\b)/',
+        $upper
+    ) === 1 && preg_match('/\b(?:CLSD|CLOSED)\b/', $upper) === 1;
+}
+
+/**
+ * Whether NOTAM prose indicates aerodrome-level closure (AD AP / airport).
+ */
+function notamTextIndicatesAerodromeClosurePhrase(string $text): bool
+{
+    $upper = notamNormalizeProse($text);
+    if ($upper === '' || !notamProseHasClosureKeyword($upper)) {
+        return false;
+    }
+
+    if (preg_match('/\bAD\s+AP\s+(?:CLSD|CLOSED)\b/', $upper) === 1) {
+        return true;
+    }
+
+    return preg_match('/\b(?:ARPT|AIRPORT)\s+(?:CLSD|CLOSED)\b/', $upper) === 1
+        || preg_match('/\b(?:ARPT|AIRPORT)\b.+\b(?:CLSD|CLOSED)\b/', $upper) === 1;
+}
+
+/**
+ * Whether NOTAM prose indicates a runway or aerodrome closure when Q-code is absent.
+ */
+function notamTextIndicatesRunwayOrAerodromeClosure(string $text): bool
+{
+    return notamTextIndicatesDirectRunwayClosure($text)
+        || notamTextIndicatesAerodromeClosurePhrase($text);
+}
+
+/**
+ * Whether closure text limits aircraft (wingspan, weight) rather than full closure.
+ */
+function notamTextIndicatesPartialRunwayRestriction(string $text): bool
+{
+    if ($text === '') {
+        return false;
+    }
+
+    $upper = notamNormalizeProse($text);
+    if (str_contains($upper, 'WINGSPAN')) {
+        return true;
+    }
+    if (preg_match('/\bCLSD\s+TO\b/', $upper) === 1) {
+        return true;
+    }
+
+    return preg_match('/\bTO\s+ACFT\b/', $upper) === 1 && str_contains($upper, 'CLSD');
+}
+
+/**
+ * Whether a partial restriction materially affects runway operations (banner-worthy).
+ */
+function notamTextIndicatesRunwayAffectingPartialRestriction(string $text): bool
+{
+    if (!notamTextIndicatesPartialRunwayRestriction($text)) {
+        return false;
+    }
+
+    if (notamTextIndicatesDirectRunwayClosure($text)) {
+        return true;
+    }
+
+    $upper = notamNormalizeProse($text);
+
+    if (preg_match(
+        '/\b(?:APCH|DEP)\s+END\s+RWY\s+' . NOTAM_RWY_DESIGNATOR_CAPTURE . '\b/',
+        $upper
+    ) === 1) {
+        return true;
+    }
+
+    return preg_match(
+        '/\b(?:TKOF|TKOFF|LNDG|LND)\s+RWY\s+' . NOTAM_RWY_DESIGNATOR_CAPTURE . '\b/',
+        $upper
+    ) === 1;
+}
+
+/**
+ * Normalize a captured runway designator token for display and pair matching.
+ */
+function notamNormalizeRunwayDesignatorToken(string $raw): ?string
+{
+    $normalized = strtoupper(str_replace(' ', '', trim($raw)));
+    if ($normalized === '') {
+        return null;
+    }
+
+    if (!str_contains($normalized, '/')) {
+        return canonicalizeRunwayEndIdent($normalized) ?? $normalized;
+    }
+
+    [$endA, $endB] = explode('/', $normalized, 2);
+    $canonicalA = canonicalizeRunwayEndIdent($endA) ?? strtoupper($endA);
+    $canonicalB = canonicalizeRunwayEndIdent($endB) ?? strtoupper($endB);
+
+    return $canonicalA . '/' . $canonicalB;
+}
+
+/**
+ * Runway designator for closure cards and banner headlines from NOTAM prose.
+ */
+function notamExtractRunwayDesignatorForDisplay(string $text): ?string
+{
+    $upper = notamNormalizeProse($text);
+
+    if (preg_match(notamDirectRunwayClosureRegex(), $upper, $matches) === 1) {
+        return notamNormalizeRunwayDesignatorToken($matches[1]);
+    }
+
+    if (preg_match(
+        '/\b(?:APCH|DEP)\s+END\s+RWY\s+' . NOTAM_RWY_DESIGNATOR_CAPTURE . '\b/',
+        $upper,
+        $matches
+    ) === 1) {
+        return notamNormalizeRunwayDesignatorToken($matches[1]);
+    }
+
+    if (preg_match(
+        '/\b(?:TKOF|TKOFF|LNDG|LND)\s+RWY\s+' . NOTAM_RWY_DESIGNATOR_CAPTURE . '\b/',
+        $upper,
+        $matches
+    ) === 1) {
+        return notamNormalizeRunwayDesignatorToken($matches[1]);
+    }
+
+    return null;
+}
+
+/**
+ * Whether a QMR-coded NOTAM prose contradicts runway closure (taxiway-only wording).
+ */
+function notamQmrCodeContradictsRunwayClosureScope(string $text): bool
+{
+    return notamTextIndicatesTaxiwayOnlyClosure($text)
+        && !notamTextIndicatesDirectRunwayClosure($text);
+}

--- a/lib/notam/filter.php
+++ b/lib/notam/filter.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/../airport-identifiers.php';
 require_once __DIR__ . '/../weather/utils.php';
 require_once __DIR__ . '/schedule.php';
 require_once __DIR__ . '/tfr-indicators.php';
+require_once __DIR__ . '/closure-parse.php';
 
 /** Epsilon for comparing decoded TFR vertices (degrees) */
 const TFR_VERTEX_EQUAL_EPSILON_DEG = 1.0e-6;
@@ -727,35 +728,6 @@ function isNotamCancellation(array $notam): bool {
 }
 
 /**
- * Whether NOTAM prose indicates a runway or aerodrome closure when Q-code is absent.
- *
- * @param string $text NOTAM body (any case)
- * @return bool True for RWY/AD AP/ARPT closure phrases; false for taxiway-only or hazard-only text
- */
-function notamTextIndicatesRunwayOrAerodromeClosure(string $text): bool {
-    $upper = strtoupper($text);
-    if ($upper === '') {
-        return false;
-    }
-
-    if (!str_contains($upper, 'CLSD') && !str_contains($upper, 'CLOSED')) {
-        return false;
-    }
-
-    if (preg_match('/\bRWY\b.*\b(CLSD|CLOSED)\b/', $upper) === 1) {
-        return true;
-    }
-    if (preg_match('/\bAD\s+AP\b.*\b(CLSD|CLOSED)\b/', $upper) === 1) {
-        return true;
-    }
-    if (preg_match('/\b(ARPT|AIRPORT)\b.*\b(CLSD|CLOSED)\b/', $upper) === 1) {
-        return true;
-    }
-
-    return false;
-}
-
-/**
  * Whether a parsed NOTAM is runway- or aerodrome-level (not taxiway/apron).
  *
  * Accepts QMR/QFA Q-codes, FAA scenario 86 / AIXM runway members, or conservative text fallback.
@@ -764,43 +736,70 @@ function notamTextIndicatesRunwayOrAerodromeClosure(string $text): bool {
  * @return bool True when scope is runway or aerodrome
  */
 function notamRestrictionScopeIsRunwayOrAerodrome(array $notam): bool {
+    $text = (string) ($notam['text'] ?? '');
     $code = strtoupper((string) ($notam['code'] ?? ''));
     if (str_starts_with($code, 'QMX') || str_starts_with($code, 'QMA') || str_starts_with($code, 'QMP')) {
         return false;
     }
-    if (str_starts_with($code, 'QMR') || str_starts_with($code, 'QFA')) {
+    if (str_starts_with($code, 'QMR')) {
+        if (notamQmrCodeContradictsRunwayClosureScope($text)) {
+            return false;
+        }
+
+        return true;
+    }
+    if (str_starts_with($code, 'QFA')) {
         return true;
     }
 
     $scenario = (string) ($notam['scenario'] ?? '');
     if ($scenario === NOTAM_FAA_SCENARIO_RUNWAY_CLOSURE) {
+        if (notamTextIndicatesTaxiwayOnlyClosure($text) && !notamTextIndicatesDirectRunwayClosure($text)) {
+            return false;
+        }
+
         return true;
     }
     if (!empty($notam['aixm_runway_event'])) {
+        if (notamTextIndicatesTaxiwayOnlyClosure($text) && !notamTextIndicatesDirectRunwayClosure($text)) {
+            return false;
+        }
+
         return true;
     }
 
     if ($code === '') {
-        return notamTextIndicatesRunwayOrAerodromeClosure((string) ($notam['text'] ?? ''));
+        return notamTextIndicatesRunwayOrAerodromeClosure($text);
     }
 
     return false;
 }
 
 /**
+ * Whether a NOTAM location field or airport name matches the configured airport.
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM row
+ * @param array<string, mixed> $airport Airport configuration
+ */
+function notamMatchesAirportLocation(array $notam, array $airport): bool {
+    $identifiers = getAirportIdentifiers($airport);
+    $notamLocation = strtoupper((string) ($notam['location'] ?? ''));
+
+    if (in_array($notamLocation, $identifiers, true)) {
+        return true;
+    }
+
+    $airportName = strtoupper((string) ($airport['name'] ?? ''));
+    $notamAirportName = strtoupper((string) ($notam['airport_name'] ?? ''));
+    if ($airportName === '' || $notamAirportName === '') {
+        return false;
+    }
+
+    return isWordMatch($notamAirportName, $airportName) || isWordMatch($airportName, $notamAirportName);
+}
+
+/**
  * Check if NOTAM is a runway or aerodrome closure.
- *
- * Only matches runway-level and above closures (not taxiway/apron, not hazard-only text):
- * - QMR* = Runway closed
- * - QFA* = Aerodrome/airport closed
- * - FAA scenario 86 / AIXM runway events (DOM format without Q-code)
- * - Text fallback when Q-code is empty (RWY/AD AP/ARPT CLSD/CLOSED phrases)
- *
- * Excludes:
- * - QMX* = Taxiway closures (less critical)
- * - QMA* = Apron/ramp closures (less critical)
- * - QMP* = Parking area closures (less critical)
- * - Type C (Cancel) NOTAMs (restriction lifted, not a warning)
  *
  * @param array<string, mixed> $notam Parsed NOTAM data
  * @param array<string, mixed> $airport Airport configuration
@@ -815,30 +814,39 @@ function isAerodromeClosure(array $notam, array $airport): bool {
         return false;
     }
 
-    $text = strtoupper((string) ($notam['text'] ?? ''));
-    if (!str_contains($text, 'CLSD') && !str_contains($text, 'CLOSED')) {
+    $text = notamNormalizeProse((string) ($notam['text'] ?? ''));
+    if (!notamProseHasClosureKeyword($text)) {
         return false;
     }
 
-    // Location match (current or historical identifiers)
-    $identifiers = getAirportIdentifiers($airport);
-    $notamLocation = strtoupper($notam['location'] ?? '');
-    
-    if (!in_array($notamLocation, $identifiers)) {
-        // Also check airport name matching for geospatial queries (word boundary match)
-        $airportName = strtoupper($airport['name'] ?? '');
-        $notamAirportName = strtoupper($notam['airport_name'] ?? '');
-        
-        if (empty($airportName) || empty($notamAirportName)) {
-            return false;
-        }
-        // Use word boundary matching to avoid "FIELD" matching "SPRINGFIELD"
-        if (!isWordMatch($notamAirportName, $airportName) && !isWordMatch($airportName, $notamAirportName)) {
-            return false;
-        }
+    if (!notamMatchesAirportLocation($notam, $airport)) {
+        return false;
     }
-    
+
     return true;
+}
+
+/**
+ * Runway-affecting partial restriction (banner pipeline; does not mark runway fully closed).
+ *
+ * @param array<string, mixed> $notam Parsed NOTAM row
+ * @param array<string, mixed> $airport Airport configuration
+ */
+function isRunwayAffectingRestrictionNotam(array $notam, array $airport): bool {
+    if (isNotamCancellation($notam)) {
+        return false;
+    }
+
+    $text = (string) ($notam['text'] ?? '');
+    if (!notamTextIndicatesRunwayAffectingPartialRestriction($text)) {
+        return false;
+    }
+
+    if (isAerodromeClosure($notam, $airport)) {
+        return false;
+    }
+
+    return notamMatchesAirportLocation($notam, $airport);
 }
 
 /**
@@ -1133,7 +1141,8 @@ function filterRelevantNotams(array $notams, array $airport): array {
     $relevant = [];
     
     foreach ($notams as $notam) {
-        $isClosureNotam = isAerodromeClosure($notam, $airport);
+        $isClosureNotam = isAerodromeClosure($notam, $airport)
+            || isRunwayAffectingRestrictionNotam($notam, $airport);
         $isTfrNotam = isTfr($notam);
         
         if ($isClosureNotam) {

--- a/lib/weather/da-performance-notam-closures.php
+++ b/lib/weather/da-performance-notam-closures.php
@@ -110,7 +110,12 @@ function getActiveRunwayNotamClosuresForAirport(string $airportId, array $airpor
     }
 
     $cacheFile = notamCacheFilePath($airportId);
-    $memoKey = $airportId . ':' . (is_file($cacheFile) ? hash_file('xxh128', $cacheFile) : '0');
+    $cacheDigest = '0';
+    if (is_file($cacheFile)) {
+        $hash = hash_file('sha256', $cacheFile);
+        $cacheDigest = $hash !== false ? $hash : '0';
+    }
+    $memoKey = $airportId . ':' . $cacheDigest;
     if (isset($memo[$memoKey])) {
         return $memo[$memoKey];
     }

--- a/lib/weather/da-performance-notam-closures.php
+++ b/lib/weather/da-performance-notam-closures.php
@@ -109,8 +109,10 @@ function getActiveRunwayNotamClosuresForAirport(string $airportId, array $airpor
         ];
     }
 
-    if (isset($memo[$airportId])) {
-        return $memo[$airportId];
+    $cacheFile = notamCacheFilePath($airportId);
+    $memoKey = $airportId . ':' . (is_file($cacheFile) ? hash_file('xxh128', $cacheFile) : '0');
+    if (isset($memo[$memoKey])) {
+        return $memo[$memoKey];
     }
 
     $defaults = [
@@ -121,13 +123,13 @@ function getActiveRunwayNotamClosuresForAirport(string $airportId, array $airpor
 
     $notams = loadNotamRowsForDensityAltitudePerformance($airportId);
     if ($notams === null) {
-        $memo[$airportId] = $defaults;
+        $memo[$memoKey] = $defaults;
         return $defaults;
     }
 
-    $memo[$airportId] = notamResolveActiveDensityAltitudeRunwayClosures($notams, $airport);
+    $memo[$memoKey] = notamResolveActiveDensityAltitudeRunwayClosures($notams, $airport);
 
-    return $memo[$airportId];
+    return $memo[$memoKey];
 }
 
 /**

--- a/tests/Unit/DaPerformanceRunwayClosureTest.php
+++ b/tests/Unit/DaPerformanceRunwayClosureTest.php
@@ -132,6 +132,37 @@ class DaPerformanceRunwayClosureTest extends TestCase
         $this->assertSame(count($runways), count($filtered));
     }
 
+    public function testKboiTaxiwayNotamDoesNotMarkRunwayPairClosed(): void
+    {
+        $this->writeNotamCache('kboi', [
+            [
+                'id' => 'A1032/2026',
+                'location' => 'KBOI',
+                'text' => 'BOI RWY 10L/28R CLSD EXC XNG',
+                'code' => 'QMRXX',
+                'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() - 3600),
+                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 3600),
+            ],
+            [
+                'id' => '06/140/2026',
+                'location' => 'KBOI',
+                'text' => 'TWY G BTN RWY 10R/28L AND TWY A CLSD CONSTRUCTION',
+                'code' => '',
+                'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() - 3600),
+                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 3600),
+            ],
+        ]);
+
+        $closures = getActiveRunwayNotamClosuresForAirport('kboi', [
+            'icao' => 'KBOI',
+            'faa' => 'BOI',
+            'timezone' => 'America/Boise',
+        ]);
+
+        $this->assertSame(['10L/28R'], $closures['closed_pair_designators']);
+        $this->assertFalse($closures['aerodrome_closed']);
+    }
+
     public function testUpcomingRunwayClosureNotamDoesNotExcludeRunway(): void
     {
         $this->writeNotamCache('69v', [[

--- a/tests/Unit/NotamBannerTest.php
+++ b/tests/Unit/NotamBannerTest.php
@@ -76,6 +76,31 @@ final class NotamBannerTest extends TestCase
         );
     }
 
+    public function testNotamBannerExtractRunwayDesignator_IgnoresTaxiwayLandmarkPhrase(): void
+    {
+        $text = 'TWY G BTN RWY 10R/28L AND TWY A CLSD CONSTRUCTION';
+        $this->assertNull(notamBannerExtractRunwayDesignator($text));
+        $this->assertNull(notamBannerExtractRunwayDesignatorRaw($text));
+    }
+
+    public function testNotamBannerClassifyScope_KboiApproachRestriction_ReturnsRunwayScope(): void
+    {
+        $airport = [
+            'icao' => 'KBOI',
+            'faa' => 'BOI',
+            'name' => 'Boise Air Terminal',
+        ];
+        $notam = [
+            'notam_type' => 'aerodrome_closure',
+            'code' => '',
+            'text' => 'TWY J BTN APCH END RWY 10R AND TWY W CLSD TO ACFT WINGSPAN MORE THAN 118FT',
+            'location' => 'KBOI',
+        ];
+
+        $this->assertSame('runway', notamBannerClassifyScope($notam, $airport));
+        $this->assertSame('partial_restriction', notamBannerClassifyCategory('runway', $notam));
+    }
+
     public function testNotamBannerClassifyAirspace_FireTfrText_ReturnsFireHeadline(): void
     {
         $text = 'ID..AIRSPACE 34NM SE COEUR D\'ALENE, ID..TEMPORARY FLIGHT RESTRICTIONS. '

--- a/tests/Unit/NotamClosureParseTest.php
+++ b/tests/Unit/NotamClosureParseTest.php
@@ -97,6 +97,8 @@ final class NotamClosureParseTest extends TestCase
         yield 'kboi' => ['TWY G BTN RWY 10R/28L AND TWY A CLSD CONSTRUCTION', true];
         yield 'simple' => ['TWY A CLSD', true];
         yield 'runway closed' => ['RWY 10L/28R CLSD', false];
+        yield 'aerodrome exc twy' => ['AD AP CLSD EXC TWY A', false];
+        yield 'airport exc twy' => ['BOISE AIRPORT CLSD EXC TWY B', false];
     }
 
     #[DataProvider('taxiwayOnlyProvider')]

--- a/tests/Unit/NotamClosureParseTest.php
+++ b/tests/Unit/NotamClosureParseTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/notam/closure-parse.php';
+
+/**
+ * Subject-aware NOTAM closure phrase parsing (runway vs taxiway vs aerodrome).
+ */
+final class NotamClosureParseTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function directRunwayClosureProvider(): iterable
+    {
+        yield 'pair closed' => ['RWY 15/33 CLSD', true];
+        yield 'pair with airport prefix' => ['BOI RWY 10L/28R CLSD EXC XNG', true];
+        yield 'single end' => ['BOI RWY 10R CLSD', true];
+        yield 'segment between taxiways' => ['RWY 10R/28L CLSD BTN TWY A AND TWY B', true];
+        yield 'intersection closed' => ['RWY 10R INTERSECTION TWY G CLSD', true];
+        yield 'partial wingspan on runway' => [
+            'DFW RWY 13L/31R CLSD TO ACFT WINGSPAN MORE THAN 214FT',
+            true,
+        ];
+        yield 'closed spelling' => ['RWY 09/27 CLOSED', true];
+    }
+
+    #[DataProvider('directRunwayClosureProvider')]
+    public function testNotamTextIndicatesDirectRunwayClosure_AcceptsRunwaySubject(string $text, bool $expected): void
+    {
+        $this->assertSame($expected, notamTextIndicatesDirectRunwayClosure($text));
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function taxiwayOnlyClosureProvider(): iterable
+    {
+        yield 'kboi construction' => ['TWY G BTN RWY 10R/28L AND TWY A CLSD CONSTRUCTION'];
+        yield 'between runway and twy' => ['TWY C BTN RWY 09/27 AND TWY B CLSD'];
+        yield 'approach end landmark' => ['TWY D BTN APCH END RWY 28R AND TWY E CLSD'];
+        yield 'simple twy' => ['TWY A CLSD'];
+        yield 'twy first clsd before rwy landmark' => ['TWY G CLSD BTN RWY 10R/28L AND TWY A'];
+        yield 'construction twy at end' => ['CONSTRUCTION ON RWY 10R/28L TWY G CLSD'];
+        yield 'gate taxiway partial' => [
+            'TWY K BTN GATE D5 AND GATE E3 CLSD TO ACFT WINGSPAN MORE THAN 118FT',
+        ];
+    }
+
+    #[DataProvider('taxiwayOnlyClosureProvider')]
+    public function testNotamTextIndicatesDirectRunwayClosure_RejectsTaxiwaySubject(string $text): void
+    {
+        $this->assertFalse(notamTextIndicatesDirectRunwayClosure($text));
+    }
+
+    public function testNotamTextIndicatesDirectRunwayClosure_RejectsObstacleNearRunwayPhrase(): void
+    {
+        $this->assertFalse(
+            notamTextIndicatesDirectRunwayClosure('OBST CRANE 500FT AGL 200FT NW RWY 10R CLSD')
+        );
+    }
+
+    public function testNotamTextIndicatesDirectRunwayClosure_RejectsHazardWithoutClosure(): void
+    {
+        $this->assertFalse(notamTextIndicatesDirectRunwayClosure('RWY 12/30 UNSAFE'));
+        $this->assertFalse(notamTextIndicatesDirectRunwayClosure('RWY 12/30 HAZARD BIRDS'));
+        $this->assertFalse(notamTextIndicatesDirectRunwayClosure('RWY 10R/28L WIP'));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function runwayOrAerodromeClosureProvider(): iterable
+    {
+        yield 'runway pair' => ['RWY 15/33 CLSD', true];
+        yield 'aerodrome ad ap' => ['AD AP CLSD', true];
+        yield 'airport closed' => ['BOISE AIRPORT CLSD', true];
+        yield 'kboi taxiway' => ['TWY G BTN RWY 10R/28L AND TWY A CLSD CONSTRUCTION', false];
+        yield 'apron' => ['APRON N CLSD', false];
+    }
+
+    #[DataProvider('runwayOrAerodromeClosureProvider')]
+    public function testNotamTextIndicatesRunwayOrAerodromeClosure(string $text, bool $expected): void
+    {
+        $this->assertSame($expected, notamTextIndicatesRunwayOrAerodromeClosure($text));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function taxiwayOnlyProvider(): iterable
+    {
+        yield 'kboi' => ['TWY G BTN RWY 10R/28L AND TWY A CLSD CONSTRUCTION', true];
+        yield 'simple' => ['TWY A CLSD', true];
+        yield 'runway closed' => ['RWY 10L/28R CLSD', false];
+    }
+
+    #[DataProvider('taxiwayOnlyProvider')]
+    public function testNotamTextIndicatesTaxiwayOnlyClosure(string $text, bool $expected): void
+    {
+        $this->assertSame($expected, notamTextIndicatesTaxiwayOnlyClosure($text));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function runwayAffectingPartialProvider(): iterable
+    {
+        yield 'kboi approach twy wingspan' => [
+            'TWY J BTN APCH END RWY 10R AND TWY W CLSD TO ACFT WINGSPAN MORE THAN 118FT',
+            true,
+        ];
+        yield 'direct runway wingspan' => [
+            'HIO RWY 13R/31L CLSD TO ACFT WINGSPAN MORE THAN 118FT',
+            true,
+        ];
+        yield 'gate taxiway only' => [
+            'TWY K BTN GATE D5 AND GATE E3 CLSD TO ACFT WINGSPAN MORE THAN 118FT',
+            false,
+        ];
+        yield 'full runway closure' => ['RWY 10L/28R CLSD EXC XNG', false];
+        yield 'taxiway construction' => ['TWY G BTN RWY 10R/28L AND TWY A CLSD CONSTRUCTION', false];
+    }
+
+    #[DataProvider('runwayAffectingPartialProvider')]
+    public function testNotamTextIndicatesRunwayAffectingPartialRestriction(
+        string $text,
+        bool $expected
+    ): void {
+        $this->assertSame($expected, notamTextIndicatesRunwayAffectingPartialRestriction($text));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: ?string}>
+     */
+    public static function closureDesignatorProvider(): iterable
+    {
+        yield 'pair' => ['BOI RWY 10L/28R CLSD EXC XNG', '10L/28R'];
+        yield 'single end' => ['BOI RWY 10R CLSD', '10R'];
+        yield 'taxiway landmark' => ['TWY G BTN RWY 10R/28L AND TWY A CLSD', null];
+        yield 'approach partial' => [
+            'TWY J BTN APCH END RWY 10R AND TWY W CLSD TO ACFT WINGSPAN MORE THAN 118FT',
+            '10R',
+        ];
+    }
+
+    #[DataProvider('closureDesignatorProvider')]
+    public function testNotamExtractRunwayDesignatorForDisplay(string $text, ?string $expected): void
+    {
+        $this->assertSame($expected, notamExtractRunwayDesignatorForDisplay($text));
+    }
+}

--- a/tests/Unit/NotamFilterTest.php
+++ b/tests/Unit/NotamFilterTest.php
@@ -186,6 +186,83 @@ class NotamFilterTest extends TestCase {
         $this->assertFalse(isAerodromeClosure($notam, $airport));
     }
 
+    public function testIsAerodromeClosure_RejectsKboiTaxiwayBetweenRunwayLandmarks(): void
+    {
+        $airport = ['icao' => 'KBOI', 'faa' => 'BOI', 'name' => 'Boise Air Terminal'];
+        $notam = [
+            'code' => '',
+            'text' => 'TWY G BTN RWY 10R/28L AND TWY A CLSD CONSTRUCTION',
+            'location' => 'KBOI',
+        ];
+
+        $this->assertFalse(isAerodromeClosure($notam, $airport));
+    }
+
+    public function testIsAerodromeClosure_RejectsQmrCodeWhenProseIsTaxiwayOnly(): void
+    {
+        $airport = ['icao' => 'KBOI', 'faa' => 'BOI', 'name' => 'Boise Air Terminal'];
+        $notam = [
+            'code' => 'QMRXX',
+            'text' => 'TWY G BTN RWY 10R/28L AND TWY A CLSD CONSTRUCTION',
+            'location' => 'KBOI',
+        ];
+
+        $this->assertFalse(isAerodromeClosure($notam, $airport));
+    }
+
+    public function testIsRunwayAffectingRestrictionNotam_KboiApproachTwyWingspan(): void
+    {
+        $airport = ['icao' => 'KBOI', 'faa' => 'BOI', 'name' => 'Boise Air Terminal'];
+        $notam = [
+            'code' => '',
+            'text' => 'TWY J BTN APCH END RWY 10R AND TWY W CLSD TO ACFT WINGSPAN MORE THAN 118FT',
+            'location' => 'KBOI',
+        ];
+
+        $this->assertTrue(isRunwayAffectingRestrictionNotam($notam, $airport));
+        $this->assertFalse(isAerodromeClosure($notam, $airport));
+    }
+
+    public function testFilterRelevantNotams_Kboi_IncludesRunwayClosureAndApproachRestrictionOnly(): void
+    {
+        $airport = [
+            'icao' => 'KBOI',
+            'faa' => 'BOI',
+            'name' => 'Boise Air Terminal',
+            'timezone' => 'America/Boise',
+        ];
+        $notams = [
+            [
+                'id' => 'A1032/2026',
+                'text' => 'BOI RWY 10L/28R CLSD EXC XNG',
+                'location' => 'KBOI',
+                'start_time_utc' => '2026-04-11T14:55:00.000Z',
+                'end_time_utc' => '2026-11-01T18:00:00.000Z',
+            ],
+            [
+                'id' => '06/140/2026',
+                'text' => 'TWY G BTN RWY 10R/28L AND TWY A CLSD CONSTRUCTION',
+                'location' => 'KBOI',
+                'start_time_utc' => '2026-06-15T07:42:00.000Z',
+                'end_time_utc' => '2026-07-31T12:00:00.000Z',
+            ],
+            [
+                'id' => '07/190/2026',
+                'text' => 'TWY J BTN APCH END RWY 10R AND TWY W CLSD TO ACFT WINGSPAN MORE THAN 118FT',
+                'location' => 'KBOI',
+                'start_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 86400),
+                'end_time_utc' => gmdate('Y-m-d\TH:i:s\Z', time() + 90000),
+            ],
+        ];
+
+        $relevant = filterRelevantNotams($notams, $airport);
+        $ids = array_column($relevant, 'id');
+
+        $this->assertContains('A1032/2026', $ids);
+        $this->assertContains('07/190/2026', $ids);
+        $this->assertNotContains('06/140/2026', $ids);
+    }
+
     public function testFilterRelevantNotams_IncludesKspbScenario86Fixture(): void
     {
         require_once __DIR__ . '/../../lib/notam/parser.php';

--- a/tests/Unit/NotamFilterTest.php
+++ b/tests/Unit/NotamFilterTest.php
@@ -210,6 +210,19 @@ class NotamFilterTest extends TestCase {
         $this->assertFalse(isAerodromeClosure($notam, $airport));
     }
 
+    public function testIsAerodromeClosure_AcceptsAdApClsdExcTwyOnScenario86(): void
+    {
+        $airport = ['icao' => 'KXXX', 'name' => 'Test Field'];
+        $notam = [
+            'code' => '',
+            'text' => 'AD AP CLSD EXC TWY A',
+            'location' => 'KXXX',
+            'scenario' => '86',
+        ];
+
+        $this->assertTrue(isAerodromeClosure($notam, $airport));
+    }
+
     public function testIsRunwayAffectingRestrictionNotam_KboiApproachTwyWingspan(): void
     {
         $airport = ['icao' => 'KBOI', 'faa' => 'BOI', 'name' => 'Boise Air Terminal'];


### PR DESCRIPTION
## Summary

KBOI showed both runways closed when only 10L/28R was closed and 06/140/2026 was a taxiway closure (`TWY G BTN RWY 10R/28L AND TWY A CLSD`). The loose `RWY.*CLSD` text fallback treated the runway as the closed subject whenever it appeared before `CLSD` anywhere in the sentence.

This adds subject-aware closure parsing, keeps runway-affecting partial restrictions (for example 07/190 wingspan near APCH END RWY 10R) in the banner pipeline, and keys runway-closure memoization on NOTAM cache content so refreshed cache rows recompute correctly.

## Changes

- **`lib/notam/closure-parse.php`** - New module: direct `RWY {designator} CLSD` detection, taxiway-only rejection, obstacle phrase guard, runway-affecting partial rules, subject-aware designator extraction
- **`lib/notam/filter.php`** - QMR/scenario cross-check against taxiway-only prose; `isRunwayAffectingRestrictionNotam()` for banner eligibility without full runway closure
- **`lib/notam/banner.php`** - Headlines and designators use closure subject, not first `RWY` token in text
- **`lib/weather/da-performance-notam-closures.php`** - Memo keyed by cache file digest (fixes stale closure state across cache rewrites in the same request/test run)
- **Tests** - `NotamClosureParseTest` phrase matrix; KBOI regressions in `NotamFilterTest`, `NotamBannerTest`, `DaPerformanceRunwayClosureTest`
- **`docs/DATA_FLOW.md`** - Document subject-aware text fallback rules

## Expected behavior (KBOI)

| NOTAM | Banner | Runway card |
|-------|--------|-------------|
| A1032/2026 `RWY 10L/28R CLSD EXC XNG` | RWY 10L/28R closed | 10L/28R closed |
| 06/140/2026 taxiway between RWY and TWY | Hidden | 10R/28L open |
| 07/190/2026 wingspan near APCH END RWY 10R | RWY 10R restricted | 10R/28L open |

## Test plan

- [x] `make test-ci`
- [x] Local Docker smoke test: `http://localhost:8080/?airport=kboi` - only 10L/28R shows RWY CLSD; 06/140 absent from banner; 07/190 upcoming restriction retained