### PR TITLE
Fix upload health probes for loopback FTPS and stuck SFTP files

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -361,6 +361,8 @@ Credential shape matches push cameras: `username` is alphanumeric, max 14 charac
 
 **Production Docker:** The web container uses host networking. Set `probe_connect_host` to `127.0.0.1` so functional probes connect to local listeners on `network_ports.ftp_control` and `network_ports.sftp`. Cameras still use `upload_hostname` as usual.
 
+FTPS probes to loopback or bare IP addresses skip TLS certificate hostname verification (`curl --insecure`) because the vsftpd certificate SAN matches the public hostname, not `127.0.0.1`. Before each upload, probes remove any prior on-disk `aviationwx-probe-healthcheck.txt` under the probe account directory so a leftover file owned by another uid cannot wedge the check.
+
 **Recommended: Hostname (default)**
 
 Use `upload_hostname` for most deployments. Hostname resolution survives IP changes and works for both static and dynamic IPs:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -556,7 +556,7 @@ Production can run functional FTPS/SFTP upload probes and restart wedged daemons
 
 **Recovery policy:** Two consecutive failed or stale probe evaluations per protocol, then at most one restart per 30 minutes per daemon (vsftpd and container sshd throttled separately). Process death uses the same per-daemon throttle. Missing `jq` or a corrupt heartbeat is treated as unhealthy (fail closed).
 
-**Probe connect host:** Production Docker uses `network_mode: host`. Set `config.upload_health_probe.probe_connect_host` to `127.0.0.1` so on-box probes reach vsftpd and sshd locally. Leave empty only if probes succeed via `upload_hostname` without hairpin NAT. External cameras still use `upload_hostname`.
+**Probe connect host:** Production Docker uses `network_mode: host`. Set `config.upload_health_probe.probe_connect_host` to `127.0.0.1` so on-box probes reach vsftpd and sshd locally. Leave empty only if probes succeed via `upload_hostname` without hairpin NAT. External cameras still use `upload_hostname`. When the connect host is loopback or a bare IP, FTPS probes use `curl --insecure` so the public vsftpd certificate hostname does not fail the on-box check.
 
 **SFTP host key roster (HTTPS):** Bridge and other SFTP clients can fetch live sshd host key fingerprints from the upload hostname:
 
@@ -569,7 +569,7 @@ ssh-keyscan -p "${SFTP_PORT}" "${UPLOAD_HOST}" | ssh-keygen -lf -
 
 Every `SHA256:` from `ssh-keyscan` must appear in the JSON `sha256[]` array. Fingerprints are computed at request time from `/etc/ssh/ssh_host_*_key.pub` in the web container (same container that runs sshd). After an image rebuild, re-run the comparison to confirm the roster tracks new keys.
 
-**Probe files:** Each run overwrites `aviationwx-probe-healthcheck.txt` on the probe account (no per-run timestamp filenames).
+**Probe files:** Each run clears any prior on-disk `aviationwx-probe-healthcheck.txt` under the probe FTPS/SFTP upload directories, then uploads a fresh copy (no per-run timestamp filenames). Clearing first avoids permission-denied overwrites when a leftover file is owned by another uid.
 
 ```bash
 # Heartbeat and recent probe log

--- a/scripts/upload-daemon-common.sh
+++ b/scripts/upload-daemon-common.sh
@@ -243,6 +243,9 @@ probe_host_skips_tls_verify() {
     if [[ "$host" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         return 0
     fi
+    if [[ "$host" == *:* ]]; then
+        return 0
+    fi
     return 1
 }
 

--- a/scripts/upload-daemon-common.sh
+++ b/scripts/upload-daemon-common.sh
@@ -251,7 +251,7 @@ probe_curl_fail_detail() {
     local prefix="$1"
     local err_file="$2"
     local line
-    line="$(tr '\n|' '  ' <"$err_file" 2>/dev/null | sed -E 's/(PASS|password)[^ ]*/\1 <redacted>/gi' | sed -E 's/[[:space:]]+/ /g' | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//' | cut -c1-160)"
+    line="$(tr '\n|' '  ' <"$err_file" 2>/dev/null | sed -E 's/(PASS|password|Password|PASSWORD)[^ ]*/\1 <redacted>/g' | sed -E 's/[[:space:]]+/ /g' | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//' | cut -c1-160)"
     if [ -z "$line" ]; then
         echo "${prefix} upload failed"
         return
@@ -265,12 +265,29 @@ clear_local_probe_upload_file() {
     rm -f "$path" 2>/dev/null || true
 }
 
-# Resolve on-disk probe upload path for ftps|sftp when username is alphanumeric.
+# Wrap IPv6 literals in brackets for curl URL construction.
+probe_url_host() {
+    local host="$1"
+    if [[ "$host" == \[*\] ]]; then
+        echo "$host"
+        return 0
+    fi
+    if [[ "$host" == *:* ]]; then
+        echo "[${host}]"
+        return 0
+    fi
+    echo "$host"
+}
+
+# Resolve on-disk probe upload path for ftps|sftp when username and filename are safe.
 probe_local_upload_path() {
     local protocol="$1"
     local user="$2"
     local file_name="$3"
     if ! [[ "$user" =~ ^[A-Za-z0-9]+$ ]]; then
+        return 1
+    fi
+    if ! [[ "$file_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
         return 1
     fi
     case "$protocol" in

--- a/scripts/upload-daemon-common.sh
+++ b/scripts/upload-daemon-common.sh
@@ -231,3 +231,57 @@ try_restart_upload_daemon() {
     fi
     return 1
 }
+
+# Loopback/IP probe hosts cannot match the public TLS cert SAN.
+probe_host_skips_tls_verify() {
+    local host="$1"
+    case "$host" in
+        localhost|127.0.0.1|::1)
+            return 0
+            ;;
+    esac
+    if [[ "$host" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# Build pipe-safe curl failure detail for ok|duration|detail heartbeats (no secrets).
+probe_curl_fail_detail() {
+    local prefix="$1"
+    local err_file="$2"
+    local line
+    line="$(tr '\n|' '  ' <"$err_file" 2>/dev/null | sed -E 's/(PASS|password)[^ ]*/\1 <redacted>/gi' | sed -E 's/[[:space:]]+/ /g' | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//' | cut -c1-160)"
+    if [ -z "$line" ]; then
+        echo "${prefix} upload failed"
+        return
+    fi
+    echo "${prefix} upload failed: ${line}"
+}
+
+# Drop a prior probe artifact so SFTP/FTPS overwrite cannot fail on foreign uid ownership.
+clear_local_probe_upload_file() {
+    local path="$1"
+    rm -f "$path" 2>/dev/null || true
+}
+
+# Resolve on-disk probe upload path for ftps|sftp when username is alphanumeric.
+probe_local_upload_path() {
+    local protocol="$1"
+    local user="$2"
+    local file_name="$3"
+    if ! [[ "$user" =~ ^[A-Za-z0-9]+$ ]]; then
+        return 1
+    fi
+    case "$protocol" in
+        ftps)
+            echo "/var/www/html/cache/ftp/_probe/${user}/${file_name}"
+            return 0
+            ;;
+        sftp)
+            echo "/var/sftp/${user}/files/${file_name}"
+            return 0
+            ;;
+    esac
+    return 1
+}

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -128,7 +128,7 @@ run_ftp_probe() {
     mkdir -p "$PROBE_TMP_DIR"
     curl_err="$(mktemp "${PROBE_TMP_DIR}/curl-err.XXXXXX")"
     # ftp:// with --ftp-ssl-reqd uses explicit TLS (AUTH); vsftpd does not use implicit FTPS.
-    base_url="ftp://${host}:${port}/"
+    base_url="ftp://$(probe_url_host "$host"):${port}/"
     if vsftpd_ssl_enabled; then
         use_tls="true"
         fail_prefix="ftps"
@@ -184,7 +184,7 @@ run_sftp_probe() {
     local_file="${PROBE_TMP_DIR}/${file_name}"
     mkdir -p "$PROBE_TMP_DIR"
     curl_err="$(mktemp "${PROBE_TMP_DIR}/curl-err.XXXXXX")"
-    base_url="sftp://${host}:${port}/"
+    base_url="sftp://$(probe_url_host "$host"):${port}/"
     if local_upload_path="$(probe_local_upload_path sftp "$user" "$file_name")"; then
         clear_local_probe_upload_file "$local_upload_path"
     fi

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -120,34 +120,41 @@ vsftpd_ssl_enabled() {
 # FTP upload probe: plain FTP when ssl_enable=NO, explicit TLS (FTPS) when enabled.
 run_ftp_probe() {
     local host="$1" port="$2" user="$3" pass="$4"
-    local file_name base_url local_file start_sec end_sec elapsed use_tls ok_detail
+    local file_name base_url local_file start_sec end_sec elapsed use_tls ok_detail fail_prefix
     local -a curl_tls_args=()
+    local curl_err local_upload_path
     file_name="$PROBE_REMOTE_FILENAME"
     local_file="${PROBE_TMP_DIR}/${file_name}"
+    mkdir -p "$PROBE_TMP_DIR"
+    curl_err="$(mktemp "${PROBE_TMP_DIR}/curl-err.XXXXXX")"
     # ftp:// with --ftp-ssl-reqd uses explicit TLS (AUTH); vsftpd does not use implicit FTPS.
     base_url="ftp://${host}:${port}/"
     if vsftpd_ssl_enabled; then
         use_tls="true"
+        fail_prefix="ftps"
         curl_tls_args=(--ftp-ssl-reqd)
+        if probe_host_skips_tls_verify "$host"; then
+            curl_tls_args+=(--insecure)
+        fi
         ok_detail="ok"
     else
         use_tls="false"
+        fail_prefix="ftp"
         ok_detail="ok (plain ftp, ssl_enable=NO)"
     fi
-    mkdir -p "$PROBE_TMP_DIR"
+    if local_upload_path="$(probe_local_upload_path ftps "$user" "$file_name")"; then
+        clear_local_probe_upload_file "$local_upload_path"
+    fi
     printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"$local_file"
     probe_setup_netrc "$host" "$user" "$pass"
     trap probe_netrc_cleanup RETURN
     start_sec="$(date +%s 2>/dev/null || echo 0)"
     if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc "${curl_tls_args[@]}" --ftp-pasv \
         --connect-timeout 10 --max-time 45 \
-        --upload-file "$local_file" "${base_url}${file_name}" >/dev/null 2>&1; then
+        --upload-file "$local_file" "${base_url}${file_name}" >/dev/null 2>"$curl_err"; then
         rm -f "$local_file"
-        if [ "$use_tls" = "true" ]; then
-            echo "false|0|ftps upload failed"
-        else
-            echo "false|0|ftp upload failed"
-        fi
+        echo "false|0|$(probe_curl_fail_detail "$fail_prefix" "$curl_err")"
+        rm -f "$curl_err"
         return 1
     fi
     if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc "${curl_tls_args[@]}" --ftp-pasv \
@@ -159,7 +166,7 @@ run_ftp_probe() {
             log_probe "WARN" "FTP upload ok but delete failed for ${file_name}"
         fi
     fi
-    rm -f "$local_file"
+    rm -f "$local_file" "$curl_err"
     end_sec="$(date +%s 2>/dev/null || echo 0)"
     elapsed=$((end_sec - start_sec))
     if [ "$elapsed" -lt 0 ]; then
@@ -171,11 +178,16 @@ run_ftp_probe() {
 run_sftp_probe() {
     local host="$1" port="$2" user="$3" pass="$4"
     local file_name remote_path base_url local_file start_sec end_sec elapsed
+    local curl_err local_upload_path
     file_name="$PROBE_REMOTE_FILENAME"
     remote_path="files/${file_name}"
     local_file="${PROBE_TMP_DIR}/${file_name}"
-    base_url="sftp://${host}:${port}/"
     mkdir -p "$PROBE_TMP_DIR"
+    curl_err="$(mktemp "${PROBE_TMP_DIR}/curl-err.XXXXXX")"
+    base_url="sftp://${host}:${port}/"
+    if local_upload_path="$(probe_local_upload_path sftp "$user" "$file_name")"; then
+        clear_local_probe_upload_file "$local_upload_path"
+    fi
     printf 'aviationwx upload probe %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"$local_file"
     ensure_sftp_known_hosts "$host" "$port"
     probe_setup_netrc "$host" "$user" "$pass"
@@ -183,13 +195,14 @@ run_sftp_probe() {
     start_sec="$(date +%s 2>/dev/null || echo 0)"
     if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc \
         --connect-timeout 10 --max-time 45 \
-        --upload-file "$local_file" "${base_url}${remote_path}" >/dev/null 2>&1; then
+        --upload-file "$local_file" "${base_url}${remote_path}" >/dev/null 2>"$curl_err"; then
         rm -f "$local_file"
-        echo "false|0|sftp upload failed"
+        echo "false|0|$(probe_curl_fail_detail "sftp" "$curl_err")"
+        rm -f "$curl_err"
         return 1
     fi
     # SFTP: curl -X DELE is FTP-only; stable PROBE_REMOTE_FILENAME is overwritten each run.
-    rm -f "$local_file"
+    rm -f "$local_file" "$curl_err"
     end_sec="$(date +%s 2>/dev/null || echo 0)"
     elapsed=$((end_sec - start_sec))
     if [ "$elapsed" -lt 0 ]; then

--- a/tests/Unit/UploadHealthProbeHelpersTest.php
+++ b/tests/Unit/UploadHealthProbeHelpersTest.php
@@ -112,6 +112,40 @@ class UploadHealthProbeHelpersTest extends TestCase
         $this->assertSame('', trim(implode("\n", $output)));
     }
 
+    public function testProbeLocalUploadPath_UnsafeFilename_FailsClosed(): void
+    {
+        $cmd = sprintf(
+            'bash -c %s',
+            escapeshellarg(
+                '. ' . $this->commonScript
+                . ' && probe_local_upload_path sftp awxprobesftp "../passwd"'
+            )
+        );
+        exec($cmd, $output, $code);
+        $this->assertSame(1, $code);
+        $this->assertSame('', trim(implode("\n", $output)));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function urlHostProvider(): array
+    {
+        return [
+            'ipv4' => ['127.0.0.1', '127.0.0.1'],
+            'hostname' => ['upload.example.com', 'upload.example.com'],
+            'ipv6 loopback' => ['::1', '[::1]'],
+            'already bracketed' => ['[::1]', '[::1]'],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('urlHostProvider')]
+    public function testProbeUrlHost_FormatsHostForCurlUrls(string $host, string $expected): void
+    {
+        $result = $this->runHelperCapture('probe_url_host ' . escapeshellarg($host));
+        $this->assertSame($expected, $result);
+    }
+
     public function testClearLocalProbeUploadFile_RemovesExistingFile(): void
     {
         $dir = sys_get_temp_dir() . '/probe-clear-' . uniqid('', true);

--- a/tests/Unit/UploadHealthProbeHelpersTest.php
+++ b/tests/Unit/UploadHealthProbeHelpersTest.php
@@ -28,6 +28,7 @@ class UploadHealthProbeHelpersTest extends TestCase
             'localhost' => ['localhost', 0],
             'loopback ipv6' => ['::1', 0],
             'bare ipv4' => ['10.0.0.5', 0],
+            'bare ipv6' => ['2001:db8::1', 0],
             'public hostname' => ['upload.aviationwx.org', 1],
             'empty' => ['', 1],
         ];

--- a/tests/Unit/UploadHealthProbeHelpersTest.php
+++ b/tests/Unit/UploadHealthProbeHelpersTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Behavioral tests for upload probe helpers in upload-daemon-common.sh.
+ */
+class UploadHealthProbeHelpersTest extends TestCase
+{
+    private string $commonScript;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->commonScript = dirname(__DIR__, 2) . '/scripts/upload-daemon-common.sh';
+        $this->assertFileExists($this->commonScript);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: int}>
+     */
+    public static function tlsVerifyHostProvider(): array
+    {
+        return [
+            'loopback ipv4' => ['127.0.0.1', 0],
+            'localhost' => ['localhost', 0],
+            'loopback ipv6' => ['::1', 0],
+            'bare ipv4' => ['10.0.0.5', 0],
+            'public hostname' => ['upload.aviationwx.org', 1],
+            'empty' => ['', 1],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('tlsVerifyHostProvider')]
+    public function testProbeHostSkipsTlsVerify_HostCases_MatchExitCode(string $host, int $expectedExitCode): void
+    {
+        $cmd = sprintf(
+            'bash -c %s',
+            escapeshellarg('. ' . $this->commonScript . ' && probe_host_skips_tls_verify ' . escapeshellarg($host))
+        );
+        exec($cmd, $output, $code);
+        $this->assertSame($expectedExitCode, $code, implode("\n", $output));
+    }
+
+    public function testProbeCurlFailDetail_EmptyFile_ReturnsGenericPrefix(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'probe-err-');
+        $this->assertNotFalse($tmp);
+        file_put_contents($tmp, '');
+
+        $detail = $this->runHelperCapture(
+            'probe_curl_fail_detail ftps ' . escapeshellarg($tmp)
+        );
+        @unlink($tmp);
+
+        $this->assertSame('ftps upload failed', $detail);
+    }
+
+    public function testProbeCurlFailDetail_StripsPipesPasswordsAndNewlines(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'probe-err-');
+        $this->assertNotFalse($tmp);
+        file_put_contents(
+            $tmp,
+            "curl: (60) SSL mismatch\npassword=secretvalue|extra\nPASS ignored\n"
+        );
+
+        $detail = $this->runHelperCapture(
+            'probe_curl_fail_detail sftp ' . escapeshellarg($tmp)
+        );
+        @unlink($tmp);
+
+        $this->assertStringStartsWith('sftp upload failed: ', $detail);
+        $this->assertStringNotContainsString('|', $detail);
+        $this->assertStringNotContainsString('secretvalue', $detail);
+        $this->assertStringContainsString('password <redacted>', $detail);
+        $this->assertStringContainsString('SSL mismatch', $detail);
+    }
+
+    public function testProbeLocalUploadPath_AlphanumericUser_ReturnsExpectedPaths(): void
+    {
+        $ftps = $this->runHelperCapture(
+            'probe_local_upload_path ftps awxprobeftps aviationwx-probe-healthcheck.txt'
+        );
+        $sftp = $this->runHelperCapture(
+            'probe_local_upload_path sftp awxprobesftp aviationwx-probe-healthcheck.txt'
+        );
+
+        $this->assertSame(
+            '/var/www/html/cache/ftp/_probe/awxprobeftps/aviationwx-probe-healthcheck.txt',
+            $ftps
+        );
+        $this->assertSame(
+            '/var/sftp/awxprobesftp/files/aviationwx-probe-healthcheck.txt',
+            $sftp
+        );
+    }
+
+    public function testProbeLocalUploadPath_UnsafeUsername_FailsClosed(): void
+    {
+        $cmd = sprintf(
+            'bash -c %s',
+            escapeshellarg(
+                '. ' . $this->commonScript
+                . ' && probe_local_upload_path sftp "../etc" evil.txt'
+            )
+        );
+        exec($cmd, $output, $code);
+        $this->assertSame(1, $code);
+        $this->assertSame('', trim(implode("\n", $output)));
+    }
+
+    public function testClearLocalProbeUploadFile_RemovesExistingFile(): void
+    {
+        $dir = sys_get_temp_dir() . '/probe-clear-' . uniqid('', true);
+        $this->assertTrue(mkdir($dir, 0700, true));
+        $path = $dir . '/aviationwx-probe-healthcheck.txt';
+        file_put_contents($path, 'stale');
+
+        $this->runHelperCapture('clear_local_probe_upload_file ' . escapeshellarg($path));
+
+        $this->assertFileDoesNotExist($path);
+        @rmdir($dir);
+    }
+
+    private function runHelperCapture(string $helperInvocation): string
+    {
+        $cmd = sprintf(
+            'bash -c %s',
+            escapeshellarg('. ' . $this->commonScript . ' && ' . $helperInvocation)
+        );
+        exec($cmd, $output, $code);
+        $this->assertSame(0, $code, implode("\n", $output));
+
+        return trim(implode("\n", $output));
+    }
+}

--- a/tests/Unit/UploadHealthProbeSyncTest.php
+++ b/tests/Unit/UploadHealthProbeSyncTest.php
@@ -159,7 +159,7 @@ class UploadHealthProbeSyncTest extends TestCase
         $path = __DIR__ . '/../../scripts/upload-probe.sh';
         $contents = file_get_contents($path);
         $this->assertIsString($contents);
-        $this->assertStringContainsString('base_url="ftp://${host}:${port}/"', $contents);
+        $this->assertStringContainsString('base_url="ftp://$(probe_url_host "$host"):${port}/"', $contents);
         $this->assertStringNotContainsString('base_url="ftps://${host}:${port}/"', $contents);
     }
 

--- a/tests/Unit/UploadHealthProbeSyncTest.php
+++ b/tests/Unit/UploadHealthProbeSyncTest.php
@@ -173,6 +173,19 @@ class UploadHealthProbeSyncTest extends TestCase
         $this->assertStringContainsString('ok (plain ftp, ssl_enable=NO)', $contents);
     }
 
+    public function testUploadProbeScript_UsesInsecureTlsForSkippedHostsAndClearsLocalArtifacts(): void
+    {
+        $path = __DIR__ . '/../../scripts/upload-probe.sh';
+        $contents = file_get_contents($path);
+        $this->assertIsString($contents);
+        $this->assertStringContainsString('probe_host_skips_tls_verify', $contents);
+        $this->assertStringContainsString('curl_tls_args+=(--insecure)', $contents);
+        $this->assertStringContainsString('probe_local_upload_path ftps', $contents);
+        $this->assertStringContainsString('probe_local_upload_path sftp', $contents);
+        $this->assertStringContainsString('clear_local_probe_upload_file', $contents);
+        $this->assertStringContainsString('probe_curl_fail_detail', $contents);
+    }
+
     public function testUploadProbeRunner_WaitsForPushConfigSyncBeforeFirstProbe(): void
     {
         $path = __DIR__ . '/../../scripts/upload-probe-runner.sh';


### PR DESCRIPTION
## Summary
- FTPS probes to loopback/IP (`probe_connect_host=127.0.0.1`) were failing TLS hostname verification against the public vsftpd cert SAN, while real camera uploads stayed healthy.
- SFTP probes could wedge on a leftover `aviationwx-probe-healthcheck.txt` owned by another uid (`Permission denied`); clear the on-disk probe artifact before each upload.
- Surface sanitized curl failure detail in probe heartbeat/logs, with behavioral unit tests for the shared helpers.

## Test plan
- [x] `make test-ci`
- [x] `make test-unit PHPUNIT_ARGS='--filter UploadHealthProbe'` (39 tests)
- [x] After deploy: `upload-probe.json` shows `ftps.ok=true` and `sftp.ok=true` against `127.0.0.1`
- [x] Confirm watchdog stop restarting vsftpd/sshd for probe streaks
- [x] Spot-check a push camera still uploading normally