### PR TITLE
Fix NASR workers killed by short stuck-heartbeat cleanup

### DIFF
--- a/lib/nasr/discovery.php
+++ b/lib/nasr/discovery.php
@@ -92,6 +92,11 @@ function nasrHttpThrottlePaths(): array
  */
 function nasrHttpThrottle(): void
 {
+    // Long NASR jobs: progress signal for stuck-worker cleanup during paced HTTP.
+    if (function_exists('updateWorkerHeartbeat')) {
+        updateWorkerHeartbeat();
+    }
+
     if (!nasrHttpThrottleShouldEnforce()) {
         return;
     }

--- a/lib/nasr/discovery.php
+++ b/lib/nasr/discovery.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/../constants.php';
 require_once __DIR__ . '/../config.php';
 require_once __DIR__ . '/../logger.php';
 require_once __DIR__ . '/../cache-paths.php';
+require_once __DIR__ . '/../worker-timeout.php';
 
 /**
  * User-Agent for FAA/NFDC HTTP.
@@ -93,9 +94,7 @@ function nasrHttpThrottlePaths(): array
 function nasrHttpThrottle(): void
 {
     // Long NASR jobs: refresh silence clock on each paced FAA/NFDC attempt.
-    if (function_exists('updateWorkerHeartbeat')) {
-        updateWorkerHeartbeat();
-    }
+    updateWorkerHeartbeat();
 
     if (!nasrHttpThrottleShouldEnforce()) {
         return;

--- a/lib/nasr/discovery.php
+++ b/lib/nasr/discovery.php
@@ -92,7 +92,7 @@ function nasrHttpThrottlePaths(): array
  */
 function nasrHttpThrottle(): void
 {
-    // Long NASR jobs: progress signal for stuck-worker cleanup during paced HTTP.
+    // Long NASR jobs: refresh silence clock on each paced FAA/NFDC attempt.
     if (function_exists('updateWorkerHeartbeat')) {
         updateWorkerHeartbeat();
     }

--- a/lib/nasr/parse.php
+++ b/lib/nasr/parse.php
@@ -4,6 +4,7 @@
  */
 
 require_once __DIR__ . '/../constants.php';
+require_once __DIR__ . '/../worker-timeout.php';
 require_once __DIR__ . '/csv-validation.php';
 require_once __DIR__ . '/runway-remarks.php';
 
@@ -163,10 +164,9 @@ function nasrIterateCsvFile(string $path): Generator
         $header = array_map(static fn ($col) => trim((string) $col), $header);
 
         $rowIndex = 0;
+        // Sparse enough for large CSVs; frequent enough to beat silence stale policy.
         $heartbeatEveryRows = 5000;
-        if (function_exists('updateWorkerHeartbeat')) {
-            updateWorkerHeartbeat();
-        }
+        updateWorkerHeartbeat();
 
         while (($data = fgetcsv($handle, 0, ',', '"', '\\')) !== false) {
             if ($data === [null] || $data === false) {
@@ -179,7 +179,7 @@ function nasrIterateCsvFile(string $path): Generator
             yield $row;
 
             $rowIndex++;
-            if ($rowIndex % $heartbeatEveryRows === 0 && function_exists('updateWorkerHeartbeat')) {
+            if ($rowIndex % $heartbeatEveryRows === 0) {
                 updateWorkerHeartbeat();
             }
         }

--- a/lib/nasr/parse.php
+++ b/lib/nasr/parse.php
@@ -28,10 +28,6 @@ function nasrParseAptCsvDirectory(string $csvDir): array
     $effectiveDate = null;
     $airports = [];
 
-    if (function_exists('updateWorkerHeartbeat')) {
-        updateWorkerHeartbeat();
-    }
-
     foreach (nasrIterateCsvFile($basePath) as $row) {
         $effectiveDate = $effectiveDate ?? nasrNormalizeEffectiveDate($row['EFF_DATE'] ?? null);
         $arptId = strtoupper(trim((string) ($row['ARPT_ID'] ?? '')));
@@ -53,9 +49,6 @@ function nasrParseAptCsvDirectory(string $csvDir): array
     }
 
     $runwaysByKey = [];
-    if (function_exists('updateWorkerHeartbeat')) {
-        updateWorkerHeartbeat();
-    }
     foreach (nasrIterateCsvFile($rwyPath) as $row) {
         $effectiveDate = $effectiveDate ?? nasrNormalizeEffectiveDate($row['EFF_DATE'] ?? null);
         $arptId = strtoupper(trim((string) ($row['ARPT_ID'] ?? '')));
@@ -100,9 +93,6 @@ function nasrParseAptCsvDirectory(string $csvDir): array
     }
     unset($runwaysByKey);
 
-    if (function_exists('updateWorkerHeartbeat')) {
-        updateWorkerHeartbeat();
-    }
     foreach (nasrIterateCsvFile($endPath) as $row) {
         $effectiveDate = $effectiveDate ?? nasrNormalizeEffectiveDate($row['EFF_DATE'] ?? null);
         $arptId = strtoupper(trim((string) ($row['ARPT_ID'] ?? '')));
@@ -172,6 +162,12 @@ function nasrIterateCsvFile(string $path): Generator
 
         $header = array_map(static fn ($col) => trim((string) $col), $header);
 
+        $rowIndex = 0;
+        $heartbeatEveryRows = 5000;
+        if (function_exists('updateWorkerHeartbeat')) {
+            updateWorkerHeartbeat();
+        }
+
         while (($data = fgetcsv($handle, 0, ',', '"', '\\')) !== false) {
             if ($data === [null] || $data === false) {
                 continue;
@@ -181,6 +177,11 @@ function nasrIterateCsvFile(string $path): Generator
                 $row[$col] = $data[$i] ?? '';
             }
             yield $row;
+
+            $rowIndex++;
+            if ($rowIndex % $heartbeatEveryRows === 0 && function_exists('updateWorkerHeartbeat')) {
+                updateWorkerHeartbeat();
+            }
         }
     } finally {
         fclose($handle);

--- a/lib/nasr/parse.php
+++ b/lib/nasr/parse.php
@@ -28,6 +28,10 @@ function nasrParseAptCsvDirectory(string $csvDir): array
     $effectiveDate = null;
     $airports = [];
 
+    if (function_exists('updateWorkerHeartbeat')) {
+        updateWorkerHeartbeat();
+    }
+
     foreach (nasrIterateCsvFile($basePath) as $row) {
         $effectiveDate = $effectiveDate ?? nasrNormalizeEffectiveDate($row['EFF_DATE'] ?? null);
         $arptId = strtoupper(trim((string) ($row['ARPT_ID'] ?? '')));
@@ -49,6 +53,9 @@ function nasrParseAptCsvDirectory(string $csvDir): array
     }
 
     $runwaysByKey = [];
+    if (function_exists('updateWorkerHeartbeat')) {
+        updateWorkerHeartbeat();
+    }
     foreach (nasrIterateCsvFile($rwyPath) as $row) {
         $effectiveDate = $effectiveDate ?? nasrNormalizeEffectiveDate($row['EFF_DATE'] ?? null);
         $arptId = strtoupper(trim((string) ($row['ARPT_ID'] ?? '')));
@@ -93,6 +100,9 @@ function nasrParseAptCsvDirectory(string $csvDir): array
     }
     unset($runwaysByKey);
 
+    if (function_exists('updateWorkerHeartbeat')) {
+        updateWorkerHeartbeat();
+    }
     foreach (nasrIterateCsvFile($endPath) as $row) {
         $effectiveDate = $effectiveDate ?? nasrNormalizeEffectiveDate($row['EFF_DATE'] ?? null);
         $arptId = strtoupper(trim((string) ($row['ARPT_ID'] ?? '')));

--- a/lib/nasr/workers.php
+++ b/lib/nasr/workers.php
@@ -53,11 +53,15 @@ function nasrAptWorkerShouldRun(): bool
 /**
  * True when the scheduler should spawn fetch-nasr-frq.php.
  *
- * FRQ waits for APT fetch so cycle metadata is not updated mid-download.
+ * Requires APT cache on disk (avoids spawning FRQ before a background APT child
+ * holds its lock). Also waits while an APT fetch lock is held.
  */
 function nasrFrqWorkerShouldRun(): bool
 {
-    return nasrFrqCacheNeedsRefresh() && !nasrFrqFetchInProgress() && !nasrAptFetchInProgress();
+    return nasrAptCacheDataPresent()
+        && nasrFrqCacheNeedsRefresh()
+        && !nasrFrqFetchInProgress()
+        && !nasrAptFetchInProgress();
 }
 
 /**

--- a/lib/worker-timeout.php
+++ b/lib/worker-timeout.php
@@ -153,62 +153,86 @@ function shouldWorkerAbort(int $requiredSeconds = 10): bool {
 }
 
 /**
- * Clean up stale worker heartbeat files
- * 
- * Finds and removes heartbeat files from workers that appear to have died
- * without cleaning up. Also returns PIDs of potentially stuck workers.
- * 
- * @param int|null $staleSeconds Consider heartbeat stale after this many seconds (default: worker_timeout + 30)
+ * Stale age for a worker heartbeat (declared timeout +30s, override, or default).
+ *
+ * Declared timeout comes from initWorkerTimeout so long jobs (NASR APT) are not
+ * killed by the short webcam/weather default.
+ *
+ * @param array<string, mixed> $data Heartbeat JSON payload
+ * @param int|null $staleSecondsOverride When set, applies to all workers
+ * @param int $defaultStaleSeconds Fallback when no declared timeout (typically getWorkerTimeout()+30)
+ * @return int Seconds after last heartbeat stamp before the worker is stale
+ */
+function workerHeartbeatStaleAfterSeconds(
+    array $data,
+    ?int $staleSecondsOverride,
+    int $defaultStaleSeconds
+): int {
+    if ($staleSecondsOverride !== null) {
+        return max(1, $staleSecondsOverride);
+    }
+
+    $declaredTimeout = isset($data['timeout']) && is_numeric($data['timeout'])
+        ? (int) $data['timeout']
+        : 0;
+    if ($declaredTimeout <= 0) {
+        return max(1, $defaultStaleSeconds);
+    }
+
+    // Cap corrupt timeout values so stuck workers remain killable.
+    return min($declaredTimeout + 30, 86400 + 30);
+}
+
+/**
+ * Clean up stale worker heartbeat files and return PIDs that still look stuck.
+ *
+ * @param int|null $staleSeconds Override for all files; null uses each file's
+ *        declared timeout (+30s) or getWorkerTimeout()+30.
  * @return int[] PIDs of potentially stuck workers (empty if none found)
  */
 function cleanupStaleWorkerHeartbeats(?int $staleSeconds = null): array {
-    if ($staleSeconds === null) {
-        $staleSeconds = getWorkerTimeout() + 30;
-    }
-    
     $stuckPids = [];
     $pattern = '/tmp/worker_heartbeat_*.json';
     $files = glob($pattern);
-    
-    // glob() returns false on error, empty array if no matches
+
     if ($files === false || empty($files)) {
         return $stuckPids;
     }
-    
+
     $now = time();
+    $defaultStaleSeconds = getWorkerTimeout() + 30;
     foreach ($files as $file) {
         $content = @file_get_contents($file);
         if ($content === false) {
             continue;
         }
-        
+
         $data = @json_decode($content, true);
         if (!is_array($data) || !isset($data['heartbeat']) || !isset($data['pid'])) {
-            // Invalid format, just delete
             @unlink($file);
             continue;
         }
-        
-        $heartbeatAge = $now - $data['heartbeat'];
-        if ($heartbeatAge > $staleSeconds) {
-            // Heartbeat is stale - worker may be stuck
-            $pid = (int)$data['pid'];
-            
-            // Use cross-platform process check from process-utils.php
+
+        $effectiveStale = workerHeartbeatStaleAfterSeconds($data, $staleSeconds, $defaultStaleSeconds);
+        $heartbeatAge = $now - (int) $data['heartbeat'];
+        if ($heartbeatAge > $effectiveStale) {
+            $pid = (int) $data['pid'];
+
             if ($pid > 0 && isProcessRunning($pid, 'php')) {
                 $stuckPids[] = $pid;
                 aviationwx_log('warning', 'worker heartbeat stale - process may be stuck', [
                     'pid' => $pid,
                     'heartbeat_age' => $heartbeatAge,
-                    'file' => basename($file)
+                    'stale_after' => $effectiveStale,
+                    'file' => basename($file),
                 ], 'app');
             }
-            
-            // Clean up the file regardless
+
+            // Drop stamp either way so we do not re-warn every cleanup tick.
             @unlink($file);
         }
     }
-    
+
     return $stuckPids;
 }
 

--- a/lib/worker-timeout.php
+++ b/lib/worker-timeout.php
@@ -153,15 +153,15 @@ function shouldWorkerAbort(int $requiredSeconds = 10): bool {
 }
 
 /**
- * Stale age for a worker heartbeat (declared timeout +30s, override, or default).
+ * Silence allowed after the last heartbeat before a worker is treated as stuck.
  *
- * Declared timeout comes from initWorkerTimeout so long jobs (NASR APT) are not
- * killed by the short webcam/weather default.
+ * Uses the worker's declared timeout from initWorkerTimeout (not total runtime
+ * since start) so long jobs are not killed by the short webcam/weather default.
  *
  * @param array<string, mixed> $data Heartbeat JSON payload
  * @param int|null $staleSecondsOverride When set, applies to all workers
  * @param int $defaultStaleSeconds Fallback when no declared timeout (typically getWorkerTimeout()+30)
- * @return int Seconds after last heartbeat stamp before the worker is stale
+ * @return int Seconds of no heartbeat progress before the worker is stale
  */
 function workerHeartbeatStaleAfterSeconds(
     array $data,
@@ -184,11 +184,19 @@ function workerHeartbeatStaleAfterSeconds(
 }
 
 /**
+ * Whether a heartbeat glob is restricted to /tmp/worker_heartbeat_*.json paths.
+ */
+function workerHeartbeatGlobIsAllowed(string $globPattern): bool
+{
+    return preg_match('#^/tmp/worker_heartbeat_[A-Za-z0-9_*?\-]*\.json$#', $globPattern) === 1;
+}
+
+/**
  * Clean up stale worker heartbeat files and return PIDs that still look stuck.
  *
  * @param int|null $staleSeconds Override for all files; null uses each file's
  *        declared timeout (+30s) or getWorkerTimeout()+30.
- * @param string $globPattern Heartbeat file glob (tests may narrow this)
+ * @param string $globPattern Heartbeat file glob (tests may narrow within /tmp)
  * @return int[] PIDs of potentially stuck workers (empty if none found)
  */
 function cleanupStaleWorkerHeartbeats(
@@ -196,6 +204,10 @@ function cleanupStaleWorkerHeartbeats(
     string $globPattern = '/tmp/worker_heartbeat_*.json'
 ): array {
     $stuckPids = [];
+    if (!workerHeartbeatGlobIsAllowed($globPattern)) {
+        return $stuckPids;
+    }
+
     $files = glob($globPattern);
 
     if ($files === false || empty($files)) {

--- a/lib/worker-timeout.php
+++ b/lib/worker-timeout.php
@@ -185,12 +185,11 @@ function workerHeartbeatStaleAfterSeconds(
 
 /**
  * Whether a heartbeat glob is restricted to /tmp/worker_heartbeat_*.json paths.
- *
- * Character class includes underscore so ids like nasr_apt / test_... match.
  */
 function workerHeartbeatGlobIsAllowed(string $globPattern): bool
 {
-    return preg_match('#^/tmp/worker_heartbeat_[A-Za-z0-9_*?\-]*\.json$#', $globPattern) === 1;
+    // \w includes underscore (nasr_apt, test_...); * ? - are glob metacharacters.
+    return preg_match('#^/tmp/worker_heartbeat_[\w*?-]*\.json$#', $globPattern) === 1;
 }
 
 /**

--- a/lib/worker-timeout.php
+++ b/lib/worker-timeout.php
@@ -188,12 +188,15 @@ function workerHeartbeatStaleAfterSeconds(
  *
  * @param int|null $staleSeconds Override for all files; null uses each file's
  *        declared timeout (+30s) or getWorkerTimeout()+30.
+ * @param string $globPattern Heartbeat file glob (tests may narrow this)
  * @return int[] PIDs of potentially stuck workers (empty if none found)
  */
-function cleanupStaleWorkerHeartbeats(?int $staleSeconds = null): array {
+function cleanupStaleWorkerHeartbeats(
+    ?int $staleSeconds = null,
+    string $globPattern = '/tmp/worker_heartbeat_*.json'
+): array {
     $stuckPids = [];
-    $pattern = '/tmp/worker_heartbeat_*.json';
-    $files = glob($pattern);
+    $files = glob($globPattern);
 
     if ($files === false || empty($files)) {
         return $stuckPids;

--- a/lib/worker-timeout.php
+++ b/lib/worker-timeout.php
@@ -179,12 +179,14 @@ function workerHeartbeatStaleAfterSeconds(
         return max(1, $defaultStaleSeconds);
     }
 
-    // Cap corrupt timeout values so stuck workers remain killable.
-    return min($declaredTimeout + 30, 86400 + 30);
+    // Cap declared timeout before adding the buffer (avoids int overflow on corrupt values).
+    return min($declaredTimeout, 86400) + 30;
 }
 
 /**
  * Whether a heartbeat glob is restricted to /tmp/worker_heartbeat_*.json paths.
+ *
+ * Character class includes underscore so ids like nasr_apt / test_... match.
  */
 function workerHeartbeatGlobIsAllowed(string $globPattern): bool
 {

--- a/lib/worker-timeout.php
+++ b/lib/worker-timeout.php
@@ -163,8 +163,8 @@ function shouldWorkerAbort(int $requiredSeconds = 10): bool {
 /**
  * Silence allowed after the last heartbeat before a worker is treated as stuck.
  *
- * Uses the worker's declared timeout from initWorkerTimeout (not total runtime
- * since start) so long jobs are not killed by the short webcam/weather default.
+ * Also used as the absolute runtime ceiling from `started` so a worker that
+ * keeps refreshing heartbeats past its declared timeout is still cleaned up.
  *
  * @param array<string, mixed> $data Heartbeat JSON payload
  * @param int|null $staleSecondsOverride When set, applies to all workers
@@ -203,13 +203,18 @@ function workerHeartbeatGlobIsAllowed(string $globPattern): bool
 /**
  * Cmdline substring used to verify a heartbeat PID before kill (limits PID reuse risk).
  *
+ * Heartbeat files live in world-writable /tmp, so "script" is only trusted when it
+ * looks like a worker basename (e.g. fetch-nasr-apt.php). Broad tokens like "php"
+ * fall back to scripts/ (same idea as scheduler-health-check's "scheduler" token).
+ *
  * @param array<string, mixed> $data Heartbeat JSON payload
  */
 function workerHeartbeatExpectedProcessName(array $data): string
 {
     if (!empty($data['script']) && is_string($data['script'])) {
         $script = basename($data['script']);
-        if ($script !== '' && $script !== '.' && $script !== '..') {
+        // Reject free-form / broad tokens from forged heartbeat files.
+        if (preg_match('/^[A-Za-z0-9_-]+\.php$/', $script) === 1) {
             return $script;
         }
     }
@@ -257,80 +262,84 @@ function cleanupStaleWorkerHeartbeats(
 
         $effectiveStale = workerHeartbeatStaleAfterSeconds($data, $staleSeconds, $defaultStaleSeconds);
         $heartbeatAge = $now - (int) $data['heartbeat'];
-        if ($heartbeatAge > $effectiveStale) {
-            $pid = (int) $data['pid'];
-            $expectedName = workerHeartbeatExpectedProcessName($data);
-
-            if ($pid > 0 && isProcessRunning($pid, $expectedName)) {
-                $stuckWorkers[] = [
-                    'pid' => $pid,
-                    'expected_name' => $expectedName,
-                ];
-                aviationwx_log('warning', 'worker heartbeat stale - process may be stuck', [
-                    'pid' => $pid,
-                    'heartbeat_age' => $heartbeatAge,
-                    'stale_after' => $effectiveStale,
-                    'expected_name' => $expectedName,
-                    'file' => basename($file),
-                ], 'app');
-            }
-
-            // Drop stamp either way so we do not re-warn every cleanup tick.
-            @unlink($file);
+        $started = isset($data['started']) ? (int) $data['started'] : 0;
+        // Absolute runtime past declared timeout (defense if heartbeats keep refreshing).
+        $pastAbsoluteDeadline = $started > 0 && ($now - $started) > $effectiveStale;
+        if ($heartbeatAge <= $effectiveStale && !$pastAbsoluteDeadline) {
+            continue;
         }
+
+        $pid = (int) $data['pid'];
+        $expectedName = workerHeartbeatExpectedProcessName($data);
+
+        if ($pid > 0 && isProcessRunning($pid, $expectedName)) {
+            $stuckWorkers[] = [
+                'pid' => $pid,
+                'expected_name' => $expectedName,
+            ];
+            aviationwx_log('warning', 'worker heartbeat stale - process may be stuck', [
+                'pid' => $pid,
+                'heartbeat_age' => $heartbeatAge,
+                'stale_after' => $effectiveStale,
+                'runtime' => $started > 0 ? ($now - $started) : null,
+                'expected_name' => $expectedName,
+                'file' => basename($file),
+            ], 'app');
+            // Keep stamp so a failed kill is retried on the next cleanup tick.
+            continue;
+        }
+
+        @unlink($file);
     }
 
     return $stuckWorkers;
 }
 
 /**
- * Kill stuck worker processes
- * 
- * Attempts to terminate stuck worker processes identified by cleanupStaleWorkerHeartbeats().
- * Uses SIGTERM first, then SIGKILL if process doesn't exit.
- * 
- * @param int[] $pids Array of PIDs to kill
- * @param string $expectedName Process name substring to verify before killing (safety check)
- * @return int Number of processes killed
+ * Kill stuck workers returned by cleanupStaleWorkerHeartbeats().
+ *
+ * Matches ProcessPool / scheduler-health-check: SIGTERM, brief wait, then SIGKILL.
+ *
+ * @param list<array{pid: int, expected_name?: string}> $stuckWorkers
+ * @return list<int> PIDs that were signaled (for accurate scheduler logs)
  */
-function killStuckWorkers(array $pids, string $expectedName = 'scripts/'): int {
-    // Require posix_kill and signal constants for this function
+function killStuckWorkers(array $stuckWorkers): array
+{
     if (!function_exists('posix_kill') || !defined('SIGTERM') || !defined('SIGKILL')) {
-        return 0;
+        return [];
     }
-    
-    $killed = 0;
-    
-    foreach ($pids as $pid) {
-        $pid = (int)$pid;
-        if ($pid <= 0) {
+
+    $killedPids = [];
+
+    foreach ($stuckWorkers as $worker) {
+        $pid = (int) ($worker['pid'] ?? 0);
+        $expectedName = (string) ($worker['expected_name'] ?? 'scripts/');
+        if ($pid <= 0 || $expectedName === '') {
             continue;
         }
-        
-        // Use cross-platform process check with name verification
-        // This prevents killing unrelated processes (e.g., PID reuse)
+
+        // Name check limits PID-reuse kills of unrelated processes.
         if (!isProcessRunning($pid, $expectedName)) {
             continue;
         }
-        
-        // Try SIGTERM first (graceful shutdown)
+
         $result = @posix_kill($pid, SIGTERM);
-        if ($result) {
-            usleep(500000); // 500ms grace period
-            
-            // Check if still running
-            if (isProcessRunning($pid)) {
-                // Force kill
-                @posix_kill($pid, SIGKILL);
-            }
-            
-            $killed++;
-            aviationwx_log('info', 'killed stuck worker', [
-                'pid' => $pid
-            ], 'app');
+        if (!$result) {
+            continue;
         }
+
+        usleep(500000);
+        if (isProcessRunning($pid, $expectedName)) {
+            @posix_kill($pid, SIGKILL);
+        }
+
+        $killedPids[] = $pid;
+        aviationwx_log('info', 'killed stuck worker', [
+            'pid' => $pid,
+            'expected_name' => $expectedName,
+        ], 'app');
     }
-    
-    return $killed;
+
+    return $killedPids;
 }
 

--- a/lib/worker-timeout.php
+++ b/lib/worker-timeout.php
@@ -115,6 +115,14 @@ function updateWorkerHeartbeat(): void {
         'heartbeat' => time(),
         'timeout' => $GLOBALS['_aviationwx_worker_timeout']
     ];
+
+    $script = basename((string) ($_SERVER['SCRIPT_FILENAME'] ?? ''));
+    if ($script === '' && isset($_SERVER['argv'][0])) {
+        $script = basename((string) $_SERVER['argv'][0]);
+    }
+    if ($script !== '' && $script !== '.' && $script !== '..') {
+        $data['script'] = $script;
+    }
     
     @file_put_contents($heartbeatFile, json_encode($data), LOCK_EX);
 }
@@ -193,26 +201,44 @@ function workerHeartbeatGlobIsAllowed(string $globPattern): bool
 }
 
 /**
- * Clean up stale worker heartbeat files and return PIDs that still look stuck.
+ * Cmdline substring used to verify a heartbeat PID before kill (limits PID reuse risk).
+ *
+ * @param array<string, mixed> $data Heartbeat JSON payload
+ */
+function workerHeartbeatExpectedProcessName(array $data): string
+{
+    if (!empty($data['script']) && is_string($data['script'])) {
+        $script = basename($data['script']);
+        if ($script !== '' && $script !== '.' && $script !== '..') {
+            return $script;
+        }
+    }
+
+    // CLI workers live under scripts/; avoids matching php-fpm pool workers.
+    return 'scripts/';
+}
+
+/**
+ * Clean up stale worker heartbeat files and return stuck workers to kill.
  *
  * @param int|null $staleSeconds Override for all files; null uses each file's
  *        declared timeout (+30s) or getWorkerTimeout()+30.
  * @param string $globPattern Heartbeat file glob (tests may narrow within /tmp)
- * @return int[] PIDs of potentially stuck workers (empty if none found)
+ * @return list<array{pid: int, expected_name: string}>
  */
 function cleanupStaleWorkerHeartbeats(
     ?int $staleSeconds = null,
     string $globPattern = '/tmp/worker_heartbeat_*.json'
 ): array {
-    $stuckPids = [];
+    $stuckWorkers = [];
     if (!workerHeartbeatGlobIsAllowed($globPattern)) {
-        return $stuckPids;
+        return $stuckWorkers;
     }
 
     $files = glob($globPattern);
 
     if ($files === false || empty($files)) {
-        return $stuckPids;
+        return $stuckWorkers;
     }
 
     $now = time();
@@ -233,13 +259,18 @@ function cleanupStaleWorkerHeartbeats(
         $heartbeatAge = $now - (int) $data['heartbeat'];
         if ($heartbeatAge > $effectiveStale) {
             $pid = (int) $data['pid'];
+            $expectedName = workerHeartbeatExpectedProcessName($data);
 
-            if ($pid > 0 && isProcessRunning($pid, 'php')) {
-                $stuckPids[] = $pid;
+            if ($pid > 0 && isProcessRunning($pid, $expectedName)) {
+                $stuckWorkers[] = [
+                    'pid' => $pid,
+                    'expected_name' => $expectedName,
+                ];
                 aviationwx_log('warning', 'worker heartbeat stale - process may be stuck', [
                     'pid' => $pid,
                     'heartbeat_age' => $heartbeatAge,
                     'stale_after' => $effectiveStale,
+                    'expected_name' => $expectedName,
                     'file' => basename($file),
                 ], 'app');
             }
@@ -249,7 +280,7 @@ function cleanupStaleWorkerHeartbeats(
         }
     }
 
-    return $stuckPids;
+    return $stuckWorkers;
 }
 
 /**
@@ -262,7 +293,7 @@ function cleanupStaleWorkerHeartbeats(
  * @param string $expectedName Process name substring to verify before killing (safety check)
  * @return int Number of processes killed
  */
-function killStuckWorkers(array $pids, string $expectedName = 'php'): int {
+function killStuckWorkers(array $pids, string $expectedName = 'scripts/'): int {
     // Require posix_kill and signal constants for this function
     if (!function_exists('posix_kill') || !defined('SIGTERM') || !defined('SIGKILL')) {
         return 0;

--- a/scripts/fetch-ourairports-bulk.php
+++ b/scripts/fetch-ourairports-bulk.php
@@ -43,6 +43,7 @@ try {
     $failures = 0;
 
     foreach (ourAirportsCsvFileKeys() as $fileKey) {
+        updateWorkerHeartbeat();
         if (!ourAirportsFileNeedsFetch($fileKey)) {
             continue;
         }

--- a/scripts/scheduler.php
+++ b/scripts/scheduler.php
@@ -436,12 +436,14 @@ $workRegistry->registerEnqueueTick('reference_data', function (int $now) use (&$
     }
 
     // 8a. NASR APT: presence/age/cycle gate, then short retry if missing else weekly
+    $nasrAptStartedThisTick = false;
     if (nasrAptSchedulerShouldEnqueue($now, $lastNasrAptFetch)) {
         $nasrScript = __DIR__ . '/fetch-nasr-apt.php';
         if (file_exists($nasrScript)) {
             $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';
             exec(escapeshellarg($phpBin) . ' ' . escapeshellarg($nasrScript) . ' > /dev/null 2>&1 &');
             reapZombies();
+            $nasrAptStartedThisTick = true;
             aviationwx_log('info', 'scheduler: nasr apt fetch started', [
                 'reason' => nasrAptCacheDataPresent() ? 'refresh' : 'missing',
                 'retry_interval_sec' => nasrAptSchedulerRetryInterval(),
@@ -454,8 +456,8 @@ $workRegistry->registerEnqueueTick('reference_data', function (int $now) use (&$
         $lastNasrAptFetch = $now;
     }
 
-    // 8a-ii. NASR FRQ: same cadence policy; waits on APT lock via should-run
-    if (nasrFrqSchedulerShouldEnqueue($now, $lastNasrFrqFetch)) {
+    // 8a-ii. Skip FRQ on the same tick as APT spawn (child may not hold lock yet).
+    if (!$nasrAptStartedThisTick && nasrFrqSchedulerShouldEnqueue($now, $lastNasrFrqFetch)) {
         $nasrFrqScript = __DIR__ . '/fetch-nasr-frq.php';
         if (file_exists($nasrFrqScript)) {
             $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';

--- a/scripts/scheduler.php
+++ b/scripts/scheduler.php
@@ -920,21 +920,11 @@ while ($running) {
         if (($now - $lastStuckWorkerCleanup) >= 60) {
             $stuckWorkers = cleanupStaleWorkerHeartbeats();
             if (!empty($stuckWorkers)) {
-                $killed = 0;
-                $pids = [];
-                foreach ($stuckWorkers as $worker) {
-                    $pid = (int) ($worker['pid'] ?? 0);
-                    $expectedName = (string) ($worker['expected_name'] ?? 'scripts/');
-                    if ($pid <= 0) {
-                        continue;
-                    }
-                    $pids[] = $pid;
-                    $killed += killStuckWorkers([$pid], $expectedName);
-                }
-                if ($killed > 0) {
+                $killedPids = killStuckWorkers($stuckWorkers);
+                if ($killedPids !== []) {
                     aviationwx_log('warning', 'scheduler: cleaned up stuck workers', [
-                        'killed_count' => $killed,
-                        'pids' => $pids,
+                        'killed_count' => count($killedPids),
+                        'pids' => $killedPids,
                     ], 'app');
                 }
             }

--- a/scripts/scheduler.php
+++ b/scripts/scheduler.php
@@ -918,13 +918,23 @@ while ($running) {
         // Clean up stuck worker processes (every 60 seconds).
         // Safety net for workers that become stuck despite self-timeout mechanisms.
         if (($now - $lastStuckWorkerCleanup) >= 60) {
-            $stuckPids = cleanupStaleWorkerHeartbeats();
-            if (!empty($stuckPids)) {
-                $killed = killStuckWorkers($stuckPids);
+            $stuckWorkers = cleanupStaleWorkerHeartbeats();
+            if (!empty($stuckWorkers)) {
+                $killed = 0;
+                $pids = [];
+                foreach ($stuckWorkers as $worker) {
+                    $pid = (int) ($worker['pid'] ?? 0);
+                    $expectedName = (string) ($worker['expected_name'] ?? 'scripts/');
+                    if ($pid <= 0) {
+                        continue;
+                    }
+                    $pids[] = $pid;
+                    $killed += killStuckWorkers([$pid], $expectedName);
+                }
                 if ($killed > 0) {
                     aviationwx_log('warning', 'scheduler: cleaned up stuck workers', [
                         'killed_count' => $killed,
-                        'pids' => $stuckPids
+                        'pids' => $pids,
                     ], 'app');
                 }
             }

--- a/tests/Unit/FailClosedStalenessTest.php
+++ b/tests/Unit/FailClosedStalenessTest.php
@@ -230,11 +230,11 @@ class FailClosedStalenessTest extends TestCase
         $now = time();
         $failclosedThreshold = getStaleFailclosedSeconds();
         
-        // Create data where field has obs_time but exceeds failclosed threshold
+        // Comfortably over failclosed (avoid 1s flake if the suite is slow).
         $data = [
             'temperature' => 15.0,
             '_field_obs_time_map' => [
-                'temperature' => $now - ($failclosedThreshold + 1),  // 1 second over threshold
+                'temperature' => $now - ($failclosedThreshold + 60),
             ],
             'last_updated_primary' => $now - 300,
         ];
@@ -258,11 +258,11 @@ class FailClosedStalenessTest extends TestCase
         $now = time();
         $failclosedThreshold = getStaleFailclosedSeconds();
         
-        // Create data where field has obs_time and is under failclosed threshold
+        // Comfortably under failclosed (avoid 1s flake if the suite is slow).
         $data = [
             'temperature' => 15.0,
             '_field_obs_time_map' => [
-                'temperature' => $now - ($failclosedThreshold - 1),  // 1 second under threshold
+                'temperature' => $now - max(1, $failclosedThreshold - 60),
             ],
             'last_updated_primary' => $now - 300,
         ];

--- a/tests/Unit/MetricsSchedulerWorkersTest.php
+++ b/tests/Unit/MetricsSchedulerWorkersTest.php
@@ -215,6 +215,7 @@ final class MetricsSchedulerWorkersTest extends TestCase
         // Control-plane cleanup stays in the daemon.
         $this->assertStringContainsString('cleanupStaleWorkerHeartbeats', $scheduler);
         $this->assertStringContainsString('killStuckWorkers', $scheduler);
+        $this->assertStringContainsString("\$worker['expected_name']", $scheduler);
         // Background APT may not hold its lock yet in the same tick.
         $this->assertStringContainsString('$nasrAptStartedThisTick', $scheduler);
         $this->assertStringContainsString(

--- a/tests/Unit/MetricsSchedulerWorkersTest.php
+++ b/tests/Unit/MetricsSchedulerWorkersTest.php
@@ -214,8 +214,8 @@ final class MetricsSchedulerWorkersTest extends TestCase
 
         // Control-plane cleanup stays in the daemon.
         $this->assertStringContainsString('cleanupStaleWorkerHeartbeats', $scheduler);
-        $this->assertStringContainsString('killStuckWorkers', $scheduler);
-        $this->assertStringContainsString("\$worker['expected_name']", $scheduler);
+        $this->assertStringContainsString('killStuckWorkers($stuckWorkers)', $scheduler);
+        $this->assertStringContainsString('$killedPids', $scheduler);
         // Background APT may not hold its lock yet in the same tick.
         $this->assertStringContainsString('$nasrAptStartedThisTick', $scheduler);
         $this->assertStringContainsString(

--- a/tests/Unit/MetricsSchedulerWorkersTest.php
+++ b/tests/Unit/MetricsSchedulerWorkersTest.php
@@ -215,6 +215,12 @@ final class MetricsSchedulerWorkersTest extends TestCase
         // Control-plane cleanup stays in the daemon.
         $this->assertStringContainsString('cleanupStaleWorkerHeartbeats', $scheduler);
         $this->assertStringContainsString('killStuckWorkers', $scheduler);
+        // Background APT may not hold its lock yet in the same tick.
+        $this->assertStringContainsString('$nasrAptStartedThisTick', $scheduler);
+        $this->assertStringContainsString(
+            '!$nasrAptStartedThisTick && nasrFrqSchedulerShouldEnqueue',
+            $scheduler
+        );
 
         // Payload metrics must not run in-process after the drain gate.
         $afterGate = $scheduler;

--- a/tests/Unit/NasrWorkersTest.php
+++ b/tests/Unit/NasrWorkersTest.php
@@ -48,6 +48,8 @@ class NasrWorkersTest extends TestCase
 
     public function testFrqWorkerWaitsForAptFetchLock(): void
     {
+        $this->writeMinimalAptCache();
+
         $lockPath = getNasrAptFetchLockPath();
         $dir = dirname($lockPath);
         if (!is_dir($dir)) {
@@ -64,6 +66,13 @@ class NasrWorkersTest extends TestCase
             flock($fp, LOCK_UN);
             fclose($fp);
         }
+    }
+
+    public function testFrqWorkerWaitsUntilAptCachePresent(): void
+    {
+        $this->assertFalse(nasrAptCacheDataPresent());
+        $this->assertFalse(nasrFrqWorkerShouldRun());
+        $this->assertFalse(nasrFrqSchedulerShouldEnqueue(1_700_000_000, 0));
     }
 
     public function testAptWorkerSkipsWhenLockHeld(): void
@@ -109,7 +118,7 @@ class NasrWorkersTest extends TestCase
     {
         $now = 1_700_000_000;
         $this->assertTrue(nasrAptSchedulerShouldEnqueue($now, 0));
-        $this->assertTrue(nasrFrqSchedulerShouldEnqueue($now, 0));
+        $this->assertFalse(nasrFrqSchedulerShouldEnqueue($now, 0));
     }
 
     public function testMissingCache_RespectsShortBackoffAfterFailedAttempt(): void
@@ -127,6 +136,12 @@ class NasrWorkersTest extends TestCase
         $lastAttempt = $now - NASR_MISSING_RETRY_INTERVAL;
 
         $this->assertTrue(nasrAptSchedulerShouldEnqueue($now, $lastAttempt));
+        $this->assertFalse(
+            nasrFrqSchedulerShouldEnqueue($now, $lastAttempt),
+            'FRQ stays gated until APT JSON exists'
+        );
+
+        $this->writeMinimalAptCache();
         $this->assertTrue(nasrFrqSchedulerShouldEnqueue($now, $lastAttempt));
     }
 
@@ -175,7 +190,7 @@ class NasrWorkersTest extends TestCase
 
         $this->assertLessThan(NASR_FETCH_CHECK_INTERVAL, 60 * 60);
         $this->assertTrue(nasrAptSchedulerShouldEnqueue($now, $lastAttempt));
-        $this->assertTrue(nasrFrqSchedulerShouldEnqueue($now, $lastAttempt));
+        $this->assertFalse(nasrFrqSchedulerShouldEnqueue($now, $lastAttempt));
     }
 
     private function writeMinimalAptCache(): void

--- a/tests/Unit/WorkerTimeoutHeartbeatTest.php
+++ b/tests/Unit/WorkerTimeoutHeartbeatTest.php
@@ -65,12 +65,17 @@ class WorkerTimeoutHeartbeatTest extends TestCase
             86400 + 30,
             workerHeartbeatStaleAfterSeconds(['timeout' => 999999999], null, 120)
         );
+        $this->assertSame(
+            86400 + 30,
+            workerHeartbeatStaleAfterSeconds(['timeout' => PHP_INT_MAX], null, 120)
+        );
     }
 
     public function testGlobAllowsDefaultAndTestScopedPatterns(): void
     {
         $this->assertTrue(workerHeartbeatGlobIsAllowed('/tmp/worker_heartbeat_*.json'));
         $this->assertTrue(workerHeartbeatGlobIsAllowed($this->heartbeatGlob()));
+        $this->assertTrue(workerHeartbeatGlobIsAllowed('/tmp/worker_heartbeat_nasr_apt.json'));
         $this->assertFalse(workerHeartbeatGlobIsAllowed('/tmp/other_*.json'));
         $this->assertFalse(workerHeartbeatGlobIsAllowed('/etc/passwd'));
         $this->assertFalse(workerHeartbeatGlobIsAllowed('/tmp/../etc/passwd'));

--- a/tests/Unit/WorkerTimeoutHeartbeatTest.php
+++ b/tests/Unit/WorkerTimeoutHeartbeatTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Unit tests for worker heartbeat stale detection.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/worker-timeout.php';
+
+class WorkerTimeoutHeartbeatTest extends TestCase
+{
+    /** @var list<string> */
+    private array $heartbeatFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->heartbeatFiles as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+        $this->heartbeatFiles = [];
+        parent::tearDown();
+    }
+
+    public function testDeclaredTimeout_UsesTimeoutPlusBuffer(): void
+    {
+        $this->assertSame(
+            7230,
+            workerHeartbeatStaleAfterSeconds(['timeout' => 7200], null, 120)
+        );
+    }
+
+    public function testMissingDeclaredTimeout_UsesDefault(): void
+    {
+        $this->assertSame(
+            120,
+            workerHeartbeatStaleAfterSeconds(['pid' => 1], null, 120)
+        );
+    }
+
+    public function testOverride_WinsOverDeclaredTimeout(): void
+    {
+        $this->assertSame(
+            60,
+            workerHeartbeatStaleAfterSeconds(['timeout' => 7200], 60, 120)
+        );
+    }
+
+    public function testCorruptHugeTimeout_IsCapped(): void
+    {
+        $this->assertSame(
+            86400 + 30,
+            workerHeartbeatStaleAfterSeconds(['timeout' => 999999999], null, 120)
+        );
+    }
+
+    public function testLongDeclaredTimeout_NotTreatedStaleAtWebcamDefault(): void
+    {
+        $path = $this->writeHeartbeat([
+            'pid' => 2147483000,
+            'started' => time() - 180,
+            'heartbeat' => time() - 150,
+            'timeout' => 7200,
+        ]);
+
+        $stuck = cleanupStaleWorkerHeartbeats(null);
+        $this->assertSame([], $stuck);
+        $this->assertFileExists($path);
+    }
+
+    public function testDefaultTimeout_RemovesStaleHeartbeatWithoutDeclaredTimeout(): void
+    {
+        $path = $this->writeHeartbeat([
+            'pid' => 2147483001,
+            'started' => time() - 200,
+            'heartbeat' => time() - 150,
+        ]);
+
+        $stuck = cleanupStaleWorkerHeartbeats(null);
+        $this->assertSame([], $stuck, 'Synthetic PID must not match a live php process');
+        $this->assertFileDoesNotExist($path);
+    }
+
+    public function testExplicitStaleOverride_AppliesToLongTimeoutWorker(): void
+    {
+        $path = $this->writeHeartbeat([
+            'pid' => 2147483002,
+            'started' => time() - 180,
+            'heartbeat' => time() - 150,
+            'timeout' => 7200,
+        ]);
+
+        $stuck = cleanupStaleWorkerHeartbeats(60);
+        $this->assertSame([], $stuck);
+        $this->assertFileDoesNotExist($path);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function writeHeartbeat(array $data): string
+    {
+        $id = 'test_' . bin2hex(random_bytes(4));
+        $path = '/tmp/worker_heartbeat_' . $id . '.json';
+        file_put_contents($path, json_encode($data, JSON_UNESCAPED_SLASHES));
+        $this->heartbeatFiles[] = $path;
+
+        return $path;
+    }
+}

--- a/tests/Unit/WorkerTimeoutHeartbeatTest.php
+++ b/tests/Unit/WorkerTimeoutHeartbeatTest.php
@@ -7,6 +7,7 @@
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../lib/config.php';
+require_once __DIR__ . '/../../lib/constants.php';
 require_once __DIR__ . '/../../lib/worker-timeout.php';
 
 class WorkerTimeoutHeartbeatTest extends TestCase
@@ -35,9 +36,10 @@ class WorkerTimeoutHeartbeatTest extends TestCase
 
     public function testDeclaredTimeout_UsesTimeoutPlusBuffer(): void
     {
+        $timeout = (int) NASR_APT_WORKER_TIMEOUT;
         $this->assertSame(
-            7230,
-            workerHeartbeatStaleAfterSeconds(['timeout' => 7200], null, 120)
+            $timeout + 30,
+            workerHeartbeatStaleAfterSeconds(['timeout' => $timeout], null, 120)
         );
     }
 
@@ -53,7 +55,7 @@ class WorkerTimeoutHeartbeatTest extends TestCase
     {
         $this->assertSame(
             60,
-            workerHeartbeatStaleAfterSeconds(['timeout' => 7200], 60, 120)
+            workerHeartbeatStaleAfterSeconds(['timeout' => NASR_APT_WORKER_TIMEOUT], 60, 120)
         );
     }
 
@@ -65,6 +67,15 @@ class WorkerTimeoutHeartbeatTest extends TestCase
         );
     }
 
+    public function testGlobAllowsDefaultAndTestScopedPatterns(): void
+    {
+        $this->assertTrue(workerHeartbeatGlobIsAllowed('/tmp/worker_heartbeat_*.json'));
+        $this->assertTrue(workerHeartbeatGlobIsAllowed($this->heartbeatGlob()));
+        $this->assertFalse(workerHeartbeatGlobIsAllowed('/tmp/other_*.json'));
+        $this->assertFalse(workerHeartbeatGlobIsAllowed('/etc/passwd'));
+        $this->assertFalse(workerHeartbeatGlobIsAllowed('/tmp/../etc/passwd'));
+    }
+
     public function testLongDeclaredTimeout_NotTreatedStaleAtWebcamDefault(): void
     {
         $age = $this->agePastDefaultStaleThreshold();
@@ -72,12 +83,28 @@ class WorkerTimeoutHeartbeatTest extends TestCase
             'pid' => 2147483000,
             'started' => time() - $age - 30,
             'heartbeat' => time() - $age,
-            'timeout' => 7200,
+            'timeout' => NASR_APT_WORKER_TIMEOUT,
         ]);
 
         $stuck = cleanupStaleWorkerHeartbeats(null, $this->heartbeatGlob());
         $this->assertSame([], $stuck);
         $this->assertFileExists($path);
+    }
+
+    public function testPastDeclaredTimeout_RemovesHeartbeatWithoutLivePid(): void
+    {
+        $timeout = (int) NASR_APT_WORKER_TIMEOUT;
+        $age = $timeout + 30 + 5;
+        $path = $this->writeHeartbeat([
+            'pid' => 2147483003,
+            'started' => time() - $age - 30,
+            'heartbeat' => time() - $age,
+            'timeout' => $timeout,
+        ]);
+
+        $stuck = cleanupStaleWorkerHeartbeats(null, $this->heartbeatGlob());
+        $this->assertSame([], $stuck, 'Synthetic PID must not match a live php process');
+        $this->assertFileDoesNotExist($path);
     }
 
     public function testDefaultTimeout_RemovesStaleHeartbeatWithoutDeclaredTimeout(): void
@@ -100,7 +127,7 @@ class WorkerTimeoutHeartbeatTest extends TestCase
             'pid' => 2147483002,
             'started' => time() - 180,
             'heartbeat' => time() - 150,
-            'timeout' => 7200,
+            'timeout' => NASR_APT_WORKER_TIMEOUT,
         ]);
 
         $stuck = cleanupStaleWorkerHeartbeats(60, $this->heartbeatGlob());
@@ -108,14 +135,50 @@ class WorkerTimeoutHeartbeatTest extends TestCase
         $this->assertFileDoesNotExist($path);
     }
 
+    public function testRejectedGlob_DoesNotTouchHeartbeatFiles(): void
+    {
+        $path = $this->writeHeartbeat([
+            'pid' => 2147483004,
+            'started' => time() - 200,
+            'heartbeat' => time() - 200,
+        ]);
+
+        $stuck = cleanupStaleWorkerHeartbeats(1, '/tmp/not_worker_heartbeat_*.json');
+        $this->assertSame([], $stuck);
+        $this->assertFileExists($path);
+    }
+
+    public function testInitWorkerTimeout_WritesTimeoutUsedByStalePolicy(): void
+    {
+        $safeId = $this->heartbeatIdPrefix . '_contract';
+        try {
+            initWorkerTimeout(600, $safeId);
+            $path = '/tmp/worker_heartbeat_' . $safeId . '.json';
+            $this->heartbeatFiles[] = $path;
+
+            $this->assertFileExists($path);
+            $data = json_decode((string) file_get_contents($path), true);
+            $this->assertIsArray($data);
+            $this->assertSame(600, $data['timeout'] ?? null);
+            $this->assertSame(
+                630,
+                workerHeartbeatStaleAfterSeconds($data, null, getWorkerTimeout() + 30)
+            );
+        } finally {
+            if (function_exists('pcntl_alarm')) {
+                pcntl_alarm(0);
+            }
+        }
+    }
+
     /**
-     * Heartbeat age past getWorkerTimeout()+30, but well below NASR APT's declared timeout.
+     * Silence past getWorkerTimeout()+30, still well below NASR APT declared timeout.
      */
     private function agePastDefaultStaleThreshold(): int
     {
         $defaultStale = getWorkerTimeout() + 30;
         $age = $defaultStale + 30;
-        $this->assertLessThan(7200, $age);
+        $this->assertLessThan((int) NASR_APT_WORKER_TIMEOUT, $age);
 
         return $age;
     }

--- a/tests/Unit/WorkerTimeoutHeartbeatTest.php
+++ b/tests/Unit/WorkerTimeoutHeartbeatTest.php
@@ -59,6 +59,15 @@ class WorkerTimeoutHeartbeatTest extends TestCase
         );
     }
 
+    public function testExpectedProcessName_PrefersScriptBasename(): void
+    {
+        $this->assertSame(
+            'fetch-nasr-apt.php',
+            workerHeartbeatExpectedProcessName(['script' => '/var/www/html/scripts/fetch-nasr-apt.php'])
+        );
+        $this->assertSame('scripts/', workerHeartbeatExpectedProcessName([]));
+    }
+
     public function testCorruptHugeTimeout_IsCapped(): void
     {
         $this->assertSame(

--- a/tests/Unit/WorkerTimeoutHeartbeatTest.php
+++ b/tests/Unit/WorkerTimeoutHeartbeatTest.php
@@ -6,12 +6,21 @@
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../../lib/config.php';
 require_once __DIR__ . '/../../lib/worker-timeout.php';
 
 class WorkerTimeoutHeartbeatTest extends TestCase
 {
     /** @var list<string> */
     private array $heartbeatFiles = [];
+
+    private string $heartbeatIdPrefix = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->heartbeatIdPrefix = 'test_' . bin2hex(random_bytes(4));
+    }
 
     protected function tearDown(): void
     {
@@ -58,27 +67,29 @@ class WorkerTimeoutHeartbeatTest extends TestCase
 
     public function testLongDeclaredTimeout_NotTreatedStaleAtWebcamDefault(): void
     {
+        $age = $this->agePastDefaultStaleThreshold();
         $path = $this->writeHeartbeat([
             'pid' => 2147483000,
-            'started' => time() - 180,
-            'heartbeat' => time() - 150,
+            'started' => time() - $age - 30,
+            'heartbeat' => time() - $age,
             'timeout' => 7200,
         ]);
 
-        $stuck = cleanupStaleWorkerHeartbeats(null);
+        $stuck = cleanupStaleWorkerHeartbeats(null, $this->heartbeatGlob());
         $this->assertSame([], $stuck);
         $this->assertFileExists($path);
     }
 
     public function testDefaultTimeout_RemovesStaleHeartbeatWithoutDeclaredTimeout(): void
     {
+        $age = $this->agePastDefaultStaleThreshold();
         $path = $this->writeHeartbeat([
             'pid' => 2147483001,
-            'started' => time() - 200,
-            'heartbeat' => time() - 150,
+            'started' => time() - $age - 30,
+            'heartbeat' => time() - $age,
         ]);
 
-        $stuck = cleanupStaleWorkerHeartbeats(null);
+        $stuck = cleanupStaleWorkerHeartbeats(null, $this->heartbeatGlob());
         $this->assertSame([], $stuck, 'Synthetic PID must not match a live php process');
         $this->assertFileDoesNotExist($path);
     }
@@ -92,9 +103,26 @@ class WorkerTimeoutHeartbeatTest extends TestCase
             'timeout' => 7200,
         ]);
 
-        $stuck = cleanupStaleWorkerHeartbeats(60);
+        $stuck = cleanupStaleWorkerHeartbeats(60, $this->heartbeatGlob());
         $this->assertSame([], $stuck);
         $this->assertFileDoesNotExist($path);
+    }
+
+    /**
+     * Heartbeat age past getWorkerTimeout()+30, but well below NASR APT's declared timeout.
+     */
+    private function agePastDefaultStaleThreshold(): int
+    {
+        $defaultStale = getWorkerTimeout() + 30;
+        $age = $defaultStale + 30;
+        $this->assertLessThan(7200, $age);
+
+        return $age;
+    }
+
+    private function heartbeatGlob(): string
+    {
+        return '/tmp/worker_heartbeat_' . $this->heartbeatIdPrefix . '_*.json';
     }
 
     /**
@@ -102,8 +130,8 @@ class WorkerTimeoutHeartbeatTest extends TestCase
      */
     private function writeHeartbeat(array $data): string
     {
-        $id = 'test_' . bin2hex(random_bytes(4));
-        $path = '/tmp/worker_heartbeat_' . $id . '.json';
+        $id = bin2hex(random_bytes(4));
+        $path = '/tmp/worker_heartbeat_' . $this->heartbeatIdPrefix . '_' . $id . '.json';
         file_put_contents($path, json_encode($data, JSON_UNESCAPED_SLASHES));
         $this->heartbeatFiles[] = $path;
 

--- a/tests/Unit/WorkerTimeoutHeartbeatTest.php
+++ b/tests/Unit/WorkerTimeoutHeartbeatTest.php
@@ -31,6 +31,15 @@ class WorkerTimeoutHeartbeatTest extends TestCase
             }
         }
         $this->heartbeatFiles = [];
+
+        // initWorkerTimeout leaves process-global state; clear so later suites are unaffected.
+        if (function_exists('pcntl_alarm')) {
+            pcntl_alarm(0);
+        }
+        $GLOBALS['_aviationwx_worker_start_time'] = null;
+        $GLOBALS['_aviationwx_worker_timeout'] = null;
+        $GLOBALS['_aviationwx_worker_heartbeat_file'] = null;
+
         parent::tearDown();
     }
 
@@ -66,6 +75,14 @@ class WorkerTimeoutHeartbeatTest extends TestCase
             workerHeartbeatExpectedProcessName(['script' => '/var/www/html/scripts/fetch-nasr-apt.php'])
         );
         $this->assertSame('scripts/', workerHeartbeatExpectedProcessName([]));
+    }
+
+    public function testExpectedProcessName_RejectsBroadOrForgedTokens(): void
+    {
+        $this->assertSame('scripts/', workerHeartbeatExpectedProcessName(['script' => 'php']));
+        $this->assertSame('scripts/', workerHeartbeatExpectedProcessName(['script' => 'php-fpm']));
+        $this->assertSame('scripts/', workerHeartbeatExpectedProcessName(['script' => '../evil']));
+        $this->assertSame('scripts/', workerHeartbeatExpectedProcessName(['script' => 'not-a-php-script']));
     }
 
     public function testCorruptHugeTimeout_IsCapped(): void
@@ -162,27 +179,38 @@ class WorkerTimeoutHeartbeatTest extends TestCase
         $this->assertFileExists($path);
     }
 
+    public function testPastAbsoluteDeadline_RemovesHeartbeatEvenIfSilenceFresh(): void
+    {
+        $timeout = (int) NASR_APT_WORKER_TIMEOUT;
+        $runtime = $timeout + 30 + 5;
+        $path = $this->writeHeartbeat([
+            'pid' => 2147483005,
+            'started' => time() - $runtime,
+            'heartbeat' => time() - 10,
+            'timeout' => $timeout,
+            'script' => 'scripts/fetch-nasr-apt.php',
+        ]);
+
+        $stuck = cleanupStaleWorkerHeartbeats(null, $this->heartbeatGlob());
+        $this->assertSame([], $stuck, 'Synthetic PID must not match a live process');
+        $this->assertFileDoesNotExist($path);
+    }
+
     public function testInitWorkerTimeout_WritesTimeoutUsedByStalePolicy(): void
     {
         $safeId = $this->heartbeatIdPrefix . '_contract';
-        try {
-            initWorkerTimeout(600, $safeId);
-            $path = '/tmp/worker_heartbeat_' . $safeId . '.json';
-            $this->heartbeatFiles[] = $path;
+        initWorkerTimeout(600, $safeId);
+        $path = '/tmp/worker_heartbeat_' . $safeId . '.json';
+        $this->heartbeatFiles[] = $path;
 
-            $this->assertFileExists($path);
-            $data = json_decode((string) file_get_contents($path), true);
-            $this->assertIsArray($data);
-            $this->assertSame(600, $data['timeout'] ?? null);
-            $this->assertSame(
-                630,
-                workerHeartbeatStaleAfterSeconds($data, null, getWorkerTimeout() + 30)
-            );
-        } finally {
-            if (function_exists('pcntl_alarm')) {
-                pcntl_alarm(0);
-            }
-        }
+        $this->assertFileExists($path);
+        $data = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($data);
+        $this->assertSame(600, $data['timeout'] ?? null);
+        $this->assertSame(
+            630,
+            workerHeartbeatStaleAfterSeconds($data, null, getWorkerTimeout() + 30)
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- Honor each worker's declared timeout when judging heartbeat staleness so long NASR jobs are not SIGKILL'd after ~2 minutes by the webcam default.
- Gate FRQ until APT cache exists, and skip FRQ on the same scheduler tick as APT spawn (background child may not hold the lock yet).
- Refresh heartbeats during paced NASR HTTP, APT CSV parse stages, and OurAirports bulk downloads.

## Context
After #284, production retried NASR every 15 minutes but caches stayed empty. Logs showed APT/FRQ starting, then `worker heartbeat stale` ~2 minutes later and the processes being killed. Root cause: `cleanupStaleWorkerHeartbeats()` used `getWorkerTimeout()+30` (~120s) for all workers, ignoring NASR's declared 3600–7200s timeouts.

## Test plan
- [x] `phpunit` WorkerTimeoutHeartbeatTest, NasrWorkersTest, MetricsSchedulerWorkersTest
- [x] Full `make test-unit`
- [ ] After deploy: confirm no `worker heartbeat stale` for `nasr_apt` / `nasr_frq` within the first few minutes of a fetch
- [ ] Confirm `cache/nasr/nasr_apt.json` and `nasr_frq.json` appear (or run one-time heal with scheduler stopped if still empty from prior kills)

Closes nothing (follow-up to #284).