### PR TITLE
Tolerate missing airport address on directory cards

### DIFF
--- a/pages/airports.php
+++ b/pages/airports.php
@@ -1334,7 +1334,12 @@ $breadcrumbs = generateBreadcrumbSchema([
                         <div class="airport-code"><?= htmlspecialchars($formalIdentifier) ?></div>
                         <?php endif; ?>
                         <div class="airport-name"><?= htmlspecialchars($airport['name']) ?></div>
-                        <div class="airport-location"><?= htmlspecialchars($airport['address']) ?></div>
+                        <?php
+                        $airportAddress = trim((string) ($airport['address'] ?? ''));
+                        if ($airportAddress !== ''):
+                        ?>
+                        <div class="airport-location"><?= htmlspecialchars($airportAddress) ?></div>
+                        <?php endif; ?>
                         
                         <?php if ($hasAnyWeather): ?>
                         <div class="airport-metrics">

--- a/tests/Unit/AirportsDirectoryOptionalAddressTest.php
+++ b/tests/Unit/AirportsDirectoryOptionalAddressTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Regression: directory cards must tolerate airports without address.
+ *
+ * @see pages/airports.php
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class AirportsDirectoryOptionalAddressTest extends TestCase
+{
+    private string $airportsPhp;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $path = dirname(__DIR__, 2) . '/pages/airports.php';
+        $this->assertFileExists($path);
+        $raw = file_get_contents($path);
+        $this->assertIsString($raw);
+        $this->airportsPhp = $raw;
+    }
+
+    public function testDirectoryCardToleratesMissingAirportAddress(): void
+    {
+        $this->assertStringContainsString(
+            "\$airportAddress = trim((string) (\$airport['address'] ?? ''));",
+            $this->airportsPhp
+        );
+        $this->assertStringContainsString(
+            'if ($airportAddress !== \'\'):',
+            $this->airportsPhp
+        );
+        $this->assertStringContainsString(
+            'htmlspecialchars($airportAddress)',
+            $this->airportsPhp
+        );
+        $this->assertStringNotContainsString(
+            'htmlspecialchars($airport[\'address\'])',
+            $this->airportsPhp
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Directory airport cards no longer assume every config row has `address`.
- Location line renders only when a non-empty address is present, avoiding PHP 8 undefined-key warnings for airports that omit it.

## Test plan
- [x] Load `/pages/airports.php` (or directory route) with production-like config that includes airports without `address` (e.g. `u82`, `s87`)
- [ ] Confirm no `Undefined array key "address"` in `php-error.log`
- [x] Confirm cards with an address still show the location line
