### PR TITLE
Run deploy drain via web container (no host PHP)

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -1626,9 +1626,9 @@ jobs:
           fi
 
           clear_deploy_drain_markers() {
-            if [ -f scripts/deploy-drain.php ] && command -v php >/dev/null 2>&1; then
-              php scripts/deploy-drain.php clear --cache-dir="${AVIATIONWX_CACHE_DIR:-/tmp/aviationwx-cache}" >/dev/null 2>&1 || true
-            fi
+            # Shared host mount; no host PHP. Entrypoint also clears on successful recreate.
+            CACHE_DIR="${AVIATIONWX_CACHE_DIR:-/tmp/aviationwx-cache}"
+            rm -f "${CACHE_DIR}/deploy-drain.flag" "${CACHE_DIR}/deploy-drain.done" 2>/dev/null || true
           }
           
           # Drain in-flight workers immediately before recreate; Apache stays up. Soft-fail only.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,7 +75,7 @@ aviationwx.org/
 │   ├── scheduler-health-check.php # Cron watchdog: recover if daemon missing or unhealthy (not initial start)
 │   ├── diagnose-scheduler-duplicates.php # Read-only CLI: list scheduler PIDs and lock summary
 │   ├── deploy-drain.php      # CLI: request/wait/status/clear deploy drain markers on cache volume
-│   ├── deploy-drain-workers.sh # Host CD helper: request drain and wait before container recreate
+│   ├── deploy-drain-workers.sh # Host CD wrapper: runs drain CLI inside the live web container before recreate
 │   ├── unified-webcam-worker.php # Unified webcam worker (handles both pull and push cameras)
 │   ├── fetch-weather.php     # Weather fetcher (worker mode for scheduler)
 │   ├── fetch-notam.php       # NOTAM fetcher (worker mode for scheduler)
@@ -170,7 +170,7 @@ Part of the **Internal API** (see [API.md](API.md)): JSON for the web dashboard;
 - New gated work is added by registering a pool and/or tick; ungated paths stay outside the registry (stuck-worker heartbeat cleanup remains in-process control-plane work)
 
 **Deploy worker drain (`lib/deploy-drain.php`)**: Pause new registered work before container recreate
-- CD writes `cache/deploy-drain.flag` on the shared cache volume (host CLI: `scripts/deploy-drain.php` / `scripts/deploy-drain-workers.sh`) while Apache continues serving clients
+- CD writes `cache/deploy-drain.flag` on the shared cache volume (via `scripts/deploy-drain-workers.sh` running `deploy-drain.php` inside the live web container; host has no PHP) while Apache continues serving clients
 - The scheduler stops running registered enqueue ticks; in-flight ProcessPool workers may finish
 - When pools are idle, the scheduler writes `cache/deploy-drain.done` so CD can proceed
 - After `DEPLOY_WORKER_DRAIN_MAX_SECONDS`, remaining registered pool workers are force-terminated (`ProcessPool::cleanup`: SIGTERM, brief wait, then SIGKILL) and `.done` is written

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -517,7 +517,7 @@ git push origin main
 
 See `.github/workflows/deploy-docker.yml` for workflow details.
 
-Before recreating the `web` container, CD runs `scripts/deploy-drain-workers.sh` so the scheduler pauses registered work and drains ProcessPool workers while Apache continues serving. Behavior is documented under [Scheduler System](ARCHITECTURE.md#scheduler-system).
+Before recreating the `web` container, CD runs `scripts/deploy-drain-workers.sh`, which executes `deploy-drain.php` inside the live web container (host has no PHP) so the scheduler pauses registered work and drains ProcessPool workers while Apache continues serving. Behavior is documented under [Scheduler System](ARCHITECTURE.md#scheduler-system).
 
 ### Nginx and `embed.aviationwx.org` (CD)
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -132,8 +132,11 @@ docker compose -f docker/docker-compose.prod.yml exec web ps aux | grep schedule
 # Check lock file (shows PID and start time)
 docker compose -f docker/docker-compose.prod.yml exec web cat /tmp/scheduler.lock | jq
 
-# Inspect deploy drain markers (host cache mount)
-php scripts/deploy-drain.php status --cache-dir=/tmp/aviationwx-cache
+# Inspect deploy drain markers (via web container PHP; host has no PHP)
+docker compose -f docker/docker-compose.prod.yml exec -T web php scripts/deploy-drain.php status
+
+# Or inspect files on the shared host cache mount
+ls -la /tmp/aviationwx-cache/deploy-drain.* 2>/dev/null || echo 'no drain markers'
 
 # Force restart scheduler (watchdog may restart within about 60s when drain is not active)
 docker compose -f docker/docker-compose.prod.yml exec web pkill -f scheduler.php

--- a/scripts/deploy-drain-workers.sh
+++ b/scripts/deploy-drain-workers.sh
@@ -1,52 +1,54 @@
 #!/usr/bin/env bash
-# Pause new scheduler ProcessPool work and wait before container recreate.
-# Apache stays serving. Markers: AVIATIONWX_CACHE_DIR (default /tmp/aviationwx-cache).
+# Host CD wrapper: pause ProcessPool work before container recreate.
+# Runs deploy-drain.php inside the live web container (host has no PHP).
+# Apache stays serving. Markers live on the shared cache volume.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
 
-CACHE_DIR="${AVIATIONWX_CACHE_DIR:-/tmp/aviationwx-cache}"
 COMPOSE_FILE="${COMPOSE_FILE:-docker/docker-compose.prod.yml}"
-PHP_BIN="${PHP_BIN:-php}"
-DRAIN_CLI="${ROOT_DIR}/scripts/deploy-drain.php"
-CONSTANTS_PHP="${ROOT_DIR}/lib/constants.php"
+COMPOSE=(docker compose -f "$COMPOSE_FILE")
+WEB_SERVICE="${WEB_SERVICE:-web}"
+# Container path for the shared cache mount (host: AVIATIONWX_CACHE_DIR / /tmp/aviationwx-cache).
+CONTAINER_CACHE_DIR="${CONTAINER_CACHE_DIR:-/var/www/html/cache}"
 
-if [ ! -f "$DRAIN_CLI" ]; then
+if [ ! -f "${ROOT_DIR}/scripts/deploy-drain.php" ]; then
   echo "⚠️  deploy-drain.php missing - skipping worker drain"
   exit 0
 fi
 
-if ! command -v "$PHP_BIN" >/dev/null 2>&1; then
-  echo "⚠️  php not available on host - skipping worker drain"
+if ! command -v docker >/dev/null 2>&1; then
+  echo "⚠️  docker not available - skipping worker drain"
   exit 0
 fi
 
-if [ ! -d "$CACHE_DIR" ]; then
-  echo "⚠️  Cache dir missing (${CACHE_DIR}) - skipping worker drain"
-  exit 0
-fi
-
-if ! docker compose -f "$COMPOSE_FILE" ps web 2>/dev/null | grep -q "Up"; then
+if ! "${COMPOSE[@]}" ps "$WEB_SERVICE" 2>/dev/null | grep -q "Up"; then
   echo "✓ Web container not running - skip worker drain"
   exit 0
 fi
 
-MAX_WAIT="$("$PHP_BIN" -r "require '${CONSTANTS_PHP}'; echo (int) DEPLOY_WORKER_DRAIN_MAX_SECONDS;")"
+run_in_web() {
+  "${COMPOSE[@]}" exec -T "$WEB_SERVICE" "$@"
+}
+
+MAX_WAIT="$(
+  run_in_web php -r 'require "/var/www/html/lib/constants.php"; echo (int) DEPLOY_WORKER_DRAIN_MAX_SECONDS;'
+)"
 if ! [[ "${MAX_WAIT}" =~ ^[0-9]+$ ]] || [ "${MAX_WAIT}" -lt 1 ]; then
-  echo "⚠️  Could not read DEPLOY_WORKER_DRAIN_MAX_SECONDS - skipping worker drain"
+  echo "⚠️  Could not read DEPLOY_WORKER_DRAIN_MAX_SECONDS from container - skipping worker drain"
   exit 0
 fi
 
-echo "Requesting scheduler deploy drain (Apache stays up)..."
-if ! "$PHP_BIN" "$DRAIN_CLI" request --cache-dir="$CACHE_DIR"; then
+echo "Requesting scheduler deploy drain via web container (Apache stays up)..."
+if ! run_in_web php scripts/deploy-drain.php request --cache-dir="$CONTAINER_CACHE_DIR"; then
   echo "⚠️  Failed to write drain flag - continuing deploy"
   exit 0
 fi
 
 echo "Waiting for in-flight ProcessPool workers (max ${MAX_WAIT}s + grace)..."
 set +e
-"$PHP_BIN" "$DRAIN_CLI" wait --cache-dir="$CACHE_DIR" --max-wait="${MAX_WAIT}"
+run_in_web php scripts/deploy-drain.php wait --cache-dir="$CONTAINER_CACHE_DIR" --max-wait="${MAX_WAIT}"
 WAIT_RC=$?
 set -e
 

--- a/scripts/deploy-drain-workers.sh
+++ b/scripts/deploy-drain-workers.sh
@@ -7,8 +7,13 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
 
+# Space-separated compose files (prod default; local may add docker-compose.override.yml).
 COMPOSE_FILE="${COMPOSE_FILE:-docker/docker-compose.prod.yml}"
-COMPOSE=(docker compose -f "$COMPOSE_FILE")
+COMPOSE=(docker compose)
+# shellcheck disable=SC2086
+for _compose_file in ${COMPOSE_FILE}; do
+  COMPOSE+=(-f "${_compose_file}")
+done
 WEB_SERVICE="${WEB_SERVICE:-web}"
 # Container path for the shared cache mount (host: AVIATIONWX_CACHE_DIR / /tmp/aviationwx-cache).
 CONTAINER_CACHE_DIR="${CONTAINER_CACHE_DIR:-/var/www/html/cache}"

--- a/tests/Unit/DeployDrainTest.php
+++ b/tests/Unit/DeployDrainTest.php
@@ -705,14 +705,17 @@ final class DeployDrainTest extends TestCase
         $this->assertStringContainsString('deploy-drain-workers.sh', $workflow);
     }
 
-    public function testHostDrainHelper_ReadsPhpMaxConstant(): void
+    public function testHostDrainHelper_RunsPhpInsideWebContainer(): void
     {
         $path = dirname(__DIR__, 2) . '/scripts/deploy-drain-workers.sh';
         $this->assertFileExists($path);
-        $contents = file_get_contents($path);
-        $this->assertIsString($contents);
+        $contents = (string) file_get_contents($path);
+        $this->assertStringContainsString('docker compose', $contents);
+        $this->assertStringContainsString('exec -T', $contents);
+        $this->assertStringContainsString('WEB_SERVICE', $contents);
+        $this->assertStringContainsString('deploy-drain.php', $contents);
         $this->assertStringContainsString('DEPLOY_WORKER_DRAIN_MAX_SECONDS', $contents);
-        $this->assertStringContainsString('lib/constants.php', $contents);
+        $this->assertStringNotContainsString('php not available on host', $contents);
         $this->assertStringContainsString('exit 0', $contents);
     }
 }

--- a/tests/Unit/SchedulerDrainWiringContractTest.php
+++ b/tests/Unit/SchedulerDrainWiringContractTest.php
@@ -90,7 +90,13 @@ final class SchedulerDrainWiringContractTest extends TestCase
             'Drain in-flight workers immediately before recreate',
             $workflow
         );
-        $this->assertStringContainsString('deploy-drain.php clear', $workflow);
+        // Clear markers on the shared host cache mount (no host PHP).
+        $clearPos = strpos($workflow, 'clear_deploy_drain_markers()');
+        $this->assertNotFalse($clearPos);
+        $clearChunk = substr($workflow, $clearPos, 400);
+        $this->assertStringContainsString('rm -f', $clearChunk);
+        $this->assertStringContainsString('deploy-drain.flag', $clearChunk);
+        $this->assertStringNotContainsString('command -v php', $clearChunk);
         $this->assertStringContainsString(
             'Deploy drain markers still present after compose',
             $workflow


### PR DESCRIPTION
## Summary
- `deploy-drain-workers.sh` now runs `deploy-drain.php` with `docker compose exec` inside the live web container; host PHP is not required.
- CD failure/no-op marker cleanup uses `rm -f` on the shared cache mount instead of host PHP.
- Docs and wiring tests updated to match.

Fixes the production skip: `php not available on host - skipping worker drain`.

## Test plan
- [x] Unit tests: `DeployDrainTest` / `SchedulerDrainWiringContractTest`
- [x] Local Docker: `COMPOSE_FILE="docker/docker-compose.yml docker/docker-compose.override.yml" ./scripts/deploy-drain-workers.sh` requests drain via container PHP, waits to idle, completes (no host-PHP skip)
- [x] Local Docker: `docker compose exec -T web php scripts/deploy-drain.php status` shows requested/complete; clear restores idle markers; home stays HTTP 200 during drain
- [ ] After merge/deploy on prod: `sudo ./scripts/deploy-drain-workers.sh` should request drain (not skip for missing host PHP); clear markers afterward
