### PR TITLE
NASR missing-cache fast retry and hourly OurAirports bulk gate

### DIFF
--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -705,7 +705,7 @@ Formulas, stress ratios, and tier thresholds are in [SAFETY_CRITICAL_CALCULATION
 
 OurAirports is community-maintained; length and surface can disagree with national AIS. NASR remains authoritative for US airports when both exist.
 
-**NASR ingest**: `scripts/fetch-nasr-apt.php` (scheduler weekly + startup when missing) writes `cache/nasr/nasr_apt.json`. Failed or closed NASR pavement condition and water surfaces are excluded from runway selection.
+**NASR ingest**: `scripts/fetch-nasr-apt.php` writes `cache/nasr/nasr_apt.json`. The scheduler retries on a short interval while the APT/FRQ cache files are missing, and uses a weekly gate when the files are present but aged or a new cycle needs discovery. Failed or closed NASR pavement condition and water surfaces are excluded from runway selection.
 
 **Configured runtime slice**: Weather formatting loads `cache/nasr/nasr_apt_configured.json`, a subset containing only NASR records referenced by `airports.json`. The slice rebuilds automatically when the config file or full NASR cache changes (tracked via config SHA and source mtime in `nasr_meta.json`).
 

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -463,7 +463,7 @@ if (!defined('NASR_FETCH_CHECK_INTERVAL')) {
     define('NASR_FETCH_CHECK_INTERVAL', REFERENCE_DATA_WEEK_SECONDS);
 }
 // Cold start / wiped cache: retry sooner than the weekly gate while APT/FRQ JSON is absent.
-// Lock files still prevent overlapping workers; FAA/NFDC HTTP pacing is unchanged.
+// Lock files still prevent overlapping workers; FAA/NFDC HTTP pacing is unchanged elsewhere.
 if (!defined('NASR_MISSING_RETRY_INTERVAL')) {
     define('NASR_MISSING_RETRY_INTERVAL', 15 * 60);
 }

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -414,12 +414,14 @@ if (!defined('NASR_CYCLE_PERIOD_SECONDS')) {
     define('NASR_CYCLE_PERIOD_SECONDS', NASR_CYCLE_PERIOD_DAYS * 86400);
 }
 
-// Runway geometry (FAA + OurAirports) - daily HEAD probe; bulk fetch when upstream changes or hard max age
+// Runway geometry (FAA + OurAirports) - daily HEAD probe; bulk fetch when upstream changes or hard max age.
+// Scheduler spawn gate for bulk CSV (and runway merge after startup) - local check only; workers still
+// no-op unless needs-fetch. Hourly is enough for this slow-changing catalog (not 60s).
 if (!defined('OURAIRPORTS_PROBE_INTERVAL')) {
     define('OURAIRPORTS_PROBE_INTERVAL', 86400);
 }
 if (!defined('OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL')) {
-    define('OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL', REFERENCE_DATA_SPAWN_CHECK_INTERVAL);
+    define('OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL', 3600);
 }
 if (!defined('OURAIRPORTS_BULK_HARD_MAX_AGE')) {
     define('OURAIRPORTS_BULK_HARD_MAX_AGE', NASR_CYCLE_PERIOD_SECONDS);
@@ -459,6 +461,11 @@ if (!defined('NASR_APT_SCHEMA_VERSION')) {
 }
 if (!defined('NASR_FETCH_CHECK_INTERVAL')) {
     define('NASR_FETCH_CHECK_INTERVAL', REFERENCE_DATA_WEEK_SECONDS);
+}
+// Cold start / wiped cache: retry sooner than the weekly gate while APT/FRQ JSON is absent.
+// Lock files still prevent overlapping workers; FAA/NFDC HTTP remains paced separately.
+if (!defined('NASR_MISSING_RETRY_INTERVAL')) {
+    define('NASR_MISSING_RETRY_INTERVAL', 15 * 60);
 }
 if (!defined('NASR_CACHE_MAX_AGE')) {
     define('NASR_CACHE_MAX_AGE', NASR_CYCLE_PERIOD_SECONDS + REFERENCE_DATA_WEEK_SECONDS);

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -463,7 +463,7 @@ if (!defined('NASR_FETCH_CHECK_INTERVAL')) {
     define('NASR_FETCH_CHECK_INTERVAL', REFERENCE_DATA_WEEK_SECONDS);
 }
 // Cold start / wiped cache: retry sooner than the weekly gate while APT/FRQ JSON is absent.
-// Lock files still prevent overlapping workers; FAA/NFDC HTTP remains paced separately.
+// Lock files still prevent overlapping workers; FAA/NFDC HTTP pacing is unchanged.
 if (!defined('NASR_MISSING_RETRY_INTERVAL')) {
     define('NASR_MISSING_RETRY_INTERVAL', 15 * 60);
 }

--- a/lib/nasr/workers.php
+++ b/lib/nasr/workers.php
@@ -5,6 +5,7 @@
  */
 
 require_once __DIR__ . '/../cache-paths.php';
+require_once __DIR__ . '/../constants.php';
 require_once __DIR__ . '/../file-locks.php';
 require_once __DIR__ . '/cache.php';
 require_once __DIR__ . '/frequencies-cache.php';
@@ -26,6 +27,22 @@ function nasrFrqFetchInProgress(): bool
 }
 
 /**
+ * True when the NASR APT data file is present and readable.
+ */
+function nasrAptCacheDataPresent(): bool
+{
+    return is_readable(CACHE_NASR_APT_DATA_FILE);
+}
+
+/**
+ * True when the NASR FRQ data file is present and readable.
+ */
+function nasrFrqCacheDataPresent(): bool
+{
+    return is_readable(CACHE_NASR_FRQ_DATA_FILE);
+}
+
+/**
  * True when the scheduler should spawn fetch-nasr-apt.php.
  */
 function nasrAptWorkerShouldRun(): bool
@@ -41,4 +58,63 @@ function nasrAptWorkerShouldRun(): bool
 function nasrFrqWorkerShouldRun(): bool
 {
     return nasrFrqCacheNeedsRefresh() && !nasrFrqFetchInProgress() && !nasrAptFetchInProgress();
+}
+
+/**
+ * Scheduler backoff until the next APT spawn attempt.
+ *
+ * Missing data uses a short retry so cold start / wipe recovers without waiting a week.
+ * Present caches that still need refresh (age / cycle) keep the weekly gate.
+ */
+function nasrAptSchedulerRetryInterval(): int
+{
+    if (!nasrAptCacheDataPresent()) {
+        return (int) NASR_MISSING_RETRY_INTERVAL;
+    }
+
+    return (int) NASR_FETCH_CHECK_INTERVAL;
+}
+
+/**
+ * Scheduler backoff until the next FRQ spawn attempt.
+ *
+ * @see nasrAptSchedulerRetryInterval()
+ */
+function nasrFrqSchedulerRetryInterval(): int
+{
+    if (!nasrFrqCacheDataPresent()) {
+        return (int) NASR_MISSING_RETRY_INTERVAL;
+    }
+
+    return (int) NASR_FETCH_CHECK_INTERVAL;
+}
+
+/**
+ * Whether the scheduler should enqueue an APT fetch on this tick.
+ *
+ * Early gate is presence + needs-refresh (validity/age/cycle) via
+ * {@see nasrAptWorkerShouldRun()}, then interval since last attempt.
+ * `$lastAttemptAt === 0` means never attempted in this process (due immediately).
+ */
+function nasrAptSchedulerShouldEnqueue(int $now, int $lastAttemptAt): bool
+{
+    if (!nasrAptWorkerShouldRun()) {
+        return false;
+    }
+
+    return ($now - $lastAttemptAt) >= nasrAptSchedulerRetryInterval();
+}
+
+/**
+ * Whether the scheduler should enqueue an FRQ fetch on this tick.
+ *
+ * @see nasrAptSchedulerShouldEnqueue()
+ */
+function nasrFrqSchedulerShouldEnqueue(int $now, int $lastAttemptAt): bool
+{
+    if (!nasrFrqWorkerShouldRun()) {
+        return false;
+    }
+
+    return ($now - $lastAttemptAt) >= nasrFrqSchedulerRetryInterval();
 }

--- a/lib/reference-data-sources.php
+++ b/lib/reference-data-sources.php
@@ -303,7 +303,6 @@ function reference_data_nasr_frq_source_health(): array
     $messages = [];
     if (!$readable) {
         $status = 'down';
-        $messages[] = 'NASR FRQ cache missing';
     } else {
         if ($needsRefresh) {
             $status = 'degraded';
@@ -328,13 +327,17 @@ function reference_data_nasr_frq_source_health(): array
 
     $effectiveDate = is_array($meta) ? ($meta['frq_effective_date'] ?? null) : null;
 
-    $message = $airportCount > 0
-        ? "{$airportCount} airports in FRQ cache"
-        : 'NASR FRQ cache present';
-    if ($messages !== []) {
-        $message .= ' • ' . implode(' • ', $messages);
-    } elseif (!$needsRefresh) {
-        $message .= ' • Up to date';
+    if (!$readable) {
+        $message = 'NASR FRQ cache missing (run fetch-nasr-frq.php)';
+    } else {
+        $message = $airportCount > 0
+            ? "{$airportCount} airports in FRQ cache"
+            : 'NASR FRQ cache present';
+        if ($messages !== []) {
+            $message .= ' • ' . implode(' • ', $messages);
+        } elseif (!$needsRefresh) {
+            $message .= ' • Up to date';
+        }
     }
 
     return [

--- a/scripts/scheduler.php
+++ b/scripts/scheduler.php
@@ -75,8 +75,6 @@ $lastNwsPointsMissingLog = 0;
 $lastNmsFdcAirspaceMissingLog = 0;
 $deployDrainAnnounced = false;
 $runwaysFetchOnStartupDone = false;
-$nasrAptFetchOnStartupDone = false;
-$nasrFrqFetchOnStartupDone = false;
 $config = null;
 $healthStatus = 'healthy';
 $lastError = null;
@@ -373,7 +371,7 @@ $workRegistry->registerEnqueueTick('station_power', function (int $now) use (&$s
     }
 });
 
-$workRegistry->registerEnqueueTick('reference_data', function (int $now) use (&$lastOurAirportsProbe, &$lastOurAirportsBulkFetch, &$lastRunwaysFetch, &$runwaysFetchOnStartupDone, &$lastNasrAptFetch, &$nasrAptFetchOnStartupDone, &$lastNasrFrqFetch, &$nasrFrqFetchOnStartupDone, &$lastCountryResolutionSchedulerCheck, &$countryResolutionSchedulerStartupEval, &$lastConfigSha, &$config): void {
+$workRegistry->registerEnqueueTick('reference_data', function (int $now) use (&$lastOurAirportsProbe, &$lastOurAirportsBulkFetch, &$lastRunwaysFetch, &$runwaysFetchOnStartupDone, &$lastNasrAptFetch, &$lastNasrFrqFetch, &$lastCountryResolutionSchedulerCheck, &$countryResolutionSchedulerStartupEval, &$lastConfigSha, &$config): void {
     // 8. OurAirports upstream probe (daily; background worker only)
     if (($now - $lastOurAirportsProbe) >= OURAIRPORTS_PROBE_INTERVAL && ourAirportsProbeWorkerShouldRun()) {
         $probeScript = __DIR__ . '/probe-ourairports.php';
@@ -437,65 +435,39 @@ $workRegistry->registerEnqueueTick('reference_data', function (int $now) use (&$
         $lastRunwaysFetch = $now;
     }
 
-    // 8a. NASR APT cache fetch (weekly check; startup if missing)
-    if (!$nasrAptFetchOnStartupDone) {
-        if (nasrAptWorkerShouldRun()) {
-            $nasrScript = __DIR__ . '/fetch-nasr-apt.php';
-            if (file_exists($nasrScript)) {
-                $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';
-                exec(escapeshellarg($phpBin) . ' ' . escapeshellarg($nasrScript) . ' > /dev/null 2>&1 &');
-                reapZombies();
-                aviationwx_log('info', 'scheduler: nasr apt fetch started (startup)', [], 'app');
-            } else {
-                aviationwx_log('warning', 'scheduler: fetch-nasr-apt.php missing', [
-                'path' => $nasrScript,
-                ], 'app');
-            }
-            $lastNasrAptFetch = $now;
-        }
-        $nasrAptFetchOnStartupDone = true;
-    } elseif (($now - $lastNasrAptFetch) >= NASR_FETCH_CHECK_INTERVAL && nasrAptWorkerShouldRun()) {
+    // 8a. NASR APT: presence/age/cycle gate, then short retry if missing else weekly
+    if (nasrAptSchedulerShouldEnqueue($now, $lastNasrAptFetch)) {
         $nasrScript = __DIR__ . '/fetch-nasr-apt.php';
         if (file_exists($nasrScript)) {
             $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';
             exec(escapeshellarg($phpBin) . ' ' . escapeshellarg($nasrScript) . ' > /dev/null 2>&1 &');
             reapZombies();
-            aviationwx_log('info', 'scheduler: nasr apt fetch started (weekly)', [], 'app');
+            aviationwx_log('info', 'scheduler: nasr apt fetch started', [
+                'reason' => nasrAptCacheDataPresent() ? 'refresh' : 'missing',
+                'retry_interval_sec' => nasrAptSchedulerRetryInterval(),
+            ], 'app');
         } else {
             aviationwx_log('warning', 'scheduler: fetch-nasr-apt.php missing', [
-            'path' => $nasrScript,
+                'path' => $nasrScript,
             ], 'app');
         }
         $lastNasrAptFetch = $now;
     }
 
-    // 8a-ii. NASR FRQ cache fetch (weekly check; startup if missing)
-    if (!$nasrFrqFetchOnStartupDone) {
-        if (nasrFrqWorkerShouldRun()) {
-            $nasrFrqScript = __DIR__ . '/fetch-nasr-frq.php';
-            if (file_exists($nasrFrqScript)) {
-                $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';
-                exec(escapeshellarg($phpBin) . ' ' . escapeshellarg($nasrFrqScript) . ' > /dev/null 2>&1 &');
-                reapZombies();
-                aviationwx_log('info', 'scheduler: nasr frq fetch started (startup)', [], 'app');
-            } else {
-                aviationwx_log('warning', 'scheduler: fetch-nasr-frq.php missing', [
-                'path' => $nasrFrqScript,
-                ], 'app');
-            }
-            $lastNasrFrqFetch = $now;
-        }
-        $nasrFrqFetchOnStartupDone = true;
-    } elseif (($now - $lastNasrFrqFetch) >= NASR_FETCH_CHECK_INTERVAL && nasrFrqWorkerShouldRun()) {
+    // 8a-ii. NASR FRQ: same cadence policy; waits on APT lock via should-run
+    if (nasrFrqSchedulerShouldEnqueue($now, $lastNasrFrqFetch)) {
         $nasrFrqScript = __DIR__ . '/fetch-nasr-frq.php';
         if (file_exists($nasrFrqScript)) {
             $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';
             exec(escapeshellarg($phpBin) . ' ' . escapeshellarg($nasrFrqScript) . ' > /dev/null 2>&1 &');
             reapZombies();
-            aviationwx_log('info', 'scheduler: nasr frq fetch started (weekly)', [], 'app');
+            aviationwx_log('info', 'scheduler: nasr frq fetch started', [
+                'reason' => nasrFrqCacheDataPresent() ? 'refresh' : 'missing',
+                'retry_interval_sec' => nasrFrqSchedulerRetryInterval(),
+            ], 'app');
         } else {
             aviationwx_log('warning', 'scheduler: fetch-nasr-frq.php missing', [
-            'path' => $nasrFrqScript,
+                'path' => $nasrFrqScript,
             ], 'app');
         }
         $lastNasrFrqFetch = $now;

--- a/tests/Unit/ConstantsTest.php
+++ b/tests/Unit/ConstantsTest.php
@@ -240,6 +240,8 @@ class ConstantsTest extends TestCase
         $this->assertSame(28 * 86400, NASR_CYCLE_PERIOD_SECONDS);
         $this->assertSame(86400, OURAIRPORTS_PROBE_INTERVAL);
         $this->assertSame(REFERENCE_DATA_WEEK_SECONDS, NASR_FETCH_CHECK_INTERVAL);
+        $this->assertSame(15 * 60, NASR_MISSING_RETRY_INTERVAL);
+        $this->assertLessThan(NASR_FETCH_CHECK_INTERVAL, NASR_MISSING_RETRY_INTERVAL);
         $this->assertSame(NASR_CYCLE_PERIOD_SECONDS, OURAIRPORTS_BULK_HARD_MAX_AGE);
         $this->assertSame(NASR_CYCLE_PERIOD_SECONDS, FAA_NGDA_RUNWAY_REFRESH_MAX_AGE);
         $this->assertSame(NASR_CYCLE_PERIOD_SECONDS, RUNWAYS_CACHE_MAX_AGE);
@@ -256,10 +258,8 @@ class ConstantsTest extends TestCase
         $this->assertSame(60, NASR_HTTP_MIN_INTERVAL_SECONDS);
         $this->assertSame(7200, NASR_APT_WORKER_TIMEOUT);
         $this->assertSame(3600, NASR_FRQ_WORKER_TIMEOUT);
-        $this->assertSame(
-            REFERENCE_DATA_SPAWN_CHECK_INTERVAL,
-            OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL
-        );
+        $this->assertSame(3600, OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL);
+        $this->assertLessThan(OURAIRPORTS_PROBE_INTERVAL, OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL);
         $this->assertSame(6 * 3600, FAA_NGDA_FETCH_RETRY_INTERVAL);
     }
     

--- a/tests/Unit/NasrCacheHealthTest.php
+++ b/tests/Unit/NasrCacheHealthTest.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../../lib/config.php';
 require_once __DIR__ . '/../../lib/constants.php';
 require_once __DIR__ . '/../../lib/cache-paths.php';
 require_once __DIR__ . '/../../lib/status-checks.php';
+require_once __DIR__ . '/../../lib/reference-data-sources.php';
 
 class NasrCacheHealthTest extends TestCase
 {
@@ -17,7 +18,7 @@ class NasrCacheHealthTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        foreach ([CACHE_NASR_APT_DATA_FILE, CACHE_NASR_APT_META_FILE, CACHE_NASR_APT_CONFIGURED_FILE] as $path) {
+        foreach ([CACHE_NASR_APT_DATA_FILE, CACHE_NASR_APT_META_FILE, CACHE_NASR_APT_CONFIGURED_FILE, CACHE_NASR_FRQ_DATA_FILE] as $path) {
             if (file_exists($path)) {
                 $this->backupFiles[$path] = file_get_contents($path);
                 @unlink($path);
@@ -27,7 +28,7 @@ class NasrCacheHealthTest extends TestCase
 
     protected function tearDown(): void
     {
-        foreach ([CACHE_NASR_APT_DATA_FILE, CACHE_NASR_APT_META_FILE, CACHE_NASR_APT_CONFIGURED_FILE] as $path) {
+        foreach ([CACHE_NASR_APT_DATA_FILE, CACHE_NASR_APT_META_FILE, CACHE_NASR_APT_CONFIGURED_FILE, CACHE_NASR_FRQ_DATA_FILE] as $path) {
             if (isset($this->backupFiles[$path])) {
                 $dir = dirname($path);
                 if (!is_dir($dir)) {
@@ -95,6 +96,17 @@ class NasrCacheHealthTest extends TestCase
 
         $this->assertSame('degraded', $health['status']);
         $this->assertStringContainsString('Last fetch failed', $health['message']);
+    }
+
+    public function testNasrFrqHealthWhenMissing_DoesNotClaimPresent(): void
+    {
+        @unlink(CACHE_NASR_FRQ_DATA_FILE);
+
+        $leaf = reference_data_nasr_frq_source_health();
+
+        $this->assertSame('down', $leaf['status']);
+        $this->assertStringContainsString('missing', $leaf['message']);
+        $this->assertStringNotContainsString('cache present', $leaf['message']);
     }
 
     /**

--- a/tests/Unit/NasrWorkersTest.php
+++ b/tests/Unit/NasrWorkersTest.php
@@ -7,10 +7,45 @@
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../lib/cache-paths.php';
+require_once __DIR__ . '/../../lib/constants.php';
 require_once __DIR__ . '/../../lib/nasr/workers.php';
 
 class NasrWorkersTest extends TestCase
 {
+    /** @var array<string, string|null> */
+    private array $backupFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        foreach ([CACHE_NASR_APT_DATA_FILE, CACHE_NASR_FRQ_DATA_FILE, CACHE_NASR_APT_META_FILE] as $path) {
+            $this->backupFiles[$path] = file_exists($path) ? (string) file_get_contents($path) : null;
+            if (file_exists($path)) {
+                @unlink($path);
+            }
+        }
+        resetNasrAptCacheMemo();
+        resetNasrFrqCacheMemo();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->backupFiles as $path => $contents) {
+            if ($contents !== null) {
+                $dir = dirname($path);
+                if (!is_dir($dir)) {
+                    @mkdir($dir, 0755, true);
+                }
+                file_put_contents($path, $contents);
+            } elseif (file_exists($path)) {
+                @unlink($path);
+            }
+        }
+        resetNasrAptCacheMemo();
+        resetNasrFrqCacheMemo();
+        parent::tearDown();
+    }
+
     public function testFrqWorkerWaitsForAptFetchLock(): void
     {
         $lockPath = getNasrAptFetchLockPath();
@@ -49,5 +84,168 @@ class NasrWorkersTest extends TestCase
             flock($fp, LOCK_UN);
             fclose($fp);
         }
+    }
+
+    public function testMissingCache_UsesShortRetryInterval(): void
+    {
+        $this->assertFalse(nasrAptCacheDataPresent());
+        $this->assertFalse(nasrFrqCacheDataPresent());
+        $this->assertSame(NASR_MISSING_RETRY_INTERVAL, nasrAptSchedulerRetryInterval());
+        $this->assertSame(NASR_MISSING_RETRY_INTERVAL, nasrFrqSchedulerRetryInterval());
+    }
+
+    public function testPresentCache_UsesWeeklyRetryInterval(): void
+    {
+        $this->writeMinimalAptCache();
+        $this->writeMinimalFrqCache();
+
+        $this->assertTrue(nasrAptCacheDataPresent());
+        $this->assertTrue(nasrFrqCacheDataPresent());
+        $this->assertSame(NASR_FETCH_CHECK_INTERVAL, nasrAptSchedulerRetryInterval());
+        $this->assertSame(NASR_FETCH_CHECK_INTERVAL, nasrFrqSchedulerRetryInterval());
+    }
+
+    public function testMissingCache_ColdStartEnqueuesImmediately(): void
+    {
+        $now = 1_700_000_000;
+        $this->assertTrue(nasrAptSchedulerShouldEnqueue($now, 0));
+        $this->assertTrue(nasrFrqSchedulerShouldEnqueue($now, 0));
+    }
+
+    public function testMissingCache_RespectsShortBackoffAfterFailedAttempt(): void
+    {
+        $now = 1_700_000_000;
+        $lastAttempt = $now - (NASR_MISSING_RETRY_INTERVAL - 1);
+
+        $this->assertFalse(nasrAptSchedulerShouldEnqueue($now, $lastAttempt));
+        $this->assertFalse(nasrFrqSchedulerShouldEnqueue($now, $lastAttempt));
+    }
+
+    public function testMissingCache_RetriesAfterShortBackoff(): void
+    {
+        $now = 1_700_000_000;
+        $lastAttempt = $now - NASR_MISSING_RETRY_INTERVAL;
+
+        $this->assertTrue(nasrAptSchedulerShouldEnqueue($now, $lastAttempt));
+        $this->assertTrue(nasrFrqSchedulerShouldEnqueue($now, $lastAttempt));
+    }
+
+    public function testPresentFreshCache_DoesNotEnqueue(): void
+    {
+        $this->writeMinimalAptCache();
+        $this->writeMinimalFrqCache();
+        $this->writeFreshMeta();
+
+        $now = time();
+        $this->assertFalse(nasrAptCacheNeedsRefresh());
+        $this->assertFalse(nasrFrqCacheNeedsRefresh());
+        $this->assertFalse(nasrAptSchedulerShouldEnqueue($now, 0));
+        $this->assertFalse(nasrFrqSchedulerShouldEnqueue($now, 0));
+    }
+
+    public function testPresentStaleCache_UsesWeeklyGateNotMissingRetry(): void
+    {
+        $this->writeMinimalAptCache();
+        $this->writeMinimalFrqCache();
+        // Old mtime forces APT age refresh; FRQ uses meta frq_fetched_at
+        touch(CACHE_NASR_APT_DATA_FILE, time() - NASR_CACHE_MAX_AGE - 10);
+        $this->writeStaleFrqMeta();
+
+        $this->assertTrue(nasrAptCacheDataPresent());
+        $this->assertTrue(nasrAptCacheNeedsRefresh());
+        $this->assertSame(NASR_FETCH_CHECK_INTERVAL, nasrAptSchedulerRetryInterval());
+
+        $now = 1_700_000_000;
+        $this->assertFalse(
+            nasrAptSchedulerShouldEnqueue($now, $now - NASR_MISSING_RETRY_INTERVAL),
+            'Present-but-stale must not use the missing-cache short retry'
+        );
+        $this->assertTrue(
+            nasrAptSchedulerShouldEnqueue($now, $now - NASR_FETCH_CHECK_INTERVAL),
+            'Present-but-stale should enqueue after the weekly gate'
+        );
+    }
+
+    public function testFormerWeeklyHole_NoLongerBlocksMissingCache(): void
+    {
+        // Regression: stamping lastAttempt at startup used to block retries for a full week
+        // while the cache file was still missing.
+        $now = 1_700_000_000;
+        $lastAttempt = $now - (60 * 60); // one hour ago (failed/aborted cold start)
+
+        $this->assertLessThan(NASR_FETCH_CHECK_INTERVAL, 60 * 60);
+        $this->assertTrue(nasrAptSchedulerShouldEnqueue($now, $lastAttempt));
+        $this->assertTrue(nasrFrqSchedulerShouldEnqueue($now, $lastAttempt));
+    }
+
+    private function writeMinimalAptCache(): void
+    {
+        $dir = dirname(CACHE_NASR_APT_DATA_FILE);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        file_put_contents(CACHE_NASR_APT_DATA_FILE, json_encode([
+            'schema_version' => NASR_APT_SCHEMA_VERSION,
+            'airports' => [],
+        ], JSON_UNESCAPED_SLASHES));
+        touch(CACHE_NASR_APT_DATA_FILE, time());
+    }
+
+    private function writeMinimalFrqCache(): void
+    {
+        $dir = dirname(CACHE_NASR_FRQ_DATA_FILE);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        file_put_contents(CACHE_NASR_FRQ_DATA_FILE, json_encode([
+            'schema_version' => NASR_FRQ_SCHEMA_VERSION,
+            'airports' => [],
+        ], JSON_UNESCAPED_SLASHES));
+        touch(CACHE_NASR_FRQ_DATA_FILE, time());
+    }
+
+    private function writeFreshMeta(): void
+    {
+        $dir = dirname(CACHE_NASR_APT_META_FILE);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        $cycle = gmdate('Y-m-d');
+        $next = gmdate('Y-m-d', time() + (NASR_CYCLE_PERIOD_DAYS * 86400));
+        file_put_contents(CACHE_NASR_APT_META_FILE, json_encode([
+            'schema_version' => NASR_APT_SCHEMA_VERSION,
+            'effective_date' => $cycle,
+            'tracked_current_cycle_date' => $cycle,
+            'tracked_next_cycle_date' => $next,
+            'airport_count' => 0,
+            'fetched_at' => gmdate('c'),
+            'frq_fetched_at' => gmdate('c'),
+            'frq_airport_count' => 0,
+            'frq_effective_date' => $cycle,
+        ], JSON_UNESCAPED_SLASHES));
+        resetNasrAptCacheMemo();
+        resetNasrFrqCacheMemo();
+    }
+
+    private function writeStaleFrqMeta(): void
+    {
+        $dir = dirname(CACHE_NASR_APT_META_FILE);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        $old = gmdate('c', time() - NASR_CACHE_MAX_AGE - 100);
+        file_put_contents(CACHE_NASR_APT_META_FILE, json_encode([
+            'schema_version' => NASR_APT_SCHEMA_VERSION,
+            'effective_date' => '2020-01-01',
+            'tracked_current_cycle_date' => '2020-01-01',
+            'tracked_next_cycle_date' => '2020-01-29',
+            'airport_count' => 0,
+            'fetched_at' => $old,
+            'frq_fetched_at' => $old,
+            'frq_airport_count' => 0,
+            'frq_effective_date' => '2020-01-01',
+        ], JSON_UNESCAPED_SLASHES));
+        resetNasrAptCacheMemo();
+        resetNasrFrqCacheMemo();
     }
 }


### PR DESCRIPTION
## Summary
- Retry NASR APT/FRQ scheduler spawns on a short interval while cache JSON is missing, instead of waiting up to a week after a failed cold-start attempt (production left Reference data Down after deploy wipe).
- Keep the weekly gate when APT/FRQ files are present but aged or need cycle rediscovery; early checks remain presence, needs-refresh, and locks.
- Fix NASR FRQ status copy so a missing file no longer reads as "cache present • cache missing".
- Move OurAirports bulk (and shared runway-merge post-startup) spawn check interval from 60s to hourly; first tick still due immediately via `lastAttempt = 0`.

## Test plan
- [x] Unit: `NasrWorkersTest` (missing vs weekly gates, weekly-hole regression), `NasrCacheHealthTest` FRQ message, `ConstantsTest` cadence
- [x] Docker cold-boot simulation of enqueue helpers (wipe cache → enqueue at t=0; +15m retry after failed stamp; healthy cache uses weekly)
- [ ] After deploy: confirm `cache/nasr/` refill without manual `fetch-nasr-*.php`, and Reference data leaves Down
- [ ] Optional prod one-time heal before/after merge if still empty: `php scripts/fetch-nasr-apt.php` then `fetch-nasr-frq.php`