### PR TITLE
Stop FTPS probe WARN spam from curl false-fail on DELE

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -361,7 +361,7 @@ Credential shape matches push cameras: `username` is alphanumeric, max 14 charac
 
 **Production Docker:** The web container uses host networking. Set `probe_connect_host` to `127.0.0.1` so functional probes connect to local listeners on `network_ports.ftp_control` and `network_ports.sftp`. Cameras still use `upload_hostname` as usual.
 
-FTPS probes to loopback or bare IP addresses skip TLS certificate hostname verification (`curl --insecure`) because the vsftpd certificate SAN matches the public hostname, not `127.0.0.1`. Before each upload, probes remove any prior on-disk `aviationwx-probe-healthcheck.txt` under the probe account directory so a leftover file owned by another uid cannot wedge the check.
+FTPS probes to loopback or bare IP addresses skip TLS certificate hostname verification (`curl --insecure`) because the vsftpd certificate SAN matches the public hostname, not `127.0.0.1`. Before each upload, probes remove any prior on-disk `aviationwx-probe-healthcheck.txt` under the probe account directory so a leftover file owned by another uid cannot wedge the check. Health does not depend on a remote FTP delete after upload; FTPS and SFTP both use that local clear plus overwrite of the fixed probe filename.
 
 **Recommended: Hostname (default)**
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -569,7 +569,7 @@ ssh-keyscan -p "${SFTP_PORT}" "${UPLOAD_HOST}" | ssh-keygen -lf -
 
 Every `SHA256:` from `ssh-keyscan` must appear in the JSON `sha256[]` array. Fingerprints are computed at request time from `/etc/ssh/ssh_host_*_key.pub` in the web container (same container that runs sshd). After an image rebuild, re-run the comparison to confirm the roster tracks new keys.
 
-**Probe files:** Each run clears any prior on-disk `aviationwx-probe-healthcheck.txt` under the probe FTPS/SFTP upload directories, then uploads a fresh copy (no per-run timestamp filenames). Clearing first avoids permission-denied overwrites when a leftover file is owned by another uid.
+**Probe files:** Each run clears any prior on-disk `aviationwx-probe-healthcheck.txt` under the probe FTPS/SFTP upload directories, then uploads a fresh copy (no per-run timestamp filenames). Clearing first avoids permission-denied overwrites when a leftover file is owned by another uid. Probes do not require a remote FTP `DELE` for health: vsftpd may accept delete while `curl --fail -X DELE` still exits non-zero on a directory URL, so cleanup is local clear plus overwrite (same for FTPS and SFTP).
 
 ```bash
 # Heartbeat and recent probe log

--- a/scripts/upload-probe.sh
+++ b/scripts/upload-probe.sh
@@ -120,7 +120,7 @@ vsftpd_ssl_enabled() {
 # FTP upload probe: plain FTP when ssl_enable=NO, explicit TLS (FTPS) when enabled.
 run_ftp_probe() {
     local host="$1" port="$2" user="$3" pass="$4"
-    local file_name base_url local_file start_sec end_sec elapsed use_tls ok_detail fail_prefix
+    local file_name base_url local_file start_sec end_sec elapsed ok_detail fail_prefix
     local -a curl_tls_args=()
     local curl_err local_upload_path
     file_name="$PROBE_REMOTE_FILENAME"
@@ -130,7 +130,6 @@ run_ftp_probe() {
     # ftp:// with --ftp-ssl-reqd uses explicit TLS (AUTH); vsftpd does not use implicit FTPS.
     base_url="ftp://$(probe_url_host "$host"):${port}/"
     if vsftpd_ssl_enabled; then
-        use_tls="true"
         fail_prefix="ftps"
         curl_tls_args=(--ftp-ssl-reqd)
         if probe_host_skips_tls_verify "$host"; then
@@ -138,7 +137,6 @@ run_ftp_probe() {
         fi
         ok_detail="ok"
     else
-        use_tls="false"
         fail_prefix="ftp"
         ok_detail="ok (plain ftp, ssl_enable=NO)"
     fi
@@ -157,15 +155,8 @@ run_ftp_probe() {
         rm -f "$curl_err"
         return 1
     fi
-    if ! curl -sS --netrc-file "$PROBE_NETRC_FILE" --netrc "${curl_tls_args[@]}" --ftp-pasv \
-        --connect-timeout 10 --max-time 30 \
-        --fail -X "DELE ${file_name}" "$base_url" >/dev/null 2>&1; then
-        if [ "$use_tls" = "true" ]; then
-            log_probe "WARN" "FTPS upload ok but delete failed for ${file_name}"
-        else
-            log_probe "WARN" "FTP upload ok but delete failed for ${file_name}"
-        fi
-    fi
+    # No remote DELE: curl --fail -X DELE on a directory URL can exit non-zero after
+    # vsftpd already returns 250. Health uses local clear + overwrite (same as SFTP).
     rm -f "$local_file" "$curl_err"
     end_sec="$(date +%s 2>/dev/null || echo 0)"
     elapsed=$((end_sec - start_sec))
@@ -201,7 +192,7 @@ run_sftp_probe() {
         rm -f "$curl_err"
         return 1
     fi
-    # SFTP: curl -X DELE is FTP-only; stable PROBE_REMOTE_FILENAME is overwritten each run.
+    # No remote delete: local clear before upload + overwrite of PROBE_REMOTE_FILENAME.
     rm -f "$local_file" "$curl_err"
     end_sec="$(date +%s 2>/dev/null || echo 0)"
     elapsed=$((end_sec - start_sec))

--- a/tests/Unit/UploadHealthProbeSyncTest.php
+++ b/tests/Unit/UploadHealthProbeSyncTest.php
@@ -184,6 +184,10 @@ class UploadHealthProbeSyncTest extends TestCase
         $this->assertStringContainsString('probe_local_upload_path sftp', $contents);
         $this->assertStringContainsString('clear_local_probe_upload_file', $contents);
         $this->assertStringContainsString('probe_curl_fail_detail', $contents);
+        // Remote DELE after FTPS upload is intentionally omitted: curl --fail -X DELE can
+        // exit non-zero after vsftpd already returns 250 on a directory URL.
+        $this->assertStringNotContainsString('-X "DELE', $contents);
+        $this->assertStringNotContainsString('upload ok but delete failed', $contents);
     }
 
     public function testUploadProbeRunner_WaitsForPushConfigSyncBeforeFirstProbe(): void


### PR DESCRIPTION
## Summary
- Production FTPS upload health probes were logging `upload ok but delete failed` every ~30s even though vsftpd returned `250 Delete operation successful`.
- Root cause: `curl --fail -X DELE` against a directory URL exits non-zero (`curl: (19) RETR response: 250`) after a successful delete - a client false fail, not a server permission problem.
- Drop remote FTPS `DELE` and rely on the existing local clear + overwrite path (same model as SFTP). Probe `ok` was already based on upload success only.

## Changes
- `scripts/upload-probe.sh` - remove post-upload FTPS/FTP `DELE`; keep pre-upload `clear_local_probe_upload_file`
- Docs: `CONFIGURATION.md`, `OPERATIONS.md` - document local clear + overwrite for both protocols
- Regression test in `UploadHealthProbeSyncTest` asserts the probe script no longer uses `-X "DELE"`

## Test plan
- [x] `make test-ci`
- [x] `make test-unit PHPUNIT_ARGS='--filter UploadHealthProbe'`
- [x] Local Docker: reproduced curl DELE exit 19 after vsftpd 250; upload-only path exit 0
- [x] After deploy: `upload-probe.log` has FTPS/SFTP `ok=true` with no delete WARN lines