### PR TITLE
Stabilize flaky NASR HTTP throttle PHPUnit assertion

### DIFF
--- a/tests/Unit/NasrDiscoveryTest.php
+++ b/tests/Unit/NasrDiscoveryTest.php
@@ -166,9 +166,11 @@ class NasrDiscoveryTest extends TestCase
         try {
             nasrHttpThrottle();
             nasrHttpThrottle();
+            // Real check: back-to-back calls sleep once near the configured interval.
+            // Allow a small upper epsilon - microtime jitter can push wait slightly over 60.0.
             $this->assertCount(1, $slept);
             $this->assertGreaterThan(50.0, $slept[0]);
-            $this->assertLessThanOrEqual(60.0, $slept[0]);
+            $this->assertLessThanOrEqual(60.0 + 0.01, $slept[0]);
         } finally {
             @unlink($dir . '/.http_last_request');
             @unlink($dir . '/.http_throttle.lock');


### PR DESCRIPTION
## Summary
- Closes #281
- Loosen the NASR HTTP throttle spacing upper bound by 10ms so `microtime(true)` jitter cannot fail QA
- Keep asserting one sleep near the full configured interval on back-to-back enforced calls

## Context
QA on `606ce562` failed with `60.00000500679016 <= 60.0`, which blocked Deploy Production even though the merge was unrelated.

## Test plan
- [x] `APP_ENV=testing ./vendor/bin/phpunit --filter testNasrHttpThrottle tests/Unit/NasrDiscoveryTest.php`
- [ ] Confirm QA / Deploy gates pass on this branch after merge (or re-run QA on main)