### PR TITLE
Persist deploy GIT_SHA for CLI/cron getGitSha() fallback

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -306,9 +306,12 @@ fi
 DEPLOY_GIT_SHA_FILE="${CACHE_DIR}/.deploy-git-sha"
 if [ -d "${CACHE_DIR}" ]; then
     if [ -n "${GIT_SHA:-}" ]; then
-        printf '%s\n' "${GIT_SHA}" > "${DEPLOY_GIT_SHA_FILE}"
-        chmod 644 "${DEPLOY_GIT_SHA_FILE}" 2>/dev/null || true
-        echo "✓ Persisted deploy GIT_SHA to ${DEPLOY_GIT_SHA_FILE}"
+        if printf '%s\n' "${GIT_SHA}" > "${DEPLOY_GIT_SHA_FILE}"; then
+            chmod 644 "${DEPLOY_GIT_SHA_FILE}" 2>/dev/null || true
+            echo "✓ Persisted deploy GIT_SHA to ${DEPLOY_GIT_SHA_FILE}"
+        else
+            echo "⚠️  Failed to persist deploy GIT_SHA to ${DEPLOY_GIT_SHA_FILE}" >&2
+        fi
     else
         rm -f "${DEPLOY_GIT_SHA_FILE}" 2>/dev/null || true
         echo "⚠️  GIT_SHA unset - removed ${DEPLOY_GIT_SHA_FILE} if present"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -301,6 +301,20 @@ if [ -d "${CACHE_DIR}" ]; then
     rm -f "${CACHE_DIR}/deploy-drain.flag" "${CACHE_DIR}/deploy-drain.done" 2>/dev/null || true
 fi
 
+# Persist deploy SHA for CLI/cron: health-check restarts inherit crontab env, not compose GIT_SHA.
+# Refresh every start; remove when unset so a shared cache mount cannot keep a prior container SHA.
+DEPLOY_GIT_SHA_FILE="${CACHE_DIR}/.deploy-git-sha"
+if [ -d "${CACHE_DIR}" ]; then
+    if [ -n "${GIT_SHA:-}" ]; then
+        printf '%s\n' "${GIT_SHA}" > "${DEPLOY_GIT_SHA_FILE}"
+        chmod 644 "${DEPLOY_GIT_SHA_FILE}" 2>/dev/null || true
+        echo "✓ Persisted deploy GIT_SHA to ${DEPLOY_GIT_SHA_FILE}"
+    else
+        rm -f "${DEPLOY_GIT_SHA_FILE}" 2>/dev/null || true
+        echo "⚠️  GIT_SHA unset - removed ${DEPLOY_GIT_SHA_FILE} if present"
+    fi
+fi
+
 # Scheduler: initial start authority is this entrypoint (one daemon after cache is ready).
 # Cron runs scripts/scheduler-health-check.php every minute as a watchdog only (confirm lock/PID,
 # start a replacement when missing or unhealthy). It must not duplicate a healthy daemon.

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -1879,7 +1879,7 @@ The airports network map (`pages/airports.php`, served at `airports.aviationwx.o
 
 **Project** (`notamTfrMapLayerBuildPayloadFromAirspaceStore()` in `lib/notam/map-layer.php`; serve entry `notamTfrMapLayerServeOrRebuild()` in `lib/notam/map-layer-cache.php`):
 
-1. Read `map-airspace.json` when present, fresh (within `getNotamCacheTtlSeconds()`), and `map_layer_build_token` matches (`{deploy SHA}-v{N}` from {@see getGitSha()} and {@see NOTAM_TFR_MAP_LAYER_LOGIC_VERSION}, or `logic-v{N}` when SHA is unavailable). Otherwise fail-closed (empty features, `failclosed: true`).
+1. Read `map-airspace.json` when present, fresh (within `getNotamCacheTtlSeconds()`), and `map_layer_build_token` matches (`{deploy SHA}-v{N}` from {@see getGitSha()} and {@see NOTAM_TFR_MAP_LAYER_LOGIC_VERSION}, or `logic-v{N}` when SHA is unavailable). `getGitSha()` prefers `GIT_SHA`, then the entrypoint-persisted cache file `cache/.deploy-git-sha` (so CLI/cron workers match Apache after health-check restarts), then git metadata. Otherwise fail-closed (empty features, `failclosed: true`).
 2. For each record with `capabilities.map`, revalidate status from the embedded NOTAM (`revalidateNotamStatus()` / `isTfr()` parity with `api/notam.php`), emit a GeoJSON Feature (polygon outer ring or Point + `radius_nm` for circles).
 3. **Geometry deduplication** (`notamTfrMapLayerDeduplicateFeaturesByGeometry()`): features that share the same drawable geometry key collapse to one feature. When keys collide, keep the highest-priority status:
 

--- a/lib/cache-paths.php
+++ b/lib/cache-paths.php
@@ -85,6 +85,11 @@ if (!defined('CACHE_BASE_DIR')) {
     define('CACHE_BASE_DIR', dirname(__DIR__) . '/cache');
 }
 
+/** Deploy GIT_SHA from docker-entrypoint (CLI/cron when env is unset). */
+if (!defined('CACHE_DEPLOY_GIT_SHA_FILE')) {
+    define('CACHE_DEPLOY_GIT_SHA_FILE', CACHE_BASE_DIR . '/.deploy-git-sha');
+}
+
 // =============================================================================
 // WEATHER CACHE PATHS
 // =============================================================================

--- a/lib/config.php
+++ b/lib/config.php
@@ -3159,23 +3159,85 @@ function getSingleAirportId(): ?string {
 }
 
 /**
+ * Normalize a raw Git SHA to the short (7 character) form used in footers and map tokens.
+ *
+ * @param string $raw Raw SHA from env, file, or git output
+ * @return string Seven-character SHA, or empty string if unusable
+ */
+function normalizeGitShaShort(string $raw): string {
+    $sha = trim($raw);
+    if ($sha === '') {
+        return '';
+    }
+
+    $newlinePos = strpos($sha, "\n");
+    if ($newlinePos !== false) {
+        $sha = trim(substr($sha, 0, $newlinePos));
+    }
+
+    if (strlen($sha) >= 7) {
+        return substr($sha, 0, 7);
+    }
+
+    return '';
+}
+
+/**
+ * Path to the deploy SHA file written at container start.
+ *
+ * Override with AVIATIONWX_DEPLOY_GIT_SHA_FILE for tests.
+ *
+ * @return string Absolute path under the cache mount (or test override)
+ */
+function getDeployGitShaFilePath(): string {
+    $override = getenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE');
+    if (is_string($override) && $override !== '') {
+        return $override;
+    }
+
+    require_once __DIR__ . '/cache-paths.php';
+
+    return CACHE_DEPLOY_GIT_SHA_FILE;
+}
+
+/**
+ * Read short deploy SHA from the entrypoint-persisted cache file.
+ *
+ * @return string Seven-character SHA, or empty string if missing/invalid
+ */
+function readDeployGitShaFile(): string {
+    $path = getDeployGitShaFilePath();
+    if (!is_file($path) || !is_readable($path)) {
+        return '';
+    }
+
+    $raw = @file_get_contents($path);
+    if ($raw === false) {
+        return '';
+    }
+
+    return normalizeGitShaShort($raw);
+}
+
+/**
  * Get the current Git commit SHA (short version)
  *
- * Tries multiple methods to get the SHA for display in footers:
- * 1. Environment variable (set during deployment)
- * 2. .git/HEAD file (if in git repository)
- * 3. git command (if available)
+ * Resolution order: GIT_SHA env, cache/.deploy-git-sha (entrypoint), .git/HEAD, git CLI.
+ * The cache file keeps CLI/cron workers aligned with Apache when crontab omits GIT_SHA.
  *
  * @return string Short SHA (7 characters) or empty string if unavailable
  */
 function getGitSha(): string {
-    // Try environment variable first (set during deployment)
-    $sha = getenv('GIT_SHA');
-    if ($sha && strlen($sha) >= 7) {
-        return substr($sha, 0, 7);
+    $fromEnv = normalizeGitShaShort((string) (getenv('GIT_SHA') ?: ''));
+    if ($fromEnv !== '') {
+        return $fromEnv;
     }
-    
-    // Try reading from .git/HEAD (if in a git repository)
+
+    $fromFile = readDeployGitShaFile();
+    if ($fromFile !== '') {
+        return $fromFile;
+    }
+
     $gitHead = __DIR__ . '/.git/HEAD';
     if (file_exists($gitHead)) {
         $headContent = @file_get_contents($gitHead);
@@ -3198,21 +3260,16 @@ function getGitSha(): string {
             }
         }
     }
-    
-    // Try git command as fallback (if git is available)
-    // Use --short=7 to force 7 characters (matching GitHub's short SHA display)
+
+    // Use --short=7 to match GitHub's short SHA display
     if (function_exists('shell_exec')) {
         $sha = @shell_exec('cd ' . escapeshellarg(__DIR__) . ' && git rev-parse --short=7 HEAD 2>/dev/null');
         if ($sha) {
             $sha = trim($sha);
-            // Always return exactly 7 characters to match GitHub's display
             if (strlen($sha) >= 7) {
                 return substr($sha, 0, 7);
             } elseif (strlen($sha) > 0) {
-                // If we got a shorter SHA, pad it or use full SHA
-                // Fall back to full SHA and take first 7 characters
-                // Use @ to suppress errors for non-critical git operations
-                // We handle failures explicitly with null checks below
+                // @ suppresses non-critical git failures; null-checked below
                 $fullSha = @shell_exec('cd ' . escapeshellarg(__DIR__) . ' && git rev-parse HEAD 2>/dev/null');
                 if ($fullSha) {
                     $fullSha = trim($fullSha);
@@ -3223,8 +3280,7 @@ function getGitSha(): string {
             }
         }
     }
-    
-    // Return empty string if SHA cannot be determined
+
     return '';
 }
 

--- a/tests/Unit/GitShaTest.php
+++ b/tests/Unit/GitShaTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/config.php';
+require_once __DIR__ . '/../../lib/notam/map-layer.php';
+
+/**
+ * Deploy SHA resolution for footers and NOTAM map build tokens.
+ */
+class GitShaTest extends TestCase
+{
+    private string $originalGitSha;
+
+    private string|false $originalDeployFileEnv;
+
+    private string $tempFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $gitSha = getenv('GIT_SHA');
+        $this->originalGitSha = $gitSha === false ? '' : $gitSha;
+        $this->originalDeployFileEnv = getenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE');
+        $this->tempFile = sys_get_temp_dir() . '/aviationwx-deploy-git-sha-' . bin2hex(random_bytes(4));
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalGitSha === '') {
+            putenv('GIT_SHA');
+        } else {
+            putenv('GIT_SHA=' . $this->originalGitSha);
+        }
+
+        if ($this->originalDeployFileEnv === false) {
+            putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE');
+        } else {
+            putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE=' . $this->originalDeployFileEnv);
+        }
+
+        if (is_file($this->tempFile)) {
+            @unlink($this->tempFile);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testNormalizeGitShaShort_TrimsAndTruncates(): void
+    {
+        $this->assertSame('9f34715', normalizeGitShaShort("9f3471525bc39e8a\n"));
+        $this->assertSame('abcdef1', normalizeGitShaShort('abcdef12'));
+        $this->assertSame('', normalizeGitShaShort('abc'));
+        $this->assertSame('', normalizeGitShaShort(''));
+        $this->assertSame('', normalizeGitShaShort("   \n"));
+    }
+
+    public function testGetDeployGitShaFilePath_DefaultUnderCache(): void
+    {
+        putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE');
+        $path = getDeployGitShaFilePath();
+        $this->assertStringEndsWith('/cache/.deploy-git-sha', $path);
+        $this->assertSame(CACHE_DEPLOY_GIT_SHA_FILE, $path);
+    }
+
+    public function testGetDeployGitShaFilePath_OverrideEnv(): void
+    {
+        putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE=' . $this->tempFile);
+        $this->assertSame($this->tempFile, getDeployGitShaFilePath());
+    }
+
+    public function testReadDeployGitShaFile_ReturnsShortShaFromFile(): void
+    {
+        putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE=' . $this->tempFile);
+        file_put_contents($this->tempFile, "9f3471525bc39e8a\n");
+
+        $this->assertSame('9f34715', readDeployGitShaFile());
+    }
+
+    public function testReadDeployGitShaFile_MissingOrShort_ReturnsEmpty(): void
+    {
+        putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE=' . $this->tempFile . '-absent');
+        $this->assertSame('', readDeployGitShaFile());
+
+        putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE=' . $this->tempFile);
+        file_put_contents($this->tempFile, "abc\n");
+        $this->assertSame('', readDeployGitShaFile());
+    }
+
+    public function testGetGitSha_PrefersEnvironmentOverFile(): void
+    {
+        putenv('GIT_SHA=eeeeeee1');
+        putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE=' . $this->tempFile);
+        file_put_contents($this->tempFile, "fffffff2\n");
+
+        $this->assertSame('eeeeeee', getGitSha());
+    }
+
+    public function testGetGitSha_ReadsDeployFileWhenEnvMissing(): void
+    {
+        putenv('GIT_SHA');
+        putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE=' . $this->tempFile);
+        file_put_contents($this->tempFile, "9f3471525bc39e8a\n");
+
+        $this->assertSame('9f34715', getGitSha());
+    }
+
+    /**
+     * Cron-restarted workers lack GIT_SHA; map tokens must still match Apache via the file.
+     */
+    public function testNotamMapBuildToken_UsesDeployFileWhenEnvMissing(): void
+    {
+        putenv('GIT_SHA');
+        putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE=' . $this->tempFile);
+        file_put_contents($this->tempFile, "abcdef12\n");
+
+        $this->assertSame(
+            'abcdef1-v' . NOTAM_TFR_MAP_LAYER_LOGIC_VERSION,
+            notamTfrMapLayerCurrentBuildToken()
+        );
+    }
+
+    public function testEntrypoint_PersistsDeployGitShaFile(): void
+    {
+        $entrypoint = file_get_contents(dirname(__DIR__, 2) . '/docker/docker-entrypoint.sh');
+        $this->assertIsString($entrypoint);
+        $this->assertStringContainsString('.deploy-git-sha', $entrypoint);
+        $this->assertStringContainsString('DEPLOY_GIT_SHA_FILE', $entrypoint);
+        $this->assertMatchesRegularExpression(
+            '/DEPLOY_GIT_SHA_FILE=.*\.deploy-git-sha/s',
+            $entrypoint
+        );
+        $this->assertMatchesRegularExpression(
+            '/if \[ -n "\$\{GIT_SHA:-\}" \]; then/s',
+            $entrypoint
+        );
+        $this->assertStringContainsString('rm -f "${DEPLOY_GIT_SHA_FILE}"', $entrypoint);
+    }
+}

--- a/tests/Unit/GitShaTest.php
+++ b/tests/Unit/GitShaTest.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/../../lib/notam/map-layer.php';
  */
 class GitShaTest extends TestCase
 {
-    private string $originalGitSha;
+    private string|false $originalGitSha;
 
     private string|false $originalDeployFileEnv;
 
@@ -21,15 +21,14 @@ class GitShaTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $gitSha = getenv('GIT_SHA');
-        $this->originalGitSha = $gitSha === false ? '' : $gitSha;
+        $this->originalGitSha = getenv('GIT_SHA');
         $this->originalDeployFileEnv = getenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE');
         $this->tempFile = sys_get_temp_dir() . '/aviationwx-deploy-git-sha-' . bin2hex(random_bytes(4));
     }
 
     protected function tearDown(): void
     {
-        if ($this->originalGitSha === '') {
+        if ($this->originalGitSha === false) {
             putenv('GIT_SHA');
         } else {
             putenv('GIT_SHA=' . $this->originalGitSha);

--- a/tests/Unit/GitShaTest.php
+++ b/tests/Unit/GitShaTest.php
@@ -137,5 +137,6 @@ class GitShaTest extends TestCase
             $entrypoint
         );
         $this->assertStringContainsString('rm -f "${DEPLOY_GIT_SHA_FILE}"', $entrypoint);
+        $this->assertStringContainsString('Failed to persist deploy GIT_SHA', $entrypoint);
     }
 }


### PR DESCRIPTION
## Summary
- Persist `GIT_SHA` to `cache/.deploy-git-sha` in docker-entrypoint on container start (remove when unset).
- Teach `getGitSha()` to read that file when env is missing so cron-restarted scheduler workers match Apache.
- Fixes airports map NOTAM layer failclosed (`logic-v2` upserts vs `{sha}-v2` serve) while records were present.

## Context
Scheduler health-check restarts inherit crontab env (`CONFIG_PATH` only), not compose `GIT_SHA`. NOTAM map upserts then wrote `logic-vN` tokens; Apache expected `{deploySha}-vN` and returned empty GeoJSON with `failclosed: true`.

## Test plan
- [x] `tests/Unit/GitShaTest.php` (normalize, file read, env preference, map token, entrypoint contract)
- [x] `make test-ci`
- [x] Local Docker: file fallback without env; env overrides file; recreate with `GIT_SHA` writes file; recreate without `GIT_SHA` removes file
- [ ] After deploy: confirm `cache/.deploy-git-sha` exists; www-data `getGitSha()` matches Apache; `/api/notam-map.php` from airports origin returns features without `failclosed`