### PR TITLE
fix: hide per-end wind on helipad runway cards

### DIFF
--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -707,6 +707,10 @@
             "type": "boolean",
             "description": "True when closed in source data (NASR, OurAirports, or config); excludes NOTAM closure"
           },
+          "is_helipad": {
+            "type": "boolean",
+            "description": "True for FAA helipad designators (H1, H2, etc.); per-end wind components are omitted in UI"
+          },
           "ends": {
             "type": "array",
             "items": {
@@ -820,6 +824,10 @@
           "closed": {
             "type": "boolean",
             "description": "True when closed in source data or active NOTAM closure"
+          },
+          "is_helipad": {
+            "type": "boolean",
+            "description": "True for FAA helipad designators (H1, H2, etc.); per-end wind components are omitted in UI"
           },
           "ends": {
             "type": "array",

--- a/docs/API.md
+++ b/docs/API.md
@@ -168,7 +168,7 @@ Returns weather data for the specified airport.
 
 `density_altitude_performance.tier` and `best_end` drive UI cues. `worst_end` and `ends[]` are informational only. Caution and warning tiers are omitted when supporting weather fields are fail-closed stale.
 
-`runway_display` carries resolved runway facts for the dashboard and integrations. Per-end HW/XW are computed client-side from `wind_direction_magnetic` and `wind_speed`; missing wind shows `---`. Arrow direction is aircraft-relative per runway end (see [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md#runway-display-dashboard-per-end-hwxw)). Provenance is in `field_sources` and `runway_source`, not on dashboard cards.
+`runway_display` carries resolved runway facts for the dashboard and integrations. Per-end HW/XW are computed client-side from `wind_direction_magnetic` and `wind_speed`; missing wind shows `---`. Helipad rows (`is_helipad: true`, FAA designators such as `H1`) omit per-end wind components in the UI. Arrow direction is aircraft-relative per runway end (see [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md#runway-display-dashboard-per-end-hwxw)). Provenance is in `field_sources` and `runway_source`, not on dashboard cards.
 
 **Public API** (`GET /v1/airports/{id}/weather`): same `runway_display` shape via `formatWeatherResponse()`. OpenAPI schema: `RunwayDisplay` in `api/docs/openapi.json`.
 

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -759,7 +759,7 @@ OurAirports is community-maintained; length and surface can disagree with nation
 1. Resolve runway inventory (config override per field, NASR, OurAirports).
 2. Merge dimensions, surface, lights, traffic notes, calm-wind designation, and magnetic headings per end.
 3. Apply active NOTAM full-closure semantics on weather responses (same rules as density altitude performance).
-4. Attach `runway_display` to the formatted weather payload. Per-end headwind and crosswind are computed client-side from `wind_speed` and magnetic wind direction; missing wind shows unavailable in UI. Arrow semantics (aircraft-relative along- and cross-fuselage) are defined in [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md#runway-display-dashboard-per-end-hwxw).
+4. Attach `runway_display` to the formatted weather payload. Per-end headwind and crosswind are computed client-side from `wind_speed` and magnetic wind direction; missing wind shows unavailable in UI. Helipad rows (`is_helipad: true`) omit per-end wind components. Arrow semantics (aircraft-relative along- and cross-fuselage) are defined in [SAFETY_CRITICAL_CALCULATIONS.md](SAFETY_CRITICAL_CALCULATIONS.md#runway-display-dashboard-per-end-hwxw).
 
 **Public API airport metadata** (`GET /v1/airports/{id}`): `runway_facts` uses the same resolver with NOTAM closure omitted (metadata is cached longer). Omits calm-wind designation and traffic notes. Legacy `runways[]` remains config compass geometry only.
 

--- a/docs/SAFETY_CRITICAL_CALCULATIONS.md
+++ b/docs/SAFETY_CRITICAL_CALCULATIONS.md
@@ -571,6 +571,9 @@ rotatePointTrueToMagnetic(float $x, float $y, float $declinationDegrees): array
 **NOTAM closure on cards**:
 - When the airport NOTAM cache is within the failclosed threshold, mark a runway `closed` for aerodrome closure NOTAMs, full pair closures, and when every published end is closed by active single-end NOTAMs (same semantics as density altitude performance runway filtering). Partial restrictions and upcoming closures do not mark a runway closed.
 
+**Helipads**:
+- FAA NASR helipad rows use `rwy_id` designators such as `H1` and have no published magnetic heading. Set `is_helipad: true` on the API row and omit per-end HW/XW in the dashboard UI. Dimensions, surface, and lights still render.
+
 **Implementation**: `lib/runway-display.php`, `public/js/runway-display.js`
 **Tests**: `tests/Unit/RunwayDisplayTest.php`, `tests/js/runway-display-wind.test.js`, `tests/js/runway-display-wind-arrows.test.js`
 

--- a/lib/runway-display.php
+++ b/lib/runway-display.php
@@ -304,6 +304,17 @@ function runwayDisplayResolveCalmWind(array $configRow, array $airportCalmWind, 
 }
 
 /**
+ * Whether a runway row is a helicopter landing pad (FAA NASR designator H1, H2, etc.).
+ *
+ * Helipads have no published runway heading; per-end headwind and crosswind are not
+ * meaningful and must not be shown on dashboard cards.
+ */
+function runwayDisplayIsHelipad(string $rwyId): bool
+{
+    return (bool) preg_match('/^H\d+$/i', trim($rwyId));
+}
+
+/**
  * Whether a runway card should show closed from active NOTAM full closures.
  *
  * Matches density altitude performance NOTAM semantics: aerodrome closure,
@@ -460,6 +471,7 @@ function runwayDisplayFormatRunwayRow(
         'lights' => $lights,
         'traffic' => $traffic,
         'closed' => $closed,
+        'is_helipad' => runwayDisplayIsHelipad($rwyId),
         'ends' => $ends,
         'field_sources' => $fieldSources,
         'row_source' => $sourceName,
@@ -629,6 +641,7 @@ function runwayDisplayFormatRunwayFactsRow(array $row): array
         'surface_code' => $row['surface_code'],
         'lights' => $row['lights'],
         'closed' => $row['closed'],
+        'is_helipad' => !empty($row['is_helipad']),
         'field_sources' => $row['field_sources'] ?? [],
         'ends' => [],
     ];

--- a/public/js/runway-display.js
+++ b/public/js/runway-display.js
@@ -275,9 +275,11 @@
             ? '<div class="runway-style-traffic">' + escapeHtml(row.traffic) + '</div>'
             : '';
         const ends = Array.isArray(row.ends) ? row.ends : [];
-        const windHtml = ends.map(function (end) {
-            return endWindLine(end, weather, calm);
-        }).join('');
+        const windHtml = row.is_helipad
+            ? ''
+            : ends.map(function (end) {
+                return endWindLine(end, weather, calm);
+            }).join('');
         const specsHtml = ''
             + '<div class="runway-hybrid-specs">'
             + '<span><span class="spec-label">Surface:</span> <span class="spec-val">' + surface + '</span></span>'

--- a/tests/Unit/RunwayDisplayTest.php
+++ b/tests/Unit/RunwayDisplayTest.php
@@ -8,6 +8,86 @@ require_once __DIR__ . '/../../lib/runway-display.php';
 
 class RunwayDisplayTest extends TestCase
 {
+    public function testRunwayDisplayIsHelipad_H1_ReturnsTrue(): void
+    {
+        $this->assertTrue(runwayDisplayIsHelipad('H1'));
+        $this->assertTrue(runwayDisplayIsHelipad('h2'));
+    }
+
+    public function testRunwayDisplayIsHelipad_RunwayPair_ReturnsFalse(): void
+    {
+        $this->assertFalse(runwayDisplayIsHelipad('09/27'));
+        $this->assertFalse(runwayDisplayIsHelipad('10L/28R'));
+    }
+
+    public function testRunwayDisplayFormatRunwayRow_Helipad_SetsIsHelipadFlag(): void
+    {
+        $row = runwayDisplayFormatRunwayRow(
+            [
+                'rwy_id' => 'H1',
+                'length_ft' => 50,
+                'width_ft' => 50,
+                'surface' => 'ASPH',
+                'ends' => [
+                    ['end_id' => 'H1'],
+                ],
+            ],
+            [],
+            [],
+            [],
+            ['aerodrome_closed' => false, 'closed_pair_designators' => [], 'closed_end_idents' => []],
+            'nasr',
+            null
+        );
+
+        $this->assertNotNull($row);
+        $this->assertTrue($row['is_helipad']);
+    }
+
+    public function testRunwayDisplayFormatRunwayRow_RunwayPair_IsNotHelipad(): void
+    {
+        $row = runwayDisplayFormatRunwayRow(
+            [
+                'rwy_id' => '09/27',
+                'length_ft' => 4000,
+                'surface' => 'ASPH',
+                'ends' => [
+                    ['end_id' => '09'],
+                    ['end_id' => '27'],
+                ],
+            ],
+            [],
+            [],
+            [],
+            ['aerodrome_closed' => false, 'closed_pair_designators' => [], 'closed_end_idents' => []],
+            'nasr',
+            null
+        );
+
+        $this->assertNotNull($row);
+        $this->assertFalse($row['is_helipad']);
+    }
+
+    public function testRunwayDisplayFormatRunwayFactsRow_PreservesIsHelipad(): void
+    {
+        $facts = runwayDisplayFormatRunwayFactsRow([
+            'rwy_id' => 'H1',
+            'length_ft' => 50,
+            'width_ft' => 50,
+            'surface' => 'Asphalt',
+            'surface_code' => 'ASPH',
+            'lights' => null,
+            'closed' => false,
+            'is_helipad' => true,
+            'field_sources' => ['length_ft' => 'nasr'],
+            'ends' => [
+                ['end_id' => 'H1', 'heading_mag' => null],
+            ],
+        ]);
+
+        $this->assertTrue($facts['is_helipad']);
+    }
+
     public function testRunwayDisplaySurfaceLabel_AsphCode_ReturnsAsphalt(): void
     {
         $this->assertSame('Asphalt', runwayDisplaySurfaceLabel('ASPH'));

--- a/tests/js/runway-display-render.test.js
+++ b/tests/js/runway-display-render.test.js
@@ -95,7 +95,37 @@ test('missing wind shows --- not zero kts', () => {
     assert(!/rwy-comp-(hw|tw|xw)">\s*[↓↑←→]?\s*0 kts/.test(html), 'must not show zero runway wind rows when wind missing');
 });
 
-test('valid wind renders numeric components with aircraft-relative arrows', () => {
+test('helipad card omits per-end wind components', () => {
+    const dom = buildDom({
+        wind_direction_magnetic: 270,
+        wind_speed: 12,
+        runway_display: {
+            runway_source: 'nasr',
+            runways: [{
+                rwy_id: 'H1',
+                length_ft: 50,
+                width_ft: 50,
+                surface: 'Asphalt',
+                lights: null,
+                closed: false,
+                is_helipad: true,
+                ends: [
+                    { end_id: 'H1', heading_mag: null, calm_wind_arrival: false, calm_wind_departure: false },
+                ],
+            }],
+        },
+    });
+    const html = dom.window.document.getElementById('runway-display-list').innerHTML;
+    assert(html.includes('H1'), 'helipad headline must render');
+    assert(html.includes('50'), 'dimensions must render');
+    assert(html.includes('Asphalt'), 'surface must render');
+    assert(!html.includes('rwy-comp-hw'), 'helipad must not render headwind row');
+    assert(!html.includes('rwy-comp-xw'), 'helipad must not render crosswind row');
+    assert(!html.includes('--- kts'), 'helipad must not render placeholder wind components');
+    assert(dom.window.document.querySelectorAll('.runway-hybrid-wind-row').length === 0, 'no wind rows');
+});
+
+test('non-helipad runway still renders wind components', () => {
     const dom = buildDom(sampleWeather);
     const html = dom.window.document.getElementById('runway-display-list').innerHTML;
     assert(/rwy-comp-hw">\u2193 \d+ kts/.test(html), 'expected headwind down arrow with numeric speed');


### PR DESCRIPTION
## Summary
- Detect FAA NASR helipad rows (`H1`, `H2`, etc.) and set `is_helipad: true` on `runway_display` / `runway_facts` API payloads
- Skip per-end headwind/crosswind rows in the dashboard UI for helipads while keeping dimensions, surface, and lights
- Fixes misleading `H1: --- kts --- kts` display at airports like KBOI

## Test plan
- [x] `make test-ci` (local)
- [x] `RunwayDisplayTest` helipad detection and API flag coverage
- [x] `runway-display-render.test.js` helipad card omits wind rows; normal runways unchanged
- [x] Manual: confirm KBOI helipad card shows specs only (no HW/XW line)