### PR TITLE
Add Public API operator filter for weathercams and weather sources

### DIFF
--- a/api/docs/index.php
+++ b/api/docs/index.php
@@ -500,7 +500,7 @@ $attribution = getPublicApiAttributionText();
                 <span class="endpoint-path">/v1/airports</span>
             </div>
             <div class="endpoint-body">
-                <p class="endpoint-desc">List all available airports with basic metadata. Optional <code>operator</code> includes an airport when it has one or more weathercams or weather sources with that operator.</p>
+                <p class="endpoint-desc">List all available airports with basic metadata. Optional <code>operator</code> includes an airport when it has one or more weathercams or weather sources with that operator, including weather-source type defaults when operator is omitted (for example metar is faa).</p>
             </div>
         </div>
         

--- a/api/docs/index.php
+++ b/api/docs/index.php
@@ -500,7 +500,7 @@ $attribution = getPublicApiAttributionText();
                 <span class="endpoint-path">/v1/airports</span>
             </div>
             <div class="endpoint-body">
-                <p class="endpoint-desc">List all available airports with basic metadata.</p>
+                <p class="endpoint-desc">List all available airports with basic metadata. Optional <code>operator</code> includes an airport when it has one or more weathercams or weather sources with that operator.</p>
             </div>
         </div>
         
@@ -520,7 +520,7 @@ $attribution = getPublicApiAttributionText();
                 <span class="endpoint-path">/v1/airports/{id}/weather</span>
             </div>
             <div class="endpoint-body">
-                <p class="endpoint-desc">Get current weather conditions for an airport.</p>
+                <p class="endpoint-desc">Get the fused current weather observation. Not filtered by operator.</p>
             </div>
         </div>
         
@@ -540,7 +540,7 @@ $attribution = getPublicApiAttributionText();
                 <span class="endpoint-path">/v1/airports/{id}/webcams</span>
             </div>
             <div class="endpoint-body">
-                <p class="endpoint-desc">List webcams for an airport with metadata.</p>
+                <p class="endpoint-desc">List weathercams for an airport. Optional <code>operator</code> returns only weathercams whose operator equals that slug.</p>
             </div>
         </div>
         

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -29,7 +29,7 @@
     "/airports": {
       "get": {
         "summary": "List all airports",
-        "description": "Returns a list of all enabled airports with basic metadata. Optional operator includes an airport when airports.json has one or more weathercams or weather sources with that operator.",
+        "description": "Returns a list of all enabled airports with basic metadata. Optional operator includes an airport when airports.json has one or more weathercams or weather sources with that operator, including weather-source type defaults when operator is omitted.",
         "operationId": "listAirports",
         "tags": ["Airports"],
         "parameters": [
@@ -672,7 +672,7 @@
       "Operator": {
         "name": "operator",
         "in": "query",
-        "description": "Operating-network slug. Query values are lowercased before matching. Invalid slugs return 400. Omitted weathercam operator is aviationwx.",
+        "description": "Operating-network slug. Query values are lowercased before matching. Invalid slugs return 400. Matching uses airports.json. Omitted weathercam operator is aviationwx. Omitted weather-source operator uses the type default: metar is faa, nws is nws, swob_auto and swob_man are navcanada, awosnet is awosnet, synopticdata is synopticdata, and other types are aviationwx.",
         "schema": {
           "type": "string",
           "pattern": "^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$",

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -52,15 +52,7 @@
             }
           },
           {
-            "name": "operator",
-            "in": "query",
-            "description": "Include airports that have one or more weathercams or weather sources with this slug in airports.json. Omitted weathercam operator is aviationwx. Weather-source defaults follow type (metar is faa, nws is nws). webcam_count and has_webcams count matching weathercams only. GET /airports/{id}/weather remains the full fused observation.",
-            "schema": {
-              "type": "string",
-              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
-              "maxLength": 64,
-              "example": "aviationwx"
-            }
+            "$ref": "#/components/parameters/Operator"
           }
         ],
         "responses": {
@@ -267,15 +259,7 @@
             "$ref": "#/components/parameters/AirportId"
           },
           {
-            "name": "operator",
-            "in": "query",
-            "description": "Only include weathercams whose operator equals this slug. Omitted operator on a camera defaults to aviationwx.",
-            "schema": {
-              "type": "string",
-              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
-              "maxLength": 64,
-              "example": "aviationwx"
-            }
+            "$ref": "#/components/parameters/Operator"
           }
         ],
         "responses": {
@@ -683,6 +667,17 @@
         "schema": {
           "type": "string",
           "pattern": "^[a-zA-Z0-9-]+$"
+        }
+      },
+      "Operator": {
+        "name": "operator",
+        "in": "query",
+        "description": "Operating-network slug. Query values are lowercased before matching. Invalid slugs return 400. Omitted weathercam operator is aviationwx.",
+        "schema": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$",
+          "maxLength": 64,
+          "example": "aviationwx"
         }
       },
       "CamIndex": {

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -29,7 +29,7 @@
     "/airports": {
       "get": {
         "summary": "List all airports",
-        "description": "Returns a list of all enabled airports with basic metadata.",
+        "description": "Returns a list of all enabled airports with basic metadata. Optional operator includes an airport when airports.json has one or more weathercams or weather sources with that operator.",
         "operationId": "listAirports",
         "tags": ["Airports"],
         "parameters": [
@@ -50,6 +50,17 @@
               "type": "string",
               "enum": ["true", "false"]
             }
+          },
+          {
+            "name": "operator",
+            "in": "query",
+            "description": "Include airports that have one or more weathercams or weather sources with this slug in airports.json. Omitted weathercam operator is aviationwx. Weather-source defaults follow type (metar is faa, nws is nws). webcam_count and has_webcams count matching weathercams only. GET /airports/{id}/weather remains the full fused observation.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+              "maxLength": 64,
+              "example": "aviationwx"
+            }
           }
         ],
         "responses": {
@@ -62,6 +73,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "429": {
             "$ref": "#/components/responses/RateLimited"
@@ -103,7 +117,7 @@
     "/airports/{id}/weather": {
       "get": {
         "summary": "Get current weather",
-        "description": "Returns current weather conditions for an airport.",
+        "description": "Returns the fused current weather observation for an airport. Not filtered by operator: fields from every configured source stay together.",
         "operationId": "getWeather",
         "tags": ["Weather"],
         "parameters": [
@@ -244,13 +258,24 @@
     },
     "/airports/{id}/webcams": {
       "get": {
-        "summary": "List webcams",
-        "description": "Returns a list of webcams for an airport with metadata.",
+        "summary": "List weathercams",
+        "description": "Returns weathercams for an airport with metadata. Optional operator lists only weathercams whose operator equals the slug. Camera index values are unchanged so image URLs stay stable.",
         "operationId": "listWebcams",
         "tags": ["Webcams"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AirportId"
+          },
+          {
+            "name": "operator",
+            "in": "query",
+            "description": "Only include weathercams whose operator equals this slug. Omitted operator on a camera defaults to aviationwx.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+              "maxLength": 64,
+              "example": "aviationwx"
+            }
           }
         ],
         "responses": {
@@ -263,6 +288,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
@@ -1220,13 +1248,16 @@
             "description": "Whether airport has limited availability (off-grid, solar, battery)"
           },
           "has_weather": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True when the airport has weather sources configured. Not sliced by operator; weather remains the fused observation."
           },
           "has_webcams": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True when the airport has one or more weathercams. When operator is set, only matching weathercams are counted."
           },
           "webcam_count": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Weathercam count. When operator is set, only matching weathercams are counted."
           },
           "url": {
             "type": "string",
@@ -1905,7 +1936,8 @@
                 "name",
                 "image_url",
                 "refresh_seconds",
-                "approximate_heading"
+                "approximate_heading",
+                "operator"
               ],
               "properties": {
                 "index": {
@@ -1935,6 +1967,10 @@
                   "minimum": 0,
                   "maximum": 360,
                   "description": "Direction the camera lens points, in true-north degrees clockwise from north (0-360). Non-null on active non-maintenance airports. Null when the airport is in maintenance or heading is not yet commissioned."
+                },
+                "operator": {
+                  "type": "string",
+                  "description": "Operating network slug. Omitted config is aviationwx. Other networks (for example wsdot) are explicit."
                 }
               }
             }

--- a/api/v1/airports.php
+++ b/api/v1/airports.php
@@ -11,6 +11,7 @@
  * - maintenance: Filter by maintenance mode ('true' or 'false')
  * - limited_availability: Filter by limited availability ('true' or 'false')
  * - include_unlisted: Include unlisted airports ('true' or 'false', default: false)
+ * - operator: Include airports that have one or more matching weathercams or weather sources
  */
 
 require_once __DIR__ . '/../../lib/public-api/middleware.php';
@@ -57,11 +58,22 @@ function handleListAirports(array $params, array $context): void
             $limitedAvailabilityFilter = false;
         }
     }
+
+    $operatorParse = parseOperatorQueryFromGet();
+    if (!$operatorParse['ok']) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            $operatorParse['error'],
+            400
+        );
+        return;
+    }
+    $operatorFilter = $operatorParse['value'];
     
     // Format airports for response
     $formattedAirports = [];
     foreach ($airports as $airportId => $airport) {
-        $formatted = formatAirportSummary($airportId, $airport);
+        $formatted = formatAirportSummary($airportId, $airport, $operatorFilter);
         
         // Apply maintenance filter if specified
         if ($maintenanceFilter !== null && $formatted['maintenance'] !== $maintenanceFilter) {
@@ -70,6 +82,10 @@ function handleListAirports(array $params, array $context): void
         
         // Apply limited_availability filter if specified
         if ($limitedAvailabilityFilter !== null && $formatted['limited_availability'] !== $limitedAvailabilityFilter) {
+            continue;
+        }
+
+        if ($operatorFilter !== null && !airportMatchesOperator($airport, $operatorFilter)) {
             continue;
         }
         
@@ -96,14 +112,15 @@ function handleListAirports(array $params, array $context): void
  *
  * @param string $airportId Airport ID
  * @param array $airport Airport configuration
+ * @param string|null $operatorFilter When set, webcam_count counts matching weathercams only
  * @return array Formatted airport summary
  */
-function formatAirportSummary(string $airportId, array $airport): array
+function formatAirportSummary(string $airportId, array $airport, ?string $operatorFilter = null): array
 {
-    // Check what data is available
+    // Weather is always the fused observation, so has_weather is not operator-sliced.
     $hasWeather = hasWeatherSources($airport);
-    $hasWebcams = isset($airport['webcams']) && is_array($airport['webcams']) && count($airport['webcams']) > 0;
-    $webcamCount = $hasWebcams ? count($airport['webcams']) : 0;
+    $webcamCount = countWeathercamsForOperator($airport, $operatorFilter);
+    $hasWebcams = $webcamCount > 0;
 
     $baseDomain = getBaseDomain();
     $url = 'https://' . $airportId . '.' . $baseDomain . '/';

--- a/api/v1/weather.php
+++ b/api/v1/weather.php
@@ -3,8 +3,9 @@
  * Public API - Get Weather Endpoint
  * 
  * GET /v1/airports/{id}/weather
- * 
- * Returns current weather data for a single airport.
+ *
+ * Returns the fused current weather observation for a single airport.
+ * Not filtered by operator: mixed-operator fields stay together for safety.
  */
 
 require_once __DIR__ . '/../../lib/public-api/middleware.php';

--- a/api/v1/webcams.php
+++ b/api/v1/webcams.php
@@ -1,10 +1,14 @@
 <?php
 /**
- * Public API - List Webcams Endpoint
- * 
+ * Public API - List Weathercams Endpoint
+ *
  * GET /v1/airports/{id}/webcams
- * 
- * Returns a list of webcams for an airport with metadata.
+ *
+ * Returns a list of weathercams for an airport with metadata.
+ * Path and JSON key remain `webcams` for compatibility.
+ *
+ * Query parameters:
+ * - operator: Only include weathercams whose operator equals this slug
  */
 
 require_once __DIR__ . '/../../lib/public-api/middleware.php';
@@ -41,12 +45,25 @@ function handleListWebcams(array $params, array $context): void
         return;
     }
     
-    // Get webcams
+    $operatorParse = parseOperatorQueryFromGet();
+    if (!$operatorParse['ok']) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            $operatorParse['error'],
+            400
+        );
+        return;
+    }
+    $weathercamOperatorFilter = $operatorParse['value'];
+
     $webcams = $airport['webcams'] ?? [];
-    
-    // Format webcams for response
+
+    // Keep original indexes so image URLs do not move when a filter omits a camera
     $formattedWebcams = [];
     foreach ($webcams as $index => $webcam) {
+        if (!is_array($webcam) || !weathercamMatchesOperator($webcam, $weathercamOperatorFilter)) {
+            continue;
+        }
         $formattedWebcams[] = formatWebcamMetadata($airportId, $index, $webcam, $airport);
     }
     
@@ -68,17 +85,17 @@ function handleListWebcams(array $params, array $context): void
 }
 
 /**
- * Format webcam data for API response
- * 
+ * Format weathercam data for API response
+ *
  * @param string $airportId Airport ID
- * @param int $index Webcam index
- * @param array $webcam Webcam configuration
+ * @param int $index Weathercam index
+ * @param array $webcam Weathercam configuration
  * @param array $airport Airport configuration
- * @return array Formatted webcam metadata
+ * @return array Formatted weathercam metadata
  */
 function formatWebcamMetadata(string $airportId, int $index, array $webcam, array $airport): array
 {
-    // Check if history is enabled for this webcam (max_frames >= 2 enables history)
+    // Check if history is enabled for this weathercam (max_frames >= 2 enables history)
     $historyEnabled = isWebcamHistoryEnabledForAirport($airportId);
     
     // Get refresh interval
@@ -92,6 +109,7 @@ function formatWebcamMetadata(string $airportId, int $index, array $webcam, arra
         'image_url' => '/v1/airports/' . $airportId . '/webcams/' . $index . '/image',
         'refresh_seconds' => $refreshSeconds,
         'approximate_heading' => formatWebcamApproximateHeadingForApi($webcam),
+        'operator' => getWeathercamOperator($webcam),
     ];
 
     if ($historyEnabled) {
@@ -108,7 +126,7 @@ function formatWebcamMetadata(string $airportId, int $index, array $webcam, arra
  * Config validation requires integer 0-360, but runtime config may be stale or
  * hand-edited. Reject non-integers and out-of-range values rather than casting.
  *
- * @param array $webcam Webcam configuration
+ * @param array $webcam Weathercam configuration
  * @return int|null Heading degrees, or null when omitted or invalid
  */
 function formatWebcamApproximateHeadingForApi(array $webcam): ?int

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -224,6 +224,7 @@ Values are strings in MHz (e.g. `"122.8"`, `"123.05"`).
 | **Common** |||
 | `name` | - | Display name |
 | `approximate_heading` | - | **Required** when the airport is `enabled: true` and not in `maintenance`. Integer **0**-**360**: direction the camera lens points, in **true north** degrees. Optional on maintenance or disabled airports until commissioned. Aim within ±10° when measuring (operational target, not validated). See [Guide 02](../guides/02-location-and-siting.md) (how to measure) and [Guide 08](../guides/08-camera-configuration.md) (installer checklist). |
+| `operator` | `aviationwx` | Optional lowercase slug for the operating network. Omit for AviationWX-operated weathercams. Set explicitly for other networks (for example `wsdot`). |
 | `enabled` | `true` | When `false`, the slot stays in config/UI but acquisition fields such as `url`, `push_config`, and `base_url` are not required and workers do not run for this camera |
 | **Conditional** |||
 | `url` | - | Stream/image URL for pull types (`http` / `mjpeg` / `static_jpeg` / `static_png` / `rtsp`). Not used for `push` (credentials live under `push_config`) or for `aviationwx_api` (use `base_url`). Omit for `enabled: false` placeholders. |
@@ -611,6 +612,19 @@ All weather sources are configured in a unified `weather_sources` array. Sources
 | `metar` | NOAA Aviation Weather METAR | ~60 minutes |
 | `dyaconlive` | Dyacon MS-100 advisory aviation station (DyaconLive+ API) | ~10 minutes |
 | `davis_weatherlink_live` | Davis WeatherLink Live via bridge push cache (`awxb_` key + enable row) | Adapter rate (typically ≤10s; ≤1 Hz ceiling) |
+
+**Operator:** Optional `operator` on each `weather_sources[]` row is a lowercase slug. Public API `GET /v1/airports?operator=` matches airports.json (configured weathercams and weather sources), not the live fused observation. Omit `operator` to use the type default:
+
+| `type` | Default `operator` |
+|--------|--------------------|
+| `metar` | `faa` |
+| `nws` | `nws` |
+| `swob_auto`, `swob_man` | `navcanada` |
+| `awosnet` | `awosnet` |
+| `synopticdata` | `synopticdata` |
+| All other types (on-field stations, `aviationwx_api`) | `aviationwx` |
+
+Set `operator` only when that default would be wrong (for example an airport-owned Tempest).
 
 **Davis WeatherLink update intervals** (per [WeatherLink v2 Data Permissions](https://weatherlink.github.io/v2-api/data-permissions)): **Basic (free)** = most recent 15-minute record; **Pro (paid)** = most recent 5-minute record; **Pro+ (paid)** = most recent record (~1 minute). Historic data is only available on Pro/Pro+.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -185,6 +185,7 @@ vendor/bin/phpunit --testsuite Unit
 
 **What they test:**
 - Configuration validation
+- **Operator identity:** `tests/Unit/OperatorConfigTest.php` covers weathercam and weather-source defaults, airports.json matching (not live fused weather), and `GET` `operator` query parsing. Config slug validation is in `tests/Unit/ConfigValidationTest.php`. Camera metadata includes `operator` in `tests/Unit/PublicApiWebcamMetadataTest.php`.
 - Weather calculations
 - Data parsing and formatting
 - Utility functions
@@ -200,6 +201,7 @@ vendor/bin/phpunit --testsuite Integration
 
 **What they test:**
 - API endpoint responses
+- **Public API `operator` query:** `tests/Integration/PublicApiOperatorTest.php` (running stack, typically `TEST_API_URL=http://localhost:9080`). Airport list membership and `webcam_count` use airports.json. Webcam list keeps original indexes. Weather ignores `operator`. Cases skip when no server is listening.
 - Cache behavior
 - HTML output validation
 - Webcam refresh initialization

--- a/lib/config.php
+++ b/lib/config.php
@@ -7,6 +7,7 @@ define('AVIATIONWX_CONFIG_LOADED', true);
 
 require_once __DIR__ . '/logger.php';
 require_once __DIR__ . '/constants.php';
+require_once __DIR__ . '/operator.php';
 require_once __DIR__ . '/airport-identifiers.php';
 require_once __DIR__ . '/airport-ourairports.php';
 require_once __DIR__ . '/config-runway.php';
@@ -2791,12 +2792,12 @@ function buildAirportPageKeywords(array $airport): string
         $parts[] = $identifier;
     }
     $parts[] = $airport['name'];
-    $parts[] = 'live airport webcam';
+    $parts[] = 'live airport weathercam';
     $parts[] = 'runway conditions';
     if ($identifier !== null) {
         $parts[] = $identifier . ' weather';
     }
-    $parts[] = 'airport webcam';
+    $parts[] = 'airport weathercam';
     $parts[] = 'pilot weather';
     $parts[] = 'aviation weather';
 
@@ -4877,6 +4878,12 @@ function validateAirportsJsonStructure(array $config): array {
                     }
                     // Cache-backed bridge types: fields + bridges[].id binding in validateBridgeConfig()
                     // metar: station_id optional (nearby_stations can provide fallback)
+
+                    $operatorErrors = validateConfigOperator(
+                        $ws,
+                        "Airport '{$airportCode}' {$label}"
+                    );
+                    $errors = array_merge($errors, $operatorErrors);
                 }
             }
         }
@@ -4901,7 +4908,7 @@ function validateAirportsJsonStructure(array $config): array {
                         if ($skipAcquisitionValidation) {
                             $allowedDisabledWebcamFields = [
                                 'api_key', 'approximate_heading', 'base_url', 'camera_index', 'crop_margins',
-                                'enabled', 'name', 'push_config', 'refresh_seconds', 'rtsp_fetch_timeout',
+                                'enabled', 'name', 'operator', 'push_config', 'refresh_seconds', 'rtsp_fetch_timeout',
                                 'rtsp_max_runtime', 'rtsp_transport', 'timeout_seconds', 'transcode_timeout',
                                 'type', 'url', 'variant_heights',
                             ];
@@ -4920,7 +4927,7 @@ function validateAirportsJsonStructure(array $config): array {
                             // Define allowed fields for push cameras
                             $allowedPushWebcamFields = [
                                 'name', 'type', 'push_config', 'refresh_seconds', 'variant_heights',
-                                'crop_margins', 'enabled', 'approximate_heading',
+                                'crop_margins', 'enabled', 'approximate_heading', 'operator',
                             ];
                             
                             // Check for unknown fields in push webcam
@@ -4983,6 +4990,7 @@ function validateAirportsJsonStructure(array $config): array {
                                 'name', 'type', 'url', 'rtsp_transport', 'refresh_seconds',
                                 'rtsp_fetch_timeout', 'rtsp_max_runtime', 'transcode_timeout',
                                 'variant_heights', 'crop_margins', 'enabled', 'approximate_heading',
+                                'operator',
                             ];
                             
                             // Check for unknown fields in RTSP webcam
@@ -5002,7 +5010,7 @@ function validateAirportsJsonStructure(array $config): array {
                             $allowedFederatedWebcamFields = [
                                 'name', 'type', 'base_url', 'api_key', 'timeout_seconds',
                                 'camera_index', 'refresh_seconds', 'variant_heights', 'crop_margins',
-                                'enabled', 'approximate_heading',
+                                'enabled', 'approximate_heading', 'operator',
                             ];
                             foreach ($webcam as $key => $value) {
                                 if (!in_array($key, $allowedFederatedWebcamFields, true)) {
@@ -5030,7 +5038,7 @@ function validateAirportsJsonStructure(array $config): array {
                             // Define allowed fields for pull cameras (http/mjpeg/static_jpeg/static_png)
                             $allowedPullWebcamFields = [
                                 'name', 'type', 'url', 'refresh_seconds', 'variant_heights',
-                                'crop_margins', 'enabled', 'approximate_heading',
+                                'crop_margins', 'enabled', 'approximate_heading', 'operator',
                             ];
                             
                             // Check for unknown fields in pull webcam
@@ -5088,6 +5096,13 @@ function validateAirportsJsonStructure(array $config): array {
                             $idx
                         );
                         $errors = array_merge($errors, $headingErrors);
+
+                        $operatorErrors = validateWeathercamOperator(
+                            $webcam,
+                            $airportCode,
+                            $idx
+                        );
+                        $errors = array_merge($errors, $operatorErrors);
                     }
                 }
             }

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -25,6 +25,14 @@ if (!defined('WEBCAM_LAST_COMPLETED_PAIR_MAX_GAP_SECONDS')) {
     define('WEBCAM_LAST_COMPLETED_PAIR_MAX_GAP_SECONDS', 600); // 10 minutes
 }
 
+// Default operator when the field is omitted and no weather-source type default applies
+if (!defined('DEFAULT_OPERATOR')) {
+    define('DEFAULT_OPERATOR', 'aviationwx');
+}
+if (!defined('OPERATOR_MAX_LENGTH')) {
+    define('OPERATOR_MAX_LENGTH', 64);
+}
+
 if (!defined('DEFAULT_WEATHER_REFRESH')) {
     define('DEFAULT_WEATHER_REFRESH', 60);
 }

--- a/lib/operator.php
+++ b/lib/operator.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Operator identity for weathercams and weather sources.
+ *
+ * Matching uses airports.json only. Omitted weathercam operator is aviationwx.
+ * Omitted weather-source operator uses a type default (metar is faa, nws is nws).
+ * Explicit slugs name other networks.
+ */
+
+require_once __DIR__ . '/constants.php';
+
+/**
+ * Whether a string is a valid operator slug.
+ *
+ * @param string $operator Candidate operator slug
+ * @return bool True when the slug is valid
+ */
+function isValidOperatorSlug(string $operator): bool
+{
+    $length = strlen($operator);
+    if ($length < 1 || $length > OPERATOR_MAX_LENGTH) {
+        return false;
+    }
+
+    return (bool) preg_match('/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $operator);
+}
+
+/**
+ * Read an explicit operator slug from a config row, if present.
+ *
+ * Whitespace-only values are treated as omitted. Non-string values are invalid
+ * and must not fall through to a type default (wrong network).
+ *
+ * @param array $row Weathercam or weather source configuration
+ * @return string|null Lowercase slug, empty string when invalid, or null when omitted
+ */
+function resolveExplicitOperator(array $row): ?string
+{
+    if (!array_key_exists('operator', $row) || $row['operator'] === null) {
+        return null;
+    }
+
+    if (!is_string($row['operator'])) {
+        return '';
+    }
+
+    $operator = strtolower(trim($row['operator']));
+    if ($operator === '') {
+        return null;
+    }
+
+    return $operator;
+}
+
+/**
+ * Default operator for a weather source type when operator is omitted.
+ *
+ * @param string $type weather_sources[].type
+ * @return string Operator slug
+ */
+function defaultOperatorForWeatherSourceType(string $type): string
+{
+    switch ($type) {
+        case 'metar':
+            return 'faa';
+        case 'nws':
+            return 'nws';
+        case 'swob_auto':
+        case 'swob_man':
+            return 'navcanada';
+        case 'awosnet':
+            return 'awosnet';
+        case 'synopticdata':
+            return 'synopticdata';
+        default:
+            return DEFAULT_OPERATOR;
+    }
+}
+
+/**
+ * Resolve the operator slug for a weathercam config row.
+ *
+ * @param array $webcam Weathercam configuration
+ * @return string Operator slug
+ */
+function getWeathercamOperator(array $webcam): string
+{
+    $explicit = resolveExplicitOperator($webcam);
+    if ($explicit === null) {
+        return DEFAULT_OPERATOR;
+    }
+
+    return $explicit;
+}
+
+/**
+ * Resolve the operator slug for a weather source config row.
+ *
+ * @param array $source weather_sources[] row
+ * @return string Operator slug
+ */
+function getWeatherSourceOperator(array $source): string
+{
+    $explicit = resolveExplicitOperator($source);
+    if ($explicit === null) {
+        $type = isset($source['type']) && is_string($source['type']) ? $source['type'] : '';
+        return defaultOperatorForWeatherSourceType($type);
+    }
+
+    return $explicit;
+}
+
+/**
+ * Whether a weathercam matches an optional operator filter.
+ *
+ * @param array $webcam Weathercam configuration
+ * @param string|null $operatorFilter Lowercase slug, or null for no filter
+ * @return bool True when the camera should be included
+ */
+function weathercamMatchesOperator(array $webcam, ?string $operatorFilter): bool
+{
+    if ($operatorFilter === null) {
+        return true;
+    }
+
+    return getWeathercamOperator($webcam) === $operatorFilter;
+}
+
+/**
+ * Whether a weather source matches an optional operator filter.
+ *
+ * @param array $source weather_sources[] row
+ * @param string|null $operatorFilter Lowercase slug, or null for no filter
+ * @return bool True when the source should be counted
+ */
+function weatherSourceMatchesOperator(array $source, ?string $operatorFilter): bool
+{
+    if ($operatorFilter === null) {
+        return true;
+    }
+
+    return getWeatherSourceOperator($source) === $operatorFilter;
+}
+
+/**
+ * Count weathercams on an airport that match an optional operator filter.
+ *
+ * @param array $airport Airport configuration
+ * @param string|null $operatorFilter Lowercase slug, or null for no filter
+ * @return int Matching weathercam count
+ */
+function countWeathercamsForOperator(array $airport, ?string $operatorFilter): int
+{
+    $webcams = $airport['webcams'] ?? [];
+    if (!is_array($webcams)) {
+        return 0;
+    }
+
+    $count = 0;
+    foreach ($webcams as $webcam) {
+        if (is_array($webcam) && weathercamMatchesOperator($webcam, $operatorFilter)) {
+            $count++;
+        }
+    }
+
+    return $count;
+}
+
+/**
+ * True when any configured weather source matches an optional operator filter.
+ *
+ * Uses airports.json rows only, not the live fused observation.
+ *
+ * @param array $airport Airport configuration
+ * @param string|null $operatorFilter Lowercase slug, or null for no filter
+ * @return bool True when a matching weather source is configured
+ */
+function airportHasWeatherSourceOperator(array $airport, ?string $operatorFilter): bool
+{
+    $sources = $airport['weather_sources'] ?? [];
+    if (!is_array($sources)) {
+        return false;
+    }
+
+    foreach ($sources as $source) {
+        if (is_array($source) && !empty($source['type']) && weatherSourceMatchesOperator($source, $operatorFilter)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * True when the airport has a matching weathercam or weather source in config.
+ *
+ * @param array $airport Airport configuration
+ * @param string|null $operatorFilter Lowercase slug, or null for no filter
+ * @return bool True when either resource matches, or when the filter is omitted
+ */
+function airportMatchesOperator(array $airport, ?string $operatorFilter): bool
+{
+    if ($operatorFilter === null) {
+        return true;
+    }
+
+    return countWeathercamsForOperator($airport, $operatorFilter) > 0
+        || airportHasWeatherSourceOperator($airport, $operatorFilter);
+}
+
+/**
+ * Parse an operator query value.
+ *
+ * @param string|null $raw Raw query value, or null when the parameter is omitted
+ * @return array{ok: bool, value: string|null, error: string|null}
+ */
+function parseOperatorQueryParam(?string $raw): array
+{
+    if ($raw === null) {
+        return ['ok' => true, 'value' => null, 'error' => null];
+    }
+
+    $operator = strtolower(trim($raw));
+    if ($operator === '' || !isValidOperatorSlug($operator)) {
+        return [
+            'ok' => false,
+            'value' => null,
+            'error' => 'operator must be a lowercase slug (letters, digits, hyphens)',
+        ];
+    }
+
+    return ['ok' => true, 'value' => $operator, 'error' => null];
+}
+
+/**
+ * Parse operator from the current request query string.
+ *
+ * @return array{ok: bool, value: string|null, error: string|null}
+ */
+function parseOperatorQueryFromGet(): array
+{
+    if (!array_key_exists('operator', $_GET)) {
+        return ['ok' => true, 'value' => null, 'error' => null];
+    }
+
+    $raw = $_GET['operator'];
+    if (is_array($raw)) {
+        return [
+            'ok' => false,
+            'value' => null,
+            'error' => 'operator must be a lowercase slug (letters, digits, hyphens)',
+        ];
+    }
+
+    return parseOperatorQueryParam((string) $raw);
+}
+
+/**
+ * Validate optional operator on a config row.
+ *
+ * Config values must already be lowercase; query parsing lowercases first.
+ *
+ * @param array $row Weathercam or weather source configuration
+ * @param string $label Error-message prefix
+ * @return array Validation error strings
+ */
+function validateConfigOperator(array $row, string $label): array
+{
+    if (!array_key_exists('operator', $row)) {
+        return [];
+    }
+
+    $operator = $row['operator'];
+    if (!is_string($operator)) {
+        return ["{$label} has invalid operator: must be a lowercase slug (letters, digits, hyphens)"];
+    }
+
+    $trimmed = trim($operator);
+    if ($trimmed === '' || $trimmed !== $operator || !isValidOperatorSlug($trimmed)) {
+        return ["{$label} has invalid operator: must be a lowercase slug (letters, digits, hyphens)"];
+    }
+
+    return [];
+}
+
+/**
+ * Validate optional operator on a weathercam config row.
+ *
+ * @param array $webcam Weathercam configuration
+ * @param string $airportCode Airport identifier for error messages
+ * @param int $idx Weathercam index for error messages
+ * @return array Validation error strings
+ */
+function validateWeathercamOperator(array $webcam, string $airportCode, int $idx): array
+{
+    return validateConfigOperator($webcam, "Airport '{$airportCode}' webcam[{$idx}]");
+}

--- a/lib/operator.php
+++ b/lib/operator.php
@@ -209,6 +209,34 @@ function airportMatchesOperator(array $airport, ?string $operatorFilter): bool
 }
 
 /**
+ * Public API 400 detail for an invalid operator query value.
+ *
+ * Query values are lowercased before matching, so this does not require
+ * the client to send lowercase.
+ *
+ * @return string Error detail
+ */
+function operatorQueryShapeError(): string
+{
+    return 'operator must be a slug of 1-' . OPERATOR_MAX_LENGTH
+        . ' letters, digits, and single hyphens between segments';
+}
+
+/**
+ * Config validation error for an invalid operator field.
+ *
+ * Config slugs must already be lowercase. Query parsing lowercases first.
+ *
+ * @param string $label Error-message prefix
+ * @return string Error detail
+ */
+function operatorConfigShapeError(string $label): string
+{
+    return "{$label} has invalid operator: must be a lowercase slug of 1-"
+        . OPERATOR_MAX_LENGTH . ' letters, digits, and single hyphens between segments';
+}
+
+/**
  * Parse an operator query value.
  *
  * @param string|null $raw Raw query value, or null when the parameter is omitted
@@ -225,7 +253,7 @@ function parseOperatorQueryParam(?string $raw): array
         return [
             'ok' => false,
             'value' => null,
-            'error' => 'operator must be a lowercase slug (letters, digits, hyphens)',
+            'error' => operatorQueryShapeError(),
         ];
     }
 
@@ -248,7 +276,7 @@ function parseOperatorQueryFromGet(): array
         return [
             'ok' => false,
             'value' => null,
-            'error' => 'operator must be a lowercase slug (letters, digits, hyphens)',
+            'error' => operatorQueryShapeError(),
         ];
     }
 
@@ -272,12 +300,12 @@ function validateConfigOperator(array $row, string $label): array
 
     $operator = $row['operator'];
     if (!is_string($operator)) {
-        return ["{$label} has invalid operator: must be a lowercase slug (letters, digits, hyphens)"];
+        return [operatorConfigShapeError($label)];
     }
 
     $trimmed = trim($operator);
     if ($trimmed === '' || $trimmed !== $operator || !isValidOperatorSlug($trimmed)) {
-        return ["{$label} has invalid operator: must be a lowercase slug (letters, digits, hyphens)"];
+        return [operatorConfigShapeError($label)];
     }
 
     return [];

--- a/tests/Fixtures/airports.json.test
+++ b/tests/Fixtures/airports.json.test
@@ -90,6 +90,12 @@
           "name": "Test Camera 1",
           "url": "https://example.com/cam1.jpg",
           "approximate_heading": 318
+        },
+        {
+          "name": "WSDOT Test Camera",
+          "url": "https://example.com/cam-wsdot.jpg",
+          "approximate_heading": 180,
+          "operator": "wsdot"
         }
       ],
       "runways": [

--- a/tests/Integration/PublicApiOperatorTest.php
+++ b/tests/Integration/PublicApiOperatorTest.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Integration tests for Public API operator filtering.
+ *
+ * Airport list matches airports.json equipment. Weathercam list filters by
+ * operator. Weather remains the fused observation.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class PublicApiOperatorTest extends TestCase
+{
+    private static string $apiBaseUrl;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$apiBaseUrl = getenv('TEST_API_URL') ?: 'http://localhost:8080';
+    }
+
+    /**
+     * GET JSON from a Public API v1 path.
+     *
+     * @param string $endpoint Path beginning with / (for example /airports)
+     * @return array{status: int, json: array|null}
+     */
+    private function apiRequest(string $endpoint): array
+    {
+        usleep(100000);
+
+        $url = self::$apiBaseUrl . '/api/v1' . $endpoint;
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Accept: application/json']);
+        $body = curl_exec($ch);
+        $status = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        return [
+            'status' => $status,
+            'json' => is_string($body) ? json_decode($body, true) : null,
+        ];
+    }
+
+    /**
+     * Skip when the test web server is not running or the Public API is disabled.
+     *
+     * @param array{status: int, json: array|null} $response API response
+     */
+    private function skipUnlessPublicApiOk(array $response): void
+    {
+        if ($response['status'] === 0) {
+            $this->markTestSkipped('Web server not available at ' . self::$apiBaseUrl);
+        }
+        if ($response['status'] === 429) {
+            $this->markTestSkipped('Rate limited - test requires API key');
+        }
+        if ($response['status'] === 404 && (($response['json']['error']['code'] ?? '') === 'API_NOT_ENABLED')) {
+            $this->markTestSkipped('Public API is not enabled in configuration');
+        }
+    }
+
+    /**
+     * @param list<array<string, mixed>> $airports
+     * @return array<string, mixed>|null
+     */
+    private function findAirport(array $airports, string $id): ?array
+    {
+        foreach ($airports as $airport) {
+            if (($airport['id'] ?? '') === $id) {
+                return $airport;
+            }
+        }
+        return null;
+    }
+
+    public function testListAirports_WithoutOperatorKeepsFullWebcamCount(): void
+    {
+        $response = $this->apiRequest('/airports');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+
+        $airports = $response['json']['airports'] ?? [];
+        $kspb = $this->findAirport($airports, 'kspb');
+        $this->assertNotNull($kspb);
+        $this->assertTrue($kspb['has_webcams']);
+        $this->assertSame(2, $kspb['webcam_count']);
+    }
+
+    public function testListAirports_OperatorAviationwxIncludesKspbWithFilteredWebcamCount(): void
+    {
+        $response = $this->apiRequest('/airports?operator=aviationwx');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+
+        $airports = $response['json']['airports'] ?? [];
+        $kspb = $this->findAirport($airports, 'kspb');
+        $this->assertNotNull($kspb, 'kspb has AviationWX weathercams and weather sources');
+        $this->assertTrue($kspb['has_weather']);
+        $this->assertTrue($kspb['has_webcams']);
+        $this->assertSame(1, $kspb['webcam_count']);
+    }
+
+    public function testListAirports_OperatorWsdotIncludesKspb(): void
+    {
+        $response = $this->apiRequest('/airports?operator=wsdot');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+
+        $airports = $response['json']['airports'] ?? [];
+        $kspb = $this->findAirport($airports, 'kspb');
+        $this->assertNotNull($kspb, 'kspb fixture has a wsdot weathercam');
+        $this->assertTrue($kspb['has_weather'], 'Fused weather still exists at the airport');
+        $this->assertTrue($kspb['has_webcams']);
+        $this->assertSame(1, $kspb['webcam_count']);
+    }
+
+    public function testListAirports_OperatorNavcanadaIncludesCyav(): void
+    {
+        $response = $this->apiRequest('/airports?operator=navcanada');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+
+        $airports = $response['json']['airports'] ?? [];
+        $this->assertNotNull($this->findAirport($airports, 'cyav'));
+        $this->assertNull($this->findAirport($airports, 'kspb'));
+    }
+
+    public function testListAirports_InvalidOperatorReturns400(): void
+    {
+        $response = $this->apiRequest('/airports?operator=not%20valid');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(400, $response['status']);
+        $this->assertSame('INVALID_REQUEST', $response['json']['error']['code'] ?? null);
+    }
+
+    public function testListWebcams_WithoutOperatorReturnsAllCamerasWithStableIndexes(): void
+    {
+        $response = $this->apiRequest('/airports/kspb/webcams');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+        $webcams = $response['json']['webcams'] ?? [];
+        $this->assertCount(2, $webcams);
+        $this->assertSame(0, $webcams[0]['index']);
+        $this->assertSame('aviationwx', $webcams[0]['operator']);
+        $this->assertSame(1, $webcams[1]['index']);
+        $this->assertSame('wsdot', $webcams[1]['operator']);
+    }
+
+    public function testListWebcams_OperatorEqualsOnlyMatchingCameras(): void
+    {
+        $aviationwx = $this->apiRequest('/airports/kspb/webcams?operator=aviationwx');
+        $this->skipUnlessPublicApiOk($aviationwx);
+        $this->assertSame(200, $aviationwx['status']);
+        $aviationwxCams = $aviationwx['json']['webcams'] ?? [];
+        $this->assertCount(1, $aviationwxCams);
+        $this->assertSame(0, $aviationwxCams[0]['index']);
+        $this->assertSame('aviationwx', $aviationwxCams[0]['operator']);
+
+        $wsdot = $this->apiRequest('/airports/kspb/webcams?operator=wsdot');
+        $this->skipUnlessPublicApiOk($wsdot);
+        $this->assertSame(200, $wsdot['status']);
+        $wsdotCams = $wsdot['json']['webcams'] ?? [];
+        $this->assertCount(1, $wsdotCams);
+        $this->assertSame(1, $wsdotCams[0]['index']);
+        $this->assertSame('wsdot', $wsdotCams[0]['operator']);
+    }
+
+    public function testListWebcams_InvalidOperatorReturns400(): void
+    {
+        $response = $this->apiRequest('/airports/kspb/webcams?operator=not%20valid');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(400, $response['status']);
+        $this->assertSame('INVALID_REQUEST', $response['json']['error']['code'] ?? null);
+    }
+
+    public function testGetWeather_IgnoresOperatorAndReturnsFusedRecord(): void
+    {
+        $plain = $this->apiRequest('/airports/kspb/weather');
+        $this->skipUnlessPublicApiOk($plain);
+        if ($plain['status'] === 503) {
+            $this->markTestSkipped('Weather cache unavailable in this environment');
+        }
+        $this->assertSame(200, $plain['status']);
+
+        $filtered = $this->apiRequest('/airports/kspb/weather?operator=wsdot');
+        $this->skipUnlessPublicApiOk($filtered);
+        $this->assertSame(200, $filtered['status']);
+
+        $this->assertSame(
+            $plain['json']['weather'] ?? null,
+            $filtered['json']['weather'] ?? false,
+            'Weather must stay fused and ignore operator'
+        );
+    }
+}

--- a/tests/Integration/PublicApiWebcamTest.php
+++ b/tests/Integration/PublicApiWebcamTest.php
@@ -13,7 +13,7 @@ class PublicApiWebcamTest extends TestCase
 {
     private static $apiBaseUrl;
     private static $testAirport = 'kspb';
-    private static $testCam = 0;  // Fixture has 1 webcam at index 0
+    private static $testCam = 0;  // Fixture camera 0 is AviationWX-operated; camera 1 is wsdot
     
     public static function setUpBeforeClass(): void
     {

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -1872,6 +1872,110 @@ class ConfigValidationTest extends TestCase
         $this->assertTrue($result['valid'], implode(' ', $result['errors'] ?? []));
     }
 
+    public function testWebcam_Operator_ExplicitSlugValid(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'enabled' => true,
+                    'maintenance' => false,
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Test Camera',
+                            'url' => 'https://example.com/cam.jpg',
+                            'approximate_heading' => 90,
+                            'operator' => 'wsdot',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], implode(' ', $result['errors'] ?? []));
+    }
+
+    public function testWebcam_Operator_RejectsUppercaseSlug(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'enabled' => true,
+                    'maintenance' => false,
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Test Camera',
+                            'url' => 'https://example.com/cam.jpg',
+                            'approximate_heading' => 90,
+                            'operator' => 'WSDOT',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('invalid operator', implode(' ', $result['errors']));
+    }
+
+    public function testWeatherSource_Operator_RejectsUppercaseSlug(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'weather_sources' => [[
+                        'type' => 'metar',
+                        'station_id' => 'KSPB',
+                        'operator' => 'FAA',
+                    ]],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('invalid operator', implode(' ', $result['errors']));
+    }
+
+    public function testWeatherSource_Operator_ExplicitSlugValid(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'weather_sources' => [[
+                        'type' => 'metar',
+                        'station_id' => 'KSPB',
+                        'operator' => 'aviationwx',
+                    ]],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], implode(' ', $result['errors'] ?? []));
+    }
+
     /**
      * Test weather source validation - Valid configurations
      */

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -1927,6 +1927,38 @@ class ConfigValidationTest extends TestCase
         $result = validateAirportsJsonStructure($config);
         $this->assertFalse($result['valid']);
         $this->assertStringContainsString('invalid operator', implode(' ', $result['errors']));
+        $this->assertStringContainsString((string) OPERATOR_MAX_LENGTH, implode(' ', $result['errors']));
+        $this->assertStringContainsString('lowercase', implode(' ', $result['errors']));
+    }
+
+    public function testWebcam_Operator_RejectsOverlongSlug(): void
+    {
+        $config = [
+            'airports' => [
+                'kspb' => [
+                    'name' => 'Test Airport',
+                    'enabled' => true,
+                    'maintenance' => false,
+                    'lat' => 45.0,
+                    'lon' => -122.0,
+                    'access_type' => 'public',
+                    'tower_status' => 'non_towered',
+                    'webcams' => [
+                        [
+                            'name' => 'Test Camera',
+                            'url' => 'https://example.com/cam.jpg',
+                            'approximate_heading' => 90,
+                            'operator' => str_repeat('a', OPERATOR_MAX_LENGTH + 1),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('invalid operator', implode(' ', $result['errors']));
+        $this->assertStringContainsString((string) OPERATOR_MAX_LENGTH, implode(' ', $result['errors']));
     }
 
     public function testWeatherSource_Operator_RejectsUppercaseSlug(): void

--- a/tests/Unit/OperatorConfigTest.php
+++ b/tests/Unit/OperatorConfigTest.php
@@ -187,5 +187,13 @@ class OperatorConfigTest extends TestCase
         $this->assertSame(1, preg_match('/' . $pattern . '/', 'WSDOT'));
         $this->assertSame(1, preg_match('/' . $pattern . '/', 'wsdot'));
         $this->assertSame(0, preg_match('/' . $pattern . '/', 'not valid'));
+
+        $description = $spec['components']['parameters']['Operator']['description'] ?? '';
+        $this->assertStringContainsString('aviationwx', $description);
+        $this->assertStringContainsString('faa', $description);
+        $this->assertStringContainsString('nws', $description);
+        $this->assertStringContainsString('navcanada', $description);
+        $this->assertStringContainsString('awosnet', $description);
+        $this->assertStringContainsString('synopticdata', $description);
     }
 }

--- a/tests/Unit/OperatorConfigTest.php
+++ b/tests/Unit/OperatorConfigTest.php
@@ -119,6 +119,12 @@ class OperatorConfigTest extends TestCase
         $invalid = parseOperatorQueryParam('not valid');
         $this->assertFalse($invalid['ok']);
         $this->assertNull($invalid['value']);
+        $this->assertStringContainsString((string) OPERATOR_MAX_LENGTH, (string) $invalid['error']);
+        $this->assertStringNotContainsString('lowercase', (string) $invalid['error']);
+
+        $overlong = parseOperatorQueryParam(str_repeat('a', OPERATOR_MAX_LENGTH + 1));
+        $this->assertFalse($overlong['ok']);
+        $this->assertStringContainsString((string) OPERATOR_MAX_LENGTH, (string) $overlong['error']);
 
         $valid = parseOperatorQueryParam('wsdot');
         $this->assertTrue($valid['ok']);
@@ -163,6 +169,7 @@ class OperatorConfigTest extends TestCase
             $_GET = ['operator' => ['wsdot']];
             $array = parseOperatorQueryFromGet();
             $this->assertFalse($array['ok']);
+            $this->assertStringContainsString((string) OPERATOR_MAX_LENGTH, (string) $array['error']);
         } finally {
             $_GET = $originalGet;
         }

--- a/tests/Unit/OperatorConfigTest.php
+++ b/tests/Unit/OperatorConfigTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Unit tests for weathercam and weather-source operator defaults and matching.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class OperatorConfigTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/../../lib/config.php';
+        require_once __DIR__ . '/../../lib/weather/utils.php';
+        require_once __DIR__ . '/../../api/v1/airports.php';
+    }
+
+    public function testWeathercamOperator_DefaultsToAviationwxWhenOmitted(): void
+    {
+        $this->assertSame('aviationwx', getWeathercamOperator(['name' => 'North']));
+    }
+
+    public function testWeathercamOperator_UsesExplicitSlug(): void
+    {
+        $this->assertSame('wsdot', getWeathercamOperator(['name' => 'South', 'operator' => 'wsdot']));
+    }
+
+    public function testWeatherSourceOperator_TypeDefaults(): void
+    {
+        $this->assertSame('faa', getWeatherSourceOperator(['type' => 'metar']));
+        $this->assertSame('nws', getWeatherSourceOperator(['type' => 'nws']));
+        $this->assertSame('navcanada', getWeatherSourceOperator(['type' => 'swob_auto']));
+        $this->assertSame('navcanada', getWeatherSourceOperator(['type' => 'swob_man']));
+        $this->assertSame('awosnet', getWeatherSourceOperator(['type' => 'awosnet']));
+        $this->assertSame('synopticdata', getWeatherSourceOperator(['type' => 'synopticdata']));
+        $this->assertSame('aviationwx', getWeatherSourceOperator(['type' => 'tempest']));
+        $this->assertSame('aviationwx', getWeatherSourceOperator(['type' => 'davis_weatherlink_live']));
+        $this->assertSame('aviationwx', getWeatherSourceOperator(['type' => 'aviationwx_api']));
+    }
+
+    public function testWeatherSourceOperator_ExplicitOverridesTypeDefault(): void
+    {
+        $this->assertSame(
+            'airport-owned',
+            getWeatherSourceOperator(['type' => 'tempest', 'operator' => 'airport-owned'])
+        );
+        $this->assertSame('aviationwx', getWeatherSourceOperator(['type' => 'metar', 'operator' => 'aviationwx']));
+        $this->assertSame(
+            '',
+            getWeatherSourceOperator(['type' => 'metar', 'operator' => 1]),
+            'Invalid explicit operator must not fall through to the metar type default'
+        );
+    }
+
+    public function testAirportMatchesOperator_UsesConfiguredSourcesNotLiveFusion(): void
+    {
+        $airport = [
+            'webcams' => [
+                ['name' => 'North', 'operator' => 'wsdot'],
+            ],
+            'weather_sources' => [
+                ['type' => 'tempest', 'station_id' => '1', 'api_key' => 'k'],
+                ['type' => 'metar', 'station_id' => 'KSPB'],
+            ],
+        ];
+
+        $this->assertTrue(airportMatchesOperator($airport, 'aviationwx'));
+        $this->assertTrue(airportMatchesOperator($airport, 'faa'));
+        $this->assertTrue(airportMatchesOperator($airport, 'wsdot'));
+        $this->assertFalse(airportMatchesOperator($airport, 'nws'));
+        $this->assertTrue(airportMatchesOperator($airport, null));
+    }
+
+    public function testFormatAirportSummary_OperatorFilterUsesConfig(): void
+    {
+        $airport = [
+            'name' => 'Test Field',
+            'icao' => 'KSPB',
+            'lat' => 45.0,
+            'lon' => -122.0,
+            'timezone' => 'UTC',
+            'webcams' => [
+                ['name' => 'Ours'],
+                ['name' => 'WSDOT', 'operator' => 'wsdot'],
+            ],
+            'weather_sources' => [
+                ['type' => 'tempest', 'station_id' => '1', 'api_key' => 'k'],
+                ['type' => 'metar', 'station_id' => 'KSPB'],
+            ],
+        ];
+
+        $all = formatAirportSummary('kspb', $airport);
+        $this->assertTrue($all['has_weather']);
+        $this->assertTrue($all['has_webcams']);
+        $this->assertSame(2, $all['webcam_count']);
+
+        $aviationwx = formatAirportSummary('kspb', $airport, 'aviationwx');
+        $this->assertTrue($aviationwx['has_weather']);
+        $this->assertTrue($aviationwx['has_webcams']);
+        $this->assertSame(1, $aviationwx['webcam_count']);
+
+        $faa = formatAirportSummary('kspb', $airport, 'faa');
+        $this->assertTrue($faa['has_weather']);
+        $this->assertFalse($faa['has_webcams']);
+        $this->assertSame(0, $faa['webcam_count']);
+
+        $wsdot = formatAirportSummary('kspb', $airport, 'wsdot');
+        $this->assertTrue($wsdot['has_weather']);
+        $this->assertTrue($wsdot['has_webcams']);
+        $this->assertSame(1, $wsdot['webcam_count']);
+    }
+
+    public function testParseOperatorQueryParam_NormalizesAndRejectsInvalidSlug(): void
+    {
+        $uppercase = parseOperatorQueryParam('WSDOT');
+        $this->assertTrue($uppercase['ok']);
+        $this->assertSame('wsdot', $uppercase['value']);
+
+        $invalid = parseOperatorQueryParam('not valid');
+        $this->assertFalse($invalid['ok']);
+        $this->assertNull($invalid['value']);
+
+        $valid = parseOperatorQueryParam('wsdot');
+        $this->assertTrue($valid['ok']);
+        $this->assertSame('wsdot', $valid['value']);
+
+        $omitted = parseOperatorQueryParam(null);
+        $this->assertTrue($omitted['ok']);
+        $this->assertNull($omitted['value']);
+    }
+
+    public function testIsValidOperatorSlug_AcceptsHyphenatedAndRejectsInvalidShapes(): void
+    {
+        $this->assertTrue(isValidOperatorSlug('wsdot'));
+        $this->assertTrue(isValidOperatorSlug('airport-owned'));
+        $this->assertTrue(isValidOperatorSlug(str_repeat('a', OPERATOR_MAX_LENGTH)));
+        $this->assertFalse(isValidOperatorSlug('WSDOT'));
+        $this->assertFalse(isValidOperatorSlug('not valid'));
+        $this->assertFalse(isValidOperatorSlug('-wsdot'));
+        $this->assertFalse(isValidOperatorSlug('wsdot-'));
+        $this->assertFalse(isValidOperatorSlug('ws--dot'));
+        $this->assertFalse(isValidOperatorSlug(str_repeat('a', OPERATOR_MAX_LENGTH + 1)));
+    }
+}

--- a/tests/Unit/OperatorConfigTest.php
+++ b/tests/Unit/OperatorConfigTest.php
@@ -141,4 +141,44 @@ class OperatorConfigTest extends TestCase
         $this->assertFalse(isValidOperatorSlug('ws--dot'));
         $this->assertFalse(isValidOperatorSlug(str_repeat('a', OPERATOR_MAX_LENGTH + 1)));
     }
+
+    public function testParseOperatorQueryFromGet_ReadsQueryString(): void
+    {
+        $originalGet = $_GET;
+        try {
+            $_GET = [];
+            $omitted = parseOperatorQueryFromGet();
+            $this->assertTrue($omitted['ok']);
+            $this->assertNull($omitted['value']);
+
+            $_GET = ['operator' => 'WSDOT'];
+            $mixed = parseOperatorQueryFromGet();
+            $this->assertTrue($mixed['ok']);
+            $this->assertSame('wsdot', $mixed['value']);
+
+            $_GET = ['operator' => 'not valid'];
+            $invalid = parseOperatorQueryFromGet();
+            $this->assertFalse($invalid['ok']);
+
+            $_GET = ['operator' => ['wsdot']];
+            $array = parseOperatorQueryFromGet();
+            $this->assertFalse($array['ok']);
+        } finally {
+            $_GET = $originalGet;
+        }
+    }
+
+    public function testOpenApiOperatorQueryPattern_AcceptsMixedCase(): void
+    {
+        $spec = json_decode(
+            (string) file_get_contents(__DIR__ . '/../../api/docs/openapi.json'),
+            true
+        );
+        $this->assertIsArray($spec);
+        $pattern = $spec['components']['parameters']['Operator']['schema']['pattern'] ?? '';
+        $this->assertNotSame('', $pattern);
+        $this->assertSame(1, preg_match('/' . $pattern . '/', 'WSDOT'));
+        $this->assertSame(1, preg_match('/' . $pattern . '/', 'wsdot'));
+        $this->assertSame(0, preg_match('/' . $pattern . '/', 'not valid'));
+    }
 }

--- a/tests/Unit/PublicApiWebcamMetadataTest.php
+++ b/tests/Unit/PublicApiWebcamMetadataTest.php
@@ -56,6 +56,33 @@ class PublicApiWebcamMetadataTest extends TestCase
         $this->assertSame('wsdot', $formatted['operator']);
     }
 
+    public function testListWebcamsFilter_KeepsConfigIndexesWhenOperatorSet(): void
+    {
+        self::loadFormatWebcamMetadata();
+
+        $airport = [
+            'enabled' => true,
+            'maintenance' => false,
+            'webcams' => [
+                ['name' => 'Ours', 'approximate_heading' => 0],
+                ['name' => 'DOT', 'operator' => 'wsdot', 'approximate_heading' => 180],
+            ],
+        ];
+
+        $formatted = [];
+        foreach ($airport['webcams'] as $index => $webcam) {
+            if (!weathercamMatchesOperator($webcam, 'wsdot')) {
+                continue;
+            }
+            $formatted[] = formatWebcamMetadata('kspb', $index, $webcam, $airport);
+        }
+
+        $this->assertCount(1, $formatted);
+        $this->assertSame(1, $formatted[0]['index']);
+        $this->assertSame('wsdot', $formatted[0]['operator']);
+        $this->assertSame('/v1/airports/kspb/webcams/1/image', $formatted[0]['image_url']);
+    }
+
     public function testFormatWebcamMetadata_NullHeadingWhenOmitted(): void
     {
         self::loadFormatWebcamMetadata();

--- a/tests/Unit/PublicApiWebcamMetadataTest.php
+++ b/tests/Unit/PublicApiWebcamMetadataTest.php
@@ -35,6 +35,25 @@ class PublicApiWebcamMetadataTest extends TestCase
         $this->assertArrayHasKey('approximate_heading', $formatted);
         $this->assertArrayNotHasKey('approximate_heading_reference', $formatted);
         $this->assertSame(90, $formatted['approximate_heading']);
+        $this->assertSame('aviationwx', $formatted['operator']);
+    }
+
+    public function testFormatWebcamMetadata_UsesExplicitOperator(): void
+    {
+        self::loadFormatWebcamMetadata();
+
+        $airport = [
+            'enabled' => true,
+            'maintenance' => false,
+        ];
+        $webcam = [
+            'name' => 'DOT Camera',
+            'approximate_heading' => 180,
+            'operator' => 'wsdot',
+        ];
+
+        $formatted = formatWebcamMetadata('kspb', 0, $webcam, $airport);
+        $this->assertSame('wsdot', $formatted['operator']);
     }
 
     public function testFormatWebcamMetadata_NullHeadingWhenOmitted(): void


### PR DESCRIPTION
## Summary
- Adds optional `operator` on weathercams and weather sources in `airports.json`. Omitted weathercam operator is `aviationwx`. Weather-source defaults follow type (`metar` `faa`, `nws` `nws`, SWOB `navcanada`, `awosnet`, `synopticdata`, otherwise `aviationwx`).
- `GET /v1/airports?operator=` and `GET /v1/airports/{id}/webcams?operator=` match that config. `webcam_count` / `has_webcams` count matching weathercams only. Camera indexes stay on the config slot so image URLs do not move.
- `GET /v1/airports/{id}/weather` stays the full fused observation and ignores `operator`. Default catalog (no query) is unchanged.

Closes #289

## Breaking changes
None. `operator` is additive. Invalid `operator` query values return `400` `INVALID_REQUEST`.

## Tests
- Unit: `OperatorConfigTest`, config slug validation, Public API webcam `operator` metadata.
- Integration: `PublicApiOperatorTest` (isolated stack). KSPB fixture has an AviationWX camera at index 0 and a WSDOT camera at index 1.
- `make test-ci` passed.

## Follow-up
Tag production WSDOT weathercams with `"operator": "wsdot"` in the secrets `airports.json`.