### PR TITLE
Fix undefined $sftpRunning in FTP/SFTP status message

### DIFF
--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -975,7 +975,7 @@ function checkFtpSftpServices(): array
         $messageParts[] = 'FTP/FTPS disabled';
     }
     if ($sftpRequired) {
-        $messageParts[] = $sftpRunning ? 'SFTP running' : 'SFTP not running';
+        $messageParts[] = $sshdRunning ? 'SFTP running' : 'SFTP not running';
     } else {
         $messageParts[] = 'SFTP disabled';
     }

--- a/tests/Unit/FtpSftpStatusMessageTest.php
+++ b/tests/Unit/FtpSftpStatusMessageTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Regression: SFTP status message must use $sshdRunning (not undefined $sftpRunning).
+ *
+ * @see lib/status-checks.php::checkFtpSftpServices()
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/status-checks.php';
+
+final class FtpSftpStatusMessageTest extends TestCase
+{
+    public function testSourceUsesSshdRunningForSftpMessage(): void
+    {
+        $path = dirname(__DIR__, 2) . '/lib/status-checks.php';
+        $raw = file_get_contents($path);
+        $this->assertIsString($raw);
+        $this->assertStringContainsString(
+            "\$messageParts[] = \$sshdRunning ? 'SFTP running' : 'SFTP not running';",
+            $raw
+        );
+        $this->assertStringNotContainsString('$sftpRunning', $raw);
+    }
+
+    public function testCheckFtpSftpServices_MessageMatchesSshdStateWithoutWarnings(): void
+    {
+        $undefinedWarnings = [];
+        set_error_handler(static function (int $errno, string $message) use (&$undefinedWarnings): bool {
+            if (
+                str_contains($message, 'Undefined variable')
+                || str_contains($message, 'Undefined array key')
+            ) {
+                $undefinedWarnings[] = $errno . ':' . $message;
+            }
+
+            return true;
+        });
+
+        try {
+            $result = checkFtpSftpServices();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(
+            [],
+            $undefinedWarnings,
+            'checkFtpSftpServices must not emit undefined variable/key warnings'
+        );
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('message', $result);
+        $this->assertArrayHasKey('services', $result);
+        $this->assertArrayHasKey('sshd', $result['services']);
+
+        $sshdRunning = (bool) ($result['services']['sshd']['running'] ?? false);
+        $message = (string) $result['message'];
+        if (str_contains($message, 'SFTP disabled')) {
+            $this->assertStringNotContainsString('SFTP running', $message);
+            $this->assertStringNotContainsString('SFTP not running', $message);
+            return;
+        }
+
+        $expected = $sshdRunning ? 'SFTP running' : 'SFTP not running';
+        $this->assertStringContainsString($expected, $message);
+    }
+}


### PR DESCRIPTION
## Summary
- Status page FTP/SFTP check used `$sshdRunning` for health logic but `$sftpRunning` (never set) in the human-readable message.
- Point the message at `$sshdRunning` so PHP 8 stops warning and the copy matches actual SFTP process state.

## Test plan
- [x] With SFTP enabled and `sshd` running, status message includes `SFTP running` (not `SFTP not running`)
- [ ] With SFTP enabled and `sshd` down, message includes `SFTP not running`
- [ ] No `Undefined variable $sftpRunning` in `php-error.log` after loading the status page
