### PR TITLE
Treat bridge host maintenance as degraded in airport rollup

### DIFF
--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -1001,6 +1001,10 @@ function checkFtpSftpServices(): array
 /**
  * Check airport health
  *
+ * Overall status is down if any nested source/camera/host is down, else degraded
+ * if any is degraded (or host/component maintenance), else operational. Config
+ * `maintenance: true` then overrides overall status to maintenance.
+ *
  * @param string $airportId Airport identifier
  * @param array $airport Airport configuration array
  * @return array {

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -1617,8 +1617,8 @@ function checkAirportHealth(string $airportId, array $airport): array {
         $health['components']['bridge_hosts'] = $bridgeHostsComponent;
     }
     
-    // Determine overall airport status: any component down = down, any degraded = degraded
-    // Check all components including nested sources/cameras for complete status picture
+    // Overall airport status: down > degraded (incl. host/component maintenance) > operational.
+    // Host "maintenance" is not the same as config airport maintenance (applied below).
     $hasDown = false;
     $hasDegraded = false;
     foreach ($health['components'] as $comp) {
@@ -1651,7 +1651,7 @@ function checkAirportHealth(string $airportId, array $airport): array {
                     $hasDown = true;
                     break 2;
                 }
-                if ($hostStatus === 'degraded') {
+                if ($hostStatus === 'degraded' || $hostStatus === 'maintenance') {
                     $hasDegraded = true;
                 }
             }
@@ -1660,7 +1660,7 @@ function checkAirportHealth(string $airportId, array $airport): array {
             if ($comp['status'] === 'down') {
                 $hasDown = true;
                 break;
-            } elseif ($comp['status'] === 'degraded') {
+            } elseif ($comp['status'] === 'degraded' || $comp['status'] === 'maintenance') {
                 $hasDegraded = true;
             }
         }

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -1002,8 +1002,9 @@ function checkFtpSftpServices(): array
  * Check airport health
  *
  * Overall status is down if any nested source/camera/host is down, else degraded
- * if any is degraded (or host/component maintenance), else operational. Config
- * `maintenance: true` then overrides overall status to maintenance.
+ * if any is degraded, failed (sources), or host/component maintenance, else
+ * operational. Config `maintenance: true` then overrides overall status to
+ * maintenance.
  *
  * @param string $airportId Airport identifier
  * @param array $airport Airport configuration array

--- a/tests/Unit/BridgeHealthStatusTest.php
+++ b/tests/Unit/BridgeHealthStatusTest.php
@@ -275,4 +275,61 @@ class BridgeHealthStatusTest extends TestCase
         $this->assertNotNull($componentReversed);
         $this->assertSame('degraded', $componentReversed['status']);
     }
+
+    /**
+     * Airport rollup treats host maintenance as degraded (not operational)
+     */
+    public function testCheckAirportHealth_BridgeHostsMaintenanceOnly_IsDegraded(): void
+    {
+        require_once __DIR__ . '/../../lib/status-checks.php';
+
+        $maint = bridgeNormalizeHealthPayload([
+            'observed_at' => gmdate('c'),
+            'host' => ['status' => 'maintenance', 'ntp_ok' => true, 'ntp_failure_seconds' => 0],
+            'inventory' => ['stations' => [], 'cameras' => []],
+        ]);
+        $this->assertTrue($maint['ok']);
+        $this->assertTrue(bridgeStoreHealth('kspb', 'bridge-maint-only', $maint['health']));
+
+        $airport = [
+            'weather_sources' => [],
+            'webcams' => [],
+            'bridges' => [
+                ['id' => 'bridge-maint-only', 'label' => 'Maint'],
+            ],
+        ];
+        $health = checkAirportHealth('kspb', $airport);
+
+        $this->assertArrayHasKey('bridge_hosts', $health['components']);
+        $this->assertSame('maintenance', $health['components']['bridge_hosts']['status']);
+        $this->assertSame('degraded', $health['status']);
+    }
+
+    /**
+     * Config airport maintenance still overrides component-derived status
+     */
+    public function testCheckAirportHealth_ConfigMaintenanceOverridesBridgeDegraded(): void
+    {
+        require_once __DIR__ . '/../../lib/status-checks.php';
+
+        $maint = bridgeNormalizeHealthPayload([
+            'observed_at' => gmdate('c'),
+            'host' => ['status' => 'maintenance', 'ntp_ok' => true, 'ntp_failure_seconds' => 0],
+            'inventory' => ['stations' => [], 'cameras' => []],
+        ]);
+        $this->assertTrue($maint['ok']);
+        $this->assertTrue(bridgeStoreHealth('kspb', 'bridge-maint-cfg', $maint['health']));
+
+        $airport = [
+            'maintenance' => true,
+            'weather_sources' => [],
+            'webcams' => [],
+            'bridges' => [
+                ['id' => 'bridge-maint-cfg', 'label' => 'Maint'],
+            ],
+        ];
+        $health = checkAirportHealth('kspb', $airport);
+
+        $this->assertSame('maintenance', $health['status']);
+    }
 }

--- a/tests/Unit/BridgeHealthStatusTest.php
+++ b/tests/Unit/BridgeHealthStatusTest.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/../../lib/bridge/health.php';
 require_once __DIR__ . '/../../lib/bridge/store.php';
 require_once __DIR__ . '/../../lib/bridge/status.php';
 require_once __DIR__ . '/../../lib/cache-paths.php';
+require_once __DIR__ . '/../../lib/status-checks.php';
 
 class BridgeHealthStatusTest extends TestCase
 {
@@ -277,19 +278,11 @@ class BridgeHealthStatusTest extends TestCase
     }
 
     /**
-     * Airport rollup treats host maintenance as degraded (not operational)
+     * Airport rollup maps host maintenance to degraded (not operational)
      */
     public function testCheckAirportHealth_BridgeHostsMaintenanceOnly_IsDegraded(): void
     {
-        require_once __DIR__ . '/../../lib/status-checks.php';
-
-        $maint = bridgeNormalizeHealthPayload([
-            'observed_at' => gmdate('c'),
-            'host' => ['status' => 'maintenance', 'ntp_ok' => true, 'ntp_failure_seconds' => 0],
-            'inventory' => ['stations' => [], 'cameras' => []],
-        ]);
-        $this->assertTrue($maint['ok']);
-        $this->assertTrue(bridgeStoreHealth('kspb', 'bridge-maint-only', $maint['health']));
+        $this->storeMaintenanceBridgeHealth('bridge-maint-only');
 
         $airport = [
             'weather_sources' => [],
@@ -306,19 +299,11 @@ class BridgeHealthStatusTest extends TestCase
     }
 
     /**
-     * Config airport maintenance still overrides component-derived status
+     * Config airport maintenance must not be conflated with host maintenance
      */
     public function testCheckAirportHealth_ConfigMaintenanceOverridesBridgeDegraded(): void
     {
-        require_once __DIR__ . '/../../lib/status-checks.php';
-
-        $maint = bridgeNormalizeHealthPayload([
-            'observed_at' => gmdate('c'),
-            'host' => ['status' => 'maintenance', 'ntp_ok' => true, 'ntp_failure_seconds' => 0],
-            'inventory' => ['stations' => [], 'cameras' => []],
-        ]);
-        $this->assertTrue($maint['ok']);
-        $this->assertTrue(bridgeStoreHealth('kspb', 'bridge-maint-cfg', $maint['health']));
+        $this->storeMaintenanceBridgeHealth('bridge-maint-cfg');
 
         $airport = [
             'maintenance' => true,
@@ -331,5 +316,19 @@ class BridgeHealthStatusTest extends TestCase
         $health = checkAirportHealth('kspb', $airport);
 
         $this->assertSame('maintenance', $health['status']);
+    }
+
+    /**
+     * @param string $bridgeId Bridge id used for cache path and config
+     */
+    private function storeMaintenanceBridgeHealth(string $bridgeId): void
+    {
+        $maint = bridgeNormalizeHealthPayload([
+            'observed_at' => gmdate('c'),
+            'host' => ['status' => 'maintenance', 'ntp_ok' => true, 'ntp_failure_seconds' => 0],
+            'inventory' => ['stations' => [], 'cameras' => []],
+        ]);
+        $this->assertTrue($maint['ok']);
+        $this->assertTrue(bridgeStoreHealth('kspb', $bridgeId, $maint['health']));
     }
 }


### PR DESCRIPTION
## Summary
- Airport overall status treats Bridge Host (and generic component) `maintenance` as **degraded**, so maintenance-only bridges no longer leave the airport `operational`
- Config `maintenance: true` still overrides to airport `maintenance`
- Unit coverage for maintenance-only bridges and config override

Closes #279

## Test plan
- [x] `vendor/bin/phpunit --filter BridgeHealthStatusTest` (includes new cases)
- [ ] Confirm status page shows degraded when all configured bridges report host maintenance
- [ ] Confirm airport with `maintenance: true` still shows under maintenance