### PR TITLE
Fix NASR cold-start discovery and pace FAA/NFDC HTTP

### DIFF
--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -699,7 +699,7 @@ OurAirports is community-maintained; length and surface can disagree with nation
 
 **Configured runtime slice**: Weather formatting loads `cache/nasr/nasr_apt_configured.json`, a subset containing only NASR records referenced by `airports.json`. The slice rebuilds automatically when the config file or full NASR cache changes (tracked via config SHA and source mtime in `nasr_meta.json`).
 
-**NASR cycle discovery**: The fetcher tracks the active cycle (`tracked_current_cycle_date`) and the next preview cycle (`tracked_next_cycle_date`) in `nasr_meta.json`. It downloads only the active cycle (largest effective date on or before today). When the next cycle date passes, or when no tracked cycles exist, discovery re-runs via the FAA subscription index; if the index is unreachable, NFDC is probed in a narrow window around the expected next cycle. Failed fetches retain the last-good cache and record `last_fetch_error` for the status page.
+**NASR cycle discovery**: The fetcher tracks the active cycle (`tracked_current_cycle_date`) and the next preview cycle (`tracked_next_cycle_date`) in `nasr_meta.json`. It downloads only the active cycle (largest effective date on or before today). When the next cycle date passes, or when no tracked cycles exist, discovery re-runs in order: FAA subscription index; then a small set of AIRAC-aligned NFDC zip probes derived from a fixed 28-day epoch; then a dense daily NFDC probe window as last resort. All FAA/NFDC NASR HTTP (index, probes, and zip downloads) is paced at one attempt per minute host-wide. Failed fetches retain the last-good cache and record `last_fetch_error` for the status page.
 
 **Full model** (runway data available):
 

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -463,8 +463,10 @@ if (!defined('NASR_FETCH_CHECK_INTERVAL')) {
 if (!defined('NASR_CACHE_MAX_AGE')) {
     define('NASR_CACHE_MAX_AGE', NASR_CYCLE_PERIOD_SECONDS + REFERENCE_DATA_WEEK_SECONDS);
 }
+// Dense last-resort lookback must cover a full cycle; half-cycle misses current
+// late in the AIRAC period when the FAA index is unavailable.
 if (!defined('NASR_PROBE_DAYS_BEFORE')) {
-    define('NASR_PROBE_DAYS_BEFORE', (int) (NASR_CYCLE_PERIOD_DAYS / 2));
+    define('NASR_PROBE_DAYS_BEFORE', NASR_CYCLE_PERIOD_DAYS);
 }
 if (!defined('NASR_PROBE_DAYS_AFTER')) {
     define('NASR_PROBE_DAYS_AFTER', (int) (NASR_CYCLE_PERIOD_DAYS / 2));
@@ -474,6 +476,20 @@ if (!defined('NASR_HTTP_MAX_ATTEMPTS')) {
 }
 if (!defined('NASR_HTTP_RETRY_DELAYS_SECONDS')) {
     define('NASR_HTTP_RETRY_DELAYS_SECONDS', [5, 30]);
+}
+// Any historical NASR effective date on the 28-day AIRAC lattice.
+if (!defined('NASR_AIRAC_EPOCH_DATE')) {
+    define('NASR_AIRAC_EPOCH_DATE', '2024-01-25');
+}
+if (!defined('NASR_AIRAC_PROBE_CYCLES_BEFORE')) {
+    define('NASR_AIRAC_PROBE_CYCLES_BEFORE', 2);
+}
+if (!defined('NASR_AIRAC_PROBE_CYCLES_AFTER')) {
+    define('NASR_AIRAC_PROBE_CYCLES_AFTER', 2);
+}
+// Host-wide FAA/NFDC NASR HTTP pacing (cross-process).
+if (!defined('NASR_HTTP_MIN_INTERVAL_SECONDS')) {
+    define('NASR_HTTP_MIN_INTERVAL_SECONDS', 60);
 }
 if (!defined('NASR_CONFIG_ELEVATION_TOLERANCE_FT')) {
     define('NASR_CONFIG_ELEVATION_TOLERANCE_FT', 2);
@@ -493,11 +509,12 @@ if (!defined('NASR_FRQ_SCHEMA_VERSION')) {
 if (!defined('NASR_FRQ_MIN_AIRPORT_COUNT')) {
     define('NASR_FRQ_MIN_AIRPORT_COUNT', 5000);
 }
+// Covers last-resort dense probes at 1 req/min plus download/parse.
 if (!defined('NASR_APT_WORKER_TIMEOUT')) {
-    define('NASR_APT_WORKER_TIMEOUT', 1800);
+    define('NASR_APT_WORKER_TIMEOUT', 7200);
 }
 if (!defined('NASR_FRQ_WORKER_TIMEOUT')) {
-    define('NASR_FRQ_WORKER_TIMEOUT', 900);
+    define('NASR_FRQ_WORKER_TIMEOUT', 3600);
 }
 
 // Density altitude performance (reference AFM models, not a go/no-go judgment)

--- a/lib/nasr/discovery.php
+++ b/lib/nasr/discovery.php
@@ -4,6 +4,182 @@
  */
 
 require_once __DIR__ . '/../constants.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../logger.php';
+require_once __DIR__ . '/../cache-paths.php';
+
+/**
+ * User-Agent for FAA/NFDC HTTP.
+ *
+ * Akamai often 403s "compatible; ...Bot" style UAs on www.faa.gov; a browser-like
+ * UA with a trailing AviationWX product token is accepted.
+ *
+ * @return string
+ */
+function nasrHttpUserAgent(): string
+{
+    return 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+        . '(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 '
+        . 'AviationWX/1.0';
+}
+
+/**
+ * Min interval between any FAA/NFDC NASR HTTP attempts.
+ *
+ * @return int Seconds
+ */
+function nasrHttpMinIntervalSeconds(): int
+{
+    if (isset($GLOBALS['nasrHttpMinIntervalSeconds'])
+        && is_int($GLOBALS['nasrHttpMinIntervalSeconds'])
+        && $GLOBALS['nasrHttpMinIntervalSeconds'] >= 0
+    ) {
+        return $GLOBALS['nasrHttpMinIntervalSeconds'];
+    }
+
+    return NASR_HTTP_MIN_INTERVAL_SECONDS;
+}
+
+/**
+ * Whether the host-wide NASR HTTP throttle should enforce spacing.
+ *
+ * @return bool
+ */
+function nasrHttpThrottleShouldEnforce(): bool
+{
+    if (!empty($GLOBALS['nasrHttpThrottleTestForceEnforcement'])) {
+        return true;
+    }
+
+    return !isTestMode() && !shouldMockExternalServices();
+}
+
+/**
+ * Paths for NASR HTTP throttle state (overridable in tests).
+ *
+ * @return array{0: string, 1: string} [statePath, lockPath]
+ */
+function nasrHttpThrottlePaths(): array
+{
+    if (isset($GLOBALS['nasrHttpThrottleTestDir'])
+        && is_string($GLOBALS['nasrHttpThrottleTestDir'])
+        && $GLOBALS['nasrHttpThrottleTestDir'] !== ''
+    ) {
+        $dir = $GLOBALS['nasrHttpThrottleTestDir'];
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0700, true);
+        }
+
+        return [
+            $dir . '/.http_last_request',
+            $dir . '/.http_throttle.lock',
+        ];
+    }
+
+    ensureCacheDir(CACHE_NASR_DIR);
+
+    return [
+        CACHE_NASR_DIR . '/.http_last_request',
+        CACHE_NASR_DIR . '/.http_throttle.lock',
+    ];
+}
+
+/**
+ * Cross-process spacing for all FAA/NFDC NASR HTTP (index, probes, zip downloads).
+ *
+ * Serializes attempts across APT/FRQ workers via flock. If the lock cannot be
+ * acquired, sleeps the full interval without recording state (fail closed on pacing).
+ */
+function nasrHttpThrottle(): void
+{
+    if (!nasrHttpThrottleShouldEnforce()) {
+        return;
+    }
+
+    $interval = nasrHttpMinIntervalSeconds();
+    if ($interval <= 0) {
+        return;
+    }
+
+    [$statePath, $lockPath] = nasrHttpThrottlePaths();
+    $fh = @fopen($lockPath, 'c+');
+    if ($fh === false) {
+        aviationwx_log('warning', 'nasr http throttle: lock open failed, sleeping full interval', [
+            'lock_path' => $lockPath,
+        ], 'app');
+        nasrHttpThrottleSleep((float) $interval);
+        return;
+    }
+
+    if (!flock($fh, LOCK_EX)) {
+        fclose($fh);
+        aviationwx_log('warning', 'nasr http throttle: flock failed, sleeping full interval', [
+            'lock_path' => $lockPath,
+        ], 'app');
+        nasrHttpThrottleSleep((float) $interval);
+        return;
+    }
+
+    try {
+        $last = 0.0;
+        if (is_readable($statePath)) {
+            $raw = file_get_contents($statePath);
+            if (is_string($raw) && is_numeric(trim($raw))) {
+                $last = (float) trim($raw);
+            }
+        }
+
+        $wait = $interval - (microtime(true) - $last);
+        if ($wait > 0) {
+            nasrHttpThrottleSleep($wait);
+        }
+
+        // Stamp under the lock so concurrent workers compute wait from the same clock.
+        if (file_put_contents($statePath, (string) microtime(true)) === false) {
+            aviationwx_log('warning', 'nasr http throttle: failed to persist last-request stamp', [
+                'state_path' => $statePath,
+            ], 'app');
+        }
+    } finally {
+        flock($fh, LOCK_UN);
+        fclose($fh);
+    }
+}
+
+/**
+ * Sleep for NASR HTTP throttle pacing.
+ *
+ * @param float $seconds Seconds to wait (fractional allowed)
+ */
+function nasrHttpThrottleSleep(float $seconds): void
+{
+    if ($seconds <= 0) {
+        return;
+    }
+
+    if (isset($GLOBALS['nasrHttpThrottleTestSleep'])
+        && is_callable($GLOBALS['nasrHttpThrottleTestSleep'])
+    ) {
+        ($GLOBALS['nasrHttpThrottleTestSleep'])($seconds);
+        return;
+    }
+
+    usleep((int) ceil($seconds * 1_000_000));
+}
+
+/**
+ * Optional unit-test HTTP transport ($GLOBALS['nasrHttpTestTransport']).
+ *
+ * @return (callable(string, array): array{ok: bool, http_code: int, body: ?string, retryable: bool})|null
+ */
+function nasrHttpTestTransport(): ?callable
+{
+    if (!isset($GLOBALS['nasrHttpTestTransport']) || !is_callable($GLOBALS['nasrHttpTestTransport'])) {
+        return null;
+    }
+
+    return $GLOBALS['nasrHttpTestTransport'];
+}
 
 /**
  * HTTP status codes that warrant a retry against NFDC/FAA.
@@ -23,6 +199,13 @@ function nasrRetryableHttpStatusCodes(): array
  */
 function nasrHttpRequestOnce(string $url, array $options = []): array
 {
+    nasrHttpThrottle();
+
+    $transport = nasrHttpTestTransport();
+    if ($transport !== null) {
+        return $transport($url, $options);
+    }
+
     $noBody = !empty($options['no_body']);
     $rangeBytes = isset($options['range_bytes']) && is_string($options['range_bytes'])
         ? $options['range_bytes']
@@ -46,7 +229,7 @@ function nasrHttpRequestOnce(string $url, array $options = []): array
         CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
         CURLOPT_ENCODING => '',
         CURLOPT_NOBODY => $noBody && $rangeBytes === null,
-        CURLOPT_USERAGENT => 'Mozilla/5.0 (compatible; AviationWX/1.0; +https://aviationwx.org)',
+        CURLOPT_USERAGENT => nasrHttpUserAgent(),
         CURLOPT_HTTPHEADER => $headers,
     ]);
     $body = curl_exec($ch);
@@ -80,9 +263,10 @@ function nasrHttpRequest(string $url, array $options = []): ?string
     $maxAttempts = (int) ($options['max_attempts'] ?? NASR_HTTP_MAX_ATTEMPTS);
     $delays = NASR_HTTP_RETRY_DELAYS_SECONDS;
     $noBody = !empty($options['no_body']);
+    $skipRetryDelay = nasrHttpTestTransport() !== null;
 
     for ($attempt = 0; $attempt < $maxAttempts; $attempt++) {
-        if ($attempt > 0) {
+        if ($attempt > 0 && !$skipRetryDelay) {
             $delayIndex = min($attempt - 1, count($delays) - 1);
             sleep((int) $delays[$delayIndex]);
         }
@@ -102,6 +286,8 @@ function nasrHttpRequest(string $url, array $options = []): ?string
 
 /**
  * HTTP GET with headers suitable for FAA and NFDC endpoints.
+ *
+ * @return string|null
  */
 function nasrHttpGet(string $url): ?string
 {
@@ -116,6 +302,28 @@ function nasrHttpGet(string $url): ?string
  */
 function nasrHttpRequestOnceToFile(string $url, $fileHandle): array
 {
+    nasrHttpThrottle();
+
+    $transport = nasrHttpTestTransport();
+    if ($transport !== null) {
+        $result = $transport($url, []);
+        if ($result['ok'] && is_string($result['body'])) {
+            if (fwrite($fileHandle, $result['body']) === false) {
+                return [
+                    'ok' => false,
+                    'http_code' => (int) $result['http_code'],
+                    'retryable' => true,
+                ];
+            }
+        }
+
+        return [
+            'ok' => $result['ok'],
+            'http_code' => $result['http_code'],
+            'retryable' => $result['retryable'],
+        ];
+    }
+
     $ch = curl_init();
     curl_setopt_array($ch, [
         CURLOPT_URL => $url,
@@ -125,7 +333,7 @@ function nasrHttpRequestOnceToFile(string $url, $fileHandle): array
         CURLOPT_FOLLOWLOCATION => true,
         CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
         CURLOPT_ENCODING => '',
-        CURLOPT_USERAGENT => 'Mozilla/5.0 (compatible; AviationWX/1.0; +https://aviationwx.org)',
+        CURLOPT_USERAGENT => nasrHttpUserAgent(),
         CURLOPT_HTTPHEADER => [
             'Accept: text/html,application/xhtml+xml;q=0.9,*/*;q=0.8',
             'Accept-Language: en-US,en;q=0.9',
@@ -148,16 +356,21 @@ function nasrHttpRequestOnceToFile(string $url, $fileHandle): array
 
 /**
  * Download a remote file with retry/backoff, streaming directly to disk.
+ *
+ * @return bool True when the file was downloaded successfully
  */
 function nasrHttpDownloadToFile(string $url, string $destPath): bool
 {
     $maxAttempts = NASR_HTTP_MAX_ATTEMPTS;
     $delays = NASR_HTTP_RETRY_DELAYS_SECONDS;
+    $skipRetryDelay = nasrHttpTestTransport() !== null;
 
     for ($attempt = 0; $attempt < $maxAttempts; $attempt++) {
         if ($attempt > 0) {
-            $delayIndex = min($attempt - 1, count($delays) - 1);
-            sleep((int) $delays[$delayIndex]);
+            if (!$skipRetryDelay) {
+                $delayIndex = min($attempt - 1, count($delays) - 1);
+                sleep((int) $delays[$delayIndex]);
+            }
             @unlink($destPath);
         }
 
@@ -376,7 +589,46 @@ function nasrRemoteZipExists(string $url, bool $allowRetry = false): bool
 }
 
 /**
- * Candidate cycle dates for NFDC probing (28-day grid first, then narrow daily window).
+ * Candidate cycle dates on the NASR/AIRAC 28-day lattice near today.
+ *
+ * Fixed epoch (any known historical effective date) yields a handful of real
+ * AIRAC zip URLs instead of probing every calendar day.
+ *
+ * @return list<string> YYYY-MM-DD
+ */
+function generateNasrAiracAlignedProbeCandidates(
+    ?int $referenceTimestamp = null,
+    int $cyclesBefore = NASR_AIRAC_PROBE_CYCLES_BEFORE,
+    int $cyclesAfter = NASR_AIRAC_PROBE_CYCLES_AFTER
+): array {
+    $referenceTimestamp = $referenceTimestamp ?? time();
+    $epochTs = strtotime(NASR_AIRAC_EPOCH_DATE . ' UTC');
+    if ($epochTs === false) {
+        return [];
+    }
+
+    $daysSinceEpoch = intdiv($referenceTimestamp - $epochTs, 86400);
+    $cyclesSince = $daysSinceEpoch >= 0
+        ? intdiv($daysSinceEpoch, NASR_CYCLE_PERIOD_DAYS)
+        : 0;
+
+    $dates = [];
+    for ($k = -$cyclesBefore; $k <= $cyclesAfter; $k++) {
+        $cycleIndex = $cyclesSince + $k;
+        if ($cycleIndex < 0) {
+            continue;
+        }
+        $dates[] = gmdate(
+            'Y-m-d',
+            $epochTs + ($cycleIndex * NASR_CYCLE_PERIOD_DAYS * 86400)
+        );
+    }
+
+    return array_values(array_unique($dates));
+}
+
+/**
+ * Last-resort candidate dates for NFDC probing (28-day grid + daily window).
  *
  * @return list<string> YYYY-MM-DD
  */
@@ -413,7 +665,7 @@ function generateNasrCycleProbeCandidates(
 }
 
 /**
- * Narrow calendar window for NFDC probing when the FAA index is unreachable.
+ * Dense calendar window for last-resort NFDC probing.
  *
  * @return list<string> YYYY-MM-DD
  */
@@ -483,17 +735,22 @@ function nasrEstimateNextCycleDate(?string $currentCycleDate): ?string
 }
 
 /**
- * Probe NFDC for valid APT zip cycle dates near an anchor day.
+ * Probe NFDC for reachable APT zip cycle dates from an explicit candidate list.
  *
+ * Stops early once current and next cycles are both found.
+ *
+ * @param list<string> $probeDates YYYY-MM-DD
  * @return list<string> YYYY-MM-DD dates with a reachable APT zip
  */
-function probeNasrCycleDatesNearAnchor(?string $anchorDateYmd, ?int $referenceTimestamp = null): array
+function probeNasrCycleDates(array $probeDates, ?int $referenceTimestamp = null): array
 {
     $referenceTimestamp = $referenceTimestamp ?? time();
-    $probeDates = generateNasrCycleProbeCandidates($anchorDateYmd);
     $found = [];
 
     foreach ($probeDates as $dateYmd) {
+        if (!is_string($dateYmd) || preg_match('/^\d{4}-\d{2}-\d{2}$/', $dateYmd) !== 1) {
+            continue;
+        }
         $url = buildNasrAptZipUrl($dateYmd);
         if ($url !== '' && nasrRemoteZipExists($url)) {
             $found[] = $dateYmd;
@@ -510,7 +767,65 @@ function probeNasrCycleDatesNearAnchor(?string $anchorDateYmd, ?int $referenceTi
 }
 
 /**
+ * Last-resort NFDC probe: dense calendar window near an anchor day.
+ *
+ * @return list<string> YYYY-MM-DD dates with a reachable APT zip
+ */
+function probeNasrCycleDatesNearAnchor(?string $anchorDateYmd, ?int $referenceTimestamp = null): array
+{
+    return probeNasrCycleDates(
+        generateNasrCycleProbeCandidates($anchorDateYmd),
+        $referenceTimestamp
+    );
+}
+
+/**
+ * Finish current/next selection after an NFDC probe, including +28d next-cycle chase.
+ *
+ * @param list<string> $probed
+ * @return array{
+ *   current_cycle_date: ?string,
+ *   next_cycle_date: ?string,
+ *   known_cycle_dates: list<string>
+ * }
+ */
+function nasrFinalizeProbedCycles(array $probed, ?int $referenceTimestamp = null): array
+{
+    $referenceTimestamp = $referenceTimestamp ?? time();
+    $current = selectCurrentNasrCycleDate($probed, $referenceTimestamp);
+    $next = selectNextNasrCycleDate($probed, $current);
+
+    if ($current !== null && $next === null) {
+        $currentTs = strtotime($current . ' UTC');
+        if ($currentTs !== false) {
+            for ($mult = 1; $mult <= 2; $mult++) {
+                $candidate = gmdate(
+                    'Y-m-d',
+                    $currentTs + ($mult * NASR_CYCLE_PERIOD_DAYS * 86400)
+                );
+                $candidateUrl = buildNasrAptZipUrl($candidate);
+                if ($candidateUrl !== '' && nasrRemoteZipExists($candidateUrl)) {
+                    $probed[] = $candidate;
+                    $next = selectNextNasrCycleDate($probed, $current);
+                    if ($next !== null) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    return [
+        'current_cycle_date' => $current,
+        'next_cycle_date' => $next,
+        'known_cycle_dates' => array_values(array_unique($probed)),
+    ];
+}
+
+/**
  * Discover current and next NASR cycle dates to track.
+ *
+ * Order: cached meta → FAA index → AIRAC-aligned NFDC probes → dense daily NFDC probes.
  *
  * @param array<string, mixed>|null $cachedMeta Existing NASR meta (tracked cycles)
  * @return array{
@@ -560,6 +875,20 @@ function discoverNasrTrackedCycles(?array $cachedMeta = null, ?int $referenceTim
         ];
     }
 
+    $airacProbed = probeNasrCycleDates(
+        generateNasrAiracAlignedProbeCandidates($referenceTimestamp),
+        $referenceTimestamp
+    );
+    $airacFinal = nasrFinalizeProbedCycles($airacProbed, $referenceTimestamp);
+    if ($airacFinal['current_cycle_date'] !== null) {
+        return [
+            'current_cycle_date' => $airacFinal['current_cycle_date'],
+            'next_cycle_date' => $airacFinal['next_cycle_date'],
+            'source' => 'nfdc_airac',
+            'known_cycle_dates' => $airacFinal['known_cycle_dates'],
+        ];
+    }
+
     $anchor = null;
     if (is_array($cachedMeta)) {
         $anchor = $cachedMeta['tracked_next_cycle_date'] ?? null;
@@ -577,35 +906,16 @@ function discoverNasrTrackedCycles(?array $cachedMeta = null, ?int $referenceTim
         }
     }
 
-    $probed = probeNasrCycleDatesNearAnchor(is_string($anchor) ? $anchor : null, $referenceTimestamp);
-    $current = selectCurrentNasrCycleDate($probed, $referenceTimestamp);
-    $next = selectNextNasrCycleDate($probed, $current);
-
-    if ($current !== null && $next === null) {
-        $currentTs = strtotime($current . ' UTC');
-        if ($currentTs !== false) {
-            for ($mult = 1; $mult <= 2; $mult++) {
-                $candidate = gmdate(
-                    'Y-m-d',
-                    $currentTs + ($mult * NASR_CYCLE_PERIOD_DAYS * 86400)
-                );
-                $candidateUrl = buildNasrAptZipUrl($candidate);
-                if ($candidateUrl !== '' && nasrRemoteZipExists($candidateUrl)) {
-                    $probed[] = $candidate;
-                    $next = selectNextNasrCycleDate($probed, $current);
-                    if ($next !== null) {
-                        break;
-                    }
-                }
-            }
-        }
-    }
+    $dailyFinal = nasrFinalizeProbedCycles(
+        probeNasrCycleDatesNearAnchor(is_string($anchor) ? $anchor : null, $referenceTimestamp),
+        $referenceTimestamp
+    );
 
     return [
-        'current_cycle_date' => $current,
-        'next_cycle_date' => $next,
+        'current_cycle_date' => $dailyFinal['current_cycle_date'],
+        'next_cycle_date' => $dailyFinal['next_cycle_date'],
         'source' => 'nfdc_probe',
-        'known_cycle_dates' => $probed,
+        'known_cycle_dates' => $dailyFinal['known_cycle_dates'],
     ];
 }
 
@@ -643,7 +953,18 @@ function buildNasrAptDownloadPlans(?int $referenceTimestamp = null, ?array $cach
         ? resolveNasrAptZipUrlForCycle($current)
         : buildNasrAptZipUrl($current);
 
-    if ($url === '' || !nasrRemoteZipExists($url, true)) {
+    if ($url === '') {
+        return [];
+    }
+
+    // cached_meta / NFDC probe paths already Range-checked the zip; re-checking
+    // would burn another minute under the host-wide throttle.
+    $zipVerifiedDuringDiscovery = in_array(
+        $tracked['source'],
+        ['cached_meta', 'nfdc_airac', 'nfdc_probe'],
+        true
+    );
+    if (!$zipVerifiedDuringDiscovery && !nasrRemoteZipExists($url, true)) {
         return [];
     }
 

--- a/lib/nasr/discovery.php
+++ b/lib/nasr/discovery.php
@@ -740,10 +740,14 @@ function nasrEstimateNextCycleDate(?string $currentCycleDate): ?string
  * Stops early once current and next cycles are both found.
  *
  * @param list<string> $probeDates YYYY-MM-DD
+ * @param bool $allowRetry Retry transient NFDC failures (use for small AIRAC sets only)
  * @return list<string> YYYY-MM-DD dates with a reachable APT zip
  */
-function probeNasrCycleDates(array $probeDates, ?int $referenceTimestamp = null): array
-{
+function probeNasrCycleDates(
+    array $probeDates,
+    ?int $referenceTimestamp = null,
+    bool $allowRetry = false
+): array {
     $referenceTimestamp = $referenceTimestamp ?? time();
     $found = [];
 
@@ -752,7 +756,7 @@ function probeNasrCycleDates(array $probeDates, ?int $referenceTimestamp = null)
             continue;
         }
         $url = buildNasrAptZipUrl($dateYmd);
-        if ($url !== '' && nasrRemoteZipExists($url)) {
+        if ($url !== '' && nasrRemoteZipExists($url, $allowRetry)) {
             $found[] = $dateYmd;
         }
 
@@ -775,7 +779,8 @@ function probeNasrCycleDatesNearAnchor(?string $anchorDateYmd, ?int $referenceTi
 {
     return probeNasrCycleDates(
         generateNasrCycleProbeCandidates($anchorDateYmd),
-        $referenceTimestamp
+        $referenceTimestamp,
+        false
     );
 }
 
@@ -804,7 +809,8 @@ function nasrFinalizeProbedCycles(array $probed, ?int $referenceTimestamp = null
                     $currentTs + ($mult * NASR_CYCLE_PERIOD_DAYS * 86400)
                 );
                 $candidateUrl = buildNasrAptZipUrl($candidate);
-                if ($candidateUrl !== '' && nasrRemoteZipExists($candidateUrl)) {
+                // Small chase set: retry transient NFDC errors so next_cycle is not dropped.
+                if ($candidateUrl !== '' && nasrRemoteZipExists($candidateUrl, true)) {
                     $probed[] = $candidate;
                     $next = selectNextNasrCycleDate($probed, $current);
                     if ($next !== null) {
@@ -877,7 +883,8 @@ function discoverNasrTrackedCycles(?array $cachedMeta = null, ?int $referenceTim
 
     $airacProbed = probeNasrCycleDates(
         generateNasrAiracAlignedProbeCandidates($referenceTimestamp),
-        $referenceTimestamp
+        $referenceTimestamp,
+        true
     );
     $airacFinal = nasrFinalizeProbedCycles($airacProbed, $referenceTimestamp);
     if ($airacFinal['current_cycle_date'] !== null) {

--- a/tests/Integration/NasrDiscoveryIntegrationTest.php
+++ b/tests/Integration/NasrDiscoveryIntegrationTest.php
@@ -1,6 +1,9 @@
 <?php
 /**
- * Live NASR/FAA discovery integration tests (network-dependent).
+ * Live NASR/FAA discovery smoke tests (network-dependent).
+ *
+ * Default unit coverage uses `$GLOBALS['nasrHttpTestTransport']` in
+ * tests/Unit/NasrDiscoveryTest.php (no outbound FAA/NFDC calls).
  *
  * Not part of the default Integration suite (see phpunit.xml exclude).
  * Opt-in via RUN_EXTERNAL_UPSTREAM_TESTS=1 (make test-external-apis).

--- a/tests/Unit/ConstantsTest.php
+++ b/tests/Unit/ConstantsTest.php
@@ -248,8 +248,14 @@ class ConstantsTest extends TestCase
             NASR_CYCLE_PERIOD_SECONDS + REFERENCE_DATA_WEEK_SECONDS,
             NASR_CACHE_MAX_AGE
         );
-        $this->assertSame((int) (NASR_CYCLE_PERIOD_DAYS / 2), NASR_PROBE_DAYS_BEFORE);
+        $this->assertSame(NASR_CYCLE_PERIOD_DAYS, NASR_PROBE_DAYS_BEFORE);
         $this->assertSame((int) (NASR_CYCLE_PERIOD_DAYS / 2), NASR_PROBE_DAYS_AFTER);
+        $this->assertSame('2024-01-25', NASR_AIRAC_EPOCH_DATE);
+        $this->assertSame(2, NASR_AIRAC_PROBE_CYCLES_BEFORE);
+        $this->assertSame(2, NASR_AIRAC_PROBE_CYCLES_AFTER);
+        $this->assertSame(60, NASR_HTTP_MIN_INTERVAL_SECONDS);
+        $this->assertSame(7200, NASR_APT_WORKER_TIMEOUT);
+        $this->assertSame(3600, NASR_FRQ_WORKER_TIMEOUT);
         $this->assertSame(
             REFERENCE_DATA_SPAWN_CHECK_INTERVAL,
             OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL

--- a/tests/Unit/NasrDiscoveryTest.php
+++ b/tests/Unit/NasrDiscoveryTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Offline unit tests for NASR cycle discovery (no FAA/NFDC network).
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/nasr/discovery.php';
+
+class NasrDiscoveryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset(
+            $GLOBALS['nasrHttpTestTransport'],
+            $GLOBALS['nasrHttpThrottleTestDir'],
+            $GLOBALS['nasrHttpThrottleTestForceEnforcement'],
+            $GLOBALS['nasrHttpMinIntervalSeconds'],
+            $GLOBALS['nasrHttpThrottleTestSleep']
+        );
+        parent::tearDown();
+    }
+
+    /**
+     * @param callable(string, array): array{ok: bool, http_code: int, body: ?string, retryable: bool} $transport
+     */
+    private function setTransport(callable $transport): void
+    {
+        $GLOBALS['nasrHttpTestTransport'] = $transport;
+    }
+
+    public function testDiscoverTrackedCyclesUsesFaaIndexWithoutNetwork(): void
+    {
+        $reference = strtotime('2026-07-14 UTC');
+        $this->setTransport(static function (string $url, array $options): array {
+            if (str_contains($url, 'NASR_Subscription') && !preg_match('#/\d{4}-\d{2}-\d{2}#', $url)) {
+                return [
+                    'ok' => true,
+                    'http_code' => 200,
+                    'body' => '<a href="/air_traffic/flight_info/aeronav/aero_data/NASR_Subscription/2026-07-09">'
+                        . 'Current</a>'
+                        . '<a href="/air_traffic/flight_info/aeronav/aero_data/NASR_Subscription/2026-08-06">'
+                        . 'Preview</a>',
+                    'retryable' => false,
+                ];
+            }
+
+            return ['ok' => false, 'http_code' => 404, 'body' => null, 'retryable' => false];
+        });
+
+        $tracked = discoverNasrTrackedCycles(null, $reference);
+
+        $this->assertSame('faa_index', $tracked['source']);
+        $this->assertSame('2026-07-09', $tracked['current_cycle_date']);
+        $this->assertSame('2026-08-06', $tracked['next_cycle_date']);
+    }
+
+    public function testDiscoverTrackedCyclesUsesCachedMetaWhenZipMockedReachable(): void
+    {
+        $reference = strtotime('2026-07-14 UTC');
+        $this->setTransport(static function (string $url, array $options): array {
+            if (str_contains($url, '09_Jul_2026_APT_CSV.zip') && isset($options['range_bytes'])) {
+                return ['ok' => true, 'http_code' => 206, 'body' => 'P', 'retryable' => false];
+            }
+
+            return ['ok' => false, 'http_code' => 404, 'body' => null, 'retryable' => false];
+        });
+
+        $tracked = discoverNasrTrackedCycles([
+            'tracked_current_cycle_date' => '2026-07-09',
+            'tracked_next_cycle_date' => '2026-08-06',
+        ], $reference);
+
+        $this->assertSame('cached_meta', $tracked['source']);
+        $this->assertSame('2026-07-09', $tracked['current_cycle_date']);
+        $this->assertSame('2026-08-06', $tracked['next_cycle_date']);
+    }
+
+    public function testDiscoverTrackedCyclesFallsBackToAiracProbeWhenIndexEmpty(): void
+    {
+        $reference = strtotime('2026-07-30 UTC');
+        $hits = [];
+        $this->setTransport(static function (string $url, array $options) use (&$hits): array {
+            $hits[] = $url;
+
+            if (str_contains($url, 'NASR_Subscription')) {
+                return ['ok' => false, 'http_code' => 403, 'body' => null, 'retryable' => false];
+            }
+
+            if (isset($options['range_bytes'])
+                && (str_contains($url, '09_Jul_2026_APT_CSV.zip')
+                    || str_contains($url, '06_Aug_2026_APT_CSV.zip'))
+            ) {
+                return ['ok' => true, 'http_code' => 206, 'body' => 'P', 'retryable' => false];
+            }
+
+            return ['ok' => false, 'http_code' => 404, 'body' => null, 'retryable' => false];
+        });
+
+        $tracked = discoverNasrTrackedCycles(null, $reference);
+
+        $this->assertSame('nfdc_airac', $tracked['source']);
+        $this->assertSame('2026-07-09', $tracked['current_cycle_date']);
+        $this->assertSame('2026-08-06', $tracked['next_cycle_date']);
+        $this->assertLessThan(10, count($hits), 'AIRAC path should not spray daily probes');
+    }
+
+    public function testBuildDownloadPlansSkipsRedundantZipCheckForCachedMeta(): void
+    {
+        $reference = strtotime('2026-07-14 UTC');
+        $rangeChecks = 0;
+        $this->setTransport(static function (string $url, array $options) use (&$rangeChecks): array {
+            if (isset($options['range_bytes']) && str_contains($url, '09_Jul_2026_APT_CSV.zip')) {
+                $rangeChecks++;
+                return ['ok' => true, 'http_code' => 206, 'body' => 'P', 'retryable' => false];
+            }
+
+            return ['ok' => false, 'http_code' => 404, 'body' => null, 'retryable' => false];
+        });
+
+        $plans = buildNasrAptDownloadPlans($reference, [
+            'tracked_current_cycle_date' => '2026-07-09',
+            'tracked_next_cycle_date' => '2026-08-06',
+        ]);
+
+        $this->assertCount(1, $plans);
+        $this->assertSame('2026-07-09', $plans[0]['effective_date']);
+        $this->assertSame(1, $rangeChecks);
+    }
+
+    public function testNasrHttpThrottleSpacesRequestsWhenEnforced(): void
+    {
+        $dir = sys_get_temp_dir() . '/nasr-http-throttle-' . bin2hex(random_bytes(4));
+        mkdir($dir, 0700, true);
+        $GLOBALS['nasrHttpThrottleTestDir'] = $dir;
+        $GLOBALS['nasrHttpThrottleTestForceEnforcement'] = true;
+        $GLOBALS['nasrHttpMinIntervalSeconds'] = 60;
+        $slept = [];
+        $GLOBALS['nasrHttpThrottleTestSleep'] = static function (float $seconds) use (&$slept): void {
+            $slept[] = $seconds;
+        };
+
+        try {
+            nasrHttpThrottle();
+            nasrHttpThrottle();
+            $this->assertCount(1, $slept);
+            $this->assertGreaterThan(50.0, $slept[0]);
+            $this->assertLessThanOrEqual(60.0, $slept[0]);
+        } finally {
+            @unlink($dir . '/.http_last_request');
+            @unlink($dir . '/.http_throttle.lock');
+            @rmdir($dir);
+        }
+    }
+
+    public function testNasrHttpThrottleSkippedInTestModeByDefault(): void
+    {
+        $dir = sys_get_temp_dir() . '/nasr-http-throttle-' . bin2hex(random_bytes(4));
+        mkdir($dir, 0700, true);
+        $GLOBALS['nasrHttpThrottleTestDir'] = $dir;
+        $GLOBALS['nasrHttpMinIntervalSeconds'] = 30;
+        unset($GLOBALS['nasrHttpThrottleTestForceEnforcement']);
+        $slept = [];
+        $GLOBALS['nasrHttpThrottleTestSleep'] = static function (float $seconds) use (&$slept): void {
+            $slept[] = $seconds;
+        };
+
+        try {
+            nasrHttpThrottle();
+            nasrHttpThrottle();
+            $this->assertSame([], $slept);
+        } finally {
+            @unlink($dir . '/.http_last_request');
+            @unlink($dir . '/.http_throttle.lock');
+            @rmdir($dir);
+        }
+    }
+}

--- a/tests/Unit/NasrDiscoveryTest.php
+++ b/tests/Unit/NasrDiscoveryTest.php
@@ -128,6 +128,29 @@ class NasrDiscoveryTest extends TestCase
         $this->assertSame(1, $rangeChecks);
     }
 
+    public function testFinalizeProbedCyclesRetriesTransientNextCycleProbe(): void
+    {
+        $attempts = 0;
+        $this->setTransport(static function (string $url, array $options) use (&$attempts): array {
+            if (!isset($options['range_bytes']) || !str_contains($url, '06_Aug_2026_APT_CSV.zip')) {
+                return ['ok' => false, 'http_code' => 404, 'body' => null, 'retryable' => false];
+            }
+
+            $attempts++;
+            if ($attempts < 2) {
+                return ['ok' => false, 'http_code' => 503, 'body' => null, 'retryable' => true];
+            }
+
+            return ['ok' => true, 'http_code' => 206, 'body' => 'P', 'retryable' => false];
+        });
+
+        $final = nasrFinalizeProbedCycles(['2026-07-09'], strtotime('2026-07-14 UTC'));
+
+        $this->assertSame('2026-07-09', $final['current_cycle_date']);
+        $this->assertSame('2026-08-06', $final['next_cycle_date']);
+        $this->assertGreaterThanOrEqual(2, $attempts);
+    }
+
     public function testNasrHttpThrottleSpacesRequestsWhenEnforced(): void
     {
         $dir = sys_get_temp_dir() . '/nasr-http-throttle-' . bin2hex(random_bytes(4));

--- a/tests/Unit/NasrParseTest.php
+++ b/tests/Unit/NasrParseTest.php
@@ -130,6 +130,47 @@ class NasrParseTest extends TestCase
         $this->assertSame('2026-07-09', $current);
     }
 
+    public function testGenerateNasrAiracAlignedProbeCandidatesLateInCycle(): void
+    {
+        $reference = strtotime('2026-07-30 UTC');
+        $candidates = generateNasrAiracAlignedProbeCandidates($reference);
+
+        $this->assertSame(
+            ['2026-05-14', '2026-06-11', '2026-07-09', '2026-08-06', '2026-09-03'],
+            $candidates
+        );
+
+        $current = selectCurrentNasrCycleDate($candidates, $reference);
+        $next = selectNextNasrCycleDate($candidates, $current);
+        $this->assertSame('2026-07-09', $current);
+        $this->assertSame('2026-08-06', $next);
+    }
+
+    public function testGenerateNasrCycleProbeCandidatesIncludesCurrentLateInCycle(): void
+    {
+        // Day 21 of the 2026-07-09 cycle: half-cycle lookback (14d) misses current.
+        $candidates = generateNasrCycleProbeCandidates('2026-07-30');
+
+        $this->assertContains('2026-07-09', $candidates);
+        $this->assertContains('2026-08-06', $candidates);
+    }
+
+    public function testSelectCurrentFromLateCycleProbeHits(): void
+    {
+        $reference = strtotime('2026-07-30 UTC');
+        $candidates = generateNasrCycleProbeCandidates('2026-07-30');
+        // NFDC only returns zips for real AIRAC dates; others 404.
+        $found = array_values(array_intersect(
+            $candidates,
+            ['2026-06-11', '2026-07-09', '2026-08-06']
+        ));
+        $current = selectCurrentNasrCycleDate($found, $reference);
+        $next = selectNextNasrCycleDate($found, $current);
+
+        $this->assertSame('2026-07-09', $current);
+        $this->assertSame('2026-08-06', $next);
+    }
+
     public function testSelectNextNasrCycleDateReturnsEarliestFutureCycle(): void
     {
         $next = selectNextNasrCycleDate(


### PR DESCRIPTION
Closes #275.

## Summary
- Production Reference data went Down after cache wipe because empty NASR meta + FAA index 403 fell through to a dense today-centered probe that missed the current AIRAC cycle late in the period.
- Discovery order is now: cached meta → FAA index → small AIRAC-aligned NFDC Range probes → dense daily probe last resort only.
- Soften the User-Agent so the FAA index is less likely to 403, and pace **all** FAA/NFDC NASR HTTP at one attempt/minute host-wide (shared flock across APT/FRQ workers).
- Skip redundant zip existence checks when discovery already verified the zip (saves a minute under the throttle).
- Raise NASR worker timeouts so a throttled last-resort probe can finish.
- Add offline unit coverage via `$GLOBALS['nasrHttpTestTransport']`; keep live FAA/NFDC checks opt-in only.

## Test plan
- [x] `make test-ci`
- [x] `PHPUNIT_ARGS='--filter NasrDiscovery' make test-unit` (offline discovery + throttle)
- [ ] On status.aviationwx.org after deploy: Reference data runway performance + airport communications Operational without manual seed
- [ ] Optional: `make test-external-apis` for live FAA/NFDC smoke