### PR TITLE
Support optional WeatherLink v1 password for legacy stations

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -708,7 +708,8 @@ For older devices: Vantage Connect, WeatherLinkIP, WeatherLink USB/Serial logger
   {
     "type": "weatherlink_v1",
     "device_id": "001D0A12345678",
-    "api_token": "your-api-token"
+    "api_token": "your-api-token",
+    "password": "optional-device-password"
   }
 ]
 ```
@@ -719,6 +720,7 @@ For older devices: Vantage Connect, WeatherLinkIP, WeatherLink USB/Serial logger
 |-------|------------------|
 | `device_id` | Printed on a label on your physical device (12-16 characters) |
 | `api_token` | WeatherLink Account page → API Token section |
+| `password` | Optional. Account or device password for the station. Some legacy stations reject an empty `pass` query parameter and require this value. |
 
 See the [Weather Station Guide](../guides/09-weather-station-configuration.md) for photos and detailed instructions.
 

--- a/guides/09-weather-station-configuration.md
+++ b/guides/09-weather-station-configuration.md
@@ -428,6 +428,7 @@ For older devices: Vantage Connect, WeatherLinkIP, and WeatherLink USB/Serial da
 |-------------|-------------|---------------|
 | **Device ID (DID)** | 12-16 character code | Printed on your device |
 | **API Token** | Authentication token | WeatherLink account page |
+| **Password** (optional) | Account or device password used in the v1 `pass` query param | WeatherLink account credentials for the station. Some legacy stations require this; others accept an empty `pass`. |
 
 #### Step-by-Step: Getting Your v1 Credentials
 
@@ -453,13 +454,18 @@ The DID looks like: `001D0A12345678` (12-16 alphanumeric characters)
 4. Look for the **"API Token"** section
 5. Copy your API Token
 
+**Step 3: Password (when required)**
+
+Some legacy v1 stations reject requests with an empty `pass` parameter. If WeatherLink returns `Invalid Request!` without a password, set `password` to the station's WeatherLink account or device password. Leave it omitted when the station works with an empty `pass`.
+
 #### Example Configuration (v1)
 
 ```json
 "weather_source": {
   "type": "weatherlink_v1",
   "device_id": "001D0A12345678",
-  "api_token": "ABCDEF123456..."
+  "api_token": "ABCDEF123456...",
+  "password": "optional-device-password"
 }
 ```
 

--- a/lib/logger.php
+++ b/lib/logger.php
@@ -233,7 +233,7 @@ if (!function_exists('aviationwx_redact_sensitive_query_params')) {
 function aviationwx_redact_sensitive_query_params(string $value): string
 {
     return (string) preg_replace(
-        '/([?&])(api_key|apikey|application_key|api_secret|client_secret|client_id|api_token|access_token|token|password|secret)=([^&]*)/i',
+        '/([?&])(api_key|apikey|application_key|api_secret|client_secret|client_id|api_token|apiToken|access_token|token|password|passwd|pass|secret)=([^&]*)/i',
         '$1$2=[redacted]',
         $value,
     );

--- a/lib/weather/adapter/weatherlink-v1-api.php
+++ b/lib/weather/adapter/weatherlink-v1-api.php
@@ -1,16 +1,17 @@
 <?php
 /**
  * WeatherLink v1 API Adapter
- * 
+ *
  * Handles fetching and parsing weather data from WeatherLink v1 API (legacy).
  * Supports: Vantage Connect, WeatherLinkIP, WeatherLink USB/Serial loggers,
  *           and WeatherLink Network Annual Subscription connected stations.
- * 
+ *
  * API documentation: https://www.weatherlink.com/static/docs/APIdocumentation.pdf
- * 
- * Authentication: Device ID (DID) + API Token
+ *
+ * Authentication: Device ID (DID) + API Token; optional account/device password
  * Required config: device_id, api_token
- * 
+ * Optional config: password (some legacy stations reject empty pass=)
+ *
  * Note: The v1 API is for legacy devices. New Davis devices (WeatherLink Live,
  * WeatherLink Console, EnviroMonitor) should use the v2 API instead.
  */
@@ -28,9 +29,9 @@ use AviationWX\Weather\Data\WeatherSnapshot;
 
 /**
  * WeatherLink v1 API Adapter Class
- * 
+ *
  * Legacy Davis Instruments WeatherLink stations using older hardware.
- * The v1 API uses Device ID (DID) and API Token for authentication.
+ * The v1 API uses Device ID (DID), API Token, and optionally a password.
  * Data is returned in NOAA Extended format (JSON).
  * Updates every ~60 seconds depending on model/configuration.
  */
@@ -94,26 +95,26 @@ class WeatherLinkV1Adapter {
     
     /**
      * Build the API URL for fetching data
-     * 
-     * WeatherLink v1 API uses Device ID and API Token as query parameters.
-     * 
-     * Endpoint format: https://api.weatherlink.com/v1/NoaaExt.json?user={user}&pass={pass}&apiToken={token}
-     * Note: 'user' is the Device ID (DID) and 'pass' can be empty or any value.
-     * 
-     * @param array $config Source configuration (device_id, api_token)
+     *
+     * Endpoint: https://api.weatherlink.com/v1/NoaaExt.json?user={did}&pass={pass}&apiToken={token}
+     * 'user' is the Device ID. 'pass' stays empty when password is unset/empty so existing
+     * stations keep working; some legacy stations require the account/device password.
+     *
+     * @param array $config Source configuration (device_id, api_token; optional password)
      * @return string|null API URL or null if config is invalid
      */
     public static function buildUrl(array $config): ?string {
         if (!isset($config['device_id']) || !isset($config['api_token'])) {
             return null;
         }
-        
-        $deviceId = urlencode($config['device_id']);
-        $apiToken = urlencode($config['api_token']);
-        
-        // The v1 API uses 'user' for Device ID and 'pass' (can be empty)
-        // Format: NoaaExt.json returns JSON formatted NOAA extended data
-        return "https://api.weatherlink.com/v1/NoaaExt.json?user={$deviceId}&pass=&apiToken={$apiToken}";
+
+        $deviceId = urlencode((string) $config['device_id']);
+        $apiToken = urlencode((string) $config['api_token']);
+        $pass = isset($config['password']) && $config['password'] !== ''
+            ? urlencode((string) $config['password'])
+            : '';
+
+        return "https://api.weatherlink.com/v1/NoaaExt.json?user={$deviceId}&pass={$pass}&apiToken={$apiToken}";
     }
     
     /**
@@ -198,8 +199,12 @@ class WeatherLinkV1Adapter {
         }
         
         $data = json_decode($response, true);
-        
+
         if ($data === null || !is_array($data)) {
+            // Auth failures often return plain text (e.g. "Invalid Request!") with HTTP 200
+            aviationwx_log('warning', 'WeatherLink v1 response was not valid JSON', [
+                'body_prefix' => substr(preg_replace('/\s+/', ' ', $response) ?? $response, 0, 80),
+            ], 'app');
             return null;
         }
         
@@ -317,27 +322,25 @@ class WeatherLinkV1Adapter {
 
 /**
  * Fetch weather from WeatherLink v1 API (synchronous)
- * 
- * @param array $source Source configuration (device_id, api_token)
+ *
+ * @param array $source Source configuration (device_id, api_token; optional password)
  * @return array|null Weather data array or null on failure
  */
 function fetchWeatherLinkV1Weather($source): ?array {
     if (!is_array($source) || !isset($source['device_id']) || !isset($source['api_token'])) {
         return null;
     }
-    
+
     $url = WeatherLinkV1Adapter::buildUrl($source);
     if ($url === null) {
         return null;
     }
-    
-    // Check for mock response in test mode
+
     $mockResponse = getMockHttpResponse($url);
     if ($mockResponse !== null) {
         return WeatherLinkV1Adapter::parseResponse($mockResponse);
     }
-    
-    // Create context with timeout
+
     $context = stream_context_create([
         'http' => [
             'timeout' => CURL_TIMEOUT,
@@ -345,16 +348,17 @@ function fetchWeatherLinkV1Weather($source): ?array {
             'header' => "Accept: application/json\r\n",
         ],
     ]);
-    
+
+    // @ suppresses warning; false return is handled explicitly below
     $response = @file_get_contents($url, false, $context);
-    
+
     if ($response === false) {
         aviationwx_log('warning', 'WeatherLink v1 API fetch failed', [
-            'url_masked' => preg_replace('/apiToken=[^&]+/', 'apiToken=***', $url),
+            'url_masked' => aviationwx_redact_sensitive_query_params($url),
         ], 'app');
         return null;
     }
-    
+
     return WeatherLinkV1Adapter::parseResponse($response);
 }
 

--- a/lib/weather/adapter/weatherlink-v1-api.php
+++ b/lib/weather/adapter/weatherlink-v1-api.php
@@ -175,6 +175,19 @@ class WeatherLinkV1Adapter {
     }
     
     /**
+     * Build a short, credential-scrubbed prefix of an upstream body for app.log.
+     *
+     * aviationwx_log writes context without scrubbing; exchange forwarding does.
+     */
+    public static function logSafeBodyPrefix(string $response): string
+    {
+        $rawPrefix = substr($response, 0, 256);
+        $normalized = substr(preg_replace('/\s+/', ' ', $rawPrefix) ?? $rawPrefix, 0, 120);
+
+        return substr(aviationwx_redact_sensitive_query_params($normalized), 0, 80);
+    }
+
+    /**
      * Parse WeatherLink v1 API response (NOAA Extended JSON format)
      * 
      * The v1 API returns data in NOAA Extended format with fields like:
@@ -202,9 +215,8 @@ class WeatherLinkV1Adapter {
 
         if ($data === null || !is_array($data)) {
             // Auth failures often return plain text (e.g. "Invalid Request!") with HTTP 200
-            $rawPrefix = substr($response, 0, 256);
             aviationwx_log('warning', 'WeatherLink v1 response was not valid JSON', [
-                'body_prefix' => substr(preg_replace('/\s+/', ' ', $rawPrefix) ?? $rawPrefix, 0, 80),
+                'body_prefix' => self::logSafeBodyPrefix($response),
             ], 'app');
             return null;
         }

--- a/lib/weather/adapter/weatherlink-v1-api.php
+++ b/lib/weather/adapter/weatherlink-v1-api.php
@@ -202,8 +202,9 @@ class WeatherLinkV1Adapter {
 
         if ($data === null || !is_array($data)) {
             // Auth failures often return plain text (e.g. "Invalid Request!") with HTTP 200
+            $rawPrefix = substr($response, 0, 256);
             aviationwx_log('warning', 'WeatherLink v1 response was not valid JSON', [
-                'body_prefix' => substr(preg_replace('/\s+/', ' ', $response) ?? $response, 0, 80),
+                'body_prefix' => substr(preg_replace('/\s+/', ' ', $rawPrefix) ?? $rawPrefix, 0, 80),
             ], 'app');
             return null;
         }

--- a/tests/Unit/LoggerExchangeForwardTest.php
+++ b/tests/Unit/LoggerExchangeForwardTest.php
@@ -68,6 +68,22 @@ PHP, $configPath);
         self::assertStringNotContainsString('supersecret', $scrubbed['endpoint']);
     }
 
+    public function testScrubExchangeLogContext_RedactsPassQueryParameterInUrl(): void
+    {
+        putenv('APP_ENV=testing');
+        putenv('CONFIG_PATH=' . dirname(__DIR__, 2) . '/tests/Fixtures/airports.json.test');
+        require_once dirname(__DIR__, 2) . '/lib/logger.php';
+
+        $scrubbed = aviationwx_scrub_exchange_log_context([
+            'url_masked' => 'https://api.weatherlink.com/v1/NoaaExt.json?user=001D0ATEST01&pass=%40TestRanch&apiToken=test_api_token',
+        ]);
+
+        self::assertStringContainsString('pass=[redacted]', $scrubbed['url_masked']);
+        self::assertStringContainsString('apiToken=[redacted]', $scrubbed['url_masked']);
+        self::assertStringNotContainsString('%40TestRanch', $scrubbed['url_masked']);
+        self::assertStringNotContainsString('test_api_token', $scrubbed['url_masked']);
+    }
+
     /**
      * @return array{exit: int, output: string}
      */

--- a/tests/Unit/WeatherLinkV1AdapterTest.php
+++ b/tests/Unit/WeatherLinkV1AdapterTest.php
@@ -117,4 +117,16 @@ class WeatherLinkV1AdapterTest extends TestCase
         // WeatherLink auth failures often return plain text with HTTP 200
         $this->assertNull(WeatherLinkV1Adapter::parseResponse('Invalid Request!'));
     }
+
+    public function testLogSafeBodyPrefix_RedactsPassAndApiToken(): void
+    {
+        $raw = 'fail ?user=001D0ATEST01&pass=sekret&apiToken=tok123 trailing detail';
+        $redacted = WeatherLinkV1Adapter::logSafeBodyPrefix($raw);
+
+        $this->assertStringContainsString('pass=[redacted]', $redacted);
+        $this->assertStringContainsString('apiToken=[redacted]', $redacted);
+        $this->assertStringNotContainsString('sekret', $redacted);
+        $this->assertStringNotContainsString('tok123', $redacted);
+        $this->assertLessThanOrEqual(80, strlen($redacted));
+    }
 }

--- a/tests/Unit/WeatherLinkV1AdapterTest.php
+++ b/tests/Unit/WeatherLinkV1AdapterTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * WeatherLink v1 adapter tests (URL auth + NOAA Ext parse path).
+ *
+ * Incorrect pass encoding blocks stations that require a password; empty pass
+ * must remain valid for stations that allow it.
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/config.php';
+require_once __DIR__ . '/../../lib/weather/adapter/weatherlink-v1-api.php';
+
+class WeatherLinkV1AdapterTest extends TestCase
+{
+    public function testBuildUrl_MissingCredentials_ReturnsNull(): void
+    {
+        $this->assertNull(WeatherLinkV1Adapter::buildUrl(['device_id' => '001D0ATEST01']));
+        $this->assertNull(WeatherLinkV1Adapter::buildUrl(['api_token' => 'test_api_token']));
+        $this->assertNull(WeatherLinkV1Adapter::buildUrl([]));
+    }
+
+    public function testBuildUrl_LegacyWithoutPassword_UsesEmptyPass(): void
+    {
+        $url = WeatherLinkV1Adapter::buildUrl([
+            'device_id' => '001D0ATEST01',
+            'api_token' => 'test_api_token',
+        ]);
+
+        $this->assertNotNull($url);
+        $this->assertSame(
+            'https://api.weatherlink.com/v1/NoaaExt.json?user=001D0ATEST01&pass=&apiToken=test_api_token',
+            $url
+        );
+    }
+
+    public function testBuildUrl_WithPassword_UrlEncodesPassParam(): void
+    {
+        $url = WeatherLinkV1Adapter::buildUrl([
+            'device_id' => '001D0ATEST01',
+            'api_token' => 'test_api_token',
+            'password' => '@TestRanch',
+        ]);
+
+        $this->assertNotNull($url);
+        $this->assertSame(
+            'https://api.weatherlink.com/v1/NoaaExt.json?user=001D0ATEST01&pass=%40TestRanch&apiToken=test_api_token',
+            $url
+        );
+    }
+
+    public function testBuildUrl_PasswordWithAmpersand_UrlEncodesWithoutBreakingQuery(): void
+    {
+        $url = WeatherLinkV1Adapter::buildUrl([
+            'device_id' => '001D0ATEST01',
+            'api_token' => 'test_api_token',
+            'password' => 'a&b=c',
+        ]);
+
+        $this->assertNotNull($url);
+        $this->assertStringContainsString('pass=a%26b%3Dc&apiToken=test_api_token', $url);
+        $this->assertStringNotContainsString('pass=a&b=c', $url);
+    }
+
+    public function testBuildUrl_EmptyPassword_UsesEmptyPassLikeLegacy(): void
+    {
+        $url = WeatherLinkV1Adapter::buildUrl([
+            'device_id' => '001D0ATEST01',
+            'api_token' => 'test_api_token',
+            'password' => '',
+        ]);
+
+        $this->assertNotNull($url);
+        $this->assertSame(
+            'https://api.weatherlink.com/v1/NoaaExt.json?user=001D0ATEST01&pass=&apiToken=test_api_token',
+            $url
+        );
+    }
+
+    public function testParseResponse_MinimalNoaaExtJson_MapsCoreFields(): void
+    {
+        $json = json_encode([
+            'temp_c' => 20.5,
+            'dewpoint_c' => 10.0,
+            'relative_humidity' => 55,
+            'pressure_in' => 29.92,
+            'wind_kt' => 8,
+            'wind_degrees' => 270,
+            'observation_time_rfc822' => 'Tue, 04 Aug 2026 12:00:00 +0000',
+            'davis_current_observation' => [
+                'wind_ten_min_gust_mph' => 12.0,
+                'rain_day_in' => 0.05,
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $parsed = WeatherLinkV1Adapter::parseResponse($json);
+        $this->assertIsArray($parsed);
+        $this->assertEqualsWithDelta(20.5, $parsed['temperature'], 0.0001);
+        $this->assertEqualsWithDelta(10.0, $parsed['dewpoint'], 0.0001);
+        $this->assertSame(55.0, $parsed['humidity']);
+        $this->assertEqualsWithDelta(29.92, $parsed['pressure'], 0.0001);
+        $this->assertSame(8, $parsed['wind_speed']);
+        $this->assertSame(270, $parsed['wind_direction']);
+        // Davis gust is mph; adapter converts to knots
+        $this->assertSame(10, $parsed['gust_speed']);
+        $this->assertEqualsWithDelta(0.05, $parsed['precip_accum'], 0.0001);
+        $this->assertNotNull($parsed['obs_time']);
+    }
+
+    public function testParseResponse_InvalidJson_ReturnsNull(): void
+    {
+        $this->assertNull(WeatherLinkV1Adapter::parseResponse(''));
+        $this->assertNull(WeatherLinkV1Adapter::parseResponse('not-json'));
+        $this->assertNull(WeatherLinkV1Adapter::parseResponse(null));
+        // WeatherLink auth failures often return plain text with HTTP 200
+        $this->assertNull(WeatherLinkV1Adapter::parseResponse('Invalid Request!'));
+    }
+}


### PR DESCRIPTION
## Summary
- WeatherLink v1 `buildUrl()` now accepts optional config `password` and URL-encodes it into `pass` when set. Empty or omitted password keeps `pass=` so existing stations stay unchanged.
- Failure and exchange logs redact WeatherLink `pass=` and `apiToken=` (shared scrubber), and non-JSON responses such as `Invalid Request!` are logged instead of failing silently.
- Documents the optional field in `CONFIGURATION.md` and the weather-station guide. Unblocks on-field weather for `12or` (Skinner Ranch) once secrets are synced in production; secrets repo already has the password.

## Test plan
- [x] `make test-ci`
- [x] Unit: legacy / with password / empty password / reserved chars in password
- [x] Unit: NOAA Ext parse + plain-text `Invalid Request!` returns null
- [x] Unit: logger redacts `pass=` and `apiToken=`
- [x] Live smoke with secrets config: `12or` returns temp/wind via `fetchWeatherLinkV1Weather()`
- [ ] After deploy + secrets sync: confirm `12or` dashboard weather shows live values