### PR TITLE
Airport reference data ProcessPools (supersedes #285)

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -311,7 +311,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: check-prerequisites
-    timeout-minutes: 60
+    # Must exceed DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS (+ grace) plus build/health overhead.
+    # Reference drain alone can wait ~120 minutes for in-flight NASR/catalog workers.
+    timeout-minutes: 180
     # Only deploy if QA succeeded (or manual dispatch with skip)
     if: |
       (needs.check-prerequisites.outputs.qa-success == 'true') || 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,12 +167,14 @@ Part of the **Internal API** (see [API.md](API.md)): JSON for the web dashboard;
 - Runs continuously as a background process: **Docker entrypoint** starts one instance after cache setup; **`scheduler-health-check.php`** (cron, every minute) confirms lock/PID/health and starts a replacement only when recovery is needed
 - Dispatches weather, webcam, NOTAM, station power, reference-data / status prewarm, and metrics housekeeping on configurable intervals (minimum 5 seconds, 1-second granularity)
 - Starts work via **ProcessPool** workers (concurrency-limited, waited on for deploy drain) or fire-and-forget CLI scripts (background `exec`; not waited on)
+- **Live pools** (weather, webcam, NOTAM, station power) use the short deploy-drain force window (`DEPLOY_WORKER_DRAIN_MAX_SECONDS`)
+- **Reference pools** (OurAirports probe/bulk, runways merge, NASR APT/FRQ, country resolution) are size-1 ProcessPools with job-specific timeouts; drain waits up to `DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS` before force-terminate so mid-cycle FAA catalog work is not cut at the live window
 - Main loop: due checks, enqueue or spawn, pool cleanup, config reload, deploy-drain evaluation - registered ticks must not block on upstream I/O, image pipelines, geometry builds, or metrics aggregation (fire-and-forget CLI or ProcessPool only)
 - Automatically reloads configuration changes without restart
 
 **Work registry (`lib/scheduler-work-registry.php`)**: Drain-aware registration of scheduler work
-- ProcessPools register with `setPool` (weather, webcam, NOTAM, station power). Replacing a pool that still has active children keeps the prior pool in a retiring set until idle or force-terminate, so drain counts stay accurate across config-driven recreation.
-- Enqueue and background-start logic registers with `registerEnqueueTick` (named ticks such as weather, webcam, reference data, status prewarm, metrics spill/daily/weekly/cleanup/health, variant and upstream health flush)
+- ProcessPools register with `setPool` (weather, webcam, NOTAM, station power, plus each reference job). Replacing a pool that still has active children keeps the prior pool in a retiring set until idle or force-terminate, so drain counts stay accurate across config-driven recreation. Reference pools pass class `reference` so drain force timing can differ from live pools.
+- Enqueue and background-start logic registers with `registerEnqueueTick` (named ticks such as weather, webcam, reference data, status prewarm, metrics spill/daily/weekly/cleanup/health, variant and upstream health flush). The `reference_data` tick uses `referenceDataEnqueueDueJobs()` for dependency-aware size-1 pool enqueue (not fire-and-forget `exec`).
 - Each loop: cleanup finished pool workers, evaluate deploy drain, then run registered enqueue ticks only when new work is allowed
 - Active worker counts and force-terminate iterate registered pools only
 - New gated work is added by registering a pool and/or tick; ungated paths stay outside the registry (stuck-worker heartbeat cleanup remains in-process control-plane work)
@@ -181,11 +183,11 @@ Part of the **Internal API** (see [API.md](API.md)): JSON for the web dashboard;
 - CD writes `cache/deploy-drain.flag` on the shared cache volume (via `scripts/deploy-drain-workers.sh` running `deploy-drain.php` inside the live web container; host has no PHP) while Apache continues serving clients
 - The scheduler stops running registered enqueue ticks; in-flight ProcessPool workers may finish
 - When pools are idle, the scheduler writes `cache/deploy-drain.done` so CD can proceed
-- After `DEPLOY_WORKER_DRAIN_MAX_SECONDS`, remaining registered pool workers are force-terminated (`ProcessPool::cleanup`: SIGTERM, brief wait, then SIGKILL) and `.done` is written
-- After `MAX + DEPLOY_WORKER_DRAIN_ABANDON_SECONDS` from drain start (or for an orphan `.done` without a flag), markers are cleared and registered work resumes so a failed recreate cannot leave refresh paused indefinitely
+- After `DEPLOY_WORKER_DRAIN_MAX_SECONDS`, remaining **live** pool workers are force-terminated (`ProcessPool::cleanup`: SIGTERM, brief wait, then SIGKILL); **reference** pools may continue until idle or `DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS`, then remaining pools are force-terminated the same way and `.done` is written
+- After the active force window + `DEPLOY_WORKER_DRAIN_ABANDON_SECONDS` from drain start (or for an orphan `.done` without a flag), markers are cleared and registered work resumes so a failed recreate cannot leave refresh paused indefinitely
 - While drain is active inside that TTL, `scheduler-health-check.php` does not spawn a second daemon when a live scheduler is already present; if the daemon has died, the watchdog may start a replacement (the new process continues under the same drain markers)
 - Container entrypoint clears both markers before starting the scheduler
-- Registered CLI background ticks are not started during drain; in-flight fire-and-forget CLI processes are not waited on (only ProcessPool workers are)
+- Registered CLI background ticks are not started during drain; in-flight fire-and-forget CLI processes (metrics, airspace helpers) are not waited on; airport reference catalogs are ProcessPool-owned and are waited on
 - Slight data staleness during the drain window is preferred over killing mid-flight webcam or weather pool workers
 
 ### Webcam System

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -40,6 +40,10 @@ if (!defined('WEATHER_INTERNAL_API_ERROR_SOURCE_NOT_CONFIGURED')) {
 if (!defined('DEPLOY_WORKER_DRAIN_MAX_SECONDS')) {
     define('DEPLOY_WORKER_DRAIN_MAX_SECONDS', 120);
 }
+// Reference pools (NASR, OurAirports, ...) wait up to this before force-terminate during drain.
+if (!defined('DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS')) {
+    define('DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS', 7200);
+}
 // Extra wall time after MAX for compose/build before an abandoned drain unsticks the live site.
 if (!defined('DEPLOY_WORKER_DRAIN_ABANDON_SECONDS')) {
     define('DEPLOY_WORKER_DRAIN_ABANDON_SECONDS', 600);
@@ -600,6 +604,9 @@ if (!defined('COUNTRY_RESOLUTION_AGGREGATE_MAX_AGE_SECONDS')) {
 // Scheduler evaluates refresh at most this often (avoids reading/decoding aggregate every main-loop tick).
 if (!defined('COUNTRY_RESOLUTION_SCHEDULER_CHECK_INTERVAL')) {
     define('COUNTRY_RESOLUTION_SCHEDULER_CHECK_INTERVAL', 3600); // 1 hour
+}
+if (!defined('COUNTRY_RESOLUTION_WORKER_TIMEOUT')) {
+    define('COUNTRY_RESOLUTION_WORKER_TIMEOUT', 600);
 }
 // @deprecated Use COUNTRY_RESOLUTION_AGGREGATE_MAX_AGE_SECONDS; kept for backward compatibility (same value).
 if (!defined('COUNTRY_RESOLUTION_REFRESH_INTERVAL')) {

--- a/lib/deploy-drain.php
+++ b/lib/deploy-drain.php
@@ -334,9 +334,9 @@ function deploy_drain_evaluate_state(
     $activeWorkers = $liveActive + $referenceActive;
     $liveMaxSeconds = max(1, $liveMaxSeconds);
     $referenceMaxSeconds = max($liveMaxSeconds, $referenceMaxSeconds);
-    // Abandon TTL follows the force window still in play (reference when any reference workers remain).
-    $forceMax = $referenceActive > 0 ? $referenceMaxSeconds : $liveMaxSeconds;
-    $ttl = deploy_drain_ttl_seconds($forceMax, $abandonSeconds);
+    // Keep abandon TTL fixed at the reference-aware ceiling for the whole drain request.
+    // Shrinking TTL when reference workers finish early can abandon before .done is written.
+    $ttl = deploy_drain_ttl_seconds($referenceMaxSeconds, $abandonSeconds);
 
     if (!$requested && !$alreadyComplete) {
         return [

--- a/lib/deploy-drain.php
+++ b/lib/deploy-drain.php
@@ -442,7 +442,7 @@ function deploy_drain_evaluate_state(
  *   action: 'none'|'wait'|'mark_complete_idle'|'force_terminate_live'|'force_terminate_reference'|'force_terminate'|'already_complete'|'abandon_clear'
  * }
  */
-function deploy_drain_evaluate_scheduler_tick($activeByClass, ?int $now = null): array
+function deploy_drain_evaluate_scheduler_tick(array|int $activeByClass, ?int $now = null): array
 {
     $now = $now ?? time();
     if (is_int($activeByClass)) {

--- a/lib/deploy-drain.php
+++ b/lib/deploy-drain.php
@@ -6,12 +6,14 @@
  * depending on PHP inside the image being replaced.
  *
  * Timeline from flag started_at:
- *   - before MAX: pause new ProcessPool / background work; mark .done when pools idle
- *   - at MAX: SIGTERM remaining pool workers and mark .done
- *   - before MAX+ABANDON: stay paused so CD can recreate (Apache still serves)
- *   - at MAX+ABANDON: clear markers and resume (abandoned CD must not pause the site forever)
+ *   - before live MAX: pause new work; mark .done when all pools idle
+ *   - at live MAX: SIGTERM remaining live pools (weather/webcam/...); reference may continue
+ *   - at reference MAX: SIGTERM remaining reference pools; mark .done
+ *   - before forceMAX+ABANDON: stay paused so CD can recreate (Apache still serves)
+ *   - at forceMAX+ABANDON: clear markers and resume (abandoned CD must not pause forever)
  *
- * Fire-and-forget CLI workers (NASR, etc.) are not started during drain but are not waited on.
+ * Airport reference pools use DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS (NASR-scale).
+ * Other fire-and-forget CLIs (metrics, airspace) are not waited on.
  */
 
 require_once __DIR__ . '/constants.php';
@@ -173,6 +175,29 @@ function deploy_drain_ttl_seconds(
 }
 
 /**
+ * Wall clock used for abandon and CD wait when reference pools may still be draining.
+ *
+ * @return int
+ */
+function deploy_drain_reference_aware_max_seconds(): int
+{
+    return max(
+        (int) DEPLOY_WORKER_DRAIN_MAX_SECONDS,
+        (int) DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS
+    );
+}
+
+/**
+ * Default CD wait for .done (reference window + grace).
+ *
+ * @return int
+ */
+function deploy_drain_cd_wait_seconds(): int
+{
+    return deploy_drain_reference_aware_max_seconds() + (int) DEPLOY_WORKER_DRAIN_WAIT_GRACE_SECONDS;
+}
+
+/**
  * Temp file + rename so readers never see a partial JSON marker.
  *
  * @param string $path Destination path
@@ -275,31 +300,43 @@ function deploy_drain_clear_markers(): bool {
 /**
  * Pure decision for one scheduler drain evaluation.
  *
+ * Live pools force at $liveMaxSeconds; reference pools force at $referenceMaxSeconds.
+ * Abandon TTL uses the larger of the two force windows.
+ *
  * @param bool $requested Drain flag present
  * @param bool $alreadyComplete Done marker present
  * @param int|null $startedAt Drain start unix time (null if unknown)
- * @param int $activeWorkers Current ProcessPool active count (sum)
+ * @param int $liveActive Live ProcessPool active count
+ * @param int $referenceActive Reference ProcessPool active count
  * @param int $now Current unix time
- * @param int $maxSeconds Force-terminate ceiling
- * @param int $abandonSeconds Extra seconds after max before auto-resume
+ * @param int $liveMaxSeconds Live force-terminate ceiling
+ * @param int $referenceMaxSeconds Reference force-terminate ceiling
+ * @param int $abandonSeconds Extra seconds after max force before auto-resume
  * @return array{
  *   allow_new_work: bool,
  *   suppress_scheduler_restart: bool,
- *   action: 'none'|'wait'|'mark_complete_idle'|'force_terminate'|'already_complete'|'abandon_clear'
+ *   action: 'none'|'wait'|'mark_complete_idle'|'force_terminate_live'|'force_terminate_reference'|'force_terminate'|'already_complete'|'abandon_clear'
  * }
  */
 function deploy_drain_evaluate_state(
     bool $requested,
     bool $alreadyComplete,
     ?int $startedAt,
-    int $activeWorkers,
-    int $now,
-    int $maxSeconds = DEPLOY_WORKER_DRAIN_MAX_SECONDS,
+    int $liveActive,
+    int $referenceActive = 0,
+    int $now = 0,
+    int $liveMaxSeconds = DEPLOY_WORKER_DRAIN_MAX_SECONDS,
+    int $referenceMaxSeconds = DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS,
     int $abandonSeconds = DEPLOY_WORKER_DRAIN_ABANDON_SECONDS
 ): array {
-    $activeWorkers = max(0, $activeWorkers);
-    $maxSeconds = max(1, $maxSeconds);
-    $ttl = deploy_drain_ttl_seconds($maxSeconds, $abandonSeconds);
+    $liveActive = max(0, $liveActive);
+    $referenceActive = max(0, $referenceActive);
+    $activeWorkers = $liveActive + $referenceActive;
+    $liveMaxSeconds = max(1, $liveMaxSeconds);
+    $referenceMaxSeconds = max($liveMaxSeconds, $referenceMaxSeconds);
+    // Abandon TTL follows the force window still in play (reference when any reference workers remain).
+    $forceMax = $referenceActive > 0 ? $referenceMaxSeconds : $liveMaxSeconds;
+    $ttl = deploy_drain_ttl_seconds($forceMax, $abandonSeconds);
 
     if (!$requested && !$alreadyComplete) {
         return [
@@ -309,7 +346,6 @@ function deploy_drain_evaluate_state(
         ];
     }
 
-    // Orphan .done without a flag must not pause the site forever.
     if (!$requested && $alreadyComplete) {
         return [
             'allow_new_work' => true,
@@ -318,7 +354,6 @@ function deploy_drain_evaluate_state(
         ];
     }
 
-    // Unknown start: do not block CD or the live site indefinitely.
     if ($startedAt === null || $startedAt <= 0) {
         if ($activeWorkers > 0) {
             return [
@@ -343,7 +378,6 @@ function deploy_drain_evaluate_state(
 
     $elapsed = max(0, $now - $startedAt);
 
-    // Abandoned CD: clear markers and resume refreshes on the still-running container.
     if ($elapsed >= $ttl) {
         return [
             'allow_new_work' => true,
@@ -368,11 +402,27 @@ function deploy_drain_evaluate_state(
         ];
     }
 
-    if ($elapsed >= $maxSeconds) {
+    if ($elapsed >= $referenceMaxSeconds) {
         return [
             'allow_new_work' => false,
             'suppress_scheduler_restart' => true,
             'action' => 'force_terminate',
+        ];
+    }
+
+    if ($elapsed >= $liveMaxSeconds && $liveActive > 0) {
+        return [
+            'allow_new_work' => false,
+            'suppress_scheduler_restart' => true,
+            'action' => $referenceActive > 0 ? 'force_terminate_live' : 'force_terminate',
+        ];
+    }
+
+    if ($elapsed >= $liveMaxSeconds && $liveActive === 0 && $referenceActive > 0) {
+        return [
+            'allow_new_work' => false,
+            'suppress_scheduler_restart' => true,
+            'action' => 'wait',
         ];
     }
 
@@ -384,24 +434,34 @@ function deploy_drain_evaluate_state(
 }
 
 /**
- * @param int $activeWorkers Sum of ProcessPool active counts (caller should cleanupFinished first)
+ * @param array{live: int, reference: int}|int $activeByClass Or legacy total active count
  * @param int|null $now Current unix time (injectable for tests)
  * @return array{
  *   allow_new_work: bool,
  *   suppress_scheduler_restart: bool,
- *   action: 'none'|'wait'|'mark_complete_idle'|'force_terminate'|'already_complete'|'abandon_clear'
+ *   action: 'none'|'wait'|'mark_complete_idle'|'force_terminate_live'|'force_terminate_reference'|'force_terminate'|'already_complete'|'abandon_clear'
  * }
  */
-function deploy_drain_evaluate_scheduler_tick(int $activeWorkers, ?int $now = null): array {
+function deploy_drain_evaluate_scheduler_tick($activeByClass, ?int $now = null): array
+{
     $now = $now ?? time();
+    if (is_int($activeByClass)) {
+        $liveActive = max(0, $activeByClass);
+        $referenceActive = 0;
+    } else {
+        $liveActive = max(0, (int) ($activeByClass['live'] ?? 0));
+        $referenceActive = max(0, (int) ($activeByClass['reference'] ?? 0));
+    }
 
     return deploy_drain_evaluate_state(
         deploy_drain_is_requested(),
         deploy_drain_is_complete(),
         deploy_drain_started_at(),
-        $activeWorkers,
+        $liveActive,
+        $referenceActive,
         $now,
         DEPLOY_WORKER_DRAIN_MAX_SECONDS,
+        DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS,
         DEPLOY_WORKER_DRAIN_ABANDON_SECONDS
     );
 }
@@ -420,7 +480,7 @@ function deploy_drain_should_suppress_scheduler_restart(?int $now = null): bool 
 /**
  * @param string $action Action from deploy_drain_evaluate_*
  * @param int|null $now Current unix time
- * @param callable():void $forceTerminate SIGTERM active ProcessPool workers
+ * @param callable():void $forceTerminate Invoked for force/abandon actions (caller scopes by class)
  * @return bool False only when a required marker write/clear fails
  */
 function deploy_drain_apply_scheduler_action(string $action, ?int $now, callable $forceTerminate): bool {
@@ -434,6 +494,12 @@ function deploy_drain_apply_scheduler_action(string $action, ?int $now, callable
     if ($action === 'force_terminate') {
         $forceTerminate();
         return deploy_drain_mark_complete('forced_timeout', $now);
+    }
+
+    // Live force only: reference pools may still be draining; do not write .done yet.
+    if ($action === 'force_terminate_live') {
+        $forceTerminate();
+        return true;
     }
 
     if ($action === 'mark_complete_idle') {

--- a/lib/nasr/workers.php
+++ b/lib/nasr/workers.php
@@ -57,7 +57,10 @@ function nasrAptWorkerShouldRun(): bool
  */
 function nasrFrqWorkerShouldRun(): bool
 {
-    return nasrFrqCacheNeedsRefresh() && !nasrFrqFetchInProgress() && !nasrAptFetchInProgress();
+    return nasrAptCacheDataPresent()
+        && nasrFrqCacheNeedsRefresh()
+        && !nasrFrqFetchInProgress()
+        && !nasrAptFetchInProgress();
 }
 
 /**

--- a/lib/process-pool.php
+++ b/lib/process-pool.php
@@ -140,6 +140,16 @@ class ProcessPool {
         $this->cleanupFinished($dummyStats);
         return count($this->workers);
     }
+
+    /**
+     * Per-worker timeout in seconds (pool hard kill / timeout(1) wrapper).
+     *
+     * @return int
+     */
+    public function getTimeout(): int
+    {
+        return (int) $this->timeout;
+    }
     
     /**
      * Check if system timeout command is available

--- a/lib/reference-data/jobs.php
+++ b/lib/reference-data/jobs.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Airport reference-data ProcessPool job definitions.
+ *
+ * Size-1 pools per job; scheduler owns lifecycle (timeout, drain, SIGTERM).
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../constants.php';
+
+/** @var string Drain / registry class for live observation pools */
+const SCHEDULER_POOL_CLASS_LIVE = 'live';
+
+/** @var string Drain / registry class for airport reference catalogs */
+const SCHEDULER_POOL_CLASS_REFERENCE = 'reference';
+
+/**
+ * Canonical reference-data jobs (pool name => script + timeout).
+ *
+ * @return array<string, array{script: string, timeout: int}>
+ */
+function referenceDataJobs(): array
+{
+    return [
+        'ourairports_probe' => [
+            'script' => 'probe-ourairports.php',
+            'timeout' => (int) OURAIRPORTS_PROBE_WORKER_TIMEOUT,
+        ],
+        'ourairports_bulk' => [
+            'script' => 'fetch-ourairports-bulk.php',
+            'timeout' => (int) OURAIRPORTS_BULK_WORKER_TIMEOUT,
+        ],
+        'runways_merge' => [
+            'script' => 'fetch-runways.php',
+            'timeout' => (int) RUNWAYS_MERGE_WORKER_TIMEOUT,
+        ],
+        'nasr_apt' => [
+            'script' => 'fetch-nasr-apt.php',
+            'timeout' => (int) NASR_APT_WORKER_TIMEOUT,
+        ],
+        'nasr_frq' => [
+            'script' => 'fetch-nasr-frq.php',
+            'timeout' => (int) NASR_FRQ_WORKER_TIMEOUT,
+        ],
+        'country_resolution' => [
+            'script' => 'refresh-airport-country-resolution.php',
+            'timeout' => (int) COUNTRY_RESOLUTION_WORKER_TIMEOUT,
+        ],
+    ];
+}
+
+/**
+ * @return list<string>
+ */
+function referenceDataJobNames(): array
+{
+    return array_keys(referenceDataJobs());
+}

--- a/lib/reference-data/orchestrator.php
+++ b/lib/reference-data/orchestrator.php
@@ -29,6 +29,16 @@ function referenceDataPoolIsActive(array $pools, string $jobName): bool
 }
 
 /**
+ * Whether on-disk runway inputs are newer than the published merge cache.
+ *
+ * Used to bypass last-attempt throttling: source mtime is the freshness signal.
+ */
+function referenceDataRunwaysSourceInputsNewerThanMerge(): bool
+{
+    return ourAirportsRunwaySourcesNewerThanMerge() || faaNgdaRunwayCsvNewerThanMerge();
+}
+
+/**
  * Whether the scheduler should enqueue a reference job on this tick.
  *
  * @param array<string, object|null> $pools
@@ -74,9 +84,12 @@ function referenceDataShouldEnqueue(string $jobName, int $now, array $pools, arr
             if (!$startupDone) {
                 return runwaysMergeWorkerShouldRun();
             }
-            $last = (int) ($state['last_runways'] ?? 0);
-            if (($now - $last) < OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL) {
-                return false;
+            // Source age beats last-attempt clock after an early merge / mid-interval bulk land.
+            if (!referenceDataRunwaysSourceInputsNewerThanMerge()) {
+                $last = (int) ($state['last_runways'] ?? 0);
+                if (($now - $last) < OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL) {
+                    return false;
+                }
             }
 
             return runwaysMergeWorkerShouldRun();

--- a/lib/reference-data/orchestrator.php
+++ b/lib/reference-data/orchestrator.php
@@ -141,10 +141,14 @@ function referenceDataEnqueueDueJobs(int $now, array $pools, array &$state): arr
 
     foreach (referenceDataJobNames() as $jobName) {
         if (!referenceDataShouldEnqueue($jobName, $now, $pools, $state)) {
-            // Startup runways still advances the startup flag when skipped.
+            // Keep startup runways pending while OA probe/bulk still occupies a pool slot.
             if ($jobName === 'runways_merge' && empty($state['runways_startup_done'])) {
-                $state['runways_startup_done'] = true;
-                $state['last_runways'] = $now;
+                $blockedByUpstream = referenceDataPoolIsActive($pools, 'ourairports_bulk')
+                    || referenceDataPoolIsActive($pools, 'ourairports_probe');
+                if (!$blockedByUpstream) {
+                    $state['runways_startup_done'] = true;
+                    $state['last_runways'] = $now;
+                }
             }
             if ($jobName === 'country_resolution') {
                 $startupEval = !empty($state['country_startup_eval']);

--- a/lib/reference-data/orchestrator.php
+++ b/lib/reference-data/orchestrator.php
@@ -39,6 +39,25 @@ function referenceDataRunwaysSourceInputsNewerThanMerge(): bool
 }
 
 /**
+ * Newest mtime among runway merge input files (OurAirports CSVs + NGDA), or null.
+ */
+function referenceDataRunwaysNewestSourceMtime(): ?int
+{
+    $mtimes = [];
+    foreach (OURAIRPORTS_RUNWAY_MERGE_FILE_KEYS as $fileKey) {
+        $path = ourAirportsCsvPath($fileKey);
+        if (is_readable($path)) {
+            $mtimes[] = (int) filemtime($path);
+        }
+    }
+    if (is_readable(CACHE_FAA_NGDA_RUNWAYS_CSV)) {
+        $mtimes[] = (int) filemtime(CACHE_FAA_NGDA_RUNWAYS_CSV);
+    }
+
+    return $mtimes === [] ? null : max($mtimes);
+}
+
+/**
  * Whether the scheduler should enqueue a reference job on this tick.
  *
  * @param array<string, object|null> $pools
@@ -84,9 +103,13 @@ function referenceDataShouldEnqueue(string $jobName, int $now, array $pools, arr
             if (!$startupDone) {
                 return runwaysMergeWorkerShouldRun();
             }
-            // Source age beats last-attempt clock after an early merge / mid-interval bulk land.
-            if (!referenceDataRunwaysSourceInputsNewerThanMerge()) {
-                $last = (int) ($state['last_runways'] ?? 0);
+            $last = (int) ($state['last_runways'] ?? 0);
+            // Source age beats last-attempt clock only when inputs changed since that attempt.
+            // Otherwise a failed merge (sources still newer than merge) would spin every tick.
+            $sourcesNewerThanMerge = referenceDataRunwaysSourceInputsNewerThanMerge();
+            $newestSource = referenceDataRunwaysNewestSourceMtime();
+            $sourcesChangedSinceAttempt = $newestSource !== null && $newestSource > $last;
+            if (!($sourcesNewerThanMerge && $sourcesChangedSinceAttempt)) {
                 if (($now - $last) < OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL) {
                     return false;
                 }
@@ -164,13 +187,20 @@ function referenceDataEnqueueDueJobs(int $now, array $pools, array &$state): arr
                 }
             }
             if ($jobName === 'country_resolution') {
-                $startupEval = !empty($state['country_startup_eval']);
-                $lastCheck = (int) ($state['last_country_check'] ?? 0);
-                $due = !$startupEval
-                    || (($now - $lastCheck) >= COUNTRY_RESOLUTION_SCHEDULER_CHECK_INTERVAL);
-                if ($due) {
-                    $state['last_country_check'] = $now;
-                    $state['country_startup_eval'] = true;
+                // Do not treat a missing config identity as a completed evaluation.
+                $cfgPath = $state['config_path'] ?? null;
+                $configSha = $state['config_sha'] ?? null;
+                $identityOk = is_string($cfgPath) && $cfgPath !== '' && is_readable($cfgPath)
+                    && is_string($configSha) && $configSha !== '';
+                if ($identityOk) {
+                    $startupEval = !empty($state['country_startup_eval']);
+                    $lastCheck = (int) ($state['last_country_check'] ?? 0);
+                    $due = !$startupEval
+                        || (($now - $lastCheck) >= COUNTRY_RESOLUTION_SCHEDULER_CHECK_INTERVAL);
+                    if ($due) {
+                        $state['last_country_check'] = $now;
+                        $state['country_startup_eval'] = true;
+                    }
                 }
             }
             continue;

--- a/lib/reference-data/orchestrator.php
+++ b/lib/reference-data/orchestrator.php
@@ -35,6 +35,9 @@ function referenceDataPoolIsActive(array $pools, string $jobName): bool
  */
 function referenceDataRunwaysSourceInputsNewerThanMerge(): bool
 {
+    // Scheduler is long-lived; ProcessPool children replace these files out of process.
+    clearstatcache();
+
     return ourAirportsRunwaySourcesNewerThanMerge() || faaNgdaRunwayCsvNewerThanMerge();
 }
 
@@ -43,6 +46,9 @@ function referenceDataRunwaysSourceInputsNewerThanMerge(): bool
  */
 function referenceDataRunwaysNewestSourceMtime(): ?int
 {
+    // Same process-lifetime stat cache concern as source-newer checks above.
+    clearstatcache();
+
     $mtimes = [];
     foreach (OURAIRPORTS_RUNWAY_MERGE_FILE_KEYS as $fileKey) {
         $path = ourAirportsCsvPath($fileKey);

--- a/lib/reference-data/orchestrator.php
+++ b/lib/reference-data/orchestrator.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Dependency-aware enqueue gates for airport reference ProcessPools.
+ *
+ * Policy lives here; scripts keep file locks as crash/dedup insurance.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../nasr/workers.php';
+require_once __DIR__ . '/../ourairports/refresh.php';
+require_once __DIR__ . '/../airport-country-resolution-merge.php';
+require_once __DIR__ . '/jobs.php';
+
+/**
+ * Whether a size-1 reference pool currently has an active worker.
+ *
+ * @param array<string, object|null> $pools Map of job name => ProcessPool
+ */
+function referenceDataPoolIsActive(array $pools, string $jobName): bool
+{
+    $pool = $pools[$jobName] ?? null;
+    if ($pool === null || !method_exists($pool, 'getActiveCount')) {
+        return false;
+    }
+    $count = $pool->getActiveCount();
+
+    return (is_int($count) || is_float($count)) && (int) $count > 0;
+}
+
+/**
+ * Whether the scheduler should enqueue a reference job on this tick.
+ *
+ * @param array<string, object|null> $pools
+ * @param array<string, mixed> $state Scheduler tick state (last-attempt timestamps, config, etc.)
+ */
+function referenceDataShouldEnqueue(string $jobName, int $now, array $pools, array $state): bool
+{
+    switch ($jobName) {
+        case 'ourairports_probe':
+            if (referenceDataPoolIsActive($pools, 'ourairports_probe')
+                || referenceDataPoolIsActive($pools, 'ourairports_bulk')
+            ) {
+                return false;
+            }
+            $last = (int) ($state['last_ourairports_probe'] ?? 0);
+            if (($now - $last) < OURAIRPORTS_PROBE_INTERVAL) {
+                return false;
+            }
+
+            return ourAirportsProbeWorkerShouldRun();
+
+        case 'ourairports_bulk':
+            if (referenceDataPoolIsActive($pools, 'ourairports_bulk')
+                || referenceDataPoolIsActive($pools, 'ourairports_probe')
+                || referenceDataPoolIsActive($pools, 'runways_merge')
+            ) {
+                return false;
+            }
+            $last = (int) ($state['last_ourairports_bulk'] ?? 0);
+            if (($now - $last) < OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL) {
+                return false;
+            }
+
+            return ourAirportsBulkWorkerShouldRun();
+
+        case 'runways_merge':
+            if (referenceDataPoolIsActive($pools, 'runways_merge')
+                || referenceDataPoolIsActive($pools, 'ourairports_bulk')
+            ) {
+                return false;
+            }
+            $startupDone = !empty($state['runways_startup_done']);
+            if (!$startupDone) {
+                return runwaysMergeWorkerShouldRun();
+            }
+            $last = (int) ($state['last_runways'] ?? 0);
+            if (($now - $last) < OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL) {
+                return false;
+            }
+
+            return runwaysMergeWorkerShouldRun();
+
+        case 'nasr_apt':
+            if (referenceDataPoolIsActive($pools, 'nasr_apt')
+                || referenceDataPoolIsActive($pools, 'nasr_frq')
+            ) {
+                return false;
+            }
+
+            return nasrAptSchedulerShouldEnqueue($now, (int) ($state['last_nasr_apt'] ?? 0));
+
+        case 'nasr_frq':
+            // APT cache must exist; never overlap APT (pool or file lock).
+            if (!nasrAptCacheDataPresent()
+                || referenceDataPoolIsActive($pools, 'nasr_apt')
+                || referenceDataPoolIsActive($pools, 'nasr_frq')
+                || nasrAptFetchInProgress()
+            ) {
+                return false;
+            }
+
+            return nasrFrqSchedulerShouldEnqueue($now, (int) ($state['last_nasr_frq'] ?? 0));
+
+        case 'country_resolution':
+            if (referenceDataPoolIsActive($pools, 'country_resolution')) {
+                return false;
+            }
+            $startupEval = !empty($state['country_startup_eval']);
+            $lastCheck = (int) ($state['last_country_check'] ?? 0);
+            $due = !$startupEval
+                || (($now - $lastCheck) >= COUNTRY_RESOLUTION_SCHEDULER_CHECK_INTERVAL);
+            if (!$due) {
+                return false;
+            }
+            $cfgPath = $state['config_path'] ?? null;
+            $configSha = $state['config_sha'] ?? null;
+            if (!is_string($cfgPath) || $cfgPath === '' || !is_readable($cfgPath)
+                || !is_string($configSha) || $configSha === ''
+            ) {
+                return false;
+            }
+
+            return countryResolutionAggregateShouldRefresh($cfgPath, $configSha);
+
+        default:
+            return false;
+    }
+}
+
+/**
+ * Enqueue due reference jobs onto size-1 ProcessPools.
+ *
+ * @param array<string, object|null> $pools
+ * @param array<string, mixed> $state Mutated: last-attempt and startup flags
+ * @return list<string> Job names started this tick
+ */
+function referenceDataEnqueueDueJobs(int $now, array $pools, array &$state): array
+{
+    $started = [];
+
+    foreach (referenceDataJobNames() as $jobName) {
+        if (!referenceDataShouldEnqueue($jobName, $now, $pools, $state)) {
+            // Startup runways still advances the startup flag when skipped.
+            if ($jobName === 'runways_merge' && empty($state['runways_startup_done'])) {
+                $state['runways_startup_done'] = true;
+                $state['last_runways'] = $now;
+            }
+            if ($jobName === 'country_resolution') {
+                $startupEval = !empty($state['country_startup_eval']);
+                $lastCheck = (int) ($state['last_country_check'] ?? 0);
+                $due = !$startupEval
+                    || (($now - $lastCheck) >= COUNTRY_RESOLUTION_SCHEDULER_CHECK_INTERVAL);
+                if ($due) {
+                    $state['last_country_check'] = $now;
+                    $state['country_startup_eval'] = true;
+                }
+            }
+            continue;
+        }
+
+        $pool = $pools[$jobName] ?? null;
+        if ($pool === null || !method_exists($pool, 'addJob')) {
+            continue;
+        }
+
+        if (!$pool->addJob([])) {
+            continue;
+        }
+
+        $started[] = $jobName;
+        switch ($jobName) {
+            case 'ourairports_probe':
+                $state['last_ourairports_probe'] = $now;
+                break;
+            case 'ourairports_bulk':
+                $state['last_ourairports_bulk'] = $now;
+                break;
+            case 'runways_merge':
+                $state['runways_startup_done'] = true;
+                $state['last_runways'] = $now;
+                break;
+            case 'nasr_apt':
+                $state['last_nasr_apt'] = $now;
+                break;
+            case 'nasr_frq':
+                $state['last_nasr_frq'] = $now;
+                break;
+            case 'country_resolution':
+                $state['last_country_check'] = $now;
+                $state['country_startup_eval'] = true;
+                break;
+        }
+    }
+
+    return $started;
+}

--- a/lib/scheduler-work-registry.php
+++ b/lib/scheduler-work-registry.php
@@ -9,11 +9,15 @@
  * Replacing a pool that still has active children keeps the old pool in a retiring
  * list until idle (or terminateAll), so deploy drain cannot lose in-flight workers
  * across config-driven ProcessPool recreation.
+ *
+ * Pool class (live vs reference) controls drain force timing: live uses the short
+ * CD window; reference waits up to DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS.
  */
 
 declare(strict_types=1);
 
 require_once __DIR__ . '/deploy-drain.php';
+require_once __DIR__ . '/reference-data/jobs.php';
 
 /**
  * Named ProcessPool + enqueue-tick registry for the scheduler daemon.
@@ -23,7 +27,10 @@ final class SchedulerWorkRegistry
     /** @var array<string, object> getActiveCount / cleanupFinished / cleanup */
     private array $pools = [];
 
-    /** @var list<object> Former pools still finishing children after setPool replacement */
+    /** @var array<string, string> Pool name => SCHEDULER_POOL_CLASS_* */
+    private array $poolClasses = [];
+
+    /** @var list<array{pool: object, class: string}> Former pools still finishing children */
     private array $retiringPools = [];
 
     /** @var array<string, callable(int):void> */
@@ -32,29 +39,35 @@ final class SchedulerWorkRegistry
     /**
      * Register or replace a ProcessPool. Null removes the name.
      *
-     * @param string $name Stable worker family name (weather, webcam, ...)
+     * @param string $name Stable worker family name (weather, nasr_apt, ...)
      * @param object|null $pool Pool instance or null to unregister
+     * @param string $class SCHEDULER_POOL_CLASS_LIVE or SCHEDULER_POOL_CLASS_REFERENCE
      * @return void
      */
-    public function setPool(string $name, ?object $pool): void
+    public function setPool(string $name, ?object $pool, string $class = SCHEDULER_POOL_CLASS_LIVE): void
     {
         $name = trim($name);
         if ($name === '') {
             return;
         }
 
+        $class = $class === SCHEDULER_POOL_CLASS_REFERENCE
+            ? SCHEDULER_POOL_CLASS_REFERENCE
+            : SCHEDULER_POOL_CLASS_LIVE;
+
         if (isset($this->pools[$name])) {
             $previous = $this->pools[$name];
             if ($pool !== $previous) {
-                $this->retirePoolIfActive($previous);
+                $this->retirePoolIfActive($previous, $this->poolClasses[$name] ?? SCHEDULER_POOL_CLASS_LIVE);
             }
-            unset($this->pools[$name]);
+            unset($this->pools[$name], $this->poolClasses[$name]);
         }
 
         if ($pool === null) {
             return;
         }
         $this->pools[$name] = $pool;
+        $this->poolClasses[$name] = $class;
     }
 
     /**
@@ -90,6 +103,14 @@ final class SchedulerWorkRegistry
     }
 
     /**
+     * @return array<string, string>
+     */
+    public function registeredPoolClasses(): array
+    {
+        return $this->poolClasses;
+    }
+
+    /**
      * @return int
      */
     public function retiringPoolCount(): int
@@ -103,7 +124,8 @@ final class SchedulerWorkRegistry
      */
     public function cleanupFinishedAll(): void
     {
-        foreach ($this->allTrackedPools() as $pool) {
+        foreach ($this->allTrackedPoolEntries() as $entry) {
+            $pool = $entry['pool'];
             if (!method_exists($pool, 'cleanupFinished')) {
                 continue;
             }
@@ -118,8 +140,36 @@ final class SchedulerWorkRegistry
      */
     public function sumActiveWorkers(): int
     {
+        $byClass = $this->sumActiveWorkersByClass();
+        return $byClass['live'] + $byClass['reference'];
+    }
+
+    /**
+     * @return array{live: int, reference: int}
+     */
+    public function sumActiveWorkersByClass(): array
+    {
         $this->pruneRetiringPools();
-        return deploy_drain_sum_active_workers($this->allTrackedPools());
+        $live = 0;
+        $reference = 0;
+        foreach ($this->allTrackedPoolEntries() as $entry) {
+            $pool = $entry['pool'];
+            if (!method_exists($pool, 'getActiveCount')) {
+                continue;
+            }
+            $count = $pool->getActiveCount();
+            if (!is_int($count) && !is_float($count)) {
+                continue;
+            }
+            $n = max(0, (int) $count);
+            if ($entry['class'] === SCHEDULER_POOL_CLASS_REFERENCE) {
+                $reference += $n;
+            } else {
+                $live += $n;
+            }
+        }
+
+        return ['live' => $live, 'reference' => $reference];
     }
 
     /**
@@ -127,12 +177,48 @@ final class SchedulerWorkRegistry
      */
     public function terminateAll(): void
     {
-        foreach ($this->allTrackedPools() as $pool) {
+        foreach ($this->allTrackedPoolEntries() as $entry) {
+            $pool = $entry['pool'];
             if (method_exists($pool, 'cleanup')) {
                 $pool->cleanup();
             }
         }
         $this->retiringPools = [];
+    }
+
+    /**
+     * Force-terminate pools in one drain class only.
+     *
+     * @param string $class SCHEDULER_POOL_CLASS_LIVE or SCHEDULER_POOL_CLASS_REFERENCE
+     * @return void
+     */
+    public function terminatePoolsByClass(string $class): void
+    {
+        $class = $class === SCHEDULER_POOL_CLASS_REFERENCE
+            ? SCHEDULER_POOL_CLASS_REFERENCE
+            : SCHEDULER_POOL_CLASS_LIVE;
+
+        foreach ($this->pools as $name => $pool) {
+            if (($this->poolClasses[$name] ?? SCHEDULER_POOL_CLASS_LIVE) !== $class) {
+                continue;
+            }
+            if (method_exists($pool, 'cleanup')) {
+                $pool->cleanup();
+            }
+        }
+
+        $kept = [];
+        foreach ($this->retiringPools as $entry) {
+            if ($entry['class'] === $class) {
+                if (method_exists($entry['pool'], 'cleanup')) {
+                    $entry['pool']->cleanup();
+                }
+                continue;
+            }
+            $kept[] = $entry;
+        }
+        $this->retiringPools = $kept;
+        $this->pruneRetiringPools();
     }
 
     /**
@@ -148,9 +234,10 @@ final class SchedulerWorkRegistry
 
     /**
      * @param object $pool
+     * @param string $class
      * @return void
      */
-    private function retirePoolIfActive(object $pool): void
+    private function retirePoolIfActive(object $pool, string $class): void
     {
         if (!method_exists($pool, 'getActiveCount')) {
             return;
@@ -162,7 +249,7 @@ final class SchedulerWorkRegistry
         if ((int) $count <= 0) {
             return;
         }
-        $this->retiringPools[] = $pool;
+        $this->retiringPools[] = ['pool' => $pool, 'class' => $class];
     }
 
     /**
@@ -174,23 +261,32 @@ final class SchedulerWorkRegistry
             return;
         }
         $kept = [];
-        foreach ($this->retiringPools as $pool) {
+        foreach ($this->retiringPools as $entry) {
+            $pool = $entry['pool'];
             if (!method_exists($pool, 'getActiveCount')) {
                 continue;
             }
             $count = $pool->getActiveCount();
             if ((is_int($count) || is_float($count)) && (int) $count > 0) {
-                $kept[] = $pool;
+                $kept[] = $entry;
             }
         }
         $this->retiringPools = $kept;
     }
 
     /**
-     * @return list<object>
+     * @return list<array{pool: object, class: string}>
      */
-    private function allTrackedPools(): array
+    private function allTrackedPoolEntries(): array
     {
-        return array_merge(array_values($this->pools), $this->retiringPools);
+        $entries = [];
+        foreach ($this->pools as $name => $pool) {
+            $entries[] = [
+                'pool' => $pool,
+                'class' => $this->poolClasses[$name] ?? SCHEDULER_POOL_CLASS_LIVE,
+            ];
+        }
+
+        return array_merge($entries, $this->retiringPools);
     }
 }

--- a/lib/worker-timeout.php
+++ b/lib/worker-timeout.php
@@ -153,19 +153,45 @@ function shouldWorkerAbort(int $requiredSeconds = 10): bool {
 }
 
 /**
+ * Silence allowed after the last heartbeat before a worker is treated as stuck.
+ *
+ * Uses the worker's declared timeout from initWorkerTimeout when present so
+ * long ProcessPool jobs (NASR, etc.) are not killed by the short live default.
+ *
+ * @param array<string, mixed> $data Heartbeat JSON payload
+ * @param int|null $staleSecondsOverride When set, applies to all workers
+ * @param int $defaultStaleSeconds Fallback when no declared timeout
+ * @return int
+ */
+function workerHeartbeatStaleAfterSeconds(
+    array $data,
+    ?int $staleSecondsOverride,
+    int $defaultStaleSeconds
+): int {
+    if ($staleSecondsOverride !== null) {
+        return max(1, $staleSecondsOverride);
+    }
+
+    $declaredTimeout = isset($data['timeout']) && is_numeric($data['timeout'])
+        ? (int) $data['timeout']
+        : 0;
+    if ($declaredTimeout <= 0) {
+        return max(1, $defaultStaleSeconds);
+    }
+
+    return min($declaredTimeout, 86400) + 30;
+}
+
+/**
  * Clean up stale worker heartbeat files
  * 
  * Finds and removes heartbeat files from workers that appear to have died
  * without cleaning up. Also returns PIDs of potentially stuck workers.
  * 
- * @param int|null $staleSeconds Consider heartbeat stale after this many seconds (default: worker_timeout + 30)
+ * @param int|null $staleSeconds Consider heartbeat stale after this many seconds (default: per-file declared timeout + 30, else worker_timeout + 30)
  * @return int[] PIDs of potentially stuck workers (empty if none found)
  */
 function cleanupStaleWorkerHeartbeats(?int $staleSeconds = null): array {
-    if ($staleSeconds === null) {
-        $staleSeconds = getWorkerTimeout() + 30;
-    }
-    
     $stuckPids = [];
     $pattern = '/tmp/worker_heartbeat_*.json';
     $files = glob($pattern);
@@ -176,6 +202,7 @@ function cleanupStaleWorkerHeartbeats(?int $staleSeconds = null): array {
     }
     
     $now = time();
+    $defaultStaleSeconds = getWorkerTimeout() + 30;
     foreach ($files as $file) {
         $content = @file_get_contents($file);
         if ($content === false) {
@@ -189,17 +216,19 @@ function cleanupStaleWorkerHeartbeats(?int $staleSeconds = null): array {
             continue;
         }
         
-        $heartbeatAge = $now - $data['heartbeat'];
-        if ($heartbeatAge > $staleSeconds) {
+        $effectiveStale = workerHeartbeatStaleAfterSeconds($data, $staleSeconds, $defaultStaleSeconds);
+        $heartbeatAge = $now - (int) $data['heartbeat'];
+        if ($heartbeatAge > $effectiveStale) {
             // Heartbeat is stale - worker may be stuck
             $pid = (int)$data['pid'];
             
-            // Use cross-platform process check from process-utils.php
-            if ($pid > 0 && isProcessRunning($pid, 'php')) {
+            // Prefer scripts/ cmdline token: ProcessPool workers and CLI fetchers live there.
+            if ($pid > 0 && isProcessRunning($pid, 'scripts/')) {
                 $stuckPids[] = $pid;
                 aviationwx_log('warning', 'worker heartbeat stale - process may be stuck', [
                     'pid' => $pid,
                     'heartbeat_age' => $heartbeatAge,
+                    'stale_after' => $effectiveStale,
                     'file' => basename($file)
                 ], 'app');
             }
@@ -222,7 +251,7 @@ function cleanupStaleWorkerHeartbeats(?int $staleSeconds = null): array {
  * @param string $expectedName Process name substring to verify before killing (safety check)
  * @return int Number of processes killed
  */
-function killStuckWorkers(array $pids, string $expectedName = 'php'): int {
+function killStuckWorkers(array $pids, string $expectedName = 'scripts/'): int {
     // Require posix_kill and signal constants for this function
     if (!function_exists('posix_kill') || !defined('SIGTERM') || !defined('SIGKILL')) {
         return 0;

--- a/scripts/deploy-drain-workers.sh
+++ b/scripts/deploy-drain-workers.sh
@@ -38,7 +38,12 @@ run_in_web() {
 }
 
 MAX_WAIT="$(
-  run_in_web php -r 'require "/var/www/html/lib/constants.php"; echo (int) max(DEPLOY_WORKER_DRAIN_MAX_SECONDS, DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS);'
+  run_in_web php -r '
+    require "/var/www/html/lib/constants.php";
+    $live = defined("DEPLOY_WORKER_DRAIN_MAX_SECONDS") ? (int) DEPLOY_WORKER_DRAIN_MAX_SECONDS : 120;
+    $ref = defined("DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS") ? (int) DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS : $live;
+    echo (int) max($live, $ref);
+  '
 )"
 if ! [[ "${MAX_WAIT}" =~ ^[0-9]+$ ]] || [ "${MAX_WAIT}" -lt 1 ]; then
   echo "⚠️  Could not read deploy drain max seconds from container - skipping worker drain"
@@ -51,6 +56,7 @@ if ! run_in_web php scripts/deploy-drain.php request --cache-dir="$CONTAINER_CAC
   exit 0
 fi
 
+# deploy-drain.php wait --max-wait adds WAIT_GRACE; pass force window only.
 echo "Waiting for in-flight ProcessPool workers (max ${MAX_WAIT}s + grace; reference-aware)..."
 set +e
 run_in_web php scripts/deploy-drain.php wait --cache-dir="$CONTAINER_CACHE_DIR" --max-wait="${MAX_WAIT}"

--- a/scripts/deploy-drain-workers.sh
+++ b/scripts/deploy-drain-workers.sh
@@ -38,10 +38,10 @@ run_in_web() {
 }
 
 MAX_WAIT="$(
-  run_in_web php -r 'require "/var/www/html/lib/constants.php"; echo (int) DEPLOY_WORKER_DRAIN_MAX_SECONDS;'
+  run_in_web php -r 'require "/var/www/html/lib/constants.php"; echo (int) max(DEPLOY_WORKER_DRAIN_MAX_SECONDS, DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS);'
 )"
 if ! [[ "${MAX_WAIT}" =~ ^[0-9]+$ ]] || [ "${MAX_WAIT}" -lt 1 ]; then
-  echo "⚠️  Could not read DEPLOY_WORKER_DRAIN_MAX_SECONDS from container - skipping worker drain"
+  echo "⚠️  Could not read deploy drain max seconds from container - skipping worker drain"
   exit 0
 fi
 
@@ -51,7 +51,7 @@ if ! run_in_web php scripts/deploy-drain.php request --cache-dir="$CONTAINER_CAC
   exit 0
 fi
 
-echo "Waiting for in-flight ProcessPool workers (max ${MAX_WAIT}s + grace)..."
+echo "Waiting for in-flight ProcessPool workers (max ${MAX_WAIT}s + grace; reference-aware)..."
 set +e
 run_in_web php scripts/deploy-drain.php wait --cache-dir="$CONTAINER_CACHE_DIR" --max-wait="${MAX_WAIT}"
 WAIT_RC=$?

--- a/scripts/deploy-drain.php
+++ b/scripts/deploy-drain.php
@@ -70,7 +70,7 @@ switch ($command) {
     case 'wait':
         // Explicit --max-wait=0 is a single poll (tests / check-once). Default adds grace.
         if ($maxWait === null) {
-            $waitSeconds = DEPLOY_WORKER_DRAIN_MAX_SECONDS + DEPLOY_WORKER_DRAIN_WAIT_GRACE_SECONDS;
+            $waitSeconds = deploy_drain_cd_wait_seconds();
         } elseif ($maxWait <= 0) {
             $waitSeconds = 0;
         } else {
@@ -96,9 +96,11 @@ switch ($command) {
             'done' => deploy_drain_done_path(),
             'done_payload' => deploy_drain_read_done_payload(),
             'max_seconds' => DEPLOY_WORKER_DRAIN_MAX_SECONDS,
+            'reference_max_seconds' => DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS,
             'abandon_seconds' => DEPLOY_WORKER_DRAIN_ABANDON_SECONDS,
-            'ttl_seconds' => deploy_drain_ttl_seconds(),
+            'ttl_seconds' => deploy_drain_ttl_seconds(deploy_drain_reference_aware_max_seconds()),
             'wait_grace_seconds' => DEPLOY_WORKER_DRAIN_WAIT_GRACE_SECONDS,
+            'cd_wait_seconds' => deploy_drain_cd_wait_seconds(),
         ];
         echo json_encode($status, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
         exit(0);

--- a/scripts/refresh-airport-country-resolution.php
+++ b/scripts/refresh-airport-country-resolution.php
@@ -26,8 +26,11 @@ define('AVIATIONWX_SKIP_COUNTRY_RESOLUTION_MERGE', true);
 require_once __DIR__ . '/../lib/logger.php';
 require_once __DIR__ . '/../lib/constants.php';
 require_once __DIR__ . '/../lib/cache-paths.php';
+require_once __DIR__ . '/../lib/worker-timeout.php';
 require_once __DIR__ . '/../lib/country-resolution.php';
 require_once __DIR__ . '/../lib/config.php';
+
+initWorkerTimeout(COUNTRY_RESOLUTION_WORKER_TIMEOUT, 'country_resolution');
 
 $config = loadConfig();
 if ($config === null || !isset($config['airports']) || !is_array($config['airports'])) {

--- a/scripts/scheduler.php
+++ b/scripts/scheduler.php
@@ -35,6 +35,9 @@ require_once __DIR__ . '/../lib/nasr/frequencies-cache.php';
 require_once __DIR__ . '/../lib/nasr/workers.php';
 require_once __DIR__ . '/../lib/runways.php';
 require_once __DIR__ . '/../lib/airport-country-resolution-merge.php';
+require_once __DIR__ . '/../lib/ourairports/refresh.php';
+require_once __DIR__ . '/../lib/reference-data/jobs.php';
+require_once __DIR__ . '/../lib/reference-data/orchestrator.php';
 require_once __DIR__ . '/../lib/weather/utils.php';
 require_once __DIR__ . '/../lib/scheduler-daemon-lock.php';
 require_once __DIR__ . '/../lib/deploy-drain.php';
@@ -57,13 +60,6 @@ $lastDailySpawnAttempt = 0;
 $lastWeeklySpawnAttempt = 0;
 $lastWeatherHealthUpdate = 0;
 $lastStuckWorkerCleanup = 0;
-$lastRunwaysFetch = 0;
-$lastOurAirportsProbe = 0;
-$lastOurAirportsBulkFetch = 0;
-$lastNasrAptFetch = 0;
-$lastNasrFrqFetch = 0;
-$lastCountryResolutionSchedulerCheck = 0;
-$countryResolutionSchedulerStartupEval = false;
 $lastCloudflareAnalyticsFetch = 0;
 $lastStatusPageCachesFetch = 0;
 $lastOperationsSnapshotBuild = 0;
@@ -74,7 +70,6 @@ $lastNmsFdcAirspaceRefresh = 0;
 $lastNwsPointsMissingLog = 0;
 $lastNmsFdcAirspaceMissingLog = 0;
 $deployDrainAnnounced = false;
-$runwaysFetchOnStartupDone = false;
 $config = null;
 $healthStatus = 'healthy';
 $lastError = null;
@@ -222,9 +217,27 @@ $weatherPool = null;
 $webcamPool = null;
 $notamPool = null;
 $stationPowerPool = null;
+/** @var array<string, ProcessPool|null> */
+$referencePools = [];
+foreach (referenceDataJobNames() as $refJobName) {
+    $referencePools[$refJobName] = null;
+}
 $workRegistry = new SchedulerWorkRegistry();
 $webcamScheduleQueue = null; // Priority queue for efficient webcam scheduling
 $invocationId = aviationwx_get_invocation_id();
+
+$referenceDataState = [
+    'last_ourairports_probe' => 0,
+    'last_ourairports_bulk' => 0,
+    'last_runways' => 0,
+    'runways_startup_done' => false,
+    'last_nasr_apt' => 0,
+    'last_nasr_frq' => 0,
+    'last_country_check' => 0,
+    'country_startup_eval' => false,
+    'config_path' => null,
+    'config_sha' => null,
+];
 
 
 // Drain-gated work: register via setPool / registerEnqueueTick (run only when allow_new_work).
@@ -371,128 +384,15 @@ $workRegistry->registerEnqueueTick('station_power', function (int $now) use (&$s
     }
 });
 
-$workRegistry->registerEnqueueTick('reference_data', function (int $now) use (&$lastOurAirportsProbe, &$lastOurAirportsBulkFetch, &$lastRunwaysFetch, &$runwaysFetchOnStartupDone, &$lastNasrAptFetch, &$lastNasrFrqFetch, &$lastCountryResolutionSchedulerCheck, &$countryResolutionSchedulerStartupEval, &$lastConfigSha, &$config): void {
-    // 8. OurAirports upstream probe (daily; background worker only)
-    if (($now - $lastOurAirportsProbe) >= OURAIRPORTS_PROBE_INTERVAL && ourAirportsProbeWorkerShouldRun()) {
-        $probeScript = __DIR__ . '/probe-ourairports.php';
-        if (file_exists($probeScript)) {
-            $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';
-            exec(escapeshellarg($phpBin) . ' ' . escapeshellarg($probeScript) . ' > /dev/null 2>&1 &');
-            reapZombies();
-            aviationwx_log('info', 'scheduler: ourairports probe started', [], 'app');
-        } else {
-            aviationwx_log('warning', 'scheduler: probe-ourairports.php missing', [
-            'path' => $probeScript,
-            ], 'app');
-        }
-        $lastOurAirportsProbe = $now;
-    }
+$workRegistry->registerEnqueueTick('reference_data', function (int $now) use (&$referencePools, &$referenceDataState, &$lastConfigSha): void {
+    $referenceDataState['config_path'] = getConfigFilePath();
+    $referenceDataState['config_sha'] = $lastConfigSha;
 
-    // 8-i. OurAirports bulk CSV fetch when policy requires
-    if (($now - $lastOurAirportsBulkFetch) >= OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL && ourAirportsBulkWorkerShouldRun()) {
-        $bulkScript = __DIR__ . '/fetch-ourairports-bulk.php';
-        if (file_exists($bulkScript)) {
-            $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';
-            exec(escapeshellarg($phpBin) . ' ' . escapeshellarg($bulkScript) . ' > /dev/null 2>&1 &');
-            reapZombies();
-            aviationwx_log('info', 'scheduler: ourairports bulk fetch started', [], 'app');
-        } else {
-            aviationwx_log('warning', 'scheduler: fetch-ourairports-bulk.php missing', [
-            'path' => $bulkScript,
-            ], 'app');
-        }
-        $lastOurAirportsBulkFetch = $now;
-    }
-
-    // 8-ii. Runways merge fetch (background; reads OurAirports CSVs from disk)
-    $runwaysScript = __DIR__ . '/fetch-runways.php';
-    if (!$runwaysFetchOnStartupDone) {
-        if (runwaysMergeWorkerShouldRun()) {
-            if (file_exists($runwaysScript)) {
-                $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';
-                exec(escapeshellarg($phpBin) . ' ' . escapeshellarg($runwaysScript) . ' > /dev/null 2>&1 &');
-                reapZombies();
-                aviationwx_log('info', 'scheduler: runways fetch started (startup)', [], 'app');
-            } else {
-                aviationwx_log('warning', 'scheduler: fetch-runways.php missing', [
-                'path' => $runwaysScript,
-                ], 'app');
-            }
-        }
-        $runwaysFetchOnStartupDone = true;
-        $lastRunwaysFetch = $now;
-    } elseif (($now - $lastRunwaysFetch) >= OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL && runwaysMergeWorkerShouldRun()) {
-        if (file_exists($runwaysScript)) {
-            $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';
-            exec(escapeshellarg($phpBin) . ' ' . escapeshellarg($runwaysScript) . ' > /dev/null 2>&1 &');
-            reapZombies();
-            aviationwx_log('info', 'scheduler: runways fetch started', [], 'app');
-        } else {
-            aviationwx_log('warning', 'scheduler: fetch-runways.php missing', [
-            'path' => $runwaysScript,
-            ], 'app');
-        }
-        $lastRunwaysFetch = $now;
-    }
-
-    // 8a. NASR APT: presence/age/cycle gate, then short retry if missing else weekly
-    if (nasrAptSchedulerShouldEnqueue($now, $lastNasrAptFetch)) {
-        $nasrScript = __DIR__ . '/fetch-nasr-apt.php';
-        if (file_exists($nasrScript)) {
-            $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';
-            exec(escapeshellarg($phpBin) . ' ' . escapeshellarg($nasrScript) . ' > /dev/null 2>&1 &');
-            reapZombies();
-            aviationwx_log('info', 'scheduler: nasr apt fetch started', [
-                'reason' => nasrAptCacheDataPresent() ? 'refresh' : 'missing',
-                'retry_interval_sec' => nasrAptSchedulerRetryInterval(),
-            ], 'app');
-        } else {
-            aviationwx_log('warning', 'scheduler: fetch-nasr-apt.php missing', [
-                'path' => $nasrScript,
-            ], 'app');
-        }
-        $lastNasrAptFetch = $now;
-    }
-
-    // 8a-ii. NASR FRQ: same cadence policy; waits on APT lock via should-run
-    if (nasrFrqSchedulerShouldEnqueue($now, $lastNasrFrqFetch)) {
-        $nasrFrqScript = __DIR__ . '/fetch-nasr-frq.php';
-        if (file_exists($nasrFrqScript)) {
-            $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';
-            exec(escapeshellarg($phpBin) . ' ' . escapeshellarg($nasrFrqScript) . ' > /dev/null 2>&1 &');
-            reapZombies();
-            aviationwx_log('info', 'scheduler: nasr frq fetch started', [
-                'reason' => nasrFrqCacheDataPresent() ? 'refresh' : 'missing',
-                'retry_interval_sec' => nasrFrqSchedulerRetryInterval(),
-            ], 'app');
-        } else {
-            aviationwx_log('warning', 'scheduler: fetch-nasr-frq.php missing', [
-                'path' => $nasrFrqScript,
-            ], 'app');
-        }
-        $lastNasrFrqFetch = $now;
-    }
-
-    // 8b. Airport country resolution aggregate (first loop immediately; then at most hourly)
-    $countryResolutionScript = __DIR__ . '/refresh-airport-country-resolution.php';
-    $countryResolutionEvalDue = !$countryResolutionSchedulerStartupEval
-    || (($now - $lastCountryResolutionSchedulerCheck) >= COUNTRY_RESOLUTION_SCHEDULER_CHECK_INTERVAL);
-    if ($countryResolutionEvalDue
-    && file_exists($countryResolutionScript)
-    && $config !== null
-    && $lastConfigSha !== null) {
-        $lastCountryResolutionSchedulerCheck = $now;
-        $countryResolutionSchedulerStartupEval = true;
-        $cfgPath = getConfigFilePath();
-        if ($cfgPath !== null && is_readable($cfgPath)) {
-            $countryNeedsRefresh = countryResolutionAggregateShouldRefresh($cfgPath, $lastConfigSha);
-            if ($countryNeedsRefresh) {
-                $phpBin = PHP_BINARY !== '' && PHP_BINARY !== false ? PHP_BINARY : 'php';
-                exec(escapeshellarg($phpBin) . ' ' . escapeshellarg($countryResolutionScript) . ' > /dev/null 2>&1 &');
-                reapZombies();
-                aviationwx_log('info', 'scheduler: airport country resolution refresh spawned', [], 'app');
-            }
-        }
+    $started = referenceDataEnqueueDueJobs($now, $referencePools, $referenceDataState);
+    foreach ($started as $jobName) {
+        aviationwx_log('info', 'scheduler: reference worker started', [
+            'job' => $jobName,
+        ], 'app');
     }
 });
 
@@ -779,6 +679,23 @@ while ($running) {
                         'config_changed' => $configChanged,
                     ], 'app');
                 }
+
+                // Reference pools are size-1 / job-timeout; create once (not on every config SHA change).
+                if (($referencePools['nasr_apt'] ?? null) === null) {
+                    foreach (referenceDataJobs() as $refName => $refJob) {
+                        $referencePools[$refName] = new ProcessPool(
+                            1,
+                            $refJob['timeout'],
+                            $refJob['script'],
+                            $invocationId
+                        );
+                        $workRegistry->setPool(
+                            $refName,
+                            $referencePools[$refName],
+                            SCHEDULER_POOL_CLASS_REFERENCE
+                        );
+                    }
+                }
             }
         }
         
@@ -841,6 +758,20 @@ while ($running) {
             $workRegistry->setPool('notam', $notamPool);
             $workRegistry->setPool('station_power', $stationPowerPool);
 
+            foreach (referenceDataJobs() as $refName => $refJob) {
+                $referencePools[$refName] = new ProcessPool(
+                    1,
+                    $refJob['timeout'],
+                    $refJob['script'],
+                    $invocationId
+                );
+                $workRegistry->setPool(
+                    $refName,
+                    $referencePools[$refName],
+                    SCHEDULER_POOL_CLASS_REFERENCE
+                );
+            }
+
             // Initialize webcam schedule queue with config
             // This uses a priority queue (min-heap) for O(log N) scheduling
             $webcamScheduleQueue = new WebcamScheduleQueue();
@@ -856,16 +787,20 @@ while ($running) {
 
         reapZombies();
 
-        $drainActiveWorkers = $workRegistry->sumActiveWorkers();
-        $drainTick = deploy_drain_evaluate_scheduler_tick($drainActiveWorkers, $now);
+        $drainActiveByClass = $workRegistry->sumActiveWorkersByClass();
+        $drainActiveWorkers = $drainActiveByClass['live'] + $drainActiveByClass['reference'];
+        $drainTick = deploy_drain_evaluate_scheduler_tick($drainActiveByClass, $now);
         if (!$drainTick['allow_new_work']) {
             if (!$deployDrainAnnounced) {
                 aviationwx_log('info', 'scheduler: deploy drain active - pausing new workers', [
                     'active_workers' => $drainActiveWorkers,
+                    'live_workers' => $drainActiveByClass['live'],
+                    'reference_workers' => $drainActiveByClass['reference'],
                     'action' => $drainTick['action'],
                     'elapsed_seconds' => deploy_drain_elapsed_seconds($now),
                     'max_seconds' => DEPLOY_WORKER_DRAIN_MAX_SECONDS,
-                    'ttl_seconds' => deploy_drain_ttl_seconds(),
+                    'reference_max_seconds' => DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS,
+                    'ttl_seconds' => deploy_drain_ttl_seconds(deploy_drain_reference_aware_max_seconds()),
                     'registered_pools' => $workRegistry->registeredPoolNames(),
                 ], 'app');
                 $deployDrainAnnounced = true;
@@ -875,7 +810,7 @@ while ($running) {
                 if ($drainTick['action'] === 'abandon_clear') {
                     aviationwx_log('warning', 'scheduler: deploy drain abandoned - resuming workers', [
                         'elapsed_seconds' => deploy_drain_elapsed_seconds($now),
-                        'ttl_seconds' => deploy_drain_ttl_seconds(),
+                        'ttl_seconds' => deploy_drain_ttl_seconds(deploy_drain_reference_aware_max_seconds()),
                     ], 'app');
                 }
             }
@@ -884,7 +819,19 @@ while ($running) {
         $drainApplied = deploy_drain_apply_scheduler_action(
             $drainTick['action'],
             $now,
-            static function () use ($workRegistry, $drainActiveWorkers, $drainTick): void {
+            static function () use ($workRegistry, $drainActiveWorkers, $drainTick, $drainActiveByClass): void {
+                if ($drainTick['action'] === 'force_terminate_live') {
+                    if ($drainActiveByClass['live'] <= 0) {
+                        return;
+                    }
+                    aviationwx_log('warning', 'scheduler: deploy drain terminating live pool workers', [
+                        'live_workers' => $drainActiveByClass['live'],
+                        'reference_workers' => $drainActiveByClass['reference'],
+                        'action' => $drainTick['action'],
+                    ], 'app');
+                    $workRegistry->terminatePoolsByClass(SCHEDULER_POOL_CLASS_LIVE);
+                    return;
+                }
                 if ($drainTick['action'] !== 'force_terminate' && $drainTick['action'] !== 'abandon_clear') {
                     return;
                 }
@@ -895,6 +842,7 @@ while ($running) {
                     'active_workers' => $drainActiveWorkers,
                     'action' => $drainTick['action'],
                     'max_seconds' => DEPLOY_WORKER_DRAIN_MAX_SECONDS,
+                    'reference_max_seconds' => DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS,
                     'registered_pools' => $workRegistry->registeredPoolNames(),
                 ], 'app');
                 $workRegistry->terminateAll();

--- a/tests/Unit/DeployDrainTest.php
+++ b/tests/Unit/DeployDrainTest.php
@@ -110,6 +110,50 @@ final class DeployDrainTest extends TestCase
         $this->assertSame('force_terminate', $atRefMax['action']);
     }
 
+    public function testEvaluateState_TtlStaysReferenceAwareAfterReferenceExits(): void
+    {
+        $started = 1_700_000_000;
+        // Reference finished early; live idle. Must not abandon at live TTL (720).
+        $afterRefExit = deploy_drain_evaluate_state(
+            true,
+            false,
+            $started,
+            0,
+            0,
+            $started + 1000,
+            120,
+            7200,
+            600
+        );
+        $this->assertSame('mark_complete_idle', $afterRefExit['action']);
+
+        $beforeRefAbandon = deploy_drain_evaluate_state(
+            true,
+            true,
+            $started,
+            0,
+            0,
+            $started + 1000,
+            120,
+            7200,
+            600
+        );
+        $this->assertSame('already_complete', $beforeRefAbandon['action']);
+
+        $atRefAbandon = deploy_drain_evaluate_state(
+            true,
+            true,
+            $started,
+            0,
+            0,
+            $started + 7200 + 600,
+            120,
+            7200,
+            600
+        );
+        $this->assertSame('abandon_clear', $atRefAbandon['action']);
+    }
+
     public function testSetCacheBase_OverridesAndClears(): void
     {
         $this->assertSame(
@@ -482,7 +526,10 @@ final class DeployDrainTest extends TestCase
         $this->assertSame('already_complete', $done['action']);
         $this->assertFalse($done['allow_new_work']);
 
-        $abandoned = deploy_drain_evaluate_scheduler_tick(0, $now + deploy_drain_ttl_seconds());
+        $abandoned = deploy_drain_evaluate_scheduler_tick(
+            0,
+            $now + deploy_drain_ttl_seconds(deploy_drain_reference_aware_max_seconds())
+        );
         $this->assertSame('abandon_clear', $abandoned['action']);
         $this->assertTrue($abandoned['allow_new_work']);
     }
@@ -595,7 +642,11 @@ final class DeployDrainTest extends TestCase
         deploy_drain_clear_markers();
         deploy_drain_request($now);
         deploy_drain_mark_complete('idle', $now + 1);
-        $this->assertFalse(deploy_drain_should_suppress_scheduler_restart($now + deploy_drain_ttl_seconds()));
+        $this->assertFalse(
+            deploy_drain_should_suppress_scheduler_restart(
+                $now + deploy_drain_ttl_seconds(deploy_drain_reference_aware_max_seconds())
+            )
+        );
     }
 
     public function testCdWait_ReturnsTrueWhenDoneAppears(): void

--- a/tests/Unit/DeployDrainTest.php
+++ b/tests/Unit/DeployDrainTest.php
@@ -44,14 +44,70 @@ final class DeployDrainTest extends TestCase
     {
         $this->assertGreaterThanOrEqual(90, DEPLOY_WORKER_DRAIN_MAX_SECONDS);
         $this->assertLessThanOrEqual(300, DEPLOY_WORKER_DRAIN_MAX_SECONDS);
+        $this->assertGreaterThanOrEqual(DEPLOY_WORKER_DRAIN_MAX_SECONDS, DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS);
         $this->assertGreaterThanOrEqual(60, DEPLOY_WORKER_DRAIN_ABANDON_SECONDS);
         $this->assertGreaterThanOrEqual(1, DEPLOY_WORKER_DRAIN_WAIT_GRACE_SECONDS);
         $this->assertSame(
             DEPLOY_WORKER_DRAIN_MAX_SECONDS + DEPLOY_WORKER_DRAIN_ABANDON_SECONDS,
             deploy_drain_ttl_seconds()
         );
+        $this->assertSame(
+            DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS + DEPLOY_WORKER_DRAIN_ABANDON_SECONDS,
+            deploy_drain_ttl_seconds(deploy_drain_reference_aware_max_seconds())
+        );
+        $this->assertSame(
+            DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS + DEPLOY_WORKER_DRAIN_WAIT_GRACE_SECONDS,
+            deploy_drain_cd_wait_seconds()
+        );
         $this->assertSame('deploy-drain.flag', DEPLOY_DRAIN_FLAG_BASENAME);
         $this->assertSame('deploy-drain.done', DEPLOY_DRAIN_DONE_BASENAME);
+    }
+
+    public function testEvaluateState_ReferenceWaitsPastLiveMax(): void
+    {
+        $started = 1_700_000_000;
+        $liveMax = 120;
+        $refMax = 7200;
+
+        $atLiveMax = deploy_drain_evaluate_state(
+            true,
+            false,
+            $started,
+            1,
+            1,
+            $started + $liveMax,
+            $liveMax,
+            $refMax,
+            600
+        );
+        $this->assertSame('force_terminate_live', $atLiveMax['action']);
+        $this->assertFalse($atLiveMax['allow_new_work']);
+
+        $afterLiveOnlyRef = deploy_drain_evaluate_state(
+            true,
+            false,
+            $started,
+            0,
+            1,
+            $started + $liveMax + 10,
+            $liveMax,
+            $refMax,
+            600
+        );
+        $this->assertSame('wait', $afterLiveOnlyRef['action']);
+
+        $atRefMax = deploy_drain_evaluate_state(
+            true,
+            false,
+            $started,
+            0,
+            1,
+            $started + $refMax,
+            $liveMax,
+            $refMax,
+            600
+        );
+        $this->assertSame('force_terminate', $atRefMax['action']);
     }
 
     public function testSetCacheBase_OverridesAndClears(): void
@@ -394,7 +450,9 @@ final class DeployDrainTest extends TestCase
             (bool) $input['already_complete'],
             $input['started_at'] === null ? null : (int) $input['started_at'],
             (int) $input['active_workers'],
+            0,
             (int) $input['now'],
+            (int) $input['max_seconds'],
             (int) $input['max_seconds'],
             (int) $input['abandon_seconds']
         );

--- a/tests/Unit/MetricsSchedulerWorkersTest.php
+++ b/tests/Unit/MetricsSchedulerWorkersTest.php
@@ -216,6 +216,22 @@ final class MetricsSchedulerWorkersTest extends TestCase
         $this->assertStringContainsString('cleanupStaleWorkerHeartbeats', $scheduler);
         $this->assertStringContainsString('killStuckWorkers', $scheduler);
 
+        // Airport reference catalogs use size-1 ProcessPools (not fire-and-forget exec).
+        $this->assertStringContainsString('referenceDataEnqueueDueJobs', $scheduler);
+        $this->assertStringContainsString('SCHEDULER_POOL_CLASS_REFERENCE', $scheduler);
+        $this->assertStringContainsString('referenceDataJobs()', $scheduler);
+        $this->assertStringContainsString('sumActiveWorkersByClass', $scheduler);
+        $this->assertStringContainsString('force_terminate_live', $scheduler);
+        $this->assertStringContainsString('terminatePoolsByClass', $scheduler);
+        $this->assertDoesNotMatchRegularExpression(
+            '/fetch-nasr-apt\.php.*?>\s*\/dev\/null\s+2>&1\s*&/s',
+            $scheduler
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/fetch-ourairports-bulk\.php.*?>\s*\/dev\/null\s+2>&1\s*&/s',
+            $scheduler
+        );
+
         // Payload metrics must not run in-process after the drain gate.
         $afterGate = $scheduler;
         $gatePos = strpos($scheduler, "if (\$drainTick['allow_new_work'])");

--- a/tests/Unit/NasrWorkersTest.php
+++ b/tests/Unit/NasrWorkersTest.php
@@ -109,6 +109,10 @@ class NasrWorkersTest extends TestCase
     {
         $now = 1_700_000_000;
         $this->assertTrue(nasrAptSchedulerShouldEnqueue($now, 0));
+        // FRQ requires APT cache on disk (orchestrator / worker gate).
+        $this->assertFalse(nasrFrqSchedulerShouldEnqueue($now, 0));
+
+        $this->writeMinimalAptCache();
         $this->assertTrue(nasrFrqSchedulerShouldEnqueue($now, 0));
     }
 
@@ -118,6 +122,7 @@ class NasrWorkersTest extends TestCase
         $lastAttempt = $now - (NASR_MISSING_RETRY_INTERVAL - 1);
 
         $this->assertFalse(nasrAptSchedulerShouldEnqueue($now, $lastAttempt));
+        $this->writeMinimalAptCache();
         $this->assertFalse(nasrFrqSchedulerShouldEnqueue($now, $lastAttempt));
     }
 
@@ -127,6 +132,7 @@ class NasrWorkersTest extends TestCase
         $lastAttempt = $now - NASR_MISSING_RETRY_INTERVAL;
 
         $this->assertTrue(nasrAptSchedulerShouldEnqueue($now, $lastAttempt));
+        $this->writeMinimalAptCache();
         $this->assertTrue(nasrFrqSchedulerShouldEnqueue($now, $lastAttempt));
     }
 
@@ -175,6 +181,8 @@ class NasrWorkersTest extends TestCase
 
         $this->assertLessThan(NASR_FETCH_CHECK_INTERVAL, 60 * 60);
         $this->assertTrue(nasrAptSchedulerShouldEnqueue($now, $lastAttempt));
+        $this->assertFalse(nasrFrqSchedulerShouldEnqueue($now, $lastAttempt));
+        $this->writeMinimalAptCache();
         $this->assertTrue(nasrFrqSchedulerShouldEnqueue($now, $lastAttempt));
     }
 

--- a/tests/Unit/ReferenceDataOrchestratorTest.php
+++ b/tests/Unit/ReferenceDataOrchestratorTest.php
@@ -219,6 +219,60 @@ final class ReferenceDataOrchestratorTest extends TestCase
         );
     }
 
+    public function testRunways_KeepsBackoffWhenSourcesUnchangedAfterFailedAttempt(): void
+    {
+        $now = time();
+        // Sources newer than merge, but last attempt is after those source mtimes
+        // (failed merge that did not publish a new cache).
+        $sourceMtime = $now - 120;
+        $this->seedRunnableRunwayMergeInputs($now - 7200, $sourceMtime);
+
+        $state = [
+            'runways_startup_done' => true,
+            'last_runways' => $now - 30,
+        ];
+        $pools = [
+            'runways_merge' => $this->makePool(0),
+            'ourairports_bulk' => $this->makePool(0),
+        ];
+
+        $this->assertTrue(referenceDataRunwaysSourceInputsNewerThanMerge());
+        $this->assertFalse(
+            referenceDataShouldEnqueue('runways_merge', $now, $pools, $state),
+            'Unchanged sources after a failed attempt must keep the interval backoff'
+        );
+    }
+
+    public function testEnqueue_DoesNotAdvanceCountryEvalWhenConfigIdentityMissing(): void
+    {
+        $now = time();
+        $state = [
+            'last_ourairports_probe' => $now,
+            'last_ourairports_bulk' => $now,
+            'last_runways' => $now,
+            'runways_startup_done' => true,
+            'last_nasr_apt' => $now,
+            'last_nasr_frq' => $now,
+            'last_country_check' => 0,
+            'country_startup_eval' => false,
+            'config_path' => null,
+            'config_sha' => null,
+        ];
+        $pools = [
+            'ourairports_probe' => $this->makePool(0),
+            'ourairports_bulk' => $this->makePool(0),
+            'runways_merge' => $this->makePool(0),
+            'nasr_apt' => $this->makePool(0),
+            'nasr_frq' => $this->makePool(0),
+            'country_resolution' => $this->makePool(0),
+        ];
+
+        $started = referenceDataEnqueueDueJobs($now, $pools, $state);
+        $this->assertNotContains('country_resolution', $started);
+        $this->assertFalse($state['country_startup_eval']);
+        $this->assertSame(0, $state['last_country_check']);
+    }
+
     public function testRunways_EnqueuesWhenNgdaNewerDespiteRecentLastAttempt(): void
     {
         $now = time();

--- a/tests/Unit/ReferenceDataOrchestratorTest.php
+++ b/tests/Unit/ReferenceDataOrchestratorTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AviationWx\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Reference-data orchestrator gates (ProcessPool enqueue policy).
+ */
+final class ReferenceDataOrchestratorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 2) . '/lib/constants.php';
+        require_once dirname(__DIR__, 2) . '/lib/reference-data/orchestrator.php';
+    }
+
+    public function testJobs_ListExpectedSingletons(): void
+    {
+        $jobs = referenceDataJobs();
+        $this->assertSame(
+            [
+                'ourairports_probe',
+                'ourairports_bulk',
+                'runways_merge',
+                'nasr_apt',
+                'nasr_frq',
+                'country_resolution',
+            ],
+            array_keys($jobs)
+        );
+        $this->assertSame(NASR_APT_WORKER_TIMEOUT, $jobs['nasr_apt']['timeout']);
+        $this->assertSame(COUNTRY_RESOLUTION_WORKER_TIMEOUT, $jobs['country_resolution']['timeout']);
+    }
+
+    public function testFrq_BlockedWhileAptPoolActive(): void
+    {
+        $pools = [
+            'nasr_apt' => $this->makePool(1),
+            'nasr_frq' => $this->makePool(0),
+        ];
+        $state = ['last_nasr_frq' => 0];
+
+        $this->assertFalse(
+            referenceDataShouldEnqueue('nasr_frq', time(), $pools, $state),
+            'FRQ must not enqueue while APT pool is active'
+        );
+    }
+
+    public function testRunways_BlockedWhileBulkPoolActive(): void
+    {
+        $pools = [
+            'ourairports_bulk' => $this->makePool(1),
+            'runways_merge' => $this->makePool(0),
+        ];
+        $state = [
+            'runways_startup_done' => true,
+            'last_runways' => 0,
+        ];
+
+        $this->assertFalse(referenceDataShouldEnqueue('runways_merge', time(), $pools, $state));
+    }
+
+    public function testProbe_BlockedWhileBulkPoolActive(): void
+    {
+        $pools = [
+            'ourairports_probe' => $this->makePool(0),
+            'ourairports_bulk' => $this->makePool(1),
+        ];
+        $state = ['last_ourairports_probe' => 0];
+
+        $this->assertFalse(referenceDataShouldEnqueue('ourairports_probe', time(), $pools, $state));
+    }
+
+    public function testEnqueue_StartsJobAndUpdatesState(): void
+    {
+        $added = false;
+        $pool = new class ($added) {
+            private bool $added;
+
+            public function __construct(bool &$added)
+            {
+                $this->added = &$added;
+            }
+
+            public function getActiveCount(): int
+            {
+                return 0;
+            }
+
+            public function addJob(array $args): bool
+            {
+                $this->added = true;
+                return true;
+            }
+        };
+
+        // Force country path with unreadable config so only a stubbed job can start.
+        // Use a fake job by temporarily only enqueuing via direct shouldEnqueue false for all
+        // real jobs except we inject a pool that always would run - instead call addJob path
+        // through nasr_apt with last attempt far in the past and needs-refresh mocked is hard.
+        // Verify enqueue helper records state when addJob succeeds via a custom pool map entry
+        // for a job we force by using ourairports_probe with interval satisfied and should-run
+        // may be true/false depending on locks - assert API shape instead:
+
+        $state = [
+            'last_ourairports_probe' => time(),
+            'last_ourairports_bulk' => time(),
+            'last_runways' => time(),
+            'runways_startup_done' => true,
+            'last_nasr_apt' => time(),
+            'last_nasr_frq' => time(),
+            'last_country_check' => time(),
+            'country_startup_eval' => true,
+            'config_path' => null,
+            'config_sha' => null,
+        ];
+        $pools = [
+            'ourairports_probe' => $pool,
+            'ourairports_bulk' => $this->makePool(0),
+            'runways_merge' => $this->makePool(0),
+            'nasr_apt' => $this->makePool(0),
+            'nasr_frq' => $this->makePool(0),
+            'country_resolution' => $this->makePool(0),
+        ];
+
+        $started = referenceDataEnqueueDueJobs(time(), $pools, $state);
+        $this->assertSame([], $started);
+        $this->assertFalse($added);
+    }
+
+    /**
+     * @return object
+     */
+    private function makePool(int $active): object
+    {
+        return new class ($active) {
+            private int $active;
+
+            public function __construct(int $active)
+            {
+                $this->active = $active;
+            }
+
+            public function getActiveCount(): int
+            {
+                return $this->active;
+            }
+
+            public function addJob(array $args): bool
+            {
+                return false;
+            }
+        };
+    }
+}

--- a/tests/Unit/ReferenceDataOrchestratorTest.php
+++ b/tests/Unit/ReferenceDataOrchestratorTest.php
@@ -76,13 +76,14 @@ final class ReferenceDataOrchestratorTest extends TestCase
 
     public function testEnqueue_StartsJobAndUpdatesState(): void
     {
-        $added = false;
-        $pool = new class ($added) {
-            private bool $added;
+        $addedArgs = null;
+        $pool = new class ($addedArgs) {
+            /** @var array<string, mixed>|null */
+            private $addedArgs;
 
-            public function __construct(bool &$added)
+            public function __construct(?array &$addedArgs)
             {
-                $this->added = &$added;
+                $this->addedArgs = &$addedArgs;
             }
 
             public function getActiveCount(): int
@@ -92,27 +93,20 @@ final class ReferenceDataOrchestratorTest extends TestCase
 
             public function addJob(array $args): bool
             {
-                $this->added = true;
+                $this->addedArgs = $args;
                 return true;
             }
         };
 
-        // Force country path with unreadable config so only a stubbed job can start.
-        // Use a fake job by temporarily only enqueuing via direct shouldEnqueue false for all
-        // real jobs except we inject a pool that always would run - instead call addJob path
-        // through nasr_apt with last attempt far in the past and needs-refresh mocked is hard.
-        // Verify enqueue helper records state when addJob succeeds via a custom pool map entry
-        // for a job we force by using ourairports_probe with interval satisfied and should-run
-        // may be true/false depending on locks - assert API shape instead:
-
+        $now = time();
         $state = [
-            'last_ourairports_probe' => time(),
-            'last_ourairports_bulk' => time(),
-            'last_runways' => time(),
+            'last_ourairports_probe' => 0,
+            'last_ourairports_bulk' => $now,
+            'last_runways' => $now,
             'runways_startup_done' => true,
-            'last_nasr_apt' => time(),
-            'last_nasr_frq' => time(),
-            'last_country_check' => time(),
+            'last_nasr_apt' => $now,
+            'last_nasr_frq' => $now,
+            'last_country_check' => $now,
             'country_startup_eval' => true,
             'config_path' => null,
             'config_sha' => null,
@@ -126,9 +120,71 @@ final class ReferenceDataOrchestratorTest extends TestCase
             'country_resolution' => $this->makePool(0),
         ];
 
-        $started = referenceDataEnqueueDueJobs(time(), $pools, $state);
+        $started = referenceDataEnqueueDueJobs($now, $pools, $state);
+        $this->assertSame(['ourairports_probe'], $started);
+        $this->assertSame([], $addedArgs);
+        $this->assertSame($now, $state['last_ourairports_probe']);
+    }
+
+    public function testEnqueue_KeepsRunwaysStartupPendingWhileBulkActive(): void
+    {
+        $now = time();
+        $state = [
+            'last_ourairports_probe' => $now,
+            'last_ourairports_bulk' => $now,
+            'last_runways' => 0,
+            'runways_startup_done' => false,
+            'last_nasr_apt' => $now,
+            'last_nasr_frq' => $now,
+            'last_country_check' => $now,
+            'country_startup_eval' => true,
+            'config_path' => null,
+            'config_sha' => null,
+        ];
+        $pools = [
+            'ourairports_probe' => $this->makePool(0),
+            'ourairports_bulk' => $this->makePool(1),
+            'runways_merge' => $this->makePool(0),
+            'nasr_apt' => $this->makePool(0),
+            'nasr_frq' => $this->makePool(0),
+            'country_resolution' => $this->makePool(0),
+        ];
+
+        $started = referenceDataEnqueueDueJobs($now, $pools, $state);
         $this->assertSame([], $started);
-        $this->assertFalse($added);
+        $this->assertFalse($state['runways_startup_done']);
+        $this->assertSame(0, $state['last_runways']);
+    }
+
+    public function testEnqueue_AdvancesRunwaysStartupWhenSkippedWithoutUpstream(): void
+    {
+        $now = time();
+        $state = [
+            'last_ourairports_probe' => $now,
+            'last_ourairports_bulk' => $now,
+            'last_runways' => 0,
+            'runways_startup_done' => false,
+            'last_nasr_apt' => $now,
+            'last_nasr_frq' => $now,
+            'last_country_check' => $now,
+            'country_startup_eval' => true,
+            'config_path' => null,
+            'config_sha' => null,
+        ];
+        $pools = [
+            'ourairports_probe' => $this->makePool(0),
+            'ourairports_bulk' => $this->makePool(0),
+            'runways_merge' => $this->makePool(0),
+            'nasr_apt' => $this->makePool(0),
+            'nasr_frq' => $this->makePool(0),
+            'country_resolution' => $this->makePool(0),
+        ];
+
+        // No runway inputs in test cache => shouldEnqueue false; still advances startup flag.
+        $started = referenceDataEnqueueDueJobs($now, $pools, $state);
+        $this->assertNotContains('runways_merge', $started);
+        $this->assertTrue($state['runways_startup_done']);
+        $this->assertSame($now, $state['last_runways']);
     }
 
     /**

--- a/tests/Unit/ReferenceDataOrchestratorTest.php
+++ b/tests/Unit/ReferenceDataOrchestratorTest.php
@@ -198,6 +198,21 @@ final class ReferenceDataOrchestratorTest extends TestCase
      * System regression: early merge stamps last_runways; bulk then lands newer CSVs.
      * Source mtime must beat the last-attempt throttle so merge is not delayed an hour.
      */
+    public function testRunways_SourceAgeHelpersClearStatCache(): void
+    {
+        $src = (string) file_get_contents(dirname(__DIR__, 2) . '/lib/reference-data/orchestrator.php');
+        foreach (['referenceDataRunwaysSourceInputsNewerThanMerge', 'referenceDataRunwaysNewestSourceMtime'] as $fn) {
+            $pos = strpos($src, "function {$fn}");
+            $this->assertNotFalse($pos, $fn);
+            $chunk = substr($src, $pos, 450);
+            $this->assertStringContainsString(
+                'clearstatcache()',
+                $chunk,
+                "{$fn} must clearstatcache before filemtime so child-written CSVs are visible"
+            );
+        }
+    }
+
     public function testRunways_EnqueuesWhenSourcesNewerDespiteRecentLastAttempt(): void
     {
         $now = time();

--- a/tests/Unit/ReferenceDataOrchestratorTest.php
+++ b/tests/Unit/ReferenceDataOrchestratorTest.php
@@ -6,15 +6,22 @@ namespace AviationWx\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../Helpers/IsolatesOurAirportsCacheTrait.php';
+
 /**
  * Reference-data orchestrator gates (ProcessPool enqueue policy).
  */
 final class ReferenceDataOrchestratorTest extends TestCase
 {
+    use \IsolatesOurAirportsCacheTrait;
+
     protected function setUp(): void
     {
+        require_once dirname(__DIR__, 2) . '/lib/cache-paths.php';
         require_once dirname(__DIR__, 2) . '/lib/constants.php';
+        require_once dirname(__DIR__, 2) . '/lib/ourairports/meta.php';
         require_once dirname(__DIR__, 2) . '/lib/reference-data/orchestrator.php';
+        $this->resetOurAirportsTestCacheState();
     }
 
     public function testJobs_ListExpectedSingletons(): void
@@ -185,6 +192,174 @@ final class ReferenceDataOrchestratorTest extends TestCase
         $this->assertNotContains('runways_merge', $started);
         $this->assertTrue($state['runways_startup_done']);
         $this->assertSame($now, $state['last_runways']);
+    }
+
+    /**
+     * System regression: early merge stamps last_runways; bulk then lands newer CSVs.
+     * Source mtime must beat the last-attempt throttle so merge is not delayed an hour.
+     */
+    public function testRunways_EnqueuesWhenSourcesNewerDespiteRecentLastAttempt(): void
+    {
+        $now = time();
+        $this->seedRunnableRunwayMergeInputs($now - 7200, $now);
+
+        $state = [
+            'runways_startup_done' => true,
+            'last_runways' => $now - 60,
+        ];
+        $pools = [
+            'runways_merge' => $this->makePool(0),
+            'ourairports_bulk' => $this->makePool(0),
+        ];
+
+        $this->assertTrue(referenceDataRunwaysSourceInputsNewerThanMerge());
+        $this->assertTrue(
+            referenceDataShouldEnqueue('runways_merge', $now, $pools, $state),
+            'Newer source CSVs must bypass last_runways interval'
+        );
+    }
+
+    public function testRunways_EnqueuesWhenNgdaNewerDespiteRecentLastAttempt(): void
+    {
+        $now = time();
+        // OA CSVs not newer than merge; NGDA CSV is.
+        $this->seedRunnableRunwayMergeInputs($now - 60, $now - 60);
+        file_put_contents(CACHE_FAA_NGDA_RUNWAYS_CSV, "ARPT_ID,RWY_ID\nKTEST,18/36\n", LOCK_EX);
+        touch(CACHE_FAA_NGDA_RUNWAYS_CSV, $now);
+
+        $state = [
+            'runways_startup_done' => true,
+            'last_runways' => $now - 60,
+        ];
+        $pools = [
+            'runways_merge' => $this->makePool(0),
+            'ourairports_bulk' => $this->makePool(0),
+        ];
+
+        $this->assertTrue(faaNgdaRunwayCsvNewerThanMerge());
+        $this->assertTrue(referenceDataRunwaysSourceInputsNewerThanMerge());
+        $this->assertTrue(referenceDataShouldEnqueue('runways_merge', $now, $pools, $state));
+    }
+
+    /**
+     * Full tick: after bulk lands newer CSVs, enqueue must start merge despite a fresh last_runways.
+     */
+    public function testEnqueue_StartsRunwaysWhenSourcesNewerWithinInterval(): void
+    {
+        $now = time();
+        $this->seedRunnableRunwayMergeInputs($now - 7200, $now);
+
+        $added = false;
+        $runwaysPool = new class ($added) {
+            private bool $added;
+
+            public function __construct(bool &$added)
+            {
+                $this->added = &$added;
+            }
+
+            public function getActiveCount(): int
+            {
+                return 0;
+            }
+
+            public function addJob(array $args): bool
+            {
+                $this->added = true;
+                return true;
+            }
+        };
+
+        $state = [
+            'last_ourairports_probe' => $now,
+            'last_ourairports_bulk' => $now,
+            'last_runways' => $now - 60,
+            'runways_startup_done' => true,
+            'last_nasr_apt' => $now,
+            'last_nasr_frq' => $now,
+            'last_country_check' => $now,
+            'country_startup_eval' => true,
+            'config_path' => null,
+            'config_sha' => null,
+        ];
+        $pools = [
+            'ourairports_probe' => $this->makePool(0),
+            'ourairports_bulk' => $this->makePool(0),
+            'runways_merge' => $runwaysPool,
+            'nasr_apt' => $this->makePool(0),
+            'nasr_frq' => $this->makePool(0),
+            'country_resolution' => $this->makePool(0),
+        ];
+
+        $started = referenceDataEnqueueDueJobs($now, $pools, $state);
+        $this->assertSame(['runways_merge'], $started);
+        $this->assertTrue($added);
+        $this->assertSame($now, $state['last_runways']);
+    }
+
+    public function testRunways_IdleThrottleHoldsWhenSourcesNotNewer(): void
+    {
+        $now = time();
+        // Merge and sources share the same age; force max-age refresh due so the interval
+        // gate is the only thing preventing enqueue.
+        $this->seedRunnableRunwayMergeInputs($now - RUNWAYS_CACHE_MAX_AGE - 10, $now - RUNWAYS_CACHE_MAX_AGE - 10);
+
+        $state = [
+            'runways_startup_done' => true,
+            'last_runways' => $now - 60,
+        ];
+        $pools = [
+            'runways_merge' => $this->makePool(0),
+            'ourairports_bulk' => $this->makePool(0),
+        ];
+
+        $this->assertFalse(referenceDataRunwaysSourceInputsNewerThanMerge());
+        $this->assertTrue(runwaysCacheNeedsRefresh(), 'max-age should still make merge due');
+        $this->assertFalse(
+            referenceDataShouldEnqueue('runways_merge', $now, $pools, $state),
+            'Without newer sources, last_runways remains an idle throttle'
+        );
+    }
+
+    public function testRunways_EnqueuesAfterIntervalWhenSourcesNotNewerButDue(): void
+    {
+        $now = time();
+        $this->seedRunnableRunwayMergeInputs($now - RUNWAYS_CACHE_MAX_AGE - 10, $now - RUNWAYS_CACHE_MAX_AGE - 10);
+
+        $state = [
+            'runways_startup_done' => true,
+            'last_runways' => $now - OURAIRPORTS_BULK_FETCH_CHECK_INTERVAL - 1,
+        ];
+        $pools = [
+            'runways_merge' => $this->makePool(0),
+            'ourairports_bulk' => $this->makePool(0),
+        ];
+
+        $this->assertTrue(referenceDataShouldEnqueue('runways_merge', $now, $pools, $state));
+    }
+
+    /**
+     * @param int $mergeMtime Published merge cache mtime
+     * @param int $sourceMtime OurAirports CSV mtime
+     */
+    private function seedRunnableRunwayMergeInputs(int $mergeMtime, int $sourceMtime): void
+    {
+        file_put_contents(CACHE_RUNWAYS_DATA_FILE, '{}', LOCK_EX);
+        touch(CACHE_RUNWAYS_DATA_FILE, $mergeMtime);
+
+        file_put_contents(CACHE_OURAIRPORTS_AIRPORTS_CSV, "id,ident\n", LOCK_EX);
+        file_put_contents(CACHE_OURAIRPORTS_RUNWAYS_CSV, "id,airport_ident\n", LOCK_EX);
+        touch(CACHE_OURAIRPORTS_AIRPORTS_CSV, $sourceMtime);
+        touch(CACHE_OURAIRPORTS_RUNWAYS_CSV, $sourceMtime);
+
+        ourAirportsUpdateFileMeta('airports', [
+            'last_probe_result' => 'unchanged',
+            'last_fetch_at' => $sourceMtime,
+        ]);
+        ourAirportsUpdateFileMeta('runways', [
+            'last_probe_result' => 'unchanged',
+            'last_fetch_at' => $sourceMtime,
+        ]);
     }
 
     /**

--- a/tests/Unit/SchedulerDrainWiringContractTest.php
+++ b/tests/Unit/SchedulerDrainWiringContractTest.php
@@ -141,14 +141,18 @@ final class SchedulerDrainWiringContractTest extends TestCase
         $this->assertMatchesRegularExpression('/SIGTERM.*SIGKILL|SIGKILL.*SIGTERM/i', $arch);
     }
 
-    public function testScheduler_CountryResolutionSpawnsNonBlocking(): void
+    public function testScheduler_CountryResolutionUsesReferenceProcessPool(): void
     {
         $scheduler = (string) file_get_contents($this->root . '/scripts/scheduler.php');
-        $this->assertStringContainsString('refresh-airport-country-resolution.php', $scheduler);
-        $this->assertMatchesRegularExpression(
-            '/escapeshellarg\(\$countryResolutionScript\)\s*\.\s*[\'"]\s*>\s*\/dev\/null\s*2>&1\s*&/',
+        $jobs = (string) file_get_contents($this->root . '/lib/reference-data/jobs.php');
+        $this->assertStringContainsString('refresh-airport-country-resolution.php', $jobs);
+        $this->assertStringContainsString('country_resolution', $jobs);
+        $this->assertStringContainsString('referenceDataEnqueueDueJobs', $scheduler);
+        $this->assertStringContainsString('SCHEDULER_POOL_CLASS_REFERENCE', $scheduler);
+        $this->assertStringNotContainsString(
+            'escapeshellarg($countryResolutionScript)',
             $scheduler,
-            'Country resolution must be fire-and-forget so the dispatcher tick cannot block on geometry I/O'
+            'Country resolution must use ProcessPool enqueue, not fire-and-forget exec'
         );
         $this->assertStringNotContainsString(
             ", \$output, \$exitCode)",

--- a/tests/Unit/SchedulerDrainWiringContractTest.php
+++ b/tests/Unit/SchedulerDrainWiringContractTest.php
@@ -73,6 +73,30 @@ final class SchedulerDrainWiringContractTest extends TestCase
         $this->assertStringContainsString('--week=', $weekly);
     }
 
+    public function testWorkflow_DeployJobTimeoutExceedsReferenceDrainWindow(): void
+    {
+        require_once $this->root . '/lib/constants.php';
+        $workflow = (string) file_get_contents($this->root . '/.github/workflows/deploy-docker.yml');
+
+        $this->assertMatchesRegularExpression(
+            '/^  deploy:\n(?:.*\n)*?    timeout-minutes: (\d+)/m',
+            $workflow
+        );
+        preg_match('/^  deploy:\n(?:.*\n)*?    timeout-minutes: (\d+)/m', $workflow, $matches);
+        $timeoutMinutes = (int) ($matches[1] ?? 0);
+
+        $drainMinutes = (int) ceil(
+            (DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS + DEPLOY_WORKER_DRAIN_WAIT_GRACE_SECONDS) / 60
+        );
+        // Headroom for checkout, image build, health checks after drain returns.
+        $minimum = $drainMinutes + 30;
+        $this->assertGreaterThanOrEqual(
+            $minimum,
+            $timeoutMinutes,
+            "deploy timeout-minutes ({$timeoutMinutes}) must be >= reference drain window + overhead ({$minimum})"
+        );
+    }
+
     public function testWorkflow_DrainsImmediatelyBeforeComposeUpAndClearsOnFailure(): void
     {
         $workflow = (string) file_get_contents($this->root . '/.github/workflows/deploy-docker.yml');

--- a/tests/Unit/SchedulerWorkRegistryTest.php
+++ b/tests/Unit/SchedulerWorkRegistryTest.php
@@ -173,8 +173,10 @@ final class SchedulerWorkRegistryTest extends TestCase
             false,
             1000,
             $reg->sumActiveWorkers(),
+            0,
             1010,
             120,
+            7200,
             600
         );
         $this->assertFalse($tick['allow_new_work']);
@@ -185,7 +187,7 @@ final class SchedulerWorkRegistryTest extends TestCase
         }
         $this->assertFalse($ran);
 
-        $tickIdle = deploy_drain_evaluate_state(false, false, null, 0, 1010, 120, 600);
+        $tickIdle = deploy_drain_evaluate_state(false, false, null, 0, 0, 1010, 120, 7200, 600);
         $this->assertTrue($tickIdle['allow_new_work']);
         if ($tickIdle['allow_new_work']) {
             $reg->runEnqueueTicks(1010);

--- a/tests/Unit/SchedulerWorkRegistryTest.php
+++ b/tests/Unit/SchedulerWorkRegistryTest.php
@@ -195,35 +195,61 @@ final class SchedulerWorkRegistryTest extends TestCase
         $this->assertTrue($ran);
     }
 
-    public function testTerminateAll_UsedByForceDrainPath(): void
+    public function testTerminatePoolsByClass_OnlyCleansRequestedClassIncludingRetiring(): void
     {
         $reg = new SchedulerWorkRegistry();
-        $terminated = 0;
-        $reg->setPool('weather', new class ($terminated) {
-            private int $terminated;
-            public function __construct(int &$terminated)
+        $liveHits = 0;
+        $refHits = 0;
+
+        $reg->setPool('weather', $this->makeTerminablePool($liveHits, 2), SCHEDULER_POOL_CLASS_LIVE);
+        $reg->setPool('nasr_apt', $this->makeTerminablePool($refHits, 2), SCHEDULER_POOL_CLASS_REFERENCE);
+
+        // Replace while active so both classes keep a retiring entry.
+        $reg->setPool('weather', $this->makeTerminablePool($liveHits, 1), SCHEDULER_POOL_CLASS_LIVE);
+        $reg->setPool('nasr_apt', $this->makeTerminablePool($refHits, 1), SCHEDULER_POOL_CLASS_REFERENCE);
+
+        $byClass = $reg->sumActiveWorkersByClass();
+        $this->assertSame(3, $byClass['live']);
+        $this->assertSame(3, $byClass['reference']);
+        $this->assertSame(2, $reg->retiringPoolCount());
+
+        $reg->terminatePoolsByClass(SCHEDULER_POOL_CLASS_LIVE);
+        $this->assertSame(2, $liveHits, 'current + retiring live pools');
+        $this->assertSame(0, $refHits);
+        $this->assertSame(1, $reg->retiringPoolCount(), 'reference retiring pool remains');
+
+        $reg->terminatePoolsByClass(SCHEDULER_POOL_CLASS_REFERENCE);
+        $this->assertSame(2, $liveHits);
+        $this->assertSame(2, $refHits, 'current + retiring reference pools');
+        $this->assertSame(0, $reg->retiringPoolCount());
+    }
+
+    /**
+     * @return object
+     */
+    private function makeTerminablePool(int &$hits, int $active): object
+    {
+        return new class ($hits, $active) {
+            private int $hits;
+            private int $active;
+
+            public function __construct(int &$hits, int $active)
             {
-                $this->terminated = &$terminated;
+                $this->hits = &$hits;
+                $this->active = $active;
             }
+
             public function cleanup(): void
             {
-                $this->terminated++;
+                $this->hits++;
+                $this->active = 0;
             }
+
             public function getActiveCount(): int
             {
-                return 1;
+                return $this->active;
             }
-        });
-
-        $applied = deploy_drain_apply_scheduler_action(
-            'force_terminate',
-            1120,
-            static function () use ($reg): void {
-                $reg->terminateAll();
-            }
-        );
-        $this->assertTrue($applied);
-        $this->assertSame(1, $terminated);
+        };
     }
 
     /**

--- a/tests/Unit/WorkerTimeoutHeartbeatTest.php
+++ b/tests/Unit/WorkerTimeoutHeartbeatTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Unit tests for worker heartbeat stale detection (declared timeout).
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/config.php';
+require_once __DIR__ . '/../../lib/constants.php';
+require_once __DIR__ . '/../../lib/worker-timeout.php';
+
+class WorkerTimeoutHeartbeatTest extends TestCase
+{
+    public function testDeclaredTimeout_UsesTimeoutPlusBuffer(): void
+    {
+        $timeout = (int) NASR_APT_WORKER_TIMEOUT;
+        $this->assertSame(
+            $timeout + 30,
+            workerHeartbeatStaleAfterSeconds(['timeout' => $timeout], null, 120)
+        );
+    }
+
+    public function testMissingDeclaredTimeout_UsesDefault(): void
+    {
+        $this->assertSame(
+            120,
+            workerHeartbeatStaleAfterSeconds(['pid' => 1], null, 120)
+        );
+    }
+
+    public function testLongDeclaredTimeout_NotTreatedStaleAtWebcamDefault(): void
+    {
+        $age = getWorkerTimeout() + 30 + 30;
+        $this->assertLessThan((int) NASR_APT_WORKER_TIMEOUT, $age);
+
+        $id = 'test_' . bin2hex(random_bytes(4));
+        $path = '/tmp/worker_heartbeat_' . $id . '.json';
+        file_put_contents($path, json_encode([
+            'pid' => 2147483000,
+            'started' => time() - $age - 30,
+            'heartbeat' => time() - $age,
+            'timeout' => NASR_APT_WORKER_TIMEOUT,
+        ]));
+
+        try {
+            $stuck = cleanupStaleWorkerHeartbeats();
+            $this->assertNotContains(2147483000, $stuck);
+            $this->assertFileExists($path);
+        } finally {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Run all airport reference-data jobs (OurAirports probe/bulk, runways merge, NASR APT/FRQ, country resolution) as size-1 ProcessPools with job-specific timeouts and dependency-aware enqueue.
- Split deploy drain by pool class: live workers force at 120s; reference workers wait up to `DEPLOY_WORKER_DRAIN_REFERENCE_MAX_SECONDS` (7200) before force-terminate; CD wait is reference-aware.
- FRQ requires APT cache on disk and will not overlap an active APT pool/lock.
- Documents the live vs reference pool model in `docs/ARCHITECTURE.md`.

**Supersedes #285** - ProcessPool ownership removes the false stale-heartbeat kill class for these jobs instead of only hardening `/tmp` heartbeat cleanup.

## Test plan
- [x] `make test-ci` (local)
- [ ] Confirm scheduler registers six reference pools on startup (logs / status)
- [ ] Missing NASR APT cache enqueues APT pool; FRQ waits until APT present
- [ ] Deploy drain with only live workers still completes near 120s
- [ ] Deploy drain with in-flight NASR waits past 120s (or until job exits) before `.done`

Closes #285