### PR TITLE
Align Runways section layout and night-mode wind styling

### DIFF
--- a/guides/13-using-the-airport-dashboard.md
+++ b/guides/13-using-the-airport-dashboard.md
@@ -398,9 +398,9 @@ If something looks wrong, contact the local airport steward or email `contact@av
 
 Runway length, surface, lights, and traffic pattern notes appear in a **Runways** subsection above Frequencies. Each runway pair is shown on its own card with per-end headwind and crosswind components that update with current wind and your unit preferences.
 
-Wind arrows are **aircraft-relative** for each runway end (as if you are on final to that threshold): **↓** green = into the wind along the runway; **↑** red = tailwind; **→** / **←** = crosswind drift to your right or left.
+Wind arrows are **aircraft-relative** for each runway end (as if you are on final to that threshold): **↓** green = into the wind along the runway; **↑** red = tailwind; **→** / **←** = crosswind drift to your right or left. In night mode, into-the-wind components stay red like the rest of the UI and use **bold** instead of green.
 
-When wind is calm (below 3 kt), designated calm wind runway ends may show a tag (`Calm wind arr`, `Calm wind dep`, or `Calm Wind Runway`). Tags hide when wind is 3 kt or above - runway choice is always yours.
+When wind is calm (below 3 kt), designated calm wind runway ends may show a tag (`Calm wind arr`, `Calm wind dep`, or `Calm Wind RWY`). Tags hide when wind is 3 kt or above - runway choice is always yours.
 
 Closed runways show **RWY CLSD**. Missing width is omitted from the dimensions line (length only). Other unknown facts show `---`.
 

--- a/lib/runway-display.php
+++ b/lib/runway-display.php
@@ -82,7 +82,7 @@ function runwayDisplayTrafficNote(array $ends): ?string
         }
         $endId = (string) ($end['end_id'] ?? '');
         if ($endId !== '') {
-            $notes[] = 'Runway ' . $endId . ': Right traffic';
+            $notes[] = 'RWY ' . $endId . ': Right traffic';
         }
     }
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -3641,6 +3641,18 @@ body.night-mode .density-altitude-warning {
 }
 
 /* Runway display (Airport Information hybrid cards) */
+/* Nested section must not inherit global section card chrome (shadow/radius/padding).
+   Keep .frequencies top rule + spacing so Runways matches Frequencies/Links. */
+#runway-display-section {
+    background: transparent;
+    box-shadow: none;
+    border-radius: 0;
+    margin-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-bottom: 0;
+}
+
 .runway-style-e {
     --runway-text-primary: #1a1a1a;
     --runway-text-body: #333;
@@ -3680,11 +3692,15 @@ body.night-mode .density-altitude-warning {
     display: flex;
     flex-wrap: wrap;
     gap: 1rem;
-    justify-content: flex-start;
+    justify-content: center;
 }
 
+/* min-width covers closed status + Calm Wind RWY badge without forcing
+   rare split arr/dep + long unit chrome onto one line; those may wrap. */
 .runway-style-e .runway-hybrid-card {
-    flex: 1 1 220px;
+    flex: 0 1 auto;
+    width: fit-content;
+    min-width: min(22rem, 100%);
     max-width: 100%;
     text-align: left;
 }
@@ -3811,6 +3827,13 @@ body.night-mode .density-altitude-warning {
     font-weight: 500;
 }
 
+/* Theme section rules use !important; keep nested Runways panel uncarded. */
+body.dark-mode #runway-display-section,
+body.night-mode #runway-display-section {
+    background: transparent !important;
+    box-shadow: none !important;
+}
+
 /* Dark mode runway tokens (match weather-item / label hierarchy) */
 body.dark-mode .runway-style-e {
     --runway-text-primary: var(--dark-text-bright);
@@ -3827,20 +3850,29 @@ body.dark-mode .runway-style-e {
     --runway-status-closed: #ef5350;
 }
 
-/* Night mode runway tokens (red-safe palette, same hierarchy as dashboard) */
+/* Night mode runway tokens (red-safe only - no green/blue accents).
+   Favorable headwind matches other wind color; bold weight marks it. */
 body.night-mode .runway-style-e {
     --runway-text-primary: var(--night-text-bright);
     --runway-text-body: var(--night-text-primary);
     --runway-text-muted: var(--night-text-muted);
     --runway-text-dim: var(--night-text-muted);
     --runway-border-subtle: var(--night-border-light);
-    --runway-hw-color: #99cc99;
+    --runway-hw-color: var(--night-text-bright);
     --runway-tw-color: var(--night-text-bright);
     --runway-xw-color: var(--night-text-muted);
     --runway-badge-fg: var(--night-text-bright);
     --runway-badge-bg: var(--night-bg-button);
     --runway-badge-border: var(--night-border);
     --runway-status-closed: var(--night-text-bright);
+}
+
+body.night-mode .rwy-comp-hw {
+    font-weight: 700;
+}
+
+body.night-mode .rwy-comp-tw {
+    font-weight: 500;
 }
 
 @media (max-width: 768px) {
@@ -3883,6 +3915,11 @@ body.night-mode .runway-style-e {
 }
 
 @media (prefers-color-scheme: dark) {
+    body:not(.dark-mode):not(.night-mode):not(.light-mode) #runway-display-section {
+        background: transparent !important;
+        box-shadow: none !important;
+    }
+
     body:not(.dark-mode):not(.night-mode):not(.light-mode) .runway-style-e {
         --runway-text-primary: var(--dark-text-bright);
         --runway-text-body: var(--dark-text-primary);

--- a/public/js/runway-display.js
+++ b/public/js/runway-display.js
@@ -195,7 +195,7 @@
         const arrival = end.calm_wind_arrival === true;
         const departure = end.calm_wind_departure === true;
         if (arrival && departure) {
-            return '<span class="runway-calm-wind-badge runway-calm-wind-badge--inline">Calm Wind Runway</span>';
+            return '<span class="runway-calm-wind-badge runway-calm-wind-badge--inline">Calm Wind RWY</span>';
         }
         const tags = [];
         if (arrival) {

--- a/tests/Unit/RunwayDisplayTest.php
+++ b/tests/Unit/RunwayDisplayTest.php
@@ -379,4 +379,14 @@ class RunwayDisplayTest extends TestCase
         $this->assertFalse($withoutNotam['closed']);
         $this->assertFalse(runwayDisplayFormatRunwayFactsRow($withoutNotam)['closed']);
     }
+
+    public function testRunwayDisplayTrafficNote_UsesRwyAbbreviation(): void
+    {
+        $note = runwayDisplayTrafficNote([
+            ['end_id' => '31L', 'right_hand_traffic' => true],
+            ['end_id' => '13R', 'right_hand_traffic' => false],
+        ]);
+
+        $this->assertSame('RWY 31L: Right traffic', $note);
+    }
 }

--- a/tests/js/runway-display-render.test.js
+++ b/tests/js/runway-display-render.test.js
@@ -168,6 +168,45 @@ test('dashboard CSS hides mobile block on desktop', () => {
     assert(css.includes('@media (max-width: 768px)'), 'mobile breakpoint missing');
     assert(css.includes('body.dark-mode .runway-style-e'), 'dark mode runway tokens missing');
     assert(css.includes('body.night-mode .runway-style-e'), 'night mode runway tokens missing');
+    const nightRunwayBlock = css.match(/body\.night-mode \.runway-style-e\s*\{[^}]+\}/);
+    assert(nightRunwayBlock, 'night mode runway token block missing');
+    assert(
+        !/#99cc99|#6ecf6e|#2e7d32|#1a4f8a|#9ec5ef/i.test(nightRunwayBlock[0]),
+        'night mode runway tokens must stay red-safe (no green/blue accents)'
+    );
+    assert(
+        /--runway-hw-color:\s*var\(--night-text-bright\)/.test(nightRunwayBlock[0]),
+        'night mode headwind must match bright red wind color'
+    );
+    assert(
+        /--runway-tw-color:\s*var\(--night-text-bright\)/.test(nightRunwayBlock[0]),
+        'night mode tailwind must match bright red wind color'
+    );
+    assert(
+        /body\.night-mode \.rwy-comp-hw\s*\{[^}]*font-weight:\s*700/.test(css),
+        'night mode favorable wind must use bold weight'
+    );
+    assert(
+        /body\.night-mode \.rwy-comp-tw\s*\{[^}]*font-weight:\s*500/.test(css),
+        'night mode tailwind must not use favorable bold weight'
+    );
+    assert(css.includes('#runway-display-section'), 'nested runway section reset missing');
+    assert(
+        /\.runway-style-e \.runway-hybrid-list\s*\{[^}]*justify-content:\s*center/.test(css),
+        'runway list centering missing'
+    );
+    assert(
+        /\.runway-style-e \.runway-hybrid-card\s*\{[^}]*width:\s*fit-content/.test(css),
+        'content-sized runway cards missing'
+    );
+    assert(
+        /\.runway-style-e \.runway-hybrid-card\s*\{[^}]*flex:\s*0 1 auto/.test(css),
+        'runway card flex-grow disable missing'
+    );
+    assert(
+        /\.runway-style-e \.runway-hybrid-card\s*\{[^}]*min-width:\s*min\(22rem,\s*100%\)/.test(css),
+        'desktop runway card min-width for badges/status missing'
+    );
 });
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## Summary
- Match the Airport Information **Runways** block to other section boundaries (horizontal rule + title) by removing nested card chrome around the section.
- On desktop, size every runway card to its content, center the group, and use a modest min-width so closed / calm-wind badges fit without stretching full width; three cards (e.g. KHIO) fit on one row at typical desktop widths.
- Use aviation **RWY** wording for calm-wind badges and right-traffic notes; keep night mode red-safe and mark favorable headwind with **bold** instead of green.

## Test plan
- [x] `/?airport=7S9` - Runways uses rule + title like Frequencies; grey runway card centered, not full-bleed nested panel
- [x] `/?airport=khio` - three runway cards on one desktop row
- [x] Confirm calm wind / closed badges still readable inside the card min-width
- [x] Toggle night mode - runway cards and wind components are shades of red; favorable headwind is bold, not green
- [x] Mobile viewport - runway cards remain full width
- [x] `make test-ci` (already green locally)