### PR TITLE
Fix deploy stdin drain bug and repair NOTAM map build tokens

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -1557,6 +1557,9 @@ jobs:
           
           ssh ${{ secrets.USER }}@${{ secrets.HOST }} << EOF
           set -euo pipefail
+          # deploy-drain-workers.sh uses docker compose exec; without this, exec consumes the
+          # SSH heredoc stdin and the compose build/up below never runs on the server.
+          exec < /dev/null
           cd ~/aviationwx
           # Source deployment helper functions for consistent error handling
           if [ -f scripts/deploy-helpers.sh ]; then

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -309,6 +309,11 @@ if [ -d "${CACHE_DIR}" ]; then
         if printf '%s\n' "${GIT_SHA}" > "${DEPLOY_GIT_SHA_FILE}"; then
             chmod 644 "${DEPLOY_GIT_SHA_FILE}" 2>/dev/null || true
             echo "✓ Persisted deploy GIT_SHA to ${DEPLOY_GIT_SHA_FILE}"
+            if runuser -u www-data -- /usr/local/bin/php /var/www/html/scripts/repair-notam-map-build-token.php; then
+                :
+            else
+                echo "⚠️  NOTAM map build-token repair skipped or failed" >&2
+            fi
         else
             echo "⚠️  Failed to persist deploy GIT_SHA to ${DEPLOY_GIT_SHA_FILE}" >&2
         fi

--- a/lib/notam/map-aggregate-cache.php
+++ b/lib/notam/map-aggregate-cache.php
@@ -448,3 +448,45 @@ function notamMapAirspaceAggregateBuildTokenMatches(?array $envelope): bool
 
     return $stored === notamTfrMapLayerCurrentBuildToken();
 }
+
+/**
+ * Rewrite logic-vN store tokens when deploy SHA is now available.
+ *
+ * Cron-restarted workers without GIT_SHA label the aggregate logic-vN while Apache
+ * serves {sha}-vN. Records remain valid; only the token label is wrong.
+ *
+ * @return bool True when map-airspace.json was updated on disk
+ */
+function notamMapAirspaceAggregateRepairStaleLogicBuildToken(): bool
+{
+    $envelope = notamMapAirspaceAggregateRead();
+    if ($envelope === null) {
+        return false;
+    }
+
+    $stored = trim((string) ($envelope['map_layer_build_token'] ?? ''));
+    if ($stored === '') {
+        return false;
+    }
+
+    if (preg_match('/^logic-v(\d+)$/', $stored, $matches) !== 1) {
+        return false;
+    }
+
+    if ((int) $matches[1] !== NOTAM_TFR_MAP_LAYER_LOGIC_VERSION) {
+        return false;
+    }
+
+    if (getGitSha() === '') {
+        return false;
+    }
+
+    $current = notamTfrMapLayerCurrentBuildToken();
+    if ($stored === $current) {
+        return false;
+    }
+
+    $envelope['map_layer_build_token'] = $current;
+
+    return notamMapAirspaceAggregateWrite($envelope);
+}

--- a/lib/notam/map-aggregate-cache.php
+++ b/lib/notam/map-aggregate-cache.php
@@ -488,5 +488,17 @@ function notamMapAirspaceAggregateRepairStaleLogicBuildToken(): bool
 
     $envelope['map_layer_build_token'] = $current;
 
-    return notamMapAirspaceAggregateWrite($envelope);
+    $path = getNotamMapAirspaceAggregatePath();
+    $preserveMtime = is_file($path) ? (int) @filemtime($path) : 0;
+
+    if (!notamMapAirspaceAggregateWrite($envelope)) {
+        return false;
+    }
+
+    if ($preserveMtime > 0) {
+        @touch($path, $preserveMtime);
+        clearstatcache(true, $path);
+    }
+
+    return true;
 }

--- a/scripts/deploy-drain-workers.sh
+++ b/scripts/deploy-drain-workers.sh
@@ -34,7 +34,7 @@ if ! "${COMPOSE[@]}" ps "$WEB_SERVICE" 2>/dev/null | grep -q "Up"; then
 fi
 
 run_in_web() {
-  "${COMPOSE[@]}" exec -T "$WEB_SERVICE" "$@"
+  "${COMPOSE[@]}" exec -T "$WEB_SERVICE" "$@" < /dev/null
 }
 
 MAX_WAIT="$(

--- a/scripts/repair-notam-map-build-token.php
+++ b/scripts/repair-notam-map-build-token.php
@@ -1,0 +1,21 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Repair map-airspace.json when workers wrote logic-vN but deploy SHA is available.
+ *
+ * Invoked from docker-entrypoint.sh after persisting cache/.deploy-git-sha.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../lib/config.php';
+require_once __DIR__ . '/../lib/notam/map-aggregate-cache.php';
+
+if (!notamMapAirspaceAggregateRepairStaleLogicBuildToken()) {
+    exit(0);
+}
+
+fwrite(
+    STDOUT,
+    'Repaired map-airspace build token to ' . notamTfrMapLayerCurrentBuildToken() . PHP_EOL
+);

--- a/tests/Unit/DeployDrainTest.php
+++ b/tests/Unit/DeployDrainTest.php
@@ -715,6 +715,7 @@ final class DeployDrainTest extends TestCase
         $this->assertStringContainsString('WEB_SERVICE', $contents);
         $this->assertStringContainsString('deploy-drain.php', $contents);
         $this->assertStringContainsString('DEPLOY_WORKER_DRAIN_MAX_SECONDS', $contents);
+        $this->assertStringContainsString('< /dev/null', $contents);
         $this->assertStringNotContainsString('php not available on host', $contents);
         $this->assertStringContainsString('exit 0', $contents);
     }

--- a/tests/Unit/GitShaTest.php
+++ b/tests/Unit/GitShaTest.php
@@ -137,5 +137,6 @@ class GitShaTest extends TestCase
         );
         $this->assertStringContainsString('rm -f "${DEPLOY_GIT_SHA_FILE}"', $entrypoint);
         $this->assertStringContainsString('Failed to persist deploy GIT_SHA', $entrypoint);
+        $this->assertStringContainsString('repair-notam-map-build-token.php', $entrypoint);
     }
 }

--- a/tests/Unit/NotamMapLayerTest.php
+++ b/tests/Unit/NotamMapLayerTest.php
@@ -330,6 +330,37 @@ final class NotamMapLayerTest extends TestCase
         }
     }
 
+    public function testNotamMapAirspaceAggregateRepairStaleLogicBuildToken_PreservesAggregateMtime(): void
+    {
+        $originalGitSha = getenv('GIT_SHA');
+        $originalDeployFileEnv = getenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE');
+        putenv('GIT_SHA');
+        $deployFile = $this->cacheDir . '/.deploy-git-sha';
+        putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE=' . $deployFile);
+        file_put_contents($deployFile, "9f3471525bc39e8a\n");
+
+        try {
+            $staleMtime = time() - 4000;
+            $record = $this->drawableTfrAirspaceRecord($staleMtime, 'MTIME1/2026');
+            $this->writeAirspaceAggregate(['MTIME1/2026' => $record], $staleMtime, 'logic-v2');
+
+            $this->assertTrue(notamMapAirspaceAggregateRepairStaleLogicBuildToken());
+            $this->assertSame($staleMtime, notamMapAirspaceAggregateMtime());
+            $this->assertTrue(notamMapAirspaceAggregateIsStale(3600, time()));
+        } finally {
+            if ($originalGitSha === false) {
+                putenv('GIT_SHA');
+            } else {
+                putenv('GIT_SHA=' . $originalGitSha);
+            }
+            if ($originalDeployFileEnv === false) {
+                putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE');
+            } else {
+                putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE=' . $originalDeployFileEnv);
+            }
+        }
+    }
+
     public function testNotamMapAirspaceAggregateRepairStaleLogicBuildToken_SkipsShaOnlyMismatch(): void
     {
         $originalGitSha = getenv('GIT_SHA');

--- a/tests/Unit/NotamMapLayerTest.php
+++ b/tests/Unit/NotamMapLayerTest.php
@@ -270,6 +270,84 @@ final class NotamMapLayerTest extends TestCase
         $this->assertTrue($payload['failclosed'] ?? false);
     }
 
+    public function testNotamTfrMapLayerServeOrRebuild_LogicTokenMismatch_FailClosed(): void
+    {
+        $originalGitSha = getenv('GIT_SHA');
+        putenv('GIT_SHA=9f34715');
+        try {
+            $now = time();
+            $record = $this->drawableTfrAirspaceRecord($now, 'LOGIC1/2026');
+            $this->writeAirspaceAggregate(['LOGIC1/2026' => $record], $now, 'logic-v2');
+
+            $payload = notamTfrMapLayerServeOrRebuild();
+
+            $this->assertSame([], $payload['features']);
+            $this->assertTrue($payload['failclosed'] ?? false);
+            $this->assertSame('9f34715-v2', $payload['map_layer_build_token'] ?? null);
+        } finally {
+            if ($originalGitSha === false) {
+                putenv('GIT_SHA');
+            } else {
+                putenv('GIT_SHA=' . $originalGitSha);
+            }
+        }
+    }
+
+    public function testNotamMapAirspaceAggregateRepairStaleLogicBuildToken_RewritesLogicToken(): void
+    {
+        $originalGitSha = getenv('GIT_SHA');
+        $originalDeployFileEnv = getenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE');
+        putenv('GIT_SHA');
+        $deployFile = $this->cacheDir . '/.deploy-git-sha';
+        putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE=' . $deployFile);
+        file_put_contents($deployFile, "9f3471525bc39e8a\n");
+
+        try {
+            $now = time();
+            $record = $this->drawableTfrAirspaceRecord($now, 'FIX1/2026');
+            $this->writeAirspaceAggregate(['FIX1/2026' => $record], $now, 'logic-v2');
+
+            $this->assertTrue(notamMapAirspaceAggregateRepairStaleLogicBuildToken());
+
+            $envelope = notamMapAirspaceAggregateRead();
+            $this->assertNotNull($envelope);
+            $this->assertSame('9f34715-v2', $envelope['map_layer_build_token'] ?? null);
+
+            $payload = notamTfrMapLayerServeOrRebuild();
+            $this->assertFalse($payload['failclosed'] ?? false);
+            $this->assertCount(1, $payload['features']);
+        } finally {
+            if ($originalGitSha === false) {
+                putenv('GIT_SHA');
+            } else {
+                putenv('GIT_SHA=' . $originalGitSha);
+            }
+            if ($originalDeployFileEnv === false) {
+                putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE');
+            } else {
+                putenv('AVIATIONWX_DEPLOY_GIT_SHA_FILE=' . $originalDeployFileEnv);
+            }
+        }
+    }
+
+    public function testNotamMapAirspaceAggregateRepairStaleLogicBuildToken_SkipsShaOnlyMismatch(): void
+    {
+        $originalGitSha = getenv('GIT_SHA');
+        putenv('GIT_SHA=abcdef12');
+        try {
+            $now = time();
+            $this->writeAirspaceAggregate([], $now, 'oldsha1-v2');
+
+            $this->assertFalse(notamMapAirspaceAggregateRepairStaleLogicBuildToken());
+        } finally {
+            if ($originalGitSha === false) {
+                putenv('GIT_SHA');
+            } else {
+                putenv('GIT_SHA=' . $originalGitSha);
+            }
+        }
+    }
+
     public function testNotamTfrMapLayerServeOrRebuild_FreshStore_ReturnsFeature(): void
     {
         $now = time();

--- a/tests/Unit/SchedulerDrainWiringContractTest.php
+++ b/tests/Unit/SchedulerDrainWiringContractTest.php
@@ -103,6 +103,20 @@ final class SchedulerDrainWiringContractTest extends TestCase
         );
     }
 
+    public function testWorkflow_DeployComposeRedirectsSshHeredocStdinBeforeDrain(): void
+    {
+        $workflow = (string) file_get_contents($this->root . '/.github/workflows/deploy-docker.yml');
+        $composeStepPos = strpos($workflow, '- name: Deploy via Docker Compose');
+        $this->assertNotFalse($composeStepPos);
+        $composeChunk = substr($workflow, $composeStepPos, 9000);
+        $this->assertStringContainsString('exec < /dev/null', $composeChunk);
+        $stdinPos = strpos($composeChunk, 'exec < /dev/null');
+        $drainPos = strpos($composeChunk, 'scripts/deploy-drain-workers.sh');
+        $this->assertNotFalse($stdinPos);
+        $this->assertNotFalse($drainPos);
+        $this->assertLessThan($drainPos, $stdinPos, 'stdin redirect must precede worker drain');
+    }
+
     public function testHealthCheck_LogsDuplicateDaemonsBeforeDrainSuppressExit(): void
     {
         $health = (string) file_get_contents($this->root . '/scripts/scheduler-health-check.php');


### PR DESCRIPTION
## Summary
- Redirect SSH heredoc stdin before worker drain so `docker compose build/up` actually runs after deploy drain (fixes silent no-recreate deploys).
- Repair `logic-vN` map-airspace build tokens on container start when deploy SHA is available, restoring TFR polygons without waiting for the next NOTAM fetch.
- Add regression tests for token mismatch, repair path, and deploy wiring contracts.

## Test plan
- [x] `make test-ci` passed locally
- [x] Docker repro: `logic-v2` store + `GIT_SHA` serve path fail-closed, repair restores features
- [x] Merge and deploy; verify `airports.aviationwx.org` map shows TFR polygons
- [ ] Confirm deploy log shows compose build/up after drain and `GIT_SHA` matches expected commit
