### PR TITLE
Align embed wind compass visuals with dashboard

### DIFF
--- a/lib/embed-templates/full.php
+++ b/lib/embed-templates/full.php
@@ -462,7 +462,7 @@ HTML;
     $html .= '</a>';
     $html .= "\n</div>\n";
 
-    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 240, $fullModeOptions);
+    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 300, $fullModeOptions);
 
     return $html;
 }
@@ -627,7 +627,7 @@ HTML;
     $html .= '</a>';
     $html .= "\n</div>\n";
 
-    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 240, $fullModeOptions);
+    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 300, $fullModeOptions);
 
     return $html;
 }
@@ -794,7 +794,7 @@ HTML;
     $html .= '</a>';
     $html .= "\n</div>\n";
 
-    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 240, $fullModeOptions);
+    $html .= renderWindCompassScript($canvasId, $windSpeed, $windDirection, $isVRB, $runways, $isDark, 300, $fullModeOptions);
 
     return $html;
 }

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -2915,25 +2915,33 @@ function updateWindVisual(weather) {
     // Draw the compass on the canvas via the shared renderer (single source of truth
     // with the embeds). The detail panel below is dashboard-specific and stays here.
     if (window.AviationWX && typeof window.AviationWX.drawWindCompass === 'function') {
-        window.AviationWX.drawWindCompass(canvas, {
-            windSpeed: ws,
-            windDirection: windDirNumeric,
-            isVRB: isVariableWind,
-            isDark: isDarkMode,
-            night: isNightMode,
-            size: 'full',
-            fullMode: {
-                runwaySegments: (typeof RUNWAY_SEGMENTS !== 'undefined' && RUNWAY_SEGMENTS) ? RUNWAY_SEGMENTS : [],
-                lastHourWind: lastHourWind,
-                periodLabel: lhwPeriodLabel,
-                windDirectionMagnetic: windDirNumeric,
-                magneticDeclination: MAGNETIC_DECLINATION || 0,
-                fieldObsTimeMap: weather._field_obs_time_map || {},
-                staleFailclosedSeconds: STALE_FAILCLOSED_SECONDS,
-                metarStaleFailclosedSeconds: METAR_STALE_FAILCLOSED_SECONDS,
-                isMetarOnly: isMetarOnly
-            }
-        });
+        const drawDashboardCompass = function() {
+            window.AviationWX.drawWindCompass(canvas, {
+                windSpeed: ws,
+                windDirection: windDirNumeric,
+                isVRB: isVariableWind,
+                isDark: isDarkMode,
+                night: isNightMode,
+                size: 'full',
+                fullMode: {
+                    runwaySegments: (typeof RUNWAY_SEGMENTS !== 'undefined' && RUNWAY_SEGMENTS) ? RUNWAY_SEGMENTS : [],
+                    lastHourWind: lastHourWind,
+                    periodLabel: lhwPeriodLabel,
+                    windDirectionMagnetic: windDirNumeric,
+                    magneticDeclination: MAGNETIC_DECLINATION || 0,
+                    fieldObsTimeMap: weather._field_obs_time_map || {},
+                    staleFailclosedSeconds: STALE_FAILCLOSED_SECONDS,
+                    metarStaleFailclosedSeconds: METAR_STALE_FAILCLOSED_SECONDS,
+                    isMetarOnly: isMetarOnly
+                }
+            });
+        };
+
+        if (window.AviationWX.observeWindCompassCanvas) {
+            window.AviationWX.observeWindCompassCanvas(canvas, drawDashboardCompass, 300);
+        } else {
+            drawDashboardCompass();
+        }
     }
 
     // Get today's peak gust from server (daily tracking, never stale)

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -649,10 +649,6 @@
                     if (isFullModeCanvas && window.AviationWX.observeWindCompassCanvas) {
                         window.AviationWX.observeWindCompassCanvas(canvas, renderCompass, 300);
                     } else {
-                        const fallbackCssSize = isFullModeCanvas ? 300 : canvas.width;
-                        if (window.AviationWX.syncWindCompassCanvasPixels && isFullModeCanvas) {
-                            window.AviationWX.syncWindCompassCanvasPixels(canvas, fallbackCssSize);
-                        }
                         renderCompass();
                     }
                 });

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -622,16 +622,14 @@
                     const fullMode = weather.wind_compass_full_mode || null;
                     const isFullModeCanvas = !!fullMode || !!canvas.closest('.wind-viz-container');
 
-                    const renderCompass = (cssSize) => {
+                    const renderCompass = () => {
+                        const cssSize = canvas._aviationwxCssSize || canvas.clientWidth || 300;
                         let size = 'medium';
                         if (cssSize >= 240) size = 'full';
                         else if (cssSize >= 100) size = 'large';
                         else if (cssSize >= 80) size = 'medium';
                         else if (cssSize >= 60) size = 'small';
                         else size = 'mini';
-
-                        const ctx = canvas.getContext('2d');
-                        ctx.clearRect(0, 0, canvas.width, canvas.height);
 
                         const wd = weather.wind_direction;
                         const windDir = (wd && typeof wd === 'object') ? (wd.magnetic_north ?? null) : (weather.wind_direction_magnetic ?? null);
@@ -643,20 +641,19 @@
                             runways: runways,
                             isDark: isDark,
                             size: size,
+                            cssSize: cssSize,
                             fullMode: fullMode
                         });
                     };
 
                     if (isFullModeCanvas && window.AviationWX.observeWindCompassCanvas) {
-                        window.AviationWX.observeWindCompassCanvas(canvas, () => {
-                            renderCompass(canvas.clientWidth || 240);
-                        }, 240);
+                        window.AviationWX.observeWindCompassCanvas(canvas, renderCompass, 300);
                     } else {
-                        const fallbackCssSize = isFullModeCanvas ? 240 : canvas.width;
-                        const cssSize = (window.AviationWX.syncWindCompassCanvasPixels && isFullModeCanvas)
-                            ? window.AviationWX.syncWindCompassCanvasPixels(canvas, fallbackCssSize)
-                            : fallbackCssSize;
-                        renderCompass(cssSize);
+                        const fallbackCssSize = isFullModeCanvas ? 300 : canvas.width;
+                        if (window.AviationWX.syncWindCompassCanvasPixels && isFullModeCanvas) {
+                            window.AviationWX.syncWindCompassCanvasPixels(canvas, fallbackCssSize);
+                        }
+                        renderCompass();
                     }
                 });
             };

--- a/public/js/wind-compass-resize-utils.js
+++ b/public/js/wind-compass-resize-utils.js
@@ -11,6 +11,8 @@
 
     const MIN_CSS_SIZE = 48;
     const MAX_CSS_SIZE = 300;
+    /** Design reference for full-mode compass typography and stroke weights (dashboard size). */
+    const FULL_MODE_REFERENCE_CSS_SIZE = 300;
 
     /**
      * Clamp and round the CSS box size used for a square wind compass.
@@ -44,20 +46,35 @@
         };
     }
 
+    /**
+     * Scale factor for full-mode stroke widths and fonts relative to the 300px reference.
+     *
+     * @param {number} cssSize Display width/height in CSS pixels
+     * @returns {number}
+     */
+    function computeFullModeScale(cssSize) {
+        const safeCss = resolveWindCompassCssSize(cssSize, FULL_MODE_REFERENCE_CSS_SIZE);
+        return safeCss / FULL_MODE_REFERENCE_CSS_SIZE;
+    }
+
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = {
             MIN_CSS_SIZE,
             MAX_CSS_SIZE,
+            FULL_MODE_REFERENCE_CSS_SIZE,
             resolveWindCompassCssSize,
             computeWindCompassPixelSize,
+            computeFullModeScale,
         };
     } else {
         global.AviationWX = global.AviationWX || {};
         global.AviationWX.windCompassResize = {
             MIN_CSS_SIZE,
             MAX_CSS_SIZE,
+            FULL_MODE_REFERENCE_CSS_SIZE,
             resolveWindCompassCssSize,
             computeWindCompassPixelSize,
+            computeFullModeScale,
         };
     }
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/public/js/wind-visual.js
+++ b/public/js/wind-visual.js
@@ -708,7 +708,7 @@
         const refSize = getFullModeReferenceCssSize();
         const fallbackCss = (options && Number.isFinite(options.cssSize) && options.cssSize > 0)
             ? options.cssSize
-            : (canvas._aviationwxCssSize || canvas.clientWidth || refSize);
+            : (canvas._aviationwxCssSize || canvas.clientWidth || canvas._aviationwxWindCompassFallback || refSize);
         const cssSize = syncWindCompassCanvasPixels(canvas, fallbackCss);
         const dpr = canvas._aviationwxDpr || 1;
         const scale = getFullModeScale(cssSize);
@@ -807,6 +807,7 @@
         }
 
         const fallback = fallbackCssSize || getFullModeReferenceCssSize();
+        canvas._aviationwxWindCompassFallback = fallback;
         canvas._aviationwxWindCompassRedraw = drawFn;
 
         const redraw = function() {
@@ -827,7 +828,6 @@
                 return;
             }
 
-            syncWindCompassCanvasPixels(canvas, fallback);
             latestDraw();
         };
 

--- a/public/js/wind-visual.js
+++ b/public/js/wind-visual.js
@@ -127,12 +127,12 @@
      * Draw full-mode wind compass (dashboard-matching)
      */
     function drawWindCompassFullMode(canvas, options) {
-        const ctx = canvas.getContext('2d');
-        const width = canvas.width;
-        const height = canvas.height;
-        const cx = width / 2;
-        const cy = height / 2;
-        const r = Math.min(width, height) / 2 - 20;
+        const layout = prepareWindCompassFullModeContext(canvas, options);
+        const ctx = layout.ctx;
+        const scale = layout.scale;
+        const cx = layout.cx;
+        const cy = layout.cy;
+        const r = layout.r;
 
         const full = options.fullMode || {};
         const isNight = options.night === true;
@@ -140,8 +140,6 @@
         const magneticDeclination = full.magneticDeclination || 0;
 
         const colors = getWindCompassColors({ isDark: isDark, night: isNight });
-
-        ctx.clearRect(0, 0, width, height);
 
         const deg2rad = Math.PI / 180;
         if (magneticDeclination !== 0) {
@@ -152,7 +150,7 @@
         }
 
         ctx.strokeStyle = colors.circle;
-        ctx.lineWidth = 2;
+        ctx.lineWidth = 2 * scale;
         ctx.beginPath();
         ctx.arc(cx, cy, r, 0, 2 * Math.PI);
         ctx.stroke();
@@ -187,7 +185,7 @@
             const endY = cy - rw * ey;
 
             ctx.strokeStyle = colors.runway;
-            ctx.lineWidth = 8;
+            ctx.lineWidth = 8 * scale;
             ctx.lineCap = 'round';
             ctx.beginPath();
             ctx.moveTo(startX, startY);
@@ -216,7 +214,7 @@
             : '';
 
         if (Array.isArray(lastHourWind) && lastHourWind.length === 16) {
-            drawWindRosePetals(ctx, cx, cy, r, lastHourWind, colors);
+            drawWindRosePetals(ctx, cx, cy, r, lastHourWind, colors, scale);
         }
 
         const windDirRaw = options.windDirection ?? null;
@@ -235,12 +233,12 @@
                     : (windDirNumeric - magneticDeclination + 360) % 360;
                 const windDirToward = (windDirFromMag + 180) % 360;
                 const windAngle = (windDirToward * Math.PI) / 180;
-                drawWindArrowFull(ctx, cx, cy, r, windAngle, ws, colors);
+                drawWindArrowFull(ctx, cx, cy, r, windAngle, ws, colors, scale);
             } else if (ws !== null && ws >= CALM_WIND_THRESHOLD && isVRB) {
-                ctx.font = 'bold 20px sans-serif';
+                ctx.font = 'bold ' + (20 * scale) + 'px sans-serif';
                 ctx.textAlign = 'center';
                 ctx.strokeStyle = colors.labelOutline;
-                ctx.lineWidth = 3;
+                ctx.lineWidth = 3 * scale;
                 ctx.lineJoin = 'round';
                 if (magneticDeclination !== 0) {
                     ctx.save();
@@ -256,10 +254,10 @@
                     ctx.fillText('VRB', cx, cy);
                 }
             } else if (isCalmWindSpeed(ws)) {
-                ctx.font = 'bold 20px sans-serif';
+                ctx.font = 'bold ' + (20 * scale) + 'px sans-serif';
                 ctx.textAlign = 'center';
                 ctx.strokeStyle = colors.labelOutline;
-                ctx.lineWidth = 3;
+                ctx.lineWidth = 3 * scale;
                 ctx.lineJoin = 'round';
                 if (magneticDeclination !== 0) {
                     ctx.save();
@@ -277,7 +275,7 @@
             }
         }
 
-        ctx.font = 'bold 14px sans-serif';
+        ctx.font = 'bold ' + (14 * scale) + 'px sans-serif';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         labelPositions.forEach(function(lp) {
@@ -288,7 +286,7 @@
             const strokeW = colors.runwayLabelStrokeWidth !== undefined ? colors.runwayLabelStrokeWidth : 3;
             if (strokeW > 0) {
                 ctx.strokeStyle = colors.runwayLabelOutline !== undefined ? colors.runwayLabelOutline : colors.labelOutline;
-                ctx.lineWidth = strokeW;
+                ctx.lineWidth = strokeW * scale;
                 ctx.strokeText(lp.ident, 0, 0);
             }
             ctx.fillStyle = colors.runwayLabel;
@@ -298,11 +296,11 @@
 
         ['N', 'E', 'S', 'W'].forEach(function(l, i) {
             const ang = (i * 90) * deg2rad;
-            const labelX = cx + Math.sin(ang) * (r + 10);
-            const labelY = cy - Math.cos(ang) * (r + 10);
+            const labelX = cx + Math.sin(ang) * (r + 10 * scale);
+            const labelY = cy - Math.cos(ang) * (r + 10 * scale);
             const tangentAngle = Math.atan2(-Math.cos(ang), Math.sin(ang)) + Math.PI / 2;
             ctx.fillStyle = colors.compass;
-            ctx.font = 'bold 16px sans-serif';
+            ctx.font = 'bold ' + (16 * scale) + 'px sans-serif';
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
             ctx.save();
@@ -312,7 +310,7 @@
             ctx.restore();
         });
 
-        drawTrueNorthMarker(ctx, cx, cy, r, magneticDeclination, colors);
+        drawTrueNorthMarker(ctx, cx, cy, r, magneticDeclination, colors, scale);
 
         if (magneticDeclination !== 0) {
             ctx.restore();
@@ -323,7 +321,8 @@
      * Draw True North marker: star at top (0°), arc to N (magnetic), mag var label halfway along arc in green.
      * Compass is rotated so True North is at top; N/S/E/W are skewed by mag var.
      */
-    function drawTrueNorthMarker(ctx, cx, cy, r, declination, colors) {
+    function drawTrueNorthMarker(ctx, cx, cy, r, declination, colors, scale) {
+        const s = scale || 1;
         const absDecl = Math.abs(declination);
         if (absDecl === 0) return;
         const arcColor = colors.trueNorth ?? '#4a7';
@@ -333,7 +332,7 @@
         const canvasMagneticNorth = -Math.PI / 2;
 
         ctx.strokeStyle = arcColor;
-        ctx.lineWidth = 5;
+        ctx.lineWidth = 5 * s;
         ctx.lineCap = 'round';
         ctx.lineJoin = 'round';
         ctx.beginPath();
@@ -348,9 +347,9 @@
         ctx.textBaseline = 'middle';
         const starX = cx + Math.sin(trueNorthAngle) * r;
         const starY = cy - Math.cos(trueNorthAngle) * r;
-        ctx.font = '14px sans-serif';
+        ctx.font = (14 * s) + 'px sans-serif';
         ctx.strokeStyle = colors.labelOutline || '#fff';
-        ctx.lineWidth = 2;
+        ctx.lineWidth = 2 * s;
         ctx.lineJoin = 'round';
         ctx.save();
         ctx.translate(starX, starY);
@@ -361,27 +360,28 @@
         ctx.restore();
 
         const declLabel = Math.round(absDecl) + '\u00B0' + (declination > 0 ? 'E' : (declination < 0 ? 'W' : ''));
-        const labelRadius = r - 12;
+        const labelRadius = r - 12 * s;
         const midCanvasAngle = (canvasNorth + canvasMagneticNorth) / 2;
         const labelX = cx + labelRadius * Math.cos(midCanvasAngle);
         const labelY = cy + labelRadius * Math.sin(midCanvasAngle);
         const tangentAngle = midCanvasAngle + Math.PI / 2;
-        ctx.font = '12px sans-serif';
+        ctx.font = (12 * s) + 'px sans-serif';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.save();
         ctx.translate(labelX, labelY);
         ctx.rotate(tangentAngle);
         ctx.strokeStyle = colors.labelOutline;
-        ctx.lineWidth = 2.5;
+        ctx.lineWidth = 2.5 * s;
         ctx.strokeText(declLabel, 0, 0);
         ctx.fillStyle = arcColor;
         ctx.fillText(declLabel, 0, 0);
         ctx.restore();
     }
 
-    function drawWindRosePetals(ctx, cx, cy, r, petals, colors) {
-        const maxPetalLength = Math.min(45, r * 0.35);
+    function drawWindRosePetals(ctx, cx, cy, r, petals, colors, scale) {
+        const s = scale || 1;
+        const maxPetalLength = Math.min(45 * s, r * 0.35);
         const maxSpeed = Math.max(1, Math.max.apply(null, petals));
         const deg2rad = Math.PI / 180;
         const chevronColor = colors.chevron || 'rgba(220, 53, 69, 0.75)';
@@ -390,7 +390,7 @@
             const speed = petals[i] || 0;
             if (speed <= 0) continue;
             const length = (speed / maxSpeed) * maxPetalLength;
-            if (length < 2) continue;
+            if (length < 2 * s) continue;
 
             const centerAngle = (i * 22.5 - 90) * deg2rad;
             const halfWidth = (22.5 / 2) * deg2rad;
@@ -404,10 +404,10 @@
             ctx.fillStyle = colors.windRosePetal || 'rgba(220, 53, 69, 0.5)';
             ctx.fill();
             ctx.strokeStyle = colors.windRosePetalStroke || 'rgba(220, 53, 69, 0.4)';
-            ctx.lineWidth = 1;
+            ctx.lineWidth = 1 * s;
             ctx.stroke();
 
-            if (length < 18) continue;
+            if (length < 18 * s) continue;
             const cosA = Math.cos(centerAngle);
             const sinA = Math.sin(centerAngle);
             const petalHalfAngle = (22.5 / 2) * deg2rad;
@@ -438,18 +438,20 @@
         }
     }
 
-    function drawWindArrowFull(ctx, cx, cy, r, angle, speed, colors) {
-        const arrowLength = Math.min(speed * 6, r - 30);
+    function drawWindArrowFull(ctx, cx, cy, r, angle, speed, colors, scale) {
+        const s = scale || 1;
+        const arrowLength = Math.min(speed * 6 * s, r - 30 * s);
         const arrowEndX = cx + Math.sin(angle) * arrowLength;
         const arrowEndY = cy - Math.cos(angle) * arrowLength;
         const arrowAngle = Math.atan2(arrowEndY - cy, arrowEndX - cx);
-        const triangleBaseDist = 15 * Math.cos(Math.PI / 6);
+        const headSize = 15 * s;
+        const triangleBaseDist = headSize * Math.cos(Math.PI / 6);
         const lineEndX = arrowEndX - triangleBaseDist * Math.cos(arrowAngle);
         const lineEndY = arrowEndY - triangleBaseDist * Math.sin(arrowAngle);
 
         ctx.strokeStyle = colors.windArrow;
         ctx.fillStyle = colors.windArrow;
-        ctx.lineWidth = 4;
+        ctx.lineWidth = 4 * s;
         ctx.lineCap = 'butt';
         ctx.beginPath();
         ctx.moveTo(cx, cy);
@@ -457,8 +459,8 @@
         ctx.stroke();
         ctx.beginPath();
         ctx.moveTo(arrowEndX, arrowEndY);
-        ctx.lineTo(arrowEndX - 15 * Math.cos(arrowAngle - Math.PI / 6), arrowEndY - 15 * Math.sin(arrowAngle - Math.PI / 6));
-        ctx.lineTo(arrowEndX - 15 * Math.cos(arrowAngle + Math.PI / 6), arrowEndY - 15 * Math.sin(arrowAngle + Math.PI / 6));
+        ctx.lineTo(arrowEndX - headSize * Math.cos(arrowAngle - Math.PI / 6), arrowEndY - headSize * Math.sin(arrowAngle - Math.PI / 6));
+        ctx.lineTo(arrowEndX - headSize * Math.cos(arrowAngle + Math.PI / 6), arrowEndY - headSize * Math.sin(arrowAngle + Math.PI / 6));
         ctx.closePath();
         ctx.fill();
     }
@@ -681,6 +683,46 @@
         return (window.AviationWX && window.AviationWX.windCompassResize) || {};
     }
 
+    function getFullModeReferenceCssSize() {
+        const utils = getWindCompassResizeUtils();
+        return utils.FULL_MODE_REFERENCE_CSS_SIZE || 300;
+    }
+
+    function getFullModeScale(cssSize) {
+        const compute = getWindCompassResizeUtils().computeFullModeScale;
+        if (typeof compute === 'function') {
+            return compute(cssSize);
+        }
+        return cssSize / getFullModeReferenceCssSize();
+    }
+
+    /**
+     * Resize backing store for DPR and return logical (CSS) drawing coordinates.
+     *
+     * @param {HTMLCanvasElement} canvas
+     * @param {Object} [options]
+     * @returns {{ctx: CanvasRenderingContext2D, cssSize: number, scale: number, cx: number, cy: number, r: number}}
+     */
+    function prepareWindCompassFullModeContext(canvas, options) {
+        const ctx = canvas.getContext('2d');
+        const refSize = getFullModeReferenceCssSize();
+        const fallbackCss = (options && Number.isFinite(options.cssSize) && options.cssSize > 0)
+            ? options.cssSize
+            : (canvas._aviationwxCssSize || canvas.clientWidth || refSize);
+        const cssSize = syncWindCompassCanvasPixels(canvas, fallbackCss);
+        const dpr = canvas._aviationwxDpr || 1;
+        const scale = getFullModeScale(cssSize);
+
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        ctx.clearRect(0, 0, cssSize, cssSize);
+
+        const cx = cssSize / 2;
+        const cy = cssSize / 2;
+        const r = cssSize / 2 - 20 * scale;
+
+        return { ctx: ctx, cssSize: cssSize, scale: scale, cx: cx, cy: cy, r: r };
+    }
+
     /**
      * Resize a wind compass canvas backing store to match its displayed box.
      *
@@ -716,6 +758,12 @@
             canvas.height = resolved.pixelSize;
         }
 
+        canvas.style.width = resolved.cssSize + 'px';
+        canvas.style.height = resolved.cssSize + 'px';
+
+        canvas._aviationwxCssSize = resolved.cssSize;
+        canvas._aviationwxDpr = dpr;
+
         return resolved.cssSize;
     }
 
@@ -724,14 +772,14 @@
      *
      * @param {HTMLCanvasElement} canvas
      * @param {Function} drawFn Callback that draws using the current canvas pixels
-     * @param {number} [fallbackCssSize=240] CSS-pixel size when layout is not ready
+     * @param {number} [fallbackCssSize=300] CSS-pixel size when layout is not ready
      */
     function observeWindCompassCanvas(canvas, drawFn, fallbackCssSize) {
         if (!canvas || typeof drawFn !== 'function') {
             return;
         }
 
-        const fallback = fallbackCssSize || 240;
+        const fallback = fallbackCssSize || getFullModeReferenceCssSize();
         canvas._aviationwxWindCompassRedraw = drawFn;
 
         const redraw = function() {

--- a/public/js/wind-visual.js
+++ b/public/js/wind-visual.js
@@ -758,13 +758,40 @@
             canvas.height = resolved.pixelSize;
         }
 
-        canvas.style.width = resolved.cssSize + 'px';
-        canvas.style.height = resolved.cssSize + 'px';
+        // Dashboard canvas has no width:100% rule; without explicit CSS size the
+        // backing-store dimensions become the displayed size. Embed compasses stay
+        // responsive via container CSS (wf-compass / wind-viz-container).
+        if (shouldPinCanvasDisplaySize(canvas)) {
+            canvas.style.width = resolved.cssSize + 'px';
+            canvas.style.height = resolved.cssSize + 'px';
+        } else {
+            canvas.style.width = '';
+            canvas.style.height = '';
+        }
 
         canvas._aviationwxCssSize = resolved.cssSize;
         canvas._aviationwxDpr = dpr;
 
         return resolved.cssSize;
+    }
+
+    /**
+     * Whether to set inline canvas dimensions after backing-store resize.
+     *
+     * @param {HTMLCanvasElement} canvas
+     * @returns {boolean}
+     */
+    function shouldPinCanvasDisplaySize(canvas) {
+        if (!canvas) {
+            return false;
+        }
+        if (canvas.id === 'windCanvas') {
+            return true;
+        }
+        if (canvas.closest('.wf-compass, .wind-viz-container')) {
+            return false;
+        }
+        return false;
     }
 
     /**

--- a/tests/js/wind-compass-resize.test.js
+++ b/tests/js/wind-compass-resize.test.js
@@ -7,8 +7,10 @@
 const {
     MIN_CSS_SIZE,
     MAX_CSS_SIZE,
+    FULL_MODE_REFERENCE_CSS_SIZE,
     resolveWindCompassCssSize,
     computeWindCompassPixelSize,
+    computeFullModeScale,
 } = require('../../public/js/wind-compass-resize-utils.js');
 
 let passed = 0;
@@ -54,6 +56,17 @@ test('computeWindCompassPixelSize honors devicePixelRatio', () => {
 test('computeWindCompassPixelSize defaults DPR to 1', () => {
     const result = computeWindCompassPixelSize(160, 0);
     assertEqual(result.pixelSize, 160, 'pixel size without DPR');
+});
+
+test('computeFullModeScale uses 300px reference', () => {
+    assertEqual(FULL_MODE_REFERENCE_CSS_SIZE, 300, 'reference size');
+    assertEqual(computeFullModeScale(300), 1, 'full reference');
+    assertEqual(computeFullModeScale(150), 0.5, 'half size');
+});
+
+test('computeFullModeScale clamps before scaling', () => {
+    assertEqual(computeFullModeScale(400), 1, 'max clamp keeps scale at 1');
+    assertEqual(computeFullModeScale(MIN_CSS_SIZE), MIN_CSS_SIZE / FULL_MODE_REFERENCE_CSS_SIZE, 'min clamp');
 });
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## Summary

- Fix Retina/high-DPI rendering for full-mode wind compasses: draw in CSS pixel space with `setTransform(dpr)` so stroke widths and fonts are not halved on 2x displays.
- Scale full-mode typography and line weights proportionally from a 300px reference when the compass displays smaller than the dashboard.
- Unify the dashboard and embed paths on `observeWindCompassCanvas` and align full-embed fallbacks to 300px.
- Set explicit canvas CSS dimensions when syncing the backing store so DPR upscaling does not inflate the displayed compass size.

Closes #231

## Root cause

Embeds resized the canvas backing store to `cssSize × devicePixelRatio` but `drawWindCompassFullMode()` drew with fixed pixel sizes in device-pixel coordinates. On Retina, that made runway lines and labels appear roughly half the CSS size of the dashboard compass at the same display width.

## Files changed

- `public/js/wind-visual.js` - DPR-aware full-mode drawing, proportional scaling, display size sync
- `public/js/wind-compass-resize-utils.js` - `FULL_MODE_REFERENCE_CSS_SIZE` (300) and `computeFullModeScale()`
- `public/js/airport-dashboard.js` - dashboard uses shared resize observer
- `public/js/widget.js` - 300px fallback, pass `cssSize` through
- `lib/embed-templates/full.php` - 300px compass script fallback (was 240)
- `tests/js/wind-compass-resize.test.js` - scale helper coverage

## Self-review notes

- Weather data, runway logic, and staleness handling are unchanged (presentation only).
- Legacy non-full-mode mini compasses are out of scope and unchanged.
- Inline canvas dimensions are required so backing-store DPR scaling does not change layout size; `ResizeObserver` re-measures on container resize.

## Test plan

- [x] `make test-ci`
- [x] `node tests/js/wind-compass-resize.test.js`
- [x] Local side-by-side: KPFC embed card vs dashboard at 300px CSS on 2x Retina (both 300 CSS / 600 backing, matching line weight)
- [x] Post-deploy: verify embed on Google Sites / Friends of Pacific City page matches dashboard compass
  - Prod `kpfc.aviationwx.org` and `embed.aviationwx.org` serve identical `wind-visual.js` (sha256 prefix `ca3bb0ce2adb`) with shared `observeWindCompassCanvas`. Friends Google Site still loads KPFC embed iframe wrapper; pixel check on third-party Google Sites chrome not automated.
