### PR TITLE
Fix deploy SSH heredoc truncation that skipped container rebuild

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -1559,9 +1559,9 @@ jobs:
           
           ssh ${{ secrets.USER }}@${{ secrets.HOST }} << EOF
           set -euo pipefail
-          # deploy-drain-workers.sh uses docker compose exec; without this, exec consumes the
-          # SSH heredoc stdin and the compose build/up below never runs on the server.
-          exec < /dev/null
+          # Do not run "exec < /dev/null" here: the remote shell reads this SSH heredoc from
+          # stdin, so redirecting stdin would drop the rest of the deploy script (no build/up).
+          # deploy-drain-workers.sh and compose exec calls below use their own stdin redirects.
           cd ~/aviationwx
           # Source deployment helper functions for consistent error handling
           if [ -f scripts/deploy-helpers.sh ]; then
@@ -1725,7 +1725,7 @@ jobs:
           # Sync FTP/SFTP/FTPS configuration (runs on every deployment)
           # This ensures users and directories are created/updated immediately after deployment
           echo "Syncing FTP/SFTP/FTPS configuration..."
-          if docker compose -f docker/docker-compose.prod.yml exec -T web /usr/local/bin/php /var/www/html/scripts/sync-push-config.php 2>&1; then
+          if docker compose -f docker/docker-compose.prod.yml exec -T web /usr/local/bin/php /var/www/html/scripts/sync-push-config.php < /dev/null 2>&1; then
             echo "✓ FTP/SFTP/FTPS configuration synced successfully"
           else
             echo "⚠️  Warning: FTP/SFTP/FTPS configuration sync failed"
@@ -1742,7 +1742,7 @@ jobs:
           echo "Verifying embed nginx.conf in deployed web image (Public API v1 routing)..."
           if ! docker compose -f docker/docker-compose.prod.yml exec -T web /usr/local/bin/php \
             /var/www/html/scripts/verify-embed-nginx-conf.php \
-            /var/www/html/docker/nginx.conf; then
+            /var/www/html/docker/nginx.conf < /dev/null; then
             deployment_error \
               "Embed nginx verification" \
               "docker/nginx.conf in the web container failed embed Public API v1 checks" \
@@ -1753,7 +1753,7 @@ jobs:
           echo "Verifying ops nginx.conf in deployed web image (ops.aviationwx.org proxy)..."
           if ! docker compose -f docker/docker-compose.prod.yml exec -T web /usr/local/bin/php \
             /var/www/html/scripts/verify-ops-nginx-conf.php \
-            /var/www/html/docker/nginx.conf; then
+            /var/www/html/docker/nginx.conf < /dev/null; then
             deployment_error \
               "Ops nginx verification" \
               "docker/nginx.conf in the web container failed ops.aviationwx.org proxy checks" \

--- a/tests/Unit/SchedulerDrainWiringContractTest.php
+++ b/tests/Unit/SchedulerDrainWiringContractTest.php
@@ -103,18 +103,19 @@ final class SchedulerDrainWiringContractTest extends TestCase
         );
     }
 
-    public function testWorkflow_DeployComposeRedirectsSshHeredocStdinBeforeDrain(): void
+    public function testWorkflow_DeployComposeDoesNotRedirectSshHeredocStdin(): void
     {
         $workflow = (string) file_get_contents($this->root . '/.github/workflows/deploy-docker.yml');
         $composeStepPos = strpos($workflow, '- name: Deploy via Docker Compose');
         $this->assertNotFalse($composeStepPos);
         $composeChunk = substr($workflow, $composeStepPos, 9000);
-        $this->assertStringContainsString('exec < /dev/null', $composeChunk);
-        $stdinPos = strpos($composeChunk, 'exec < /dev/null');
-        $drainPos = strpos($composeChunk, 'scripts/deploy-drain-workers.sh');
-        $this->assertNotFalse($stdinPos);
-        $this->assertNotFalse($drainPos);
-        $this->assertLessThan($drainPos, $stdinPos, 'stdin redirect must precede worker drain');
+        $this->assertStringNotContainsString(
+            'exec < /dev/null',
+            $composeChunk,
+            'Global stdin redirect truncates the SSH heredoc before docker compose build/up'
+        );
+        $this->assertStringContainsString('scripts/deploy-drain-workers.sh', $composeChunk);
+        $this->assertStringContainsString('sync-push-config.php < /dev/null', $composeChunk);
     }
 
     public function testHealthCheck_LogsDuplicateDaemonsBeforeDrainSuppressExit(): void

--- a/tests/Unit/SchedulerDrainWiringContractTest.php
+++ b/tests/Unit/SchedulerDrainWiringContractTest.php
@@ -108,14 +108,21 @@ final class SchedulerDrainWiringContractTest extends TestCase
         $workflow = (string) file_get_contents($this->root . '/.github/workflows/deploy-docker.yml');
         $composeStepPos = strpos($workflow, '- name: Deploy via Docker Compose');
         $this->assertNotFalse($composeStepPos);
-        $composeChunk = substr($workflow, $composeStepPos, 9000);
-        $this->assertStringNotContainsString(
-            'exec < /dev/null',
-            $composeChunk,
+        $composeStepEnd = strpos($workflow, '- name: Restart Nginx container', $composeStepPos);
+        $this->assertNotFalse($composeStepEnd, 'Deploy via Docker Compose step must be followed by Nginx restart step');
+        $composeChunk = substr($workflow, $composeStepPos, $composeStepEnd - $composeStepPos);
+        $heredocStart = strpos($composeChunk, 'ssh ${{ secrets.USER }}@${{ secrets.HOST }} << EOF');
+        $this->assertNotFalse($heredocStart, 'Deploy step must use SSH heredoc');
+        $heredocEnd = strpos($composeChunk, "\n          EOF", $heredocStart);
+        $this->assertNotFalse($heredocEnd, 'Deploy SSH heredoc must close with EOF');
+        $heredocBody = substr($composeChunk, $heredocStart, $heredocEnd - $heredocStart);
+        $this->assertDoesNotMatchRegularExpression(
+            '/^\s*exec\s+<\/dev\/null\s*$/m',
+            $heredocBody,
             'Global stdin redirect truncates the SSH heredoc before docker compose build/up'
         );
-        $this->assertStringContainsString('scripts/deploy-drain-workers.sh', $composeChunk);
-        $this->assertStringContainsString('sync-push-config.php < /dev/null', $composeChunk);
+        $this->assertStringContainsString('scripts/deploy-drain-workers.sh', $heredocBody);
+        $this->assertStringContainsString('sync-push-config.php < /dev/null', $heredocBody);
     }
 
     public function testHealthCheck_LogsDuplicateDaemonsBeforeDrainSuppressExit(): void


### PR DESCRIPTION
## Summary

Production deploys were reporting success without rebuilding the web container. The deploy SSH heredoc ran `exec < /dev/null` at the top of the script (added in #260), which redirected stdin away from the heredoc before `docker compose build` / `up` could run.

This left production on the old vsftpd image after the ProFTPD merge while CI showed green.

## Changes

- Remove the global `exec < /dev/null` from the Deploy via Docker Compose SSH block
- Add per-command `< /dev/null` on `docker compose exec` calls in that same block
- Update `SchedulerDrainWiringContractTest` to guard against reintroducing the global redirect

`deploy-drain-workers.sh` already redirects stdin on its own `compose exec` calls.

## Test plan

- [x] Local one-off: `bash -s` heredoc repro shows truncation with `exec < /dev/null`, fixed without it
- [x] `phpunit tests/Unit/SchedulerDrainWiringContractTest.php --filter testWorkflow_DeployComposeDoesNotRedirectSshHeredocStdin`
- [ ] Merge and re-run deploy; confirm server logs show multi-minute `docker compose build --no-cache` and container shows `proftpd` / `GIT_SHA` set