### PR TITLE
Serve webcam originals in native formats

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,22 @@ jobs:
           else
             echo "✓ Integration tests passed"
           fi
+
+      - name: Start isolated webcam API test stack
+        run: make test-up
+
+      - name: Run native webcam HTTP integration tests
+        run: |
+          TEST_CACHE_DIR=/tmp/aviationwx-cache-test \
+          TEST_API_URL=http://127.0.0.1:9080 \
+          APP_ENV=testing \
+          vendor/bin/phpunit tests/Integration/PublicApiWebcamTest.php \
+            --testdox \
+            --no-coverage
+
+      - name: Stop isolated webcam API test stack
+        if: always()
+        run: make test-down
       
       - name: Run Critical Safety Tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -140,21 +140,19 @@ test-ci: ## Run all tests that GitHub CI runs (comprehensive)
 	if [ "$$exit_code" -ne 0 ]; then echo "❌ Unit tests failed (exit $$exit_code)"; exit 1; else echo "✓ Unit tests passed"; fi
 	@echo ""
 	@echo "3️⃣  Running Integration Tests..."
-	@# Prefer isolated test stack (:9080). Never fall through to :8080 (dev secrets).
-	@# When no stack is up, point at an unreachable URL so HTTP tests skip (CI-like).
-	@TEST_API_URL="$${TEST_API_URL:-}"; \
-	if [ -z "$$TEST_API_URL" ]; then \
-		if curl -sf --max-time 2 http://127.0.0.1:9080 >/dev/null 2>&1; then \
-			TEST_API_URL="http://127.0.0.1:9080"; \
-			echo "Using TEST_API_URL=$$TEST_API_URL"; \
-		else \
-			TEST_API_URL="http://127.0.0.1:9"; \
-			echo "Isolated :9080 not healthy - HTTP integration tests will skip (TEST_API_URL=$$TEST_API_URL)"; \
-		fi; \
-	fi; \
-	APP_ENV=testing TEST_API_URL="$$TEST_API_URL" vendor/bin/phpunit --testsuite Integration --testdox --log-junit integration-results.xml --no-coverage; \
+	@TEST_API_URL="$${TEST_API_URL:-http://127.0.0.1:9}" \
+		APP_ENV=testing vendor/bin/phpunit --testsuite Integration --testdox --log-junit integration-results.xml --no-coverage; \
 	exit_code=$$?; \
 	if [ "$$exit_code" -ne 0 ]; then echo "❌ Integration tests failed (exit $$exit_code)"; exit 1; else echo "✓ Integration tests passed"; fi
+	@echo ""
+	@echo "3b️⃣ Running Native Webcam HTTP Integration Tests..."
+	@set -eu; \
+	cleanup() { $(MAKE) test-down; }; \
+	trap cleanup EXIT; \
+	$(MAKE) test-up; \
+	TEST_CACHE_DIR="/tmp/aviationwx-cache-test" APP_ENV=testing TEST_API_URL="http://127.0.0.1:9080" \
+		vendor/bin/phpunit tests/Integration/PublicApiWebcamTest.php --testdox --no-coverage; \
+	echo "✓ Native webcam HTTP integration tests passed"
 	@echo ""
 	@echo "4️⃣  Running Critical Safety Tests..."
 	@APP_ENV=testing vendor/bin/phpunit tests/Unit/WeatherCalculationsTest.php --testdox --stop-on-failure --no-coverage; \
@@ -285,7 +283,7 @@ test-local: test-up ## Run PHPUnit tests against isolated test container
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@echo ""
 	@echo "Running PHPUnit tests..."
-	@TEST_API_URL=http://localhost:9080 APP_ENV=testing vendor/bin/phpunit --testdox || (echo ""; echo "⚠️  Some tests failed. Check output above."; $(MAKE) test-down; exit 1)
+	@TEST_CACHE_DIR=/tmp/aviationwx-cache-test TEST_API_URL=http://localhost:9080 APP_ENV=testing vendor/bin/phpunit --testdox || (echo ""; echo "⚠️  Some tests failed. Check output above."; $(MAKE) test-down; exit 1)
 	@$(MAKE) test-down
 
 test-error-detector: ## Test webcam error frame detector (requires running containers)

--- a/api/docs/index.php
+++ b/api/docs/index.php
@@ -550,7 +550,7 @@ $attribution = getPublicApiAttributionText();
                 <span class="endpoint-path">/v1/airports/{id}/webcams/{cam}/image</span>
             </div>
             <div class="endpoint-body">
-                <p class="endpoint-desc">Get the current webcam image. Supports <code>fmt</code> parameter (jpg, webp).</p>
+                <p class="endpoint-desc">Get the current webcam image. Native original has no <code>fmt</code> (type is read from the file). <code>fmt</code> is for generated size variants (jpg, webp).</p>
             </div>
         </div>
         
@@ -560,7 +560,7 @@ $attribution = getPublicApiAttributionText();
                 <span class="endpoint-path">/v1/airports/{id}/webcams/{cam}/history</span>
             </div>
             <div class="endpoint-body">
-                <p class="endpoint-desc">Get historical webcam frames. Use <code>ts</code> parameter to retrieve specific frame.</p>
+                <p class="endpoint-desc">Get historical webcam frames. Use <code>ts</code> for a specific frame. Omit <code>fmt</code> for the native original; <code>fmt</code> is for generated size variants.</p>
             </div>
         </div>
         

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -306,7 +306,7 @@
     "/airports/{id}/webcams/{cam}/image": {
       "get": {
         "summary": "Get webcam image",
-        "description": "Returns the current webcam image with optional dimension transformations.\n\n**Profiles:**\n- `profile=faa`: FAA WCPO compliant output (4:3, margins applied, quality-capped, JPG)\n\n**Dimension behavior:**\n- `profile=faa`: Applies crop margins, 4:3 aspect, 1280x960 or 640x480 (no upscaling)\n- `width` + `height`: Center-crop to target aspect ratio, then scale to exact dimensions\n- `width` only: Scale to width, preserve original aspect ratio\n- `height` only: Scale to height, preserve original aspect ratio\n- `size`: Height-based variant from pre-generated set (no cropping)\n- Neither: Original image\n\n**FAA Profile Example:**\n```\nGET /v1/airports/kspb/webcams/0/image?profile=faa\n```",
+        "description": "Returns the current webcam image with optional dimension transformations.\n\n**Profiles:**\n- `profile=faa`: FAA WCPO compliant output (4:3, margins applied, quality-capped, JPG)\n\n**Dimension behavior:**\n- `profile=faa`: Applies crop margins, 4:3 aspect, 1280x960 or 640x480 (no upscaling)\n- `width` + `height`: Center-crop to target aspect ratio, then scale to exact dimensions\n- `width` only: Scale to width, preserve original aspect ratio\n- `height` only: Scale to height, preserve original aspect ratio\n- `size`: Height-based variant from pre-generated set (no cropping)\n- Neither: Native original. Format is read from the file (jpg, png, or webp) and returned in Content-Type. Files that are not those types are not served.\n\n**FAA Profile Example:**\n```\nGET /v1/airports/kspb/webcams/0/image?profile=faa\n```",
         "operationId": "getWebcamImage",
         "tags": ["Webcams"],
         "parameters": [
@@ -328,11 +328,10 @@
           {
             "name": "fmt",
             "in": "query",
-            "description": "Image format (ignored when profile=faa)",
+            "description": "Image format for generated size variants (ignored when profile=faa). Not valid on the original. Must be enabled in airports.json (jpg always; webp when config.webcam_generate_webp is true).",
             "schema": {
               "type": "string",
-              "enum": ["jpg", "webp"],
-              "default": "jpg"
+              "enum": ["jpg", "webp"]
             }
           },
           {
@@ -383,6 +382,7 @@
             "description": "Image data or metadata (when metadata=1)",
             "content": {
               "image/jpeg": {},
+              "image/png": {},
               "image/webp": {},
               "application/json": {
                 "schema": {
@@ -406,7 +406,7 @@
     "/airports/{id}/webcams/{cam}/history": {
       "get": {
         "summary": "Get webcam history",
-        "description": "Returns list of historical webcam frames, or a specific frame when ts parameter is provided.",
+        "description": "Returns list of historical webcam frames, or a specific frame image when ts is provided.\n\nWhen ts is set, omit fmt for the native original. Format is read from the file (jpg, png, or webp) and returned in Content-Type. fmt applies only to generated size variants. fmt with no size, or with size=original, returns 400.",
         "operationId": "getWebcamHistory",
         "tags": ["Webcams"],
         "parameters": [
@@ -427,20 +427,18 @@
           {
             "name": "fmt",
             "in": "query",
-            "description": "Image format (only used with ts parameter)",
+            "description": "Image format for generated size variants. Not valid on the original. Only used with ts. Must be enabled in airports.json (jpg always; webp when config.webcam_generate_webp is true).",
             "schema": {
               "type": "string",
-              "enum": ["jpg", "webp"],
-              "default": "jpg"
+              "enum": ["jpg", "webp"]
             }
           },
           {
             "name": "size",
             "in": "query",
-            "description": "Image size variant (only used with ts parameter)",
+            "description": "Height-based variant from the pre-generated set. Only used with ts. Omit fmt when requesting the original.",
             "schema": {
               "type": "string",
-              "default": "original",
               "example": "720"
             }
           }
@@ -454,8 +452,13 @@
                   "$ref": "#/components/schemas/WebcamHistoryResponse"
                 }
               },
-              "image/jpeg": {}
+              "image/jpeg": {},
+              "image/png": {},
+              "image/webp": {}
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
@@ -2020,10 +2023,10 @@
           },
           "images": {
             "type": "array",
-            "description": "Configured original plus height variants. Original is jpg only. Sized rows follow enabled formats. Not a disk probe of the current frame.",
+            "description": "Configured original plus height variants. Original URL has no fmt; format is the native type when the current original is a supported jpg, png, or webp. Omitted when missing or unsupported. Sized rows follow enabled generation formats from airports.json.",
             "items": {
               "type": "object",
-              "required": ["variant", "height", "format", "url"],
+              "required": ["variant", "height", "url"],
               "properties": {
                 "variant": {
                   "type": "string",
@@ -2036,7 +2039,8 @@
                 },
                 "format": {
                   "type": "string",
-                  "enum": ["jpg", "webp"]
+                  "enum": ["jpg", "png", "webp"],
+                  "description": "Native type of the current original, or an enabled generation format on sized rows. Omitted on original when the file is missing or not a supported jpg, png, or webp."
                 },
                 "url": {
                   "type": "string"
@@ -2241,7 +2245,7 @@
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "enum": ["jpg", "webp"]
+                    "enum": ["jpg", "png", "webp"]
                   }
                 },
                 "example": {

--- a/api/v1/weathercam-bulk.php
+++ b/api/v1/weathercam-bulk.php
@@ -39,7 +39,8 @@ function handleGetWeathercamBulk(array $params, array $context): void
         $webcamCount += count($airport['webcams'] ?? []);
     }
 
-    sendPublicApiCacheHeaders('metadata');
+    // images[0].format is read from disk, so this payload is not hour-stable metadata.
+    sendPublicApiCacheHeaders('live');
     sendPublicApiSuccess(
         ['airports' => $catalog],
         [
@@ -67,7 +68,67 @@ function getWeathercamBulkAirports(?string $operatorFilter): array
         rememberWeathercamBulkCatalogIfConfigShaStable($full, $shaBefore, getConfigFileSha256());
     }
 
-    return filterWeathercamBulkAirportsByOperator($full, $operatorFilter);
+    return refreshWeathercamBulkOriginalFormats(
+        filterWeathercamBulkAirportsByOperator($full, $operatorFilter)
+    );
+}
+
+/**
+ * Replace cached images[0].format with the current original on disk.
+ *
+ * Catalog rows are config-keyed; format is not. Does not write back to cache.
+ *
+ * @param list<array<string, mixed>> $airports
+ * @return list<array<string, mixed>>
+ */
+function refreshWeathercamBulkOriginalFormats(array $airports): array
+{
+    $refreshed = [];
+    foreach ($airports as $airport) {
+        if (!is_array($airport)) {
+            $refreshed[] = $airport;
+            continue;
+        }
+        $airportId = $airport['id'] ?? '';
+        $webcams = $airport['webcams'] ?? [];
+        if (!is_string($airportId) || $airportId === '' || !is_array($webcams)) {
+            $refreshed[] = $airport;
+            continue;
+        }
+        $newWebcams = [];
+        foreach ($webcams as $webcam) {
+            if (!is_array($webcam)) {
+                $newWebcams[] = $webcam;
+                continue;
+            }
+            $index = $webcam['index'] ?? null;
+            $images = $webcam['images'] ?? null;
+            $indexOk = is_int($index) || (is_string($index) && ctype_digit($index));
+            if (!$indexOk || !is_array($images) || !isset($images[0]) || !is_array($images[0])) {
+                $newWebcams[] = $webcam;
+                continue;
+            }
+            $original = $images[0];
+            if (($original['variant'] ?? 'original') !== 'original') {
+                $newWebcams[] = $webcam;
+                continue;
+            }
+            $path = getWebcamOriginalPath($airportId, (int) $index);
+            $detected = $path !== null ? detectServableWebcamImageFormat($path) : null;
+            if ($detected !== null) {
+                $original['format'] = $detected;
+            } else {
+                unset($original['format']);
+            }
+            $images[0] = $original;
+            $webcam['images'] = $images;
+            $newWebcams[] = $webcam;
+        }
+        $airport['webcams'] = $newWebcams;
+        $refreshed[] = $airport;
+    }
+
+    return $refreshed;
 }
 
 /**

--- a/api/v1/webcam-history.php
+++ b/api/v1/webcam-history.php
@@ -12,6 +12,7 @@
  */
 
 require_once __DIR__ . '/../../lib/public-api/middleware.php';
+require_once __DIR__ . '/../../lib/public-api/query.php';
 require_once __DIR__ . '/../../lib/public-api/response.php';
 require_once __DIR__ . '/../../lib/config.php';
 require_once __DIR__ . '/../../lib/cache-paths.php';
@@ -195,39 +196,63 @@ function handleGetFrameList(string $airportId, int $camIndex, array $airport): v
 function handleGetHistoricalFrame(string $airportId, int $camIndex, int $timestamp): void
 {
     require_once __DIR__ . '/../../lib/webcam-history.php';
-    
-    // Get requested format and size
-    $format = $_GET['fmt'] ?? 'jpg';
-    if (!in_array($format, ['jpg', 'webp'])) {
-        $format = 'jpg';
-    }
-    
-    // Get requested size (variant) - supports height-based variants or 'original'
+
     $size = $_GET['size'] ?? 'original';
-    
-    // Validate size: numeric height or 'original'
     if ($size !== 'original' && (!is_numeric($size) || (int)$size < 1 || (int)$size > 5000)) {
         $size = 'original';
     }
-    
-    // Get image path for requested size using new variant system
-    $cacheFile = getImagePathForSize($airportId, $camIndex, $timestamp, $size, $format);
-    
-    // Fall back to original if variant doesn't exist
-    if ($cacheFile === null && $size !== 'original') {
-        $cacheFile = getImagePathForSize($airportId, $camIndex, $timestamp, 'original', $format);
-        $size = 'original';
+
+    $fmtParse = parsePublicApiWebcamFmtQueryFromGet();
+    if (!$fmtParse['ok']) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            $fmtParse['error'],
+            400
+        );
+        return;
     }
-    
-    // Fall back to JPG if requested format doesn't exist
-    if ($cacheFile === null && $format !== 'jpg') {
-        $cacheFile = getImagePathForSize($airportId, $camIndex, $timestamp, $size, 'jpg');
-        if ($cacheFile === null && $size !== 'original') {
-            $cacheFile = getImagePathForSize($airportId, $camIndex, $timestamp, 'original', 'jpg');
+    $explicitFmt = $fmtParse['explicit'];
+
+    if ($size === 'original' && $explicitFmt) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            'fmt applies to generated size variants. Omit fmt for the original.',
+            400
+        );
+        return;
+    }
+
+    $cacheFile = null;
+    $format = 'jpg';
+
+    if ($size === 'original' && !$explicitFmt) {
+        $resolved = resolveWebcamOriginalAtTimestamp($airportId, $camIndex, $timestamp);
+        if (!$resolved['ok']) {
+            if ($resolved['error'] === 'unknown') {
+                sendPublicApiError(
+                    PUBLIC_API_ERROR_INVALID_REQUEST,
+                    'Original image format is not supported',
+                    400
+                );
+            } else {
+                sendPublicApiError(
+                    PUBLIC_API_ERROR_INVALID_REQUEST,
+                    'Historical frame not found for timestamp: ' . $timestamp,
+                    404
+                );
+            }
+            return;
         }
-        $format = 'jpg';
+        $cacheFile = $resolved['path'];
+        $format = $resolved['format'];
+    } else {
+        $format = $fmtParse['format'] ?? 'jpg';
+
+        $found = findHistoricalWebcamSizeFile($airportId, $camIndex, $timestamp, $size, $format);
+        $cacheFile = $found['path'];
+        $size = $found['size'];
     }
-    
+
     if ($cacheFile === null || !file_exists($cacheFile)) {
         sendPublicApiError(
             PUBLIC_API_ERROR_INVALID_REQUEST,
@@ -236,38 +261,41 @@ function handleGetHistoricalFrame(string $airportId, int $camIndex, int $timesta
         );
         return;
     }
-    
-    // Get file info
-    $fileSize = filesize($cacheFile);
-    $mtime = filemtime($cacheFile);
-    
-    // Set content type based on format
-    $contentType = match ($format) {
-        'webp' => 'image/webp',
-        default => 'image/jpeg',
-    };
-    
-    // Build filename matching server naming convention: {timestamp}_{variant}.{ext}
+
+    $meta = webcamServableImageFileMeta($cacheFile);
+    if ($meta === null) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            'Image format is not supported',
+            400
+        );
+        return;
+    }
+    if (!webcamExplicitFmtMatchesFile($explicitFmt, $format, $meta['format'])) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            "Requested format '{$format}' does not match the image file",
+            400
+        );
+        return;
+    }
+    $format = $meta['format'];
+
     $variant = ($size === 'original') ? 'original' : (int)$size;
     $filename = $timestamp . '_' . $variant . '.' . $format;
-    
+
+    header('Cache-Control: public, max-age=31536000, immutable');
+    header('Access-Control-Allow-Origin: *');
+
     require_once __DIR__ . '/../../lib/http-integrity.php';
-    if (addIntegrityHeadersForFile($cacheFile, $mtime)) {
+    if (addIntegrityHeadersForFile($cacheFile, $meta['mtime'])) {
         return;
     }
 
-    // Send headers
-    header('Content-Type: ' . $contentType);
+    header('Content-Type: ' . $meta['content_type']);
     header('Content-Disposition: inline; filename="' . $filename . '"');
-    header('Content-Length: ' . $fileSize);
-    
-    // Immutable cache - historical frames never change
-    header('Cache-Control: public, max-age=31536000, immutable');
-    
-    // CORS headers
-    header('Access-Control-Allow-Origin: *');
-    
-    // Output image
+    header('Content-Length: ' . $meta['size']);
+
     readfile($cacheFile);
 }
 

--- a/api/v1/webcam-image.php
+++ b/api/v1/webcam-image.php
@@ -8,7 +8,7 @@
  * 
  * Query parameters:
  * - profile: Output profile ('faa') - applies FAA-compliant settings
- * - fmt: Image format ('jpg', 'webp') - default is jpg
+ * - fmt: Enabled generation format for sized variants ('jpg', 'webp' when configured). Not valid on the original.
  * - size: Height-based variant (e.g., '720', '1080') or 'original' - preserves aspect ratio
  * - width: Target width in pixels (16-3840) - used with height for exact dimensions
  * - height: Target height in pixels (16-2160) - used with width for exact dimensions
@@ -19,7 +19,7 @@
  * - width only: Scale to width, preserve original aspect ratio
  * - height only: Scale to height, preserve original aspect ratio (same as size=)
  * - size=: Height-based variant from pre-generated set (no cropping)
- * - Neither: Original image
+ * - Neither: Native original. Format is read from the file (jpg, png, or webp) and returned in Content-Type. Unsupported files are not served.
  * 
  * FAA Profile (profile=faa):
  *   - Applies per-camera crop_margins to exclude timestamps/watermarks
@@ -30,12 +30,81 @@
  */
 
 require_once __DIR__ . '/../../lib/public-api/middleware.php';
+require_once __DIR__ . '/../../lib/public-api/query.php';
 require_once __DIR__ . '/../../lib/public-api/response.php';
 require_once __DIR__ . '/../../lib/config.php';
 require_once __DIR__ . '/../../lib/cache-headers.php';
 require_once __DIR__ . '/../../lib/webcam-metadata.php';
 require_once __DIR__ . '/../../lib/image-transform.php';
 require_once __DIR__ . '/../../lib/metrics.php';
+
+/**
+ * @param string $format jpg, png, or webp
+ * @return string Content-Type
+ * @throws InvalidArgumentException When $format is not jpg, png, or webp
+ */
+function publicApiWebcamContentType(string $format): string
+{
+    $type = webcamImageContentType($format);
+    if ($type === null) {
+        throw new InvalidArgumentException('Unsupported webcam image format');
+    }
+
+    return $type;
+}
+
+/**
+ * fmt is only valid with a generated size or width/height transform.
+ *
+ * @param bool $explicitFormatRequest True when the client sent fmt
+ * @param string $size Normalized size (original or a height)
+ * @param int|null $requestedWidth Transform width
+ * @param int|null $requestedHeight Transform height
+ * @return bool True when fmt must be rejected
+ */
+function publicApiWebcamFmtRejectedOnOriginal(
+    bool $explicitFormatRequest,
+    string $size,
+    ?int $requestedWidth,
+    ?int $requestedHeight
+): bool {
+    if (!$explicitFormatRequest) {
+        return false;
+    }
+    if ($requestedWidth !== null || $requestedHeight !== null) {
+        return false;
+    }
+
+    return $size === 'original';
+}
+
+/**
+ * Public API image URL for a variant/format pair.
+ *
+ * Native original has no fmt. Sized rows add fmt only when the generation format is not jpg.
+ *
+ * @param string $airportId Airport ID
+ * @param int $camIndex Camera index
+ * @param string $variantKey original or a height as a string
+ * @param string $format jpg, png, or webp
+ * @return string Path with optional query
+ */
+function publicApiWebcamVariantUrl(string $airportId, int $camIndex, string $variantKey, string $format): string
+{
+    $url = '/v1/airports/' . $airportId . '/webcams/' . $camIndex . '/image';
+    $params = [];
+    if ($variantKey !== 'original') {
+        if ($format !== 'jpg') {
+            $params[] = 'fmt=' . $format;
+        }
+        $params[] = 'size=' . $variantKey;
+    }
+    if ($params !== []) {
+        $url .= '?' . implode('&', $params);
+    }
+
+    return $url;
+}
 
 /**
  * Handle GET /v1/airports/{id}/webcams/{cam}/image request
@@ -93,65 +162,98 @@ function handleGetWebcamImage(array $params, array $context): void
     // Track API request metric (combined with private API metrics for high-level view)
     metrics_track_webcam_request($airportId, $camIndex);
     
-    // Handle download request - always serves original JPG with proper filename
+    // Handle download request - native original with attachment filename
     if (isset($_GET['download']) && $_GET['download'] == '1') {
-        require_once __DIR__ . '/../../lib/webcam-metadata.php';
-        $cacheDir = getWebcamCameraDir($airportId, $camIndex);
-        $originalJpg = $cacheDir . '/original.jpg';
-        
-        if (!file_exists($originalJpg) || !is_readable($originalJpg)) {
+        $fmtParse = parsePublicApiWebcamFmtQueryFromGet();
+        if (!$fmtParse['ok']) {
             sendPublicApiError(
-                PUBLIC_API_ERROR_SERVICE_UNAVAILABLE,
-                'Original image not available for download',
-                404
+                PUBLIC_API_ERROR_INVALID_REQUEST,
+                $fmtParse['error'],
+                400
             );
             return;
         }
-        
-        // Get EXIF capture time for filename
+        if ($fmtParse['explicit']) {
+            sendPublicApiError(
+                PUBLIC_API_ERROR_INVALID_REQUEST,
+                'fmt applies to generated size variants. Omit fmt for the original.',
+                400
+            );
+            return;
+        }
+
+        $currentOriginal = getCurrentServableWebcamOriginal($airportId, $camIndex);
+        if ($currentOriginal === null || !is_readable($currentOriginal['path'])) {
+            sendPublicApiError(
+                PUBLIC_API_ERROR_SERVICE_UNAVAILABLE,
+                'Original image not available for download',
+                503
+            );
+            return;
+        }
+        $originalFile = $currentOriginal['path'];
+
+        $meta = webcamServableImageFileMeta($originalFile);
+        if ($meta === null) {
+            sendPublicApiError(
+                PUBLIC_API_ERROR_INVALID_REQUEST,
+                'Image format is not supported',
+                400
+            );
+            return;
+        }
+        $format = $currentOriginal['format'];
+
         $captureTime = 0;
-        if (function_exists('exif_read_data')) {
-            $exif = @exif_read_data($originalJpg, 'EXIF', true);
+        if ($format === 'jpg' && function_exists('exif_read_data')) {
+            $exif = @exif_read_data($originalFile, 'EXIF', true);
             if ($exif !== false && isset($exif['EXIF']['DateTimeOriginal'])) {
                 $dateTime = $exif['EXIF']['DateTimeOriginal'];
-                $timestamp = @strtotime(str_replace(':', '-', substr($dateTime, 0, 10)) . ' ' . substr($dateTime, 11) . ' UTC');
-                if ($timestamp !== false && $timestamp > 0) {
-                    $captureTime = (int)$timestamp;
+                $parsed = @strtotime(str_replace(':', '-', substr($dateTime, 0, 10)) . ' ' . substr($dateTime, 11) . ' UTC');
+                if ($parsed !== false && $parsed > 0) {
+                    $captureTime = (int) $parsed;
                 }
             } elseif (isset($exif['DateTimeOriginal'])) {
                 $dateTime = $exif['DateTimeOriginal'];
-                $timestamp = @strtotime(str_replace(':', '-', substr($dateTime, 0, 10)) . ' ' . substr($dateTime, 11) . ' UTC');
-                if ($timestamp !== false && $timestamp > 0) {
-                    $captureTime = (int)$timestamp;
+                $parsed = @strtotime(str_replace(':', '-', substr($dateTime, 0, 10)) . ' ' . substr($dateTime, 11) . ' UTC');
+                if ($parsed !== false && $parsed > 0) {
+                    $captureTime = (int) $parsed;
                 }
             }
         }
-        
-        // Use EXIF time if available, otherwise file mtime
+
+        $mtime = $meta['mtime'];
         if ($captureTime > 0) {
-            $timestamp = gmdate('Y-m-d_His', $captureTime) . '_UTC';
+            $filenameStamp = gmdate('Y-m-d_His', $captureTime) . '_UTC';
         } else {
-            $mtime = filemtime($originalJpg);
-            $timestamp = gmdate('Y-m-d_His', $mtime) . '_UTC';
+            $filenameStamp = gmdate('Y-m-d_His', $currentOriginal['timestamp']) . '_UTC';
         }
-        
-        // Build filename: {airport}_{cam}_{timestamp}.jpg
-        $filename = strtolower($airportId) . "_{$camIndex}_{$timestamp}.jpg";
-        
+
+        $filename = strtolower($airportId) . "_{$camIndex}_{$filenameStamp}." . $format;
+
+        // Latest download is mutable; use the live-image cache policy.
+        $webcamRefresh = getDefaultWebcamRefresh();
+        if (isset($airport['webcam_refresh_seconds'])) {
+            $webcamRefresh = intval($airport['webcam_refresh_seconds']);
+        }
+        if (isset($webcam['refresh_seconds'])) {
+            $webcamRefresh = intval($webcam['refresh_seconds']);
+        }
+        $headers = generateCacheHeaders($webcamRefresh, $webcamRefresh);
+        foreach ($headers as $name => $value) {
+            header($name . ': ' . $value);
+        }
+
         require_once __DIR__ . '/../../lib/http-integrity.php';
-        $mtime = filemtime($originalJpg);
-        if (addIntegrityHeadersForFile($originalJpg, $mtime)) {
+        if (addIntegrityHeadersForFile($originalFile, $mtime)) {
             exit;
         }
 
-        // Force download with proper filename
-        header('Content-Type: image/jpeg');
+        header('Content-Type: ' . $meta['content_type']);
         header('Content-Disposition: attachment; filename="' . $filename . '"');
-        header('Content-Length: ' . filesize($originalJpg));
-        header('Cache-Control: public, max-age=31536000, immutable');
-        
-        // Serve original file
-        readfile($originalJpg);
+        header('Content-Length: ' . $meta['size']);
+
+        readfile($originalFile);
         exit;
     }
     
@@ -170,19 +272,29 @@ function handleGetWebcamImage(array $params, array $context): void
         return;
     }
     
-    // Get requested format
-    $format = $_GET['fmt'] ?? 'jpg';
-    if (!in_array($format, ['jpg', 'webp'])) {
-        $format = 'jpg';
+    $fmtParse = parsePublicApiWebcamFmtQueryFromGet();
+    if (!$fmtParse['ok']) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            $fmtParse['error'],
+            400
+        );
+        return;
     }
-    
+
     // Parse dimension parameters
     $requestedWidth = isset($_GET['width']) && is_numeric($_GET['width']) ? (int)$_GET['width'] : null;
     $requestedHeight = isset($_GET['height']) && is_numeric($_GET['height']) ? (int)$_GET['height'] : null;
     $size = $_GET['size'] ?? null;
-    
-    // Get latest timestamp
-    $timestamp = getLatestImageTimestamp($airportId, $camIndex);
+    if (
+        $size === null ||
+        ($size !== 'original' && (!is_numeric($size) || (int)$size < 1 || (int)$size > 5000))
+    ) {
+        $size = 'original';
+    }
+
+    $currentOriginal = getCurrentServableWebcamOriginal($airportId, $camIndex);
+    $timestamp = $currentOriginal['timestamp'] ?? getLatestImageTimestamp($airportId, $camIndex);
     
     if ($timestamp === 0) {
         sendPublicApiError(
@@ -196,9 +308,10 @@ function handleGetWebcamImage(array $params, array $context): void
     // Determine which path to take: transform (width/height) or variant (size)
     $cacheFile = null;
     $variant = 'original';
-    
+    $format = $fmtParse['format'] ?? 'jpg';
+    $explicitFormatRequest = $fmtParse['explicit'];
+
     if ($requestedWidth !== null || $requestedHeight !== null) {
-        // Use image transformation (center-crop + resize)
         $cacheFile = handleTransformRequest(
             $airportId,
             $camIndex,
@@ -209,11 +322,9 @@ function handleGetWebcamImage(array $params, array $context): void
         );
         
         if ($cacheFile === null) {
-            // Error already sent by handleTransformRequest
             return;
         }
         
-        // Build variant name for filename
         if ($requestedWidth !== null && $requestedHeight !== null) {
             $variant = $requestedWidth . 'x' . $requestedHeight;
         } elseif ($requestedWidth !== null) {
@@ -222,73 +333,65 @@ function handleGetWebcamImage(array $params, array $context): void
             $variant = 'h' . $requestedHeight;
         }
     } else {
-        // Use existing variant system (no cropping)
-        if ($size === null) {
-            $size = 'original';
+        if (publicApiWebcamFmtRejectedOnOriginal(
+            $explicitFormatRequest,
+            $size,
+            $requestedWidth,
+            $requestedHeight
+        )) {
+            sendPublicApiError(
+                PUBLIC_API_ERROR_INVALID_REQUEST,
+                'fmt applies to generated size variants. Omit fmt for the original.',
+                400
+            );
+            return;
         }
-        
-        // Validate size: numeric height or 'original'
-        if ($size !== 'original' && (!is_numeric($size) || (int)$size < 1 || (int)$size > 5000)) {
-            $size = 'original';
-        }
-        
-        // Track if format was explicitly requested via query parameter
-        $explicitFormatRequest = isset($_GET['fmt']);
-        $requestedFormat = $format;
-        
-        // Get image path for requested size
-        $cacheFile = getImagePathForSize($airportId, $camIndex, $timestamp, $size, $format);
-        
-        // Fall back to original if variant doesn't exist
-        if ($cacheFile === null && $size !== 'original') {
-            $cacheFile = getImagePathForSize($airportId, $camIndex, $timestamp, 'original', $format);
-            $size = 'original';
-        }
-        
-        // Handle explicit format request for unavailable format
-        if ($cacheFile === null && $explicitFormatRequest && $requestedFormat !== 'jpg') {
-            // Check if the format exists for any sized variant
-            require_once __DIR__ . '/../../lib/webcam-metadata.php';
-            $variantHeights = getVariantHeights($airportId, $camIndex);
-            $availableSizes = [];
-            
-            foreach ($variantHeights as $height) {
-                $variantPath = getImagePathForSize($airportId, $camIndex, $timestamp, $height, $requestedFormat);
-                if ($variantPath !== null) {
-                    $availableSizes[] = $height;
+
+        if ($size === 'original' && !$explicitFormatRequest) {
+            if ($currentOriginal === null) {
+                sendPublicApiError(
+                    PUBLIC_API_ERROR_SERVICE_UNAVAILABLE,
+                    'Webcam image temporarily unavailable',
+                    503
+                );
+                return;
+            }
+            $cacheFile = $currentOriginal['path'];
+            $format = $currentOriginal['format'];
+        } else {
+            $cacheFile = getImagePathForSize($airportId, $camIndex, $timestamp, $size, $format);
+
+            if ($cacheFile === null && $explicitFormatRequest) {
+                $variantHeights = getVariantHeights($airportId, $camIndex);
+                $availableSizes = [];
+
+                foreach ($variantHeights as $height) {
+                    $variantPath = getImagePathForSize($airportId, $camIndex, $timestamp, $height, $format);
+                    if ($variantPath !== null) {
+                        $availableSizes[] = $height;
+                    }
                 }
-            }
-            
-            if (!empty($availableSizes)) {
-                // Format exists for sized variants but not for original
+
+                if (!empty($availableSizes)) {
+                    sendPublicApiError(
+                        PUBLIC_API_ERROR_INVALID_REQUEST,
+                        "Format '{$format}' is not available for size '{$size}'. " .
+                        "Available sizes for {$format}: " . implode(', ', $availableSizes) . '.',
+                        400
+                    );
+                    return;
+                }
+
                 sendPublicApiError(
                     PUBLIC_API_ERROR_INVALID_REQUEST,
-                    "Format '{$requestedFormat}' is not available for size 'original'. " .
-                    "Available sizes for {$requestedFormat}: " . implode(', ', $availableSizes) . ". " .
-                    "Note: Original images preserve the source format from the camera.",
+                    "Format '{$format}' is not available for this webcam. Use the size parameter to request specific variants (e.g. 720, 1080).",
                     400
                 );
                 return;
-            } else {
-                // Format doesn't exist at all
-                sendPublicApiError(
-                    PUBLIC_API_ERROR_INVALID_REQUEST,
-                    "Format '{$requestedFormat}' is not available for this webcam. Use the size parameter to request specific variants (e.g. 720, 1080).",
-                    400
-                );
-                return;
             }
+
         }
-        
-        // Fall back to JPG if requested format doesn't exist (only for non-explicit requests)
-        if ($cacheFile === null && $format !== 'jpg' && !$explicitFormatRequest) {
-            $cacheFile = getImagePathForSize($airportId, $camIndex, $timestamp, $size, 'jpg');
-            if ($cacheFile === null && $size !== 'original') {
-                $cacheFile = getImagePathForSize($airportId, $camIndex, $timestamp, 'original', 'jpg');
-            }
-            $format = 'jpg';
-        }
-        
+
         $variant = ($size === 'original') ? 'original' : (int)$size;
     }
     
@@ -300,8 +403,26 @@ function handleGetWebcamImage(array $params, array $context): void
         );
         return;
     }
-    
-    // Send the image response
+
+    $served = webcamServableImageContent($cacheFile);
+    if ($served === null) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            'Image format is not supported',
+            400
+        );
+        return;
+    }
+    if (!webcamExplicitFmtMatchesFile($explicitFormatRequest, $format, $served['format'])) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            "Requested format '{$format}' does not match the image file",
+            400
+        );
+        return;
+    }
+    $format = $served['format'];
+
     sendImageResponse($airportId, $camIndex, $cacheFile, $timestamp, $variant, $format, $airport, $webcams[$camIndex]);
 }
 
@@ -325,8 +446,8 @@ function handleFaaProfileRequest(
     array $airport,
     array $webcam
 ): void {
-    // Get latest timestamp
-    $timestamp = getLatestImageTimestamp($airportId, $camIndex);
+    $currentOriginal = getCurrentServableWebcamOriginal($airportId, $camIndex);
+    $timestamp = $currentOriginal['timestamp'] ?? 0;
     
     if ($timestamp === 0) {
         sendPublicApiError(
@@ -405,13 +526,8 @@ function handleTransformRequest(
     
     // If only one dimension specified, we need to calculate the other from source
     if ($requestedWidth === null || $requestedHeight === null) {
-        // Get source image dimensions
-        $sourcePath = getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, 'jpg');
-        if (!file_exists($sourcePath)) {
-            $sourcePath = getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, 'webp');
-        }
-        
-        if (!file_exists($sourcePath)) {
+        $sourcePath = resolveWebcamTransformSourcePath($airportId, $camIndex, $timestamp);
+        if ($sourcePath === null) {
             sendPublicApiError(
                 PUBLIC_API_ERROR_SERVICE_UNAVAILABLE,
                 'Webcam image temporarily unavailable',
@@ -486,7 +602,7 @@ function handleTransformRequest(
  * @param string $cacheFile Path to image file
  * @param int $timestamp Image timestamp
  * @param string|int $variant Variant identifier for filename (original, 720, faa_1280x960, etc.)
- * @param string $format Image format (jpg, webp)
+ * @param string $format Caller hint; body type is taken from the file header
  * @param array $airport Airport configuration
  * @param array $cam Camera configuration
  */
@@ -500,7 +616,22 @@ function sendImageResponse(
     array $airport,
     array $cam
 ): void {
-    // Track webcam serve for status page format/size breakdown
+    $meta = webcamServableImageFileMeta($cacheFile);
+    if ($meta === null) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            'Image format is not supported',
+            400
+        );
+        return;
+    }
+    $format = $meta['format'];
+
+    // A capture older than the fail-closed threshold is a "last known good frame":
+    // still served as 200, but marked stale so it is not cached as current. The
+    // capture time (authoritative EXIF) travels in the bytes and is exposed via Last-Modified.
+    $stale = $timestamp > 0 && (time() - $timestamp) > getStaleFailclosedSeconds($airport);
+
     $sizeForMetrics = 'original';
     if (is_numeric($variant) && (int)$variant >= 1 && (int)$variant <= 5000) {
         $sizeForMetrics = (string)(int)$variant;
@@ -513,20 +644,9 @@ function sendImageResponse(
     }
     metrics_track_webcam_serve($airportId, $camIndex, $format, $sizeForMetrics);
 
-    // Get file info
-    $fileSize = filesize($cacheFile);
-    $mtime = filemtime($cacheFile);
-    
-    // Set content type
-    $contentType = match ($format) {
-        'webp' => 'image/webp',
-        default => 'image/jpeg',
-    };
-    
-    // Build filename
+    $mtime = $meta['mtime'];
     $filename = $timestamp . '_' . $variant . '.' . $format;
-    
-    // Get webcam refresh interval (from camera config, airport config, or default)
+
     $webcamRefresh = getDefaultWebcamRefresh();
     if (isset($airport['webcam_refresh_seconds'])) {
         $webcamRefresh = intval($airport['webcam_refresh_seconds']);
@@ -534,29 +654,38 @@ function sendImageResponse(
     if (isset($cam['refresh_seconds'])) {
         $webcamRefresh = intval($cam['refresh_seconds']);
     }
-    
-    require_once __DIR__ . '/../../lib/http-integrity.php';
 
-    // Integrity headers (ETag, Content-Digest, Content-MD5) - 304 if unchanged
+    if ($stale) {
+        // Last known good frame; log the over-age delivery so it is auditable.
+        aviationwx_log('warn', 'serving over-age webcam frame past fail-closed threshold', [
+            'airport' => $airportId,
+            'cam' => $camIndex,
+            'capture_timestamp' => $timestamp,
+            'age_seconds' => time() - $timestamp,
+            'failclosed_seconds' => getStaleFailclosedSeconds($airport),
+        ], 'app');
+        header('Warning: 110 - "Response is stale"');
+        $headers = generateCacheHeaders(0, 0, false);
+        $headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
+        $lastModified = gmdate('D, d M Y H:i:s', $timestamp) . ' GMT';
+        header('Last-Modified: ' . $lastModified);
+    } else {
+        $headers = generateCacheHeaders($webcamRefresh, $webcamRefresh);
+    }
+    foreach ($headers as $name => $value) {
+        header($name . ': ' . $value);
+    }
+    header('Access-Control-Allow-Origin: *');
+
+    require_once __DIR__ . '/../../lib/http-integrity.php';
     if (addIntegrityHeadersForFile($cacheFile, $mtime)) {
         return;
     }
 
-    // Send headers
-    header('Content-Type: ' . $contentType);
+    header('Content-Type: ' . $meta['content_type']);
     header('Content-Disposition: inline; filename="' . $filename . '"');
-    header('Content-Length: ' . $fileSize);
-    
-    // Cache headers: browser cache matches refresh interval, CDN uses half (min 5s)
-    $headers = generateCacheHeaders($webcamRefresh, $webcamRefresh);
-    foreach ($headers as $name => $value) {
-        header($name . ': ' . $value);
-    }
-    
-    // CORS headers
-    header('Access-Control-Allow-Origin: *');
-    
-    // Output image
+    header('Content-Length: ' . $meta['size']);
+
     readfile($cacheFile);
 }
 
@@ -578,10 +707,8 @@ function handleGetWebcamMetadata(
 ): void {
     require_once __DIR__ . '/../../lib/webcam-metadata.php';
     
-    // Get latest timestamp
-    $timestamp = getLatestImageTimestamp($airportId, $camIndex);
-    
-    if ($timestamp === 0) {
+    $currentOriginal = getCurrentServableWebcamOriginal($airportId, $camIndex);
+    if ($currentOriginal === null) {
         sendPublicApiError(
             PUBLIC_API_ERROR_SERVICE_UNAVAILABLE,
             'Webcam image temporarily unavailable',
@@ -589,6 +716,7 @@ function handleGetWebcamMetadata(
         );
         return;
     }
+    $timestamp = $currentOriginal['timestamp'];
     
     // Get available variants
     $availableVariants = getAvailableVariants($airportId, $camIndex, $timestamp);
@@ -616,21 +744,12 @@ function handleGetWebcamMetadata(
         // Build URLs for each format
         foreach ($variantFormats as $format) {
             $urlKey = $variantKey . '_' . $format;
-            $url = '/v1/airports/' . $airportId . '/webcams/' . $camIndex . '/image';
-            
-            $params = [];
-            if ($format !== 'jpg') {
-                $params[] = 'fmt=' . $format;
-            }
-            if ($variant !== 'original') {
-                $params[] = 'size=' . $variant;
-            }
-            
-            if (!empty($params)) {
-                $url .= '?' . implode('&', $params);
-            }
-            
-            $urls[$urlKey] = $url;
+            $urls[$urlKey] = publicApiWebcamVariantUrl(
+                $airportId,
+                $camIndex,
+                (string) $variantKey,
+                $format
+            );
         }
     }
     
@@ -642,9 +761,13 @@ function handleGetWebcamMetadata(
     rsort($recommendedSizes);
     
     // Build response
+    $ageSeconds = max(0, time() - $timestamp);
+    $staleFailClosed = getStaleFailclosedSeconds($airport);
     $data = [
         'timestamp' => $timestamp,
         'timestamp_iso' => gmdate('c', $timestamp),
+        'age_seconds' => $ageSeconds,
+        'stale' => $ageSeconds > $staleFailClosed,
         'formats' => $formats,
         'recommended_sizes' => array_values($recommendedSizes),
         'urls' => $urls,

--- a/api/v1/webcams.php
+++ b/api/v1/webcams.php
@@ -70,7 +70,8 @@ function handleListWebcams(array $params, array $context): void
         'webcam_count' => count($formattedWebcams),
     ];
 
-    sendPublicApiCacheHeaders('metadata');
+    // images[0].format is read from disk, so this payload is not hour-stable metadata.
+    sendPublicApiCacheHeaders('live');
     sendPublicApiSuccess(
         ['webcams' => $formattedWebcams],
         $meta
@@ -164,13 +165,18 @@ function formatWebcamMetadata(
 }
 
 /**
- * Configured original plus height variants. Original is jpg only.
+ * Configured original plus height variants.
+ *
+ * Original URL has no fmt: clients cannot pick the native type. format is set
+ * when the current original is a supported jpg, png, or webp so callers know
+ * what GET will return. Omitted when missing or unsupported. Sized rows follow
+ * enabled generation formats.
  *
  * @param string $airportId Airport ID
  * @param int $index Weathercam index
  * @param bool $absoluteUrls When true, URLs use the canonical v1 base
  * @param array|null $config Already-loaded configuration
- * @return list<array{variant: string, height: int|null, format: string, url: string}>
+ * @return list<array{variant: string, height: int|null, format?: string, url: string}>
  */
 function formatWebcamImageVariants(
     string $airportId,
@@ -180,14 +186,17 @@ function formatWebcamImageVariants(
 ): array
 {
     $imagePath = '/airports/' . $airportId . '/webcams/' . $index . '/image';
-    $images = [
-        [
-            'variant' => 'original',
-            'height' => null,
-            'format' => 'jpg',
-            'url' => publicApiV1Url($imagePath, $absoluteUrls),
-        ],
+    $original = [
+        'variant' => 'original',
+        'height' => null,
+        'url' => publicApiV1Url($imagePath, $absoluteUrls),
     ];
+    $path = getWebcamOriginalPath($airportId, $index);
+    $detected = $path !== null ? detectServableWebcamImageFormat($path) : null;
+    if ($detected !== null) {
+        $original['format'] = $detected;
+    }
+    $images = [$original];
 
     $formats = getEnabledWebcamFormats($config);
     foreach (getVariantHeights($airportId, $index, $config) as $height) {

--- a/api/webcam-history.php
+++ b/api/webcam-history.php
@@ -20,8 +20,9 @@
  * 
  *   GET /api/webcam-history.php?id={airport}&cam={index}&ts={timestamp}&fmt={format}
  *     Returns the image for that timestamp in requested format
- *     fmt: 'jpg' (default) or 'webp'
- *     Falls back to JPG if requested format not available
+ *     fmt: 'jpg' (default), 'webp', or 'png'
+ *     Explicit fmt requests are exact; omitted fmt may select another available
+ *     generated format, while omitted fmt for original returns the native format
  * 
  * Response (manifest):
  * {
@@ -51,14 +52,34 @@ require_once __DIR__ . '/../lib/metrics.php';
 // Supported image formats with MIME types
 $supportedFormats = [
     'jpg' => 'image/jpeg',
-    'webp' => 'image/webp'
+    'webp' => 'image/webp',
+    'png' => 'image/png'
 ];
 
 // Get parameters
 $rawIdentifier = isset($_GET['id']) ? trim($_GET['id']) : '';
 $camIndex = isset($_GET['cam']) ? intval($_GET['cam']) : 0;
 $timestamp = isset($_GET['ts']) ? intval($_GET['ts']) : null;
-$requestedFormat = isset($_GET['fmt']) ? strtolower(trim($_GET['fmt'])) : 'jpg';
+$explicitFormatRequest = array_key_exists('fmt', $_GET);
+$rawFormat = $_GET['fmt'] ?? null;
+if (is_array($rawFormat)) {
+    header('Content-Type: application/json');
+    http_response_code(400);
+    echo json_encode(['error' => 'fmt must be a single value']);
+    exit;
+}
+// Normalize through the shared alias map so fmt=jpeg is accepted here as everywhere else.
+$requestedFormat = $explicitFormatRequest ? strtolower(trim((string) $rawFormat)) : 'jpg';
+if ($explicitFormatRequest) {
+    $normalized = normalizeWebcamFormatName($requestedFormat);
+    $requestedFormat = $normalized ?? $requestedFormat;
+}
+if ($explicitFormatRequest && !isset($supportedFormats[$requestedFormat])) {
+    header('Content-Type: application/json');
+    http_response_code(400);
+    echo json_encode(['error' => 'Unsupported image format']);
+    exit;
+}
 $requestedSize = isset($_GET['size']) ? trim($_GET['size']) : 'original';
 
 // Validate airport ID parameter exists
@@ -98,11 +119,6 @@ if ($timestamp !== null) {
     // History images are stored in the camera cache directory (unified storage)
     $cacheDir = getWebcamCameraDir($airportId, $camIndex);
     
-    // Validate requested format
-    if (!isset($supportedFormats[$requestedFormat])) {
-        $requestedFormat = 'jpg';
-    }
-    
     $size = $requestedSize;
     if ($size !== 'original' && is_numeric($size)) {
         $size = (int)$size;
@@ -113,20 +129,34 @@ if ($timestamp !== null) {
         $size = 'original';
     }
     
-    require_once __DIR__ . '/../lib/webcam-metadata.php';
-    $imageFile = getImagePathForSize($airportId, $camIndex, $timestamp, $size, $requestedFormat);
-    $servedFormat = $requestedFormat;
     $servedSize = $size;
-    
-    if ($imageFile === null) {
+    if ($size === 'original') {
+        $resolved = resolveWebcamOriginalAtTimestamp($airportId, $camIndex, $timestamp);
+        $imageFile = $resolved['ok'] ? $resolved['path'] : null;
+    } else {
+        $imageFile = timestampedWebcamImagePathIfExists(
+            $airportId,
+            $camIndex,
+            $timestamp,
+            $size,
+            $requestedFormat
+        );
+    }
+
+    if ($imageFile === null && !$explicitFormatRequest && $size !== 'original') {
         $enabledFormats = getEnabledWebcamFormats();
         foreach ($enabledFormats as $format) {
             if ($format === $requestedFormat) {
                 continue;
             }
-            $imageFile = getImagePathForSize($airportId, $camIndex, $timestamp, $size, $format);
+            $imageFile = timestampedWebcamImagePathIfExists(
+                $airportId,
+                $camIndex,
+                $timestamp,
+                $size,
+                $format
+            );
             if ($imageFile !== null) {
-                $servedFormat = $format;
                 break;
             }
         }
@@ -153,6 +183,25 @@ if ($timestamp !== null) {
         echo json_encode(['error' => 'Access denied']);
         exit;
     }
+
+    $meta = webcamServableImageFileMeta($imageFile);
+    if ($meta === null) {
+        header('Content-Type: application/json');
+        http_response_code(404);
+        echo json_encode(['error' => 'Frame not found', 'timestamp' => $timestamp]);
+        exit;
+    }
+    $servedFormat = $meta['format'];
+    if ($explicitFormatRequest && $servedFormat !== $requestedFormat) {
+        header('Content-Type: application/json');
+        http_response_code(400);
+        echo json_encode([
+            'error' => 'Requested format does not match the image file',
+            'requested_format' => $requestedFormat,
+            'actual_format' => $servedFormat
+        ]);
+        exit;
+    }
     
     // Track webcam serve (history player traffic)
     metrics_track_webcam_request($airportId, $camIndex);
@@ -169,16 +218,17 @@ if ($timestamp !== null) {
     $retentionHours = getWebcamHistoryRetentionHours($airportId);
     $retentionSeconds = $retentionHours * 3600;
     $cacheMaxAge = max(86400, min(2592000, $retentionSeconds));
-    
+
+    header("Cache-Control: public, max-age={$cacheMaxAge}, immutable");
+    header('Access-Control-Allow-Origin: *');
+
     require_once __DIR__ . '/../lib/http-integrity.php';
-    $mtime = filemtime($imageFile);
-    if (addIntegrityHeadersForFile($imageFile, $mtime)) {
+    if (addIntegrityHeadersForFile($imageFile, $meta['mtime'])) {
         exit;
     }
-    header('Content-Type: ' . $supportedFormats[$servedFormat]);
+    header('Content-Type: ' . $meta['content_type']);
     header('Content-Disposition: inline; filename="' . $filename . '"');
-    header("Cache-Control: public, max-age={$cacheMaxAge}, immutable");
-    header('Content-Length: ' . filesize($imageFile));
+    header('Content-Length: ' . $meta['size']);
     header('X-Content-Type-Options: nosniff');
     
     if ($servedFormat !== $requestedFormat) {

--- a/api/webcam.php
+++ b/api/webcam.php
@@ -22,6 +22,7 @@ require_once __DIR__ . '/../lib/constants.php';
 require_once __DIR__ . '/../lib/circuit-breaker.php';
 require_once __DIR__ . '/../lib/webcam-format-generation.php';
 require_once __DIR__ . '/../lib/webcam-metadata.php';
+require_once __DIR__ . '/../lib/webcam-history.php';
 require_once __DIR__ . '/../lib/metrics.php';
 require_once __DIR__ . '/../lib/cache-headers.php';
 // Note: Background refresh for webcams is now handled by the scheduler daemon using
@@ -458,8 +459,11 @@ if (isset($_GET['mtime']) && $_GET['mtime'] === '1') {
         header('X-RateLimit-Remaining: ' . (int)$rl['remaining']);
         header('X-RateLimit-Reset: ' . (int)$rl['reset']);
     }
-    // Get latest timestamp
-    $timestamp = getLatestImageTimestamp($airportId, $camIndex);
+    // Use the same capture identity as current image responses.
+    $currentOriginal = getCurrentServableWebcamOriginal($airportId, $camIndex);
+    $timestamp = $currentOriginal !== null
+        ? $currentOriginal['timestamp']
+        : getLatestImageTimestamp($airportId, $camIndex);
     
     if ($timestamp === 0) {
         echo json_encode([
@@ -583,7 +587,14 @@ if ($rl !== null) {
 
 
 // Parse format parameter (if specified)
-$fmt = isset($_GET['fmt']) ? strtolower(trim($_GET['fmt'])) : null;
+$rawFormat = $_GET['fmt'] ?? null;
+if (is_array($rawFormat)) {
+    http_response_code(400);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'fmt must be a single value']);
+    exit;
+}
+$fmt = $rawFormat !== null ? strtolower(trim((string) $rawFormat)) : null;
 if ($fmt !== null && !in_array($fmt, ['jpg', 'jpeg', 'webp'])) {
     $fmt = null; // Invalid fmt, treat as unspecified
 }
@@ -616,63 +627,60 @@ $airportWebcamRefresh = isset($config['airports'][$airportId]['webcam_refresh_se
 $perCamRefresh = isset($cam['refresh_seconds']) ? intval($cam['refresh_seconds']) : $airportWebcamRefresh;
 $perCamRefresh = max(60, $perCamRefresh); // Enforce minimum 60 seconds (cron constraint)
 
-// Handle download request - serves original JPG with proper filename
-// When ts= provided (history player), serve that frame; otherwise serve latest
+// Download the native original (history player passes ts=; otherwise latest)
 if (isset($_GET['download']) && $_GET['download'] == '1') {
-    $cacheDir = getWebcamCameraDir($airportId, $camIndex);
-    $originalJpg = null;
-
+    $unsupportedOriginal = false;
     if ($requestedTimestamp !== null && $requestedTimestamp > 0) {
-        $originalJpg = getImagePathForSize($airportId, $camIndex, $requestedTimestamp, 'original', 'jpg');
-        if ($originalJpg === null) {
-            $originalJpg = getImagePathForSize($airportId, $camIndex, $requestedTimestamp, 'original', 'webp');
-            if ($originalJpg !== null) {
-                require_once __DIR__ . '/../lib/http-integrity.php';
-                if (addIntegrityHeadersForFile($originalJpg)) {
-                    exit;
-                }
-                header('Content-Type: image/webp');
-                header('Content-Disposition: attachment; filename="' . strtolower($airportId) . "_{$camIndex}_{$requestedTimestamp}.webp\"");
-                header('Content-Length: ' . filesize($originalJpg));
-                readfile($originalJpg);
-                exit;
-            }
-        }
+        $resolved = resolveWebcamOriginalAtTimestamp($airportId, $camIndex, $requestedTimestamp);
+        $originalPath = $resolved['ok'] ? $resolved['path'] : null;
+        $unsupportedOriginal = !$resolved['ok'] && ($resolved['error'] ?? '') === 'unknown';
+    } else {
+        $originalPath = getWebcamOriginalPath($airportId, $camIndex);
     }
 
-    if ($originalJpg === null) {
-        $originalJpg = $cacheDir . '/original.jpg';
+    if ($originalPath === null || !is_readable($originalPath)) {
+        $code = $unsupportedOriginal ? 400 : 404;
+        http_response_code($code);
+        header('Content-Type: application/json');
+        echo json_encode($unsupportedOriginal
+            ? ['error' => 'unsupported_format', 'message' => 'Image format is not supported']
+            : ['error' => 'original_not_available', 'message' => 'Original image not available for download']
+        );
+        exit;
     }
 
-    if (!file_exists($originalJpg) || !is_readable($originalJpg)) {
-        http_response_code(404);
+    $meta = webcamServableImageFileMeta($originalPath);
+    if ($meta === null) {
+        http_response_code(400);
         header('Content-Type: application/json');
         echo json_encode([
-            'error' => 'original_not_available',
-            'message' => 'Original image not available for download'
+            'error' => 'unsupported_format',
+            'message' => 'Image format is not supported'
         ]);
         exit;
     }
 
-    // Get EXIF capture time for filename (or use requested timestamp for history)
-    $captureTime = $requestedTimestamp ?? getImageCaptureTime($originalJpg);
+    $captureTime = $requestedTimestamp ?? getImageCaptureTime($originalPath);
     if ($captureTime > 0) {
         $timestamp = gmdate('Y-m-d_His', $captureTime) . '_UTC';
     } else {
-        $mtime = filemtime($originalJpg);
-        $timestamp = gmdate('Y-m-d_His', $mtime) . '_UTC';
+        $timestamp = gmdate('Y-m-d_His', $meta['mtime']) . '_UTC';
     }
 
-    $filename = strtolower($airportId) . "_{$camIndex}_{$timestamp}.jpg";
+    $filename = strtolower($airportId) . "_{$camIndex}_{$timestamp}." . $meta['format'];
+    if ($requestedTimestamp !== null && $requestedTimestamp > 0) {
+        header('Cache-Control: public, max-age=31536000, immutable');
+    } else {
+        header('Cache-Control: public, max-age=60, s-maxage=60, stale-while-revalidate=30');
+    }
     require_once __DIR__ . '/../lib/http-integrity.php';
-    $mtime = filemtime($originalJpg);
-    if (addIntegrityHeadersForFile($originalJpg, $mtime)) {
+    if (addIntegrityHeadersForFile($originalPath, $meta['mtime'])) {
         exit;
     }
-    header('Content-Type: image/jpeg');
+    header('Content-Type: ' . $meta['content_type']);
     header('Content-Disposition: attachment; filename="' . $filename . '"');
-    header('Content-Length: ' . filesize($originalJpg));
-    readfile($originalJpg);
+    header('Content-Length: ' . $meta['size']);
+    readfile($originalPath);
     exit;
 }
 
@@ -723,7 +731,7 @@ function getImageCaptureTime($filePath) {
  * 
  * @param string $airportId Airport ID
  * @param int $camIndex Camera index
- * @param string $format Format: 'jpg' or 'webp'
+ * @param string $format Format: 'jpg', 'png', or 'webp'
  * @param int $timestamp Image timestamp
  * @return string Webcam URL
  */
@@ -763,6 +771,8 @@ function getMimeTypeForFormat(string $format): string {
     switch ($format) {
         case 'webp':
             return 'image/webp';
+        case 'png':
+            return 'image/png';
         case 'jpg':
         case 'jpeg':
         default:
@@ -1056,10 +1066,11 @@ function serve200Response(string $filePath, string $contentType, ?int $mtime = n
         $metricsTracked = true;
         
         // Determine format from content type
-        $format = 'jpg';
-        if ($contentType === 'image/webp') {
-            $format = 'webp';
-        }
+        $format = match ($contentType) {
+            'image/png' => 'png',
+            'image/webp' => 'webp',
+            default => 'jpg',
+        };
         
         // Track webcam serve
         $size = $requestedSize ?? 'primary';
@@ -1088,7 +1099,11 @@ function serve200Response(string $filePath, string $contentType, ?int $mtime = n
         $timestamp = $latestTimestamp;
     }
     $variant = is_string($requestedSize) ? $requestedSize : (is_numeric($requestedSize) ? (int)$requestedSize : 'original');
-    $ext = ($contentType === 'image/webp') ? 'webp' : 'jpg';
+    $ext = match ($contentType) {
+        'image/png' => 'png',
+        'image/webp' => 'webp',
+        default => 'jpg',
+    };
     $filename = $timestamp . '_' . $variant . '.' . $ext;
     header('Content-Disposition: inline; filename="' . $filename . '"');
     
@@ -1315,8 +1330,19 @@ if (!is_dir($cacheDir) || !is_readable($cacheDir)) {
 
 // Get latest timestamp
 $latestTimestamp = getLatestImageTimestamp($airportId, $camIndex);
+$currentOriginal = null;
 $refreshInterval = getRefreshIntervalForCamera($airportId, $config, $cam);
 $enabledFormats = getEnabledWebcamFormats();
+
+// Judge staleness from the servable capture, not the newest filename: a fresh but
+// corrupt capture must not mask an aged servable original as current.
+$servingNativeCurrentOriginal = $requestedSize === 'original' && !isset($_GET['fmt']);
+if ($servingNativeCurrentOriginal) {
+    $currentOriginal = getCurrentServableWebcamOriginal($airportId, $camIndex);
+    if ($currentOriginal !== null) {
+        $latestTimestamp = $currentOriginal['timestamp'];
+    }
+}
 
 // If no image exists, serve placeholder
 if ($latestTimestamp === 0) {
@@ -1377,11 +1403,31 @@ if ($requestedTimestamp !== null && $requestedTimestamp > 0) {
         $requestedFormat = 'jpg';
     }
     
-    $timestampFile = getImagePathForSize($airportId, $camIndex, $requestedTimestamp, $requestedSize, $requestedFormat);
+    if ($requestedSize === 'original' && !isset($_GET['fmt'])) {
+        $resolved = resolveWebcamOriginalAtTimestamp($airportId, $camIndex, $requestedTimestamp);
+        $timestampFile = $resolved['ok'] ? $resolved['path'] : null;
+        if ($resolved['ok']) {
+            $requestedFormat = $resolved['format'];
+        }
+    } else {
+        $timestampFile = timestampedWebcamImagePathIfExists(
+            $airportId,
+            $camIndex,
+            $requestedTimestamp,
+            $requestedSize,
+            $requestedFormat
+        );
+    }
     
     // Try requested format first, fall back to JPG
     if ($timestampFile === null && $requestedFormat !== 'jpg') {
-        $timestampFile = getImagePathForSize($airportId, $camIndex, $requestedTimestamp, $requestedSize, 'jpg');
+        $timestampFile = timestampedWebcamImagePathIfExists(
+            $airportId,
+            $camIndex,
+            $requestedTimestamp,
+            $requestedSize,
+            'jpg'
+        );
         $requestedFormat = 'jpg';
     }
     
@@ -1391,28 +1437,34 @@ if ($requestedTimestamp !== null && $requestedTimestamp > 0) {
         $cacheDir = getWebcamCameraDir($airportId, $camIndex);
         $realCacheDir = realpath($cacheDir);
         if ($realPath !== false && $realCacheDir !== false && strpos($realPath, $realCacheDir) === 0) {
-            // Track webcam serve (timestamp-based URLs used by dashboard srcset)
-            $sizeForMetrics = $requestedSize ?? 'original';
-            metrics_track_webcam_serve($airportId, $camIndex, $requestedFormat, $sizeForMetrics);
-
-            // Serve timestamp-based file with immutable cache headers
-            $mimeType = getMimeTypeForFormat($requestedFormat);
-            $mtime = @filemtime($timestampFile);
-            
-            // Build filename matching server naming convention: {timestamp}_{variant}.{ext}
-            $variant = ($requestedSize === 'original') ? 'original' : (int)$requestedSize;
-            $filename = $requestedTimestamp . '_' . $variant . '.' . $requestedFormat;
-            
-            require_once __DIR__ . '/../lib/http-integrity.php';
-            if (addIntegrityHeadersForFile($timestampFile, $mtime !== false ? $mtime : null)) {
+            $meta = webcamServableImageFileMeta($timestampFile);
+            if ($meta === null) {
+                http_response_code(400);
+                header('Content-Type: application/json');
+                echo json_encode([
+                    'error' => 'unsupported_format',
+                    'message' => 'Image format is not supported'
+                ]);
                 exit;
             }
-            header('Content-Type: ' . $mimeType);
-            header('Content-Disposition: inline; filename="' . $filename . '"');
+
+            $sizeForMetrics = $requestedSize ?? 'original';
+            metrics_track_webcam_serve($airportId, $camIndex, $meta['format'], $sizeForMetrics);
+
+            $variant = ($requestedSize === 'original') ? 'original' : (int)$requestedSize;
+            $filename = $requestedTimestamp . '_' . $variant . '.' . $meta['format'];
+
             header('Cache-Control: public, max-age=31536000, immutable');
-            header('Content-Length: ' . filesize($timestampFile));
+
+            require_once __DIR__ . '/../lib/http-integrity.php';
+            if (addIntegrityHeadersForFile($timestampFile, $meta['mtime'])) {
+                exit;
+            }
+            header('Content-Type: ' . $meta['content_type']);
+            header('Content-Disposition: inline; filename="' . $filename . '"');
+            header('Content-Length: ' . $meta['size']);
             header('X-Content-Type-Options: nosniff');
-            
+
             readfile($timestampFile);
             exit;
         }
@@ -1434,7 +1486,21 @@ if ($requestedTimestamp !== null && $requestedTimestamp > 0) {
     exit;
 }
 
-$imagePath = getImagePathForSize($airportId, $camIndex, $latestTimestamp, $requestedSize, $preferredFormat);
+if ($servingNativeCurrentOriginal) {
+    $imagePath = $currentOriginal['path'] ?? null;
+    if ($currentOriginal !== null) {
+        $latestTimestamp = $currentOriginal['timestamp'];
+        $preferredFormat = $currentOriginal['format'];
+    }
+} else {
+    $imagePath = getImagePathForSize(
+        $airportId,
+        $camIndex,
+        $latestTimestamp,
+        $requestedSize,
+        $preferredFormat
+    );
+}
 
 // Try preferred format first, then fallback to other enabled formats
 if ($imagePath === null) {
@@ -1480,22 +1546,24 @@ $isExplicitFormatRequest = isset($_GET['fmt']) &&
 
 // Re-determine preferred format (may have changed based on enabled formats)
 $requestedFormatOriginal = null;
-if (isset($_GET['fmt'])) {
-    // Explicit format request
-    $fmt = strtolower(trim($_GET['fmt']));
-    if (in_array($fmt, ['webp', 'jpg', 'jpeg'])) {
-        $preferredFormat = ($fmt === 'jpeg') ? 'jpg' : $fmt;
-        $requestedFormatOriginal = $preferredFormat; // Store original for disabled check
+if (!$servingNativeCurrentOriginal) {
+    if (isset($_GET['fmt'])) {
+        // Explicit format request
+        $fmt = strtolower(trim($_GET['fmt']));
+        if (in_array($fmt, ['webp', 'jpg', 'jpeg'])) {
+            $preferredFormat = ($fmt === 'jpeg') ? 'jpg' : $fmt;
+            $requestedFormatOriginal = $preferredFormat; // Store original for disabled check
+        } else {
+            $preferredFormat = 'jpg'; // Invalid fmt, fallback to JPEG
+        }
     } else {
-        $preferredFormat = 'jpg'; // Invalid fmt, fallback to JPEG
-    }
-} else {
-    // No explicit format - use Accept header for preference, but serve immediately
-    $acceptHeader = $_SERVER['HTTP_ACCEPT'] ?? '';
-    if (stripos($acceptHeader, 'image/webp') !== false) {
-        $preferredFormat = 'webp';
-    } else {
-        $preferredFormat = 'jpg';
+        // No explicit format - use Accept header for preference, but serve immediately
+        $acceptHeader = $_SERVER['HTTP_ACCEPT'] ?? '';
+        if (stripos($acceptHeader, 'image/webp') !== false) {
+            $preferredFormat = 'webp';
+        } else {
+            $preferredFormat = 'jpg';
+        }
     }
 }
 
@@ -1521,7 +1589,7 @@ if ($isExplicitFormatRequest && $requestedFormatOriginal !== null && !in_array($
 }
 
 // Adjust preferred format if disabled
-if (!in_array($preferredFormat, $enabledFormats)) {
+if (!$servingNativeCurrentOriginal && !in_array($preferredFormat, $enabledFormats)) {
     // Find next best enabled format
     if ($preferredFormat === 'webp' && in_array('jpg', $enabledFormats)) {
         $preferredFormat = 'jpg';
@@ -1532,7 +1600,7 @@ if (!in_array($preferredFormat, $enabledFormats)) {
 
 // Check rate limiting (before format logic)
 // If rate limited, serve best available format immediately
-if ($isRateLimited) {
+if ($isRateLimited && !$servingNativeCurrentOriginal) {
     $mostEfficient = findMostEfficientFormat($formatStatus, $airportId, $camIndex, $requestedSize);
     if ($mostEfficient) {
         // Get mtime from format status based on file extension

--- a/lib/cache-paths.php
+++ b/lib/cache-paths.php
@@ -277,10 +277,10 @@ function getWebcamFramesDir(string $airportId, int $camIndex, int $timestamp): s
  *
  * @param string $airportId Airport identifier
  * @param int $camIndex Camera index (0-based)
- * @param string $pattern Glob pattern for files (e.g., '*_*.{jpg,jpeg,webp}' or '*_original.{jpg,jpeg,webp}')
+ * @param string $pattern Glob pattern for files (e.g., '*_*.{jpg,jpeg,png,webp}' or '*_original.{jpg,jpeg,png,webp}')
  * @return array List of full paths to matching files
  */
-function getWebcamImageFiles(string $airportId, int $camIndex, string $pattern = '*_*.{jpg,jpeg,webp}'): array {
+function getWebcamImageFiles(string $airportId, int $camIndex, string $pattern = '*_*.{jpg,jpeg,png,webp}'): array {
     $cacheDir = getWebcamCameraDir($airportId, $camIndex);
     if (!is_dir($cacheDir)) {
         return [];

--- a/lib/embed-templates/dual.php
+++ b/lib/embed-templates/dual.php
@@ -115,7 +115,7 @@ function processDualWidgetData($data, $options) {
             require_once __DIR__ . '/../cache-paths.php';
             require_once __DIR__ . '/../webcam-format-generation.php';
             
-            $files = getWebcamImageFiles($airportId, $camIdx, '*_*.{jpg,jpeg,webp}');
+            $files = getWebcamImageFiles($airportId, $camIdx, '*_*.{jpg,jpeg,png,webp}');
             if (!empty($files)) {
                 usort($files, function($a, $b) {
                     return filemtime($b) - filemtime($a);

--- a/lib/embed-templates/multi.php
+++ b/lib/embed-templates/multi.php
@@ -110,7 +110,7 @@ function processMultiWidgetData($data, $options) {
             require_once __DIR__ . '/../cache-paths.php';
             require_once __DIR__ . '/../webcam-format-generation.php';
             
-            $files = getWebcamImageFiles($airportId, $camIdx, '*_*.{jpg,jpeg,webp}');
+            $files = getWebcamImageFiles($airportId, $camIdx, '*_*.{jpg,jpeg,png,webp}');
             if (!empty($files)) {
                 usort($files, function($a, $b) {
                     return filemtime($b) - filemtime($a);

--- a/lib/embed-templates/webcam.php
+++ b/lib/embed-templates/webcam.php
@@ -38,7 +38,7 @@ function processWebcamWidgetData($data, $options) {
         require_once __DIR__ . '/../cache-paths.php';
         require_once __DIR__ . '/../webcam-format-generation.php';
         
-        $files = getWebcamImageFiles($airportId, $webcamIndex, '*_*.{jpg,jpeg,webp}');
+        $files = getWebcamImageFiles($airportId, $webcamIndex, '*_*.{jpg,jpeg,png,webp}');
         if (!empty($files)) {
             usort($files, function($a, $b) {
                 return filemtime($b) - filemtime($a);

--- a/lib/image-transform.php
+++ b/lib/image-transform.php
@@ -15,6 +15,18 @@
 require_once __DIR__ . '/cache-paths.php';
 require_once __DIR__ . '/logger.php';
 require_once __DIR__ . '/exif-utils.php';
+require_once __DIR__ . '/webcam-metadata.php';
+
+/**
+ * Native original used as the transform source (jpg, png, or webp).
+ *
+ * @return string|null Path to a servable original, or null if missing/unsupported
+ */
+function resolveWebcamTransformSourcePath(string $airportId, int $camIndex, int $timestamp): ?string
+{
+    $resolved = resolveWebcamOriginalAtTimestamp($airportId, $camIndex, $timestamp);
+    return $resolved['ok'] ? $resolved['path'] : null;
+}
 
 // Maximum dimensions to prevent abuse
 if (!defined('IMAGE_TRANSFORM_MAX_WIDTH')) {
@@ -224,15 +236,8 @@ function getTransformedImagePath(
         return $cachePath;
     }
     
-    // Find source image (prefer original JPG)
-    $sourcePath = getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, 'jpg');
-    
-    if (!file_exists($sourcePath)) {
-        // Try WebP source
-        $sourcePath = getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, 'webp');
-    }
-    
-    if (!file_exists($sourcePath)) {
+    $sourcePath = resolveWebcamTransformSourcePath($airportId, $camIndex, $timestamp);
+    if ($sourcePath === null) {
         aviationwx_log('warning', 'image transform no source found', [
             'airport' => $airportId,
             'cam' => $camIndex,
@@ -674,15 +679,8 @@ function getFaaTransformedImagePath(
         }
     }
     
-    // Find source image (prefer original JPG)
-    $sourcePath = getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, 'jpg');
-    
-    if (!file_exists($sourcePath)) {
-        // Try WebP source
-        $sourcePath = getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, 'webp');
-    }
-    
-    if (!file_exists($sourcePath)) {
+    $sourcePath = resolveWebcamTransformSourcePath($airportId, $camIndex, $timestamp);
+    if ($sourcePath === null) {
         aviationwx_log('warning', 'FAA transform no source found', [
             'airport' => $airportId,
             'cam' => $camIndex,

--- a/lib/metrics-apply-counters.php
+++ b/lib/metrics-apply-counters.php
@@ -45,7 +45,7 @@ function metrics_apply_flat_counters_to_hour_data(array &$hourData, array $count
             if (!isset($hourData['webcams'][$webcamKey])) {
                 $hourData['webcams'][$webcamKey] = [
                     'requests' => 0,
-                    'by_format' => ['jpg' => 0, 'webp' => 0],
+                    'by_format' => ['jpg' => 0, 'png' => 0, 'webp' => 0],
                     'by_size' => [] // Dynamic: height-based variants like '720', '360', 'original'
                 ];
             }
@@ -53,15 +53,18 @@ function metrics_apply_flat_counters_to_hour_data(array &$hourData, array $count
                 $hourData['webcams'][$webcamKey]['requests'] = 0;
             }
             $hourData['webcams'][$webcamKey]['requests'] += $value;
-        } elseif (preg_match('/^webcam_([a-z0-9]+)_(\d+)_(jpg|webp)$/', $key, $m)) {
+        } elseif (preg_match('/^webcam_([a-z0-9]+)_(\d+)_(jpg|png|webp)$/', $key, $m)) {
             $webcamKey = $m[1] . '_' . $m[2];
             $format = $m[3];
             if (!isset($hourData['webcams'][$webcamKey])) {
                 $hourData['webcams'][$webcamKey] = [
                     'requests' => 0,
-                    'by_format' => ['jpg' => 0, 'webp' => 0],
+                    'by_format' => ['jpg' => 0, 'png' => 0, 'webp' => 0],
                     'by_size' => []
                 ];
+            }
+            if (!isset($hourData['webcams'][$webcamKey]['by_format'][$format])) {
+                $hourData['webcams'][$webcamKey]['by_format'][$format] = 0;
             }
             $hourData['webcams'][$webcamKey]['by_format'][$format] += $value;
         } elseif (preg_match('/^webcam_([a-z0-9]+)_(\d+)_size_(\w+)$/', $key, $m)) {
@@ -71,7 +74,7 @@ function metrics_apply_flat_counters_to_hour_data(array &$hourData, array $count
             if (!isset($hourData['webcams'][$webcamKey])) {
                 $hourData['webcams'][$webcamKey] = [
                     'requests' => 0,
-                    'by_format' => ['jpg' => 0, 'webp' => 0],
+                    'by_format' => ['jpg' => 0, 'png' => 0, 'webp' => 0],
                     'by_size' => []
                 ];
             }
@@ -79,7 +82,10 @@ function metrics_apply_flat_counters_to_hour_data(array &$hourData, array $count
                 $hourData['webcams'][$webcamKey]['by_size'][$size] = 0;
             }
             $hourData['webcams'][$webcamKey]['by_size'][$size] += $value;
-        } elseif (preg_match('/^format_(jpg|webp)_served$/', $key, $m)) {
+        } elseif (preg_match('/^format_(jpg|png|webp)_served$/', $key, $m)) {
+            if (!isset($hourData['global']['format_served'][$m[1]])) {
+                $hourData['global']['format_served'][$m[1]] = 0;
+            }
             $hourData['global']['format_served'][$m[1]] += $value;
         } elseif (preg_match('/^size_(\w+)_served$/', $key, $m)) {
             // Match both height-based and named sizes
@@ -211,9 +217,9 @@ function metrics_flat_counter_key_is_recognized(string $key): bool
         || preg_match('/^airport_([a-z0-9]+)_weather$/', $key) === 1
         || preg_match('/^airport_([a-z0-9]+)_webcam_requests$/', $key) === 1
         || preg_match('/^webcam_([a-z0-9]+)_(\d+)_requests$/', $key) === 1
-        || preg_match('/^webcam_([a-z0-9]+)_(\d+)_(jpg|webp)$/', $key) === 1
+        || preg_match('/^webcam_([a-z0-9]+)_(\d+)_(jpg|png|webp)$/', $key) === 1
         || preg_match('/^webcam_([a-z0-9]+)_(\d+)_size_(\w+)$/', $key) === 1
-        || preg_match('/^format_(jpg|webp)_served$/', $key) === 1
+        || preg_match('/^format_(jpg|png|webp)_served$/', $key) === 1
         || preg_match('/^size_(\w+)_served$/', $key) === 1
         || $key === 'global_page_views'
         || $key === 'global_weather_requests'

--- a/lib/metrics.php
+++ b/lib/metrics.php
@@ -7,7 +7,7 @@
  * 
  * Metrics tracked:
  * - Airport page views, weather requests, webcam requests
- * - Webcam serves by format (jpg, webp)
+ * - Webcam serves by format (jpg, png, webp)
  * - Webcam serves by size (height-based: 720, 360, 1080, original)
  * - Webcam image processing (variants_generated, verified, rejected)
  * - Map tile serves by source (openweathermap, rainviewer)
@@ -54,7 +54,7 @@ function metrics_get_empty_global(): array {
         'variants_generated' => 0,
         'tiles_served' => 0,
         'tiles_by_source' => ['openweathermap' => 0, 'rainviewer' => 0],
-        'format_served' => ['jpg' => 0, 'webp' => 0],
+        'format_served' => ['jpg' => 0, 'png' => 0, 'webp' => 0],
         'size_served' => [],
         'browser_support' => ['webp' => 0, 'jpg_only' => 0],
         'cache' => ['hits' => 0, 'misses' => 0]
@@ -82,9 +82,37 @@ function metrics_get_empty_airport(): array {
 function metrics_get_empty_webcam(): array {
     return [
         'requests' => 0,
-        'by_format' => ['jpg' => 0, 'webp' => 0],
+        'by_format' => ['jpg' => 0, 'png' => 0, 'webp' => 0],
         'by_size' => []
     ];
+}
+
+/**
+ * Sum per-webcam by_format counts for status display.
+ *
+ * Unknown format keys are initialized on first sight (same as by_size) so a
+ * PNG or future bucket does not warn under error reporting.
+ *
+ * @param array $webcamMetrics Map of webcam key => metrics row
+ * @return array<string, int>
+ */
+function metricsSumWebcamFormatTotals(array $webcamMetrics): array
+{
+    $formatTotals = metrics_get_empty_webcam()['by_format'];
+    foreach ($webcamMetrics as $camData) {
+        if (!is_array($camData)) {
+            continue;
+        }
+        foreach ($camData['by_format'] ?? [] as $fmt => $count) {
+            $fmt = (string) $fmt;
+            if (!isset($formatTotals[$fmt])) {
+                $formatTotals[$fmt] = 0;
+            }
+            $formatTotals[$fmt] += (int) $count;
+        }
+    }
+
+    return $formatTotals;
 }
 
 // =============================================================================
@@ -434,7 +462,7 @@ function metrics_track_webcam_request(string $airportId, int $camIndex): void {
  * 
  * @param string $airportId Airport identifier
  * @param int $camIndex Camera index
- * @param string $format Image format (jpg, webp)
+ * @param string $format Image format (jpg, png, webp)
  * @param string|int $size Image size variant (height like 720, 360, 1080 or 'original')
  * @return void
  */
@@ -708,7 +736,7 @@ function metrics_new_empty_hour_bucket(string $hourId): array {
             'variants_generated' => 0,
             'tiles_served' => 0,
             'tiles_by_source' => ['openweathermap' => 0, 'rainviewer' => 0],
-            'format_served' => ['jpg' => 0, 'webp' => 0],
+            'format_served' => ['jpg' => 0, 'png' => 0, 'webp' => 0],
             'size_served' => [],
             'browser_support' => ['webp' => 0, 'jpg_only' => 0],
             'cache' => ['hits' => 0, 'misses' => 0],

--- a/lib/public-api/query.php
+++ b/lib/public-api/query.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Public API query parsing helpers.
+ */
+
+require_once dirname(__DIR__) . '/webcam-format-generation.php';
+
+/**
+ * Parse fmt against enabled webcam generation formats.
+ *
+ * Omit fmt for the native original; fmt is only for generated size variants.
+ *
+ * @param string|null $raw Raw fmt query value
+ * @return array{ok: true, explicit: bool, format: ?string, error: null}|array{ok: false, explicit: true, format: ?string, error: string}
+ */
+function parsePublicApiWebcamFmtQuery(?string $raw): array
+{
+    if ($raw === null || trim($raw) === '') {
+        return ['ok' => true, 'explicit' => false, 'format' => null, 'error' => null];
+    }
+
+    $format = normalizeWebcamFormatName($raw);
+    if ($format === null) {
+        return [
+            'ok' => false,
+            'explicit' => true,
+            'format' => null,
+            'error' => 'Unknown image format',
+        ];
+    }
+
+    if (!in_array($format, getEnabledWebcamFormats(), true)) {
+        return [
+            'ok' => false,
+            'explicit' => true,
+            'format' => $format,
+            'error' => "Format '{$format}' is not enabled",
+        ];
+    }
+
+    return ['ok' => true, 'explicit' => true, 'format' => $format, 'error' => null];
+}
+
+/**
+ * Parse fmt from the current request without coercing array-shaped input.
+ *
+ * @return array{ok: true, explicit: bool, format: ?string, error: null}|array{ok: false, explicit: true, format: ?string, error: string}
+ */
+function parsePublicApiWebcamFmtQueryFromGet(): array
+{
+    if (!array_key_exists('fmt', $_GET)) {
+        return parsePublicApiWebcamFmtQuery(null);
+    }
+
+    $raw = $_GET['fmt'];
+    if (is_array($raw)) {
+        return [
+            'ok' => false,
+            'explicit' => true,
+            'format' => null,
+            'error' => 'fmt must be a single value',
+        ];
+    }
+
+    return parsePublicApiWebcamFmtQuery((string) $raw);
+}

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -113,10 +113,7 @@ function checkSystemHealth(): array {
                             $hourDirs = glob($dateDir . '/[0-2][0-9]', GLOB_ONLYDIR);
                             if ($hourDirs !== false) {
                                 foreach ($hourDirs as $hourDir) {
-                                    $hourFiles = glob($hourDir . '/*.{jpg,webp}', GLOB_BRACE);
-                                    if ($hourFiles !== false) {
-                                        $files = array_merge($files, $hourFiles);
-                                    }
+                                    $files = array_merge($files, globWebcamHourDirImageFiles($hourDir));
                                 }
                             }
                         }
@@ -1560,10 +1557,7 @@ function checkAirportHealth(string $airportId, array $airport): array {
                         $hourDirs = glob($dateDir . '/[0-2][0-9]', GLOB_ONLYDIR);
                         if ($hourDirs !== false) {
                             foreach ($hourDirs as $hourDir) {
-                                $hourFiles = glob($hourDir . '/*.{jpg,webp}', GLOB_BRACE);
-                                if ($hourFiles !== false) {
-                                    $files = array_merge($files, $hourFiles);
-                                }
+                                $files = array_merge($files, globWebcamHourDirImageFiles($hourDir));
                             }
                         }
                     }

--- a/lib/webcam-acquisition.php
+++ b/lib/webcam-acquisition.php
@@ -1345,12 +1345,9 @@ class PushAcquisitionStrategy extends BaseAcquisitionStrategy
         require_once __DIR__ . '/webcam-format-generation.php';
         require_once __DIR__ . '/webcam-history.php';
 
-        $format = detectImageFormat($file);
+        $format = detectServableWebcamImageFormat($file);
         if ($format === null) {
             return ['valid' => false, 'reason' => 'invalid_format'];
-        }
-        if ($format === 'jpeg') {
-            $format = 'jpg';
         }
 
         if (isImageComplete($file, $format)) {
@@ -1415,12 +1412,9 @@ class PushAcquisitionStrategy extends BaseAcquisitionStrategy
 
         // Check image format
         require_once __DIR__ . '/webcam-format-generation.php';
-        $format = detectImageFormat($file);
+        $format = detectServableWebcamImageFormat($file);
         if ($format === null) {
             return ['valid' => false, 'reason' => 'invalid_format'];
-        }
-        if ($format === 'jpeg') {
-            $format = 'jpg';
         }
 
         // Truncated uploads (defense in depth; primary gate runs before EXIF)

--- a/lib/webcam-format-generation.php
+++ b/lib/webcam-format-generation.php
@@ -22,50 +22,340 @@ require_once __DIR__ . '/variant-health.php';
 require_once __DIR__ . '/webcam-image-metrics.php';
 
 /**
- * Detect image format from file headers
- * 
- * Reads file headers to determine image format.
- * 
- * @param string $filePath Path to image file
- * @return string|null Format: 'jpg', 'png', 'webp', or null if unknown
+ * Classify jpg, png, or webp from magic bytes.
+ *
+ * @param string $header At least 12 bytes of the file, or the full body
+ * @return string|null jpg, png, or webp
  */
-function detectImageFormat($filePath) {
+function detectImageFormatFromHeader(string $header): ?string
+{
+    if (strlen($header) < 12) {
+        return null;
+    }
+
+    if (substr($header, 0, 3) === "\xFF\xD8\xFF") {
+        return 'jpg';
+    }
+
+    if (substr($header, 0, 8) === "\x89\x50\x4E\x47\x0D\x0A\x1A\x0A") {
+        return 'png';
+    }
+
+    if (substr($header, 0, 4) === 'RIFF' && substr($header, 8, 4) === 'WEBP') {
+        // A WebP RIFF header opens with RIFF + a uint32 little-endian size
+        // (file bytes minus 8) + WEBP. Reject a zero-sized chunk stub so a
+        // truncated RIFF\\0\\0\\0\\0WEBP isn't served as a valid webp.
+        $riffSize = unpack('V', substr($header, 4, 4))[1];
+        if ($riffSize < 4) {
+            return null;
+        }
+        return 'webp';
+    }
+
+    return null;
+}
+
+/**
+ * Detect image format from file headers.
+ *
+ * @param string $filePath Path to image file
+ * @return string|null jpg, png, webp, or null if the bytes are not one of those types
+ */
+function detectImageFormat($filePath): ?string
+{
+    // @: missing or unreadable files are treated as unknown type
     $handle = @fopen($filePath, 'rb');
     if (!$handle) {
         return null;
     }
-    
+
+    // @: short or unreadable files are unknown type
     $header = @fread($handle, 12);
-    if (!$header || strlen($header) < 12) {
-        @fclose($handle);
-        return null;
-    }
-    
-    // JPEG: FF D8 FF
-    if (substr($header, 0, 3) === "\xFF\xD8\xFF") {
-        @fclose($handle);
-        return 'jpg';
-    }
-    
-    // PNG: 89 50 4E 47 0D 0A 1A 0A
-    if (substr($header, 0, 8) === "\x89\x50\x4E\x47\x0D\x0A\x1A\x0A") {
-        @fclose($handle);
-        return 'png';
-    }
-    
-    // WebP: RIFF...WEBP
-    if (substr($header, 0, 4) === 'RIFF') {
-        @fseek($handle, 8);
-        $more = @fread($handle, 4);
-        @fclose($handle);
-        if ($more && strpos($more, 'WEBP') !== false) {
-            return 'webp';
-        }
-        return null;
-    }
-    
     @fclose($handle);
-    return null;
+    if (!$header) {
+        return null;
+    }
+
+    return detectImageFormatFromHeader($header);
+}
+
+/**
+ * Formats allowed for native originals and Public API image bodies.
+ *
+ * @return list<string>
+ */
+function getSupportedWebcamSourceFormats(): array
+{
+    return ['jpg', 'png', 'webp'];
+}
+
+/**
+ * File extensions stored for a format name (jpeg files are jpg).
+ *
+ * @param string $format Format name from getSupportedWebcamSourceFormats()
+ * @return list<string>
+ */
+function webcamSourceFormatFileExtensions(string $format): array
+{
+    if (!in_array($format, getSupportedWebcamSourceFormats(), true)) {
+        return [];
+    }
+
+    if ($format === 'jpg') {
+        return ['jpg', 'jpeg'];
+    }
+
+    return [$format];
+}
+
+/**
+ * Extensions scanned for native originals (jpg, jpeg, png, webp).
+ *
+ * @return list<string>
+ */
+function webcamSupportedOriginalFileExtensions(): array
+{
+    $exts = [];
+    foreach (getSupportedWebcamSourceFormats() as $format) {
+        foreach (webcamSourceFormatFileExtensions($format) as $ext) {
+            $exts[] = $ext;
+        }
+    }
+
+    return $exts;
+}
+
+/**
+ * Normalize a format query to a supported name, or null if unknown.
+ *
+ * @param string $format Raw fmt value
+ * @return string|null jpg, png, or webp
+ */
+function normalizeWebcamFormatName(string $format): ?string
+{
+    $format = strtolower(trim($format));
+    if ($format === 'jpeg') {
+        $format = 'jpg';
+    }
+
+    if (!in_array($format, getSupportedWebcamSourceFormats(), true)) {
+        return null;
+    }
+
+    return $format;
+}
+
+/**
+ * Header-detected format if it is on the serve allowlist.
+ *
+ * @param string $path Existing image path
+ * @return string|null jpg, png, or webp
+ */
+function detectServableWebcamImageFormat(string $path): ?string
+{
+    $detected = detectImageFormat($path);
+    if ($detected === null || !in_array($detected, getSupportedWebcamSourceFormats(), true)) {
+        return null;
+    }
+
+    return $detected;
+}
+
+/**
+ * @param string $bytes File contents
+ * @return string|null jpg, png, or webp
+ */
+function detectServableWebcamImageFormatFromBytes(string $bytes): ?string
+{
+    $detected = detectImageFormatFromHeader($bytes);
+    if ($detected === null || !in_array($detected, getSupportedWebcamSourceFormats(), true)) {
+        return null;
+    }
+
+    return $detected;
+}
+
+/**
+ * Explicit fmt= must match file magic. Native original (no fmt) uses the detected type.
+ */
+function webcamExplicitFmtMatchesFile(bool $explicitRequest, string $requestedFormat, string $detectedFormat): bool
+{
+    return !$explicitRequest || $requestedFormat === $detectedFormat;
+}
+
+/**
+ * Content-Type for a supported webcam image format.
+ *
+ * @param string $format jpg, png, or webp
+ * @return string|null Null when the format must not be served
+ */
+function webcamImageContentType(string $format): ?string
+{
+    return match ($format) {
+        'jpg' => 'image/jpeg',
+        'png' => 'image/png',
+        'webp' => 'image/webp',
+        default => null,
+    };
+}
+
+/**
+ * @param string $bytes File contents
+ * @return array{format: string, content_type: string}|null
+ */
+function webcamServableImageContentFromBytes(string $bytes): ?array
+{
+    $format = detectServableWebcamImageFormatFromBytes($bytes);
+    if ($format === null) {
+        return null;
+    }
+
+    $contentType = webcamImageContentType($format);
+    if ($contentType === null) {
+        return null;
+    }
+
+    return ['format' => $format, 'content_type' => $contentType];
+}
+
+/**
+ * Type from path using a 12-byte header read (not the body that will be sent).
+ *
+ * @param string $path Existing file path
+ * @return array{format: string, content_type: string}|null
+ */
+function webcamServableImageContent(string $path): ?array
+{
+    $format = detectServableWebcamImageFormat($path);
+    if ($format === null) {
+        return null;
+    }
+
+    $contentType = webcamImageContentType($format);
+    if ($contentType === null) {
+        return null;
+    }
+
+    return ['format' => $format, 'content_type' => $contentType];
+}
+
+/**
+ * Read a file and classify the same buffer that will be sent.
+ *
+ * @param string $path Existing file path
+ * @return array{format: string, content_type: string, bytes: string}|null
+ */
+function webcamReadServableImage(string $path): ?array
+{
+    // @: file can vanish between existence check and read
+    $bytes = @file_get_contents($path);
+    if ($bytes === false || $bytes === '') {
+        return null;
+    }
+
+    $served = webcamServableImageContentFromBytes($bytes);
+    if ($served === null) {
+        return null;
+    }
+
+    $served['bytes'] = $bytes;
+
+    return $served;
+}
+
+/**
+ * Classify a file from its 12-byte header and stat it for a streamed send.
+ *
+ * Magic-byte type does not require the body in PHP memory. Callers hash and
+ * stream from the file descriptor path instead of buffering the admission-sized
+ * original.
+ *
+ * @return array{format: string, content_type: string, size: int, mtime: int}|null
+ */
+function webcamServableImageFileMeta(string $path): ?array
+{
+    $served = webcamServableImageContent($path);
+    if ($served === null) {
+        return null;
+    }
+
+    // @: file can vanish between classify and stat
+    $size = @filesize($path);
+    $mtime = @filemtime($path);
+    if ($size === false || $size <= 0 || $mtime === false) {
+        return null;
+    }
+
+    return [
+        'format' => $served['format'],
+        'content_type' => $served['content_type'],
+        'size' => (int) $size,
+        'mtime' => (int) $mtime,
+    ];
+}
+
+/**
+ * Brace glob of extensions for native originals and timestamp scans.
+ *
+ * @return string e.g. {jpg,jpeg,png,webp}
+ */
+function webcamSupportedOriginalGlobBrace(): string
+{
+    return '{' . implode(',', webcamSupportedOriginalFileExtensions()) . '}';
+}
+
+/**
+ * Alternation for basename matching of original and variant files.
+ *
+ * @return string e.g. jpg|jpeg|png|webp
+ */
+function webcamSupportedOriginalExtensionPattern(): string
+{
+    $quoted = [];
+    foreach (webcamSupportedOriginalFileExtensions() as $ext) {
+        $quoted[] = preg_quote($ext, '/');
+    }
+
+    return implode('|', $quoted);
+}
+
+/**
+ * Timestamped image files in a date/hour frames directory.
+ *
+ * @param string $hourDir Absolute path to a YYYY-MM-DD/HH frames directory
+ * @return list<string>
+ */
+function globWebcamHourDirImageFiles(string $hourDir): array
+{
+    $files = glob($hourDir . '/*.' . webcamSupportedOriginalGlobBrace(), GLOB_BRACE);
+    if ($files === false) {
+        return [];
+    }
+
+    return $files;
+}
+
+/**
+ * Capture timestamp for a servable original, or null if it must not be used.
+ *
+ * Basename `{timestamp}_original.*` wins over mtime so a leftover file cannot
+ * outrank a newer frame when mtimes are equal or rewritten.
+ *
+ * @param string $path Existing original file path
+ * @return int|null Unix timestamp rank
+ */
+function webcamServableOriginalCaptureRank(string $path): ?int
+{
+    if (!file_exists($path) || detectServableWebcamImageFormat($path) === null) {
+        return null;
+    }
+
+    if (preg_match('/^(\d+)_original\./', basename($path), $matches) === 1) {
+        return (int) $matches[1];
+    }
+
+    $mtime = filemtime($path);
+    return $mtime !== false ? $mtime : 0;
 }
 
 /**
@@ -201,8 +491,7 @@ function getSourceCaptureTime($filePath) {
 /**
  * Convert PNG to JPEG
  * 
- * PNG is always converted to JPEG (we don't serve PNG).
- * Uses GD library for fast conversion.
+ * Used when a downstream variant explicitly requires JPEG output.
  * 
  * @param string $pngFile Source PNG file path
  * @param string $jpegFile Target JPEG file path
@@ -301,8 +590,6 @@ function getTimestampCacheFilePath(string $airportId, int $camIndex, int $timest
     $framesDir = getWebcamFramesDir($airportId, $camIndex, $timestamp);
     return $framesDir . '/' . $timestamp . '_' . $variant . '.' . $format;
 }
-
-// getCacheSymlinkPath() is now defined in cache-paths.php
 
 /**
  * Get cache file path for a webcam image
@@ -471,6 +758,37 @@ function cleanupStagingFiles(string $airportId, int $camIndex): int {
 }
 
 /**
+ * Resolve timestamped files protected by live webcam symlinks.
+ *
+ * @param string $cacheDir Camera cache directory
+ * @return array<string, true> Real target path set
+ */
+function getWebcamLiveSymlinkTargets(string $cacheDir): array
+{
+    $targets = [];
+    $symlinks = array_merge(
+        glob($cacheDir . '/current.*') ?: [],
+        glob($cacheDir . '/original.*') ?: []
+    );
+    foreach ($symlinks as $symlink) {
+        if (!is_link($symlink)) {
+            continue;
+        }
+        $target = readlink($symlink);
+        if ($target === false) {
+            continue;
+        }
+        $targetPath = $target[0] === '/' ? $target : dirname($symlink) . '/' . $target;
+        $realTarget = realpath($targetPath);
+        if ($realTarget !== false) {
+            $targets[$realTarget] = true;
+        }
+    }
+
+    return $targets;
+}
+
+/**
  * Cleanup old timestamp-based cache files
  * 
  * Uses time-based retention with a frame count safety limit.
@@ -521,10 +839,7 @@ function cleanupOldTimestampFiles(string $airportId, int $camIndex, ?int $keepCo
             $hourDirs = glob($dateDir . '/[0-2][0-9]', GLOB_ONLYDIR);
             if ($hourDirs !== false) {
                 foreach ($hourDirs as $hourDir) {
-                    $files = glob($hourDir . '/*.{jpg,webp}', GLOB_BRACE);
-                    if ($files !== false) {
-                        $allFiles = array_merge($allFiles, $files);
-                    }
+                    $allFiles = array_merge($allFiles, globWebcamHourDirImageFiles($hourDir));
                 }
             }
         }
@@ -533,17 +848,15 @@ function cleanupOldTimestampFiles(string $airportId, int $camIndex, ?int $keepCo
         return 0;
     }
     
-    // Filter out symlinks and only keep timestamp-based files
     $timestampFiles = [];
+    $extPattern = webcamSupportedOriginalExtensionPattern();
     foreach ($allFiles as $file) {
-        // Skip symlinks (they're not timestamp files themselves)
         if (is_link($file)) {
             continue;
         }
-        
+
         $basename = basename($file);
-        // Match timestamp-based filename: "1703700000_original.jpg" or "1703700000_720.jpg"
-        if (preg_match('/^(\d+)(?:_[^_]+)?\.(jpg|webp)$/', $basename, $matches)) {
+        if (preg_match('/^(\d+)(?:_[^_]+)?\.(' . $extPattern . ')$/', $basename, $matches)) {
             $timestamp = (int)$matches[1];
             if (!isset($timestampFiles[$timestamp])) {
                 $timestampFiles[$timestamp] = [];
@@ -556,23 +869,7 @@ function cleanupOldTimestampFiles(string $airportId, int $camIndex, ?int $keepCo
         return 0;
     }
     
-    // Get symlink targets to protect from deletion (targets are in date/hour subdirs)
-    $symlinkTargets = [];
-    $symlinks = glob($cacheDir . '/current.*');
-    if ($symlinks !== false) {
-        foreach ($symlinks as $symlink) {
-            if (is_link($symlink)) {
-                $target = readlink($symlink);
-                if ($target !== false) {
-                    $targetPath = $target[0] === '/' ? $target : dirname($symlink) . '/' . $target;
-                    $realTarget = realpath($targetPath);
-                    if ($realTarget !== false) {
-                        $symlinkTargets[basename($realTarget)] = true;
-                    }
-                }
-            }
-        }
-    }
+    $symlinkTargets = getWebcamLiveSymlinkTargets($cacheDir);
     
     $cleaned = 0;
     $initialCount = count($timestampFiles);
@@ -588,8 +885,8 @@ function cleanupOldTimestampFiles(string $airportId, int $camIndex, ?int $keepCo
     
     foreach ($timestampsToRemoveByTime as $timestamp) {
         foreach ($timestampFiles[$timestamp] as $file) {
-            $basename = basename($file);
-            if (isset($symlinkTargets[$basename])) {
+            $realFile = realpath($file);
+            if ($realFile !== false && isset($symlinkTargets[$realFile])) {
                 continue;
             }
             if (@unlink($file)) {
@@ -612,8 +909,8 @@ function cleanupOldTimestampFiles(string $airportId, int $camIndex, ?int $keepCo
         
         foreach ($timestampsToRemoveBySafety as $timestamp) {
             foreach ($timestampFiles[$timestamp] as $file) {
-                $basename = basename($file);
-                if (isset($symlinkTargets[$basename])) {
+                $realFile = realpath($file);
+                if ($realFile !== false && isset($symlinkTargets[$realFile])) {
                     continue;
                 }
                 if (@unlink($file)) {
@@ -1266,6 +1563,17 @@ function generateVariantsFromOriginal(string $sourceFile, string $airportId, int
     
     $timeout = getFormatGenerationTimeout();
     $deadline = time() + $timeout;
+
+    // Format before dimensions: ffprobe can size non-images. Do not assume JPEG.
+    $sourceFormat = detectServableWebcamImageFormat($sourceFile);
+    if ($sourceFormat === null) {
+        aviationwx_log('error', 'generateVariantsFromOriginal: unsupported source format', [
+            'airport' => $airportId,
+            'cam' => $camIndex,
+            'source_file' => $sourceFile
+        ], 'app');
+        return ['original' => null, 'variants' => [], 'metadata' => null];
+    }
     
     // Get input dimensions
     $inputDimensions = getImageDimensions($sourceFile);
@@ -1281,12 +1589,6 @@ function generateVariantsFromOriginal(string $sourceFile, string $airportId, int
     $originalWidth = $inputDimensions['width'];
     $originalHeight = $inputDimensions['height'];
     $aspectRatio = $originalWidth / $originalHeight;
-    
-    // Detect source format
-    $sourceFormat = detectImageFormat($sourceFile);
-    if ($sourceFormat === null) {
-        $sourceFormat = 'jpg'; // Default fallback
-    }
     
     require_once __DIR__ . '/webcam-metadata.php';
     $variantHeights = getVariantHeights($airportId, $camIndex);

--- a/lib/webcam-history.php
+++ b/lib/webcam-history.php
@@ -18,6 +18,85 @@
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/logger.php';
 require_once __DIR__ . '/cache-paths.php';
+require_once __DIR__ . '/webcam-metadata.php';
+
+/**
+ * Locate a historical size variant without substituting a different format.
+ *
+ * History URLs are immutable, so only files for this timestamp are used.
+ * Staging files belong to in-progress live promotion and must not be served
+ * as an old timestamp. When the requested height is missing, the same-format
+ * original for that timestamp may be used. A missing format is not replaced
+ * with another format.
+ *
+ * @param string $airportId Airport ID
+ * @param int $camIndex Camera index (0-based)
+ * @param int $timestamp Frame timestamp
+ * @param string|int $size original or height
+ * @param string $format Requested generation format (jpg, webp)
+ * @return array{path: ?string, size: string|int}
+ */
+function findHistoricalWebcamSizeFile(
+    string $airportId,
+    int $camIndex,
+    int $timestamp,
+    string|int $size,
+    string $format
+): array {
+    $resolvedSize = $size;
+    $cacheFile = timestampedWebcamImagePathIfExists($airportId, $camIndex, $timestamp, $size, $format);
+    if ($cacheFile === null && $size !== 'original') {
+        $original = timestampedWebcamImagePathIfExists(
+            $airportId,
+            $camIndex,
+            $timestamp,
+            'original',
+            $format
+        );
+        if ($original !== null) {
+            $cacheFile = $original;
+            $resolvedSize = 'original';
+        }
+    }
+
+    return ['path' => $cacheFile, 'size' => $resolvedSize];
+}
+
+/**
+ * Resolve the exact timestamped frame path for a requested size/format.
+ *
+ * For the original size, only the known source-format extensions are probed;
+ * for a numeric size the variant path is returned if it exists. Returns null
+ * when no matching file is present on disk.
+ *
+ * @param string $airportId Airport identifier
+ * @param int $camIndex Camera index (0-based)
+ * @param int $timestamp Exact capture timestamp for the frame
+ * @param string|int $size "original" or a numeric variant height
+ * @param string $format jpg, png, or webp
+ * @return string|null Path to the frame, or null when not present
+ */
+function timestampedWebcamImagePathIfExists(
+    string $airportId,
+    int $camIndex,
+    int $timestamp,
+    string|int $size,
+    string $format
+): ?string {
+    if ($size === 'original') {
+        foreach (webcamSourceFormatFileExtensions($format) as $ext) {
+            $path = getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, $ext);
+            if (file_exists($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    $path = getWebcamVariantPath($airportId, $camIndex, $timestamp, (int) $size, $format);
+    return file_exists($path) ? $path : null;
+}
 
 /**
  * Get list of available history frames
@@ -32,7 +111,7 @@ require_once __DIR__ . '/cache-paths.php';
  * 
  * @param string $airportId Airport ID (e.g., 'kspb')
  * @param int $camIndex Camera index (0-based)
- * @return array Array of frames: [['timestamp' => int, 'filename' => string, 'formats' => ['jpg', 'webp']], ...]
+ * @return array Array of frames: [['timestamp' => int, 'filename' => string, 'formats' => ['jpg', 'png', 'webp']], ...]
  */
 function getHistoryFrames(string $airportId, int $camIndex): array {
     // Get max_frames config - if < 2, history is disabled
@@ -54,10 +133,7 @@ function getHistoryFrames(string $airportId, int $camIndex): array {
             $hourDirs = glob($dateDir . '/[0-2][0-9]', GLOB_ONLYDIR);
             if ($hourDirs !== false) {
                 foreach ($hourDirs as $hourDir) {
-                    $files = glob($hourDir . '/*.{jpg,webp}', GLOB_BRACE);
-                    if ($files !== false) {
-                        $allFiles = array_merge($allFiles, $files);
-                    }
+                    $allFiles = array_merge($allFiles, globWebcamHourDirImageFiles($hourDir));
                 }
             }
         }
@@ -66,21 +142,28 @@ function getHistoryFrames(string $airportId, int $camIndex): array {
         return [];
     }
     
-    // Group by timestamp and variant (exclude symlinks)
     $timestampGroups = [];
     
+    $extPattern = webcamSupportedOriginalExtensionPattern();
     foreach ($allFiles as $file) {
-        // Skip symlinks (current.jpg, current.webp, etc.)
         if (is_link($file)) {
             continue;
         }
-        
+
         $basename = basename($file);
-        // Match: {timestamp}_original.{format} or {timestamp}_{height}.{format}
-        if (preg_match('/^(\d+)_(original|\d+)\.(jpg|webp)$/', $basename, $matches)) {
+        if (preg_match('/^(\d+)_(original|\d+)\.(' . $extPattern . ')$/', $basename, $matches)) {
             $timestamp = (int)$matches[1];
             $variant = $matches[2];
-            $format = $matches[3];
+            $format = $matches[3] === 'jpeg' ? 'jpg' : $matches[3];
+            $meta = webcamServableImageFileMeta($file);
+            if ($meta === null) {
+                continue;
+            }
+            if ($variant === 'original') {
+                $format = $meta['format'];
+            } elseif ($meta['format'] !== $format) {
+                continue;
+            }
             
             if (!isset($timestampGroups[$timestamp])) {
                 $timestampGroups[$timestamp] = [
@@ -355,7 +438,7 @@ function parseGPSTimestamp(array $gps): int {
 /**
  * Get total size of webcam cache for an airport camera
  * 
- * Includes all format files (jpg, webp) in the camera cache directory.
+ * Includes all format files (jpg, png, webp) in the camera cache directory.
  * Useful for monitoring disk usage.
  * 
  * @param string $airportId Airport ID
@@ -375,10 +458,7 @@ function getHistoryDiskUsage(string $airportId, int $camIndex): int {
             $hourDirs = glob($dateDir . '/[0-2][0-9]', GLOB_ONLYDIR);
             if ($hourDirs !== false) {
                 foreach ($hourDirs as $hourDir) {
-                    $hourFiles = glob($hourDir . '/*.{jpg,webp}', GLOB_BRACE);
-                    if ($hourFiles !== false) {
-                        $files = array_merge($files, $hourFiles);
-                    }
+                    $files = array_merge($files, globWebcamHourDirImageFiles($hourDir));
                 }
             }
         }

--- a/lib/webcam-metadata.php
+++ b/lib/webcam-metadata.php
@@ -236,37 +236,89 @@ function validateVariantHeights(array $heights): array {
 }
 
 /**
- * Get path to latest original image
- * 
+ * Get path to the newest servable original image
+ *
+ * Prefers original.{format} symlinks. Falls back to a directory scan when none
+ * are valid. Unservable files are skipped so a leftover JPEG cannot hide PNG.
+ *
  * @param string $airportId Airport identifier
  * @param int $camIndex Camera index (0-based)
  * @return string|null Path to original file or null if not found
  */
 function getWebcamOriginalPath(string $airportId, int $camIndex): ?string {
-    // Try symlink first
-    $symlink = getWebcamOriginalSymlinkPath($airportId, $camIndex, 'jpg');
-    if (is_link($symlink) && file_exists($symlink)) {
-        $realPath = readlink($symlink);
-        if ($realPath !== false) {
-            $fullPath = dirname($symlink) . '/' . $realPath;
-            if (file_exists($fullPath)) {
-                return $fullPath;
-            }
+    $bestPath = null;
+    $bestRank = -1;
+    // Legitimate symlink targets always resolve under the airport cache dir.
+    $airportDir = getWebcamAirportDir($airportId);
+    foreach (getSupportedWebcamSourceFormats() as $format) {
+        $symlink = getWebcamOriginalSymlinkPath($airportId, $camIndex, $format);
+        if (!is_link($symlink)) {
+            continue;
         }
+        $realPath = readlink($symlink);
+        if ($realPath === false) {
+            continue;
+        }
+        $fullPath = $realPath[0] === '/' ? $realPath : dirname($symlink) . '/' . $realPath;
+        // Refuse symlinks that resolve outside the airport cache (defense in depth).
+        $realTarget = realpath($fullPath);
+        if ($realTarget === false || !str_starts_with($realTarget, $airportDir . '/')) {
+            aviationwx_log('warn', 'webcam original symlink escapes airport cache', [
+                'airport' => $airportId,
+                'cam' => $camIndex,
+                'symlink' => $symlink,
+                'target' => $fullPath,
+            ], 'app');
+            continue;
+        }
+        $rank = webcamServableOriginalCaptureRank($fullPath);
+        if ($rank === null || $rank <= $bestRank) {
+            continue;
+        }
+        $bestRank = $rank;
+        $bestPath = $fullPath;
     }
-    
-    $files = getWebcamImageFiles($airportId, $camIndex, '*_original.{jpg,jpeg,webp}');
-    
-    if (empty($files)) {
+    if ($bestPath !== null) {
+        return $bestPath;
+    }
+
+    $files = getWebcamImageFiles($airportId, $camIndex, '*_original.' . webcamSupportedOriginalGlobBrace());
+    foreach ($files as $file) {
+        if (is_link($file)) {
+            continue;
+        }
+        $rank = webcamServableOriginalCaptureRank($file);
+        if ($rank === null || $rank <= $bestRank) {
+            continue;
+        }
+        $bestRank = $rank;
+        $bestPath = $file;
+    }
+
+    return $bestPath;
+}
+
+/**
+ * Get the current servable original and its capture identity.
+ *
+ * @param string $airportId Airport identifier
+ * @param int $camIndex Camera index (0-based)
+ * @return array{path: string, format: string, timestamp: int}|null
+ */
+function getCurrentServableWebcamOriginal(string $airportId, int $camIndex): ?array
+{
+    $path = getWebcamOriginalPath($airportId, $camIndex);
+    if ($path === null) {
         return null;
     }
-    
-    // Sort by mtime descending
-    usort($files, function($a, $b) {
-        return filemtime($b) - filemtime($a);
-    });
-    
-    return $files[0];
+
+    $format = detectServableWebcamImageFormat($path);
+    $timestamp = webcamServableOriginalCaptureRank($path);
+    if ($format === null || $timestamp === null || $timestamp <= 0) {
+        return null;
+    }
+
+    return ['path' => $path, 'format' => $format, 'timestamp' => $timestamp];
 }
 
 /**
@@ -290,8 +342,10 @@ function getStagingPathForVariant(string $airportId, int $camIndex, $size, strin
 
 /**
  * Get image file path for requested size and format
- * 
+ *
  * Falls back to staging files if promotion is in progress, waiting up to 100ms.
+ * That fallback is for live current-image serving. Historical lookups must use
+ * timestamped files only so an old immutable URL cannot return the live staging frame.
  * 
  * @param string $airportId Airport identifier
  * @param int $camIndex Camera index
@@ -346,6 +400,45 @@ function getImagePathForSize(string $airportId, int $camIndex, int $timestamp, $
 }
 
 /**
+ * Native original for a timestamp: path plus format from file headers.
+ *
+ * Skips unreadable candidates so a leftover corrupt jpg cannot hide a valid png.
+ * Returns unknown only when at least one original file exists and none are a
+ * supported type.
+ *
+ * @param string $airportId Airport ID
+ * @param int $camIndex Camera index (0-based)
+ * @param int $timestamp Frame timestamp
+ * @return array{ok: true, path: string, format: string}|array{ok: false, error: 'missing'|'unknown'}
+ */
+function resolveWebcamOriginalAtTimestamp(string $airportId, int $camIndex, int $timestamp): array
+{
+    if ($timestamp <= 0) {
+        return ['ok' => false, 'error' => 'missing'];
+    }
+
+    $sawFile = false;
+    foreach (getSupportedWebcamSourceFormats() as $format) {
+        foreach (webcamSourceFormatFileExtensions($format) as $ext) {
+            $path = getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, $ext);
+            if (!file_exists($path)) {
+                continue;
+            }
+
+            $sawFile = true;
+            $detected = detectServableWebcamImageFormat($path);
+            if ($detected === null) {
+                continue;
+            }
+
+            return ['ok' => true, 'path' => $path, 'format' => $detected];
+        }
+    }
+
+    return ['ok' => false, 'error' => $sawFile ? 'unknown' : 'missing'];
+}
+
+/**
  * Get available variants for an image
  * 
  * @param string $airportId Airport identifier
@@ -359,20 +452,27 @@ function getAvailableVariants(string $airportId, int $camIndex, int $timestamp):
         return [];
     }
     
-    // Only check for enabled formats
     require_once __DIR__ . '/config.php';
     $enabledFormats = getEnabledWebcamFormats();
     
     $variants = [];
     
-    // Check original files for enabled formats only
-    foreach ($enabledFormats as $format) {
-        $path = getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, $format);
-        if (file_exists($path)) {
+    foreach (getSupportedWebcamSourceFormats() as $format) {
+        foreach (webcamSourceFormatFileExtensions($format) as $ext) {
+            $path = getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, $ext);
+            if (!file_exists($path)) {
+                continue;
+            }
+            $detected = detectServableWebcamImageFormat($path);
+            if ($detected === null) {
+                continue;
+            }
             if (!isset($variants['original'])) {
                 $variants['original'] = [];
             }
-            $variants['original'][] = $format;
+            if (!in_array($detected, $variants['original'], true)) {
+                $variants['original'][] = $detected;
+            }
         }
     }
     
@@ -411,6 +511,9 @@ function getAvailableVariants(string $airportId, int $camIndex, int $timestamp):
             if (!in_array($format, $enabledFormats)) {
                 continue;
             }
+            if (detectServableWebcamImageFormat($file) !== $format) {
+                continue;
+            }
             
             if (!isset($variants[$height])) {
                 $variants[$height] = [];
@@ -432,19 +535,20 @@ function getAvailableVariants(string $airportId, int $camIndex, int $timestamp):
  * @return int[] Unique timestamps, newest first (descending)
  */
 function collectWebcamFrameTimestampsFromFiles(string $airportId, int $camIndex): array {
-    $files = getWebcamImageFiles($airportId, $camIndex, '*_*.{jpg,jpeg,webp}');
+    $files = getWebcamImageFiles($airportId, $camIndex, '*_*.' . webcamSupportedOriginalGlobBrace());
     if (empty($files)) {
         return [];
     }
 
     $seen = [];
+    $extPattern = webcamSupportedOriginalExtensionPattern();
     foreach ($files as $file) {
         if (is_link($file)) {
             continue;
         }
 
         $basename = basename($file);
-        if (preg_match('/^(\d+)_(original|\d+)\.(jpg|jpeg|webp)$/', $basename, $matches)) {
+        if (preg_match('/^(\d+)_(original|\d+)\.(' . $extPattern . ')$/', $basename, $matches)) {
             $seen[(int)$matches[1]] = true;
         }
     }

--- a/lib/webcam-pipeline.php
+++ b/lib/webcam-pipeline.php
@@ -269,20 +269,19 @@ class ProcessingPipeline
             return ['success' => false, 'reason' => 'file_too_large'];
         }
 
-        // Detect format
-        $format = detectImageFormat($imagePath);
-        if ($format === null) {
-            return ['success' => false, 'reason' => 'invalid_format'];
-        }
-
-        // Load into GD for validation (single load for pipeline)
+        // @: file can vanish between size check and read
         $imageData = @file_get_contents($imagePath);
         if ($imageData === false) {
             return ['success' => false, 'reason' => 'read_error'];
         }
 
+        $format = detectServableWebcamImageFormatFromBytes($imageData);
+        if ($format === null) {
+            return ['success' => false, 'reason' => 'invalid_format'];
+        }
+
         $this->gdImage = @imagecreatefromstring($imageData);
-        unset($imageData); // Free memory
+        unset($imageData);
 
         if ($this->gdImage === false) {
             $this->gdImage = null;

--- a/pages/status.php
+++ b/pages/status.php
@@ -1538,14 +1538,10 @@ if (php_sapi_name() === 'cli') {
                     $weeklyAirportMetrics = $usageMetrics['airports'][$airportIdLower] ?? null;
                     
                     // Calculate webcam totals (serves = successful image deliveries)
-                    $totalWebcamServes = 0;
-                    $formatTotals = ['jpg' => 0, 'webp' => 0];
+                    $formatTotals = metricsSumWebcamFormatTotals($webcamMetrics);
+                    $totalWebcamServes = array_sum($formatTotals);
                     $sizeTotals = []; // Dynamic: height-based variants like '720', '360', 'original'
                     foreach ($webcamMetrics as $camData) {
-                        foreach ($camData['by_format'] ?? [] as $fmt => $count) {
-                            $formatTotals[$fmt] += $count;
-                            $totalWebcamServes += $count;
-                        }
                         foreach ($camData['by_size'] ?? [] as $sz => $count) {
                             if (!isset($sizeTotals[$sz])) {
                                 $sizeTotals[$sz] = 0;

--- a/public/js/airport-dashboard.js
+++ b/public/js/airport-dashboard.js
@@ -3292,10 +3292,10 @@ const WebcamPlayer = {
 
     // Build URL for a frame using the browser's preferred format and variant
     buildImageUrl(frame) {
-        // Use preferred format if available for this frame, otherwise fall back to jpg
-        const format = (frame.formats && Array.isArray(frame.formats) && frame.formats.includes(this.preferredFormat))
-            ? this.preferredFormat 
-            : 'jpg';
+        const format = window.AviationWX.webcamPlayerUtils.selectWebcamHistoryFormat(
+            frame.formats,
+            this.preferredFormat
+        );
         
         // Get available heights from variant manifest
         const availableHeights = frame.variants ? Object.keys(frame.variants)

--- a/public/js/webcam-player-utils.js
+++ b/public/js/webcam-player-utils.js
@@ -69,9 +69,30 @@
         });
     }
 
+    /**
+     * Select a format advertised by a history frame.
+     *
+     * @param {string[]} formats Available normalized formats
+     * @param {string} preferredFormat Browser-preferred format
+     * @returns {string}
+     */
+    function selectWebcamHistoryFormat(formats, preferredFormat) {
+        if (!Array.isArray(formats) || formats.length === 0) {
+            return 'jpg';
+        }
+        if (formats.includes(preferredFormat)) {
+            return preferredFormat;
+        }
+        if (formats.includes('jpg')) {
+            return 'jpg';
+        }
+        return formats[0];
+    }
+
     const api = {
         makeWebcamPreloadKey: makeWebcamPreloadKey,
-        pruneWebcamPreloadForCameraPeriod: pruneWebcamPreloadForCameraPeriod
+        pruneWebcamPreloadForCameraPeriod: pruneWebcamPreloadForCameraPeriod,
+        selectWebcamHistoryFormat: selectWebcamHistoryFormat
     };
 
     if (typeof module !== 'undefined' && module.exports) {

--- a/scripts/cleanup-cache.php
+++ b/scripts/cleanup-cache.php
@@ -75,6 +75,7 @@ chdir(__DIR__ . '/..');
 require_once __DIR__ . '/../lib/logger.php';
 require_once __DIR__ . '/../lib/config.php';
 require_once __DIR__ . '/../lib/cache-paths.php';
+require_once __DIR__ . '/../lib/webcam-format-generation.php';
 
 // ============================================================================
 // CONFIGURATION - Cleanup Thresholds (in seconds)
@@ -683,7 +684,7 @@ function cleanupFilesByAge(
 /**
  * Cleanup webcam history frame directories
  *
- * Structure: cache/webcams/{airportId}/{camIndex}/{YYYY-MM-DD}/{HH}/*.{jpg,webp}
+ * Structure: cache/webcams/{airportId}/{camIndex}/{YYYY-MM-DD}/{HH}/*.{jpg,jpeg,png,webp}
  */
 function cleanupWebcamHistoryFrames(
     string $webcamsDir,
@@ -714,6 +715,7 @@ function cleanupWebcamHistoryFrames(
             continue;
         }
         foreach ($camDirs as $camDir) {
+            $liveTargets = getWebcamLiveSymlinkTargets($camDir);
             $dateDirs = glob($camDir . '/????-??-??', GLOB_ONLYDIR);
             if ($dateDirs === false) {
                 continue;
@@ -724,10 +726,7 @@ function cleanupWebcamHistoryFrames(
                     continue;
                 }
                 foreach ($hourDirs as $hourDir) {
-                    $files = array_merge(
-                        glob($hourDir . '/*.jpg') ?: [],
-                        glob($hourDir . '/*.webp') ?: []
-                    );
+                    $files = globWebcamHourDirImageFiles($hourDir);
                     foreach ($files as $file) {
                         $stats['files_checked']++;
                         $mtime = @filemtime($file);
@@ -736,6 +735,10 @@ function cleanupWebcamHistoryFrames(
                         }
                         $age = $now - $mtime;
                         if ($age > $maxAge) {
+                            $realFile = realpath($file);
+                            if ($realFile !== false && isset($liveTargets[$realFile])) {
+                                continue;
+                            }
                             $size = @filesize($file) ?: 0;
                             if ($verbose) {
                                 $parts = explode('/', $camDir);

--- a/tests/Fixtures/airports.json.test
+++ b/tests/Fixtures/airports.json.test
@@ -315,6 +315,31 @@
         }
       ]
     },
+    "wcfx": {
+      "name": "Webcam API Test Fixture",
+      "enabled": true,
+      "maintenance": false,
+      "unlisted": true,
+      "webcam_history_retention_hours": 1,
+      "icao": "WCFX",
+      "iata": null,
+      "faa": "WCFX",
+      "address": "Test, Oregon",
+      "lat": 45.0,
+      "lon": -122.0,
+      "elevation_ft": 100,
+      "timezone": "America/Los_Angeles",
+      "access_type": "public",
+      "tower_status": "non_towered",
+      "webcams": [
+        {
+          "name": "Webcam API Fixture",
+          "url": "https://example.com/webcam-api.jpg",
+          "approximate_heading": 180,
+          "refresh_seconds": 60
+        }
+      ]
+    },
     "kaoc": {
       "name": "Afton Municipal Airport",
       "enabled": true,

--- a/tests/Integration/PublicApiWebcamTest.php
+++ b/tests/Integration/PublicApiWebcamTest.php
@@ -12,17 +12,68 @@ require_once __DIR__ . '/../../lib/cache-paths.php';
 class PublicApiWebcamTest extends TestCase
 {
     private static $apiBaseUrl;
-    private static $testAirport = 'kspb';
-    private static $testCam = 0;  // Fixture camera 0 is AviationWX-operated; camera 1 is wsdot
+    private static $testAirport = 'wcfx';
+    private static $testCam = 0;
+    private static bool $fixtureReady = false;
     
     public static function setUpBeforeClass(): void
     {
         self::$apiBaseUrl = getenv('TEST_API_URL') ?: 'http://localhost:8080';
-        
-        // Ensure test images exist (use CACHE_WEBCAMS_DIR so server sees them when TEST_API_URL is set)
+
+        $testCacheDir = getenv('TEST_CACHE_DIR');
+        if (!is_string($testCacheDir) || $testCacheDir === '') {
+            return;
+        }
+        if (rtrim($testCacheDir, '/') !== CACHE_BASE_DIR) {
+            return;
+        }
+
+        self::$fixtureReady = true;
+        self::removeFixtureTree();
         self::createTestImages();
     }
-    
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!self::$fixtureReady) {
+            $this->markTestSkipped('TEST_CACHE_DIR must identify the isolated HTTP test cache');
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::$fixtureReady) {
+            self::removeFixtureTree();
+        }
+        parent::tearDownAfterClass();
+    }
+
+    private static function removeFixtureTree(?string $dir = null): void
+    {
+        $dir ??= CACHE_WEBCAMS_DIR . '/' . self::$testAirport;
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                self::removeFixtureTree($path);
+            }
+        }
+        rmdir($dir);
+    }
+
     /**
      * Create test images for testing (uses date/hour subdir structure)
      */
@@ -75,7 +126,8 @@ class PublicApiWebcamTest extends TestCase
         // Small delay to avoid rate limiting in tests
         usleep(100000); // 100ms
         
-        $url = self::$apiBaseUrl . '/api/v1' . $endpoint;
+        $url = self::$apiBaseUrl;
+        $url .= str_starts_with($endpoint, '/api/') ? $endpoint : '/api/v1' . $endpoint;
         
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -135,7 +187,16 @@ class PublicApiWebcamTest extends TestCase
         $this->assertArrayHasKey('data', $data, 'Should have data field');
         $this->assertArrayHasKey('timestamp', $data['data'], 'Should have timestamp');
         $this->assertArrayHasKey('timestamp_iso', $data['data'], 'Should have timestamp_iso');
+        $this->assertArrayHasKey('age_seconds', $data['data'], 'Should have age_seconds');
+        $this->assertArrayHasKey('stale', $data['data'], 'Should have stale flag');
         $this->assertArrayHasKey('formats', $data['data'], 'Should have formats');
+
+        // age_seconds must be consistent with the capture timestamp and current time.
+        $age = $data['data']['age_seconds'];
+        $this->assertIsInt($age);
+        $this->assertGreaterThanOrEqual(0, $age);
+        // stale is true exactly when age exceeds the (default-minimum) threshold.
+        $this->assertIsBool($data['data']['stale']);
         $this->assertArrayHasKey('recommended_sizes', $data['data'], 'Should have recommended_sizes');
         $this->assertArrayHasKey('urls', $data['data'], 'Should have urls');
         
@@ -204,34 +265,44 @@ class PublicApiWebcamTest extends TestCase
         }
     }
     
-    /**
-     * Test explicit format request for unavailable format returns error
-     * 
-     * This tests Issue #1 fix: when WebP is requested but doesn't exist for original,
-     * should return helpful error instead of silently falling back to JPG.
-     */
-    public function testExplicitFormatRequest_UnavailableFormat_ReturnsError(): void
+    public function testExplicitFormatRequest_DisabledFormat_ReturnsError(): void
     {
-        // Request WebP for original (which typically doesn't exist - only variants have WebP)
         $response = $this->apiRequest('/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image?fmt=webp');
         
         if ($response['status'] === 0) {
             $this->markTestSkipped('Web server not available at ' . self::$apiBaseUrl);
         }
         
-        // Should return 400 Bad Request with helpful error
         $this->assertEquals(400, $response['status'], 
-            'Explicit WebP request for unavailable format should return 400');
+            'Explicit request for a disabled generation format should return 400');
         
         $data = $response['json'];
         $this->assertFalse($data['success'] ?? true, 'Success should be false');
         $this->assertArrayHasKey('error', $data, 'Should have error field');
         $this->assertArrayHasKey('message', $data['error'], 'Error should have message');
         
-        // Error message should mention format not available
         $message = $data['error']['message'];
-        $this->assertStringContainsString('not available', $message, 
-            'Error message should mention format not available');
+        $this->assertStringContainsString('not enabled', $message,
+            'Error message should mention the format is not enabled');
+    }
+
+    public function testExplicitFormatRequest_ArrayValue_ReturnsCleanJsonError(): void
+    {
+        $response = $this->apiRequest(
+            '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image?fmt[]=webp&size=720'
+        );
+
+        if ($response['status'] === 0) {
+            $this->markTestSkipped('Web server not available at ' . self::$apiBaseUrl);
+        }
+
+        $this->assertSame(400, $response['status']);
+        $this->assertStringContainsString('application/json', $response['content_type']);
+        $this->assertIsArray($response['json'], 'Response body should be clean JSON without PHP warnings');
+        $this->assertSame(
+            'fmt must be a single value',
+            $response['json']['error']['message'] ?? null
+        );
     }
     
     /**
@@ -267,9 +338,9 @@ class PublicApiWebcamTest extends TestCase
     }
     
     /**
-     * Test default request (no fmt parameter) returns JPG
+     * Test default request (no fmt parameter) returns the native original
      */
-    public function testDefaultRequest_NoFmtParameter_ReturnsJpg(): void
+    public function testDefaultRequest_NoFmtParameter_ReturnsNativeOriginal(): void
     {
         $response = $this->apiRequest('/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image');
         
@@ -277,14 +348,652 @@ class PublicApiWebcamTest extends TestCase
             $this->markTestSkipped('Web server not available at ' . self::$apiBaseUrl);
         }
         
-        // Should return 200 with JPG (or 503 if no image available)
         $this->assertContains($response['status'], [200, 503], 
             'Default request should return 200 or 503');
         
         if ($response['status'] === 200) {
-            $this->assertStringContainsString('image/jpeg', $response['content_type'],
-                'Default request should return JPEG content type');
+            $this->assertMatchesRegularExpression(
+                '#image/(jpeg|png|webp)#',
+                $response['content_type'],
+                'Default request should return the native original content type'
+            );
         }
+    }
+
+    public function testDefaultRequest_PngOriginal_ReturnsPngContentTypeAndMagic(): void
+    {
+        $this->assertNativeOriginalHttpResponse('png', 'image/png', "\x89PNG\r\n\x1a\n");
+    }
+
+    public function testDefaultRequest_WebpOriginal_ReturnsWebpContentTypeAndMagic(): void
+    {
+        if (!function_exists('imagewebp')) {
+            $this->markTestSkipped('GD WebP support is not available');
+        }
+        $this->assertNativeOriginalHttpResponse('webp', 'image/webp', 'RIFF');
+    }
+
+    public function testDownload_PngOriginal_ReturnsNativeAttachmentWithLiveCachePolicy(): void
+    {
+        $installedPath = null;
+        try {
+            $installedPath = self::installNativeOriginal('png');
+            $response = $this->apiRequest(
+                '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image?download=1'
+            );
+
+            $this->assertSame(200, $response['status']);
+            $this->assertStringContainsString('image/png', $response['content_type']);
+            $this->assertStringContainsString(
+                'attachment;',
+                $response['headers']['Content-Disposition'] ?? ''
+            );
+            $this->assertStringContainsString(
+                '.png"',
+                $response['headers']['Content-Disposition'] ?? ''
+            );
+            $cacheControl = $response['headers']['Cache-Control'] ?? '';
+            $this->assertStringContainsString('max-age=60', $cacheControl);
+            $this->assertStringNotContainsString('immutable', $cacheControl);
+            $this->assertSame("\x89PNG\r\n\x1a\n", substr($response['body'], 0, 8));
+
+            $etag = $response['headers']['ETag'] ?? null;
+            $this->assertNotNull($etag);
+            $conditional = $this->apiRequest(
+                '/airports/' . self::$testAirport . '/webcams/' . self::$testCam .
+                '/image?download=1',
+                ['If-None-Match: ' . $etag]
+            );
+            $this->assertSame(304, $conditional['status']);
+            $this->assertStringContainsString(
+                'max-age=60',
+                $conditional['headers']['Cache-Control'] ?? ''
+            );
+            $this->assertStringNotContainsString(
+                'immutable',
+                $conditional['headers']['Cache-Control'] ?? ''
+            );
+        } finally {
+            self::restoreDefaultOriginalFixture($installedPath);
+        }
+    }
+
+    public function testHistory_PngOriginal_ReturnsNativeImageWithImmutableCachePolicy(): void
+    {
+        $installedPath = null;
+        try {
+            $installedPath = self::installNativeOriginal('png');
+            $timestamp = (int)explode('_', basename($installedPath), 2)[0];
+            $response = $this->apiRequest(
+                '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/history?ts=' . $timestamp
+            );
+
+            $this->assertSame(200, $response['status']);
+            $this->assertStringContainsString('image/png', $response['content_type']);
+            $this->assertStringContainsString(
+                'immutable',
+                $response['headers']['Cache-Control'] ?? ''
+            );
+            $this->assertSame("\x89PNG\r\n\x1a\n", substr($response['body'], 0, 8));
+            $this->assertConditionalImageHeaders($response, (
+                '/airports/' . self::$testAirport . '/webcams/' . self::$testCam .
+                '/history?ts=' . $timestamp
+            ), true);
+        } finally {
+            self::restoreDefaultOriginalFixture($installedPath);
+        }
+    }
+
+    public function testLegacyHistory_PngOriginalReturnsNativeImage(): void
+    {
+        $installedPath = null;
+        try {
+            $installedPath = self::installNativeOriginal('png');
+            $timestamp = (int)explode('_', basename($installedPath), 2)[0];
+            $response = $this->apiRequest(
+                '/api/webcam-history.php?id=' . self::$testAirport .
+                '&cam=' . self::$testCam .
+                '&ts=' . $timestamp .
+                '&fmt=png&size=original'
+            );
+
+            $this->assertSame(200, $response['status']);
+            $this->assertStringContainsString('image/png', $response['content_type']);
+            $this->assertSame("\x89PNG\r\n\x1a\n", substr($response['body'], 0, 8));
+            $this->assertConditionalImageHeaders(
+                $response,
+                '/api/webcam-history.php?id=' . self::$testAirport .
+                '&cam=' . self::$testCam .
+                '&ts=' . $timestamp .
+                '&fmt=png&size=original',
+                true
+            );
+        } finally {
+            self::restoreDefaultOriginalFixture($installedPath);
+        }
+    }
+
+    public function testLegacyTimestamp_PngOriginalReturnsNativeImageWhenFormatOmitted(): void
+    {
+        $installedPath = null;
+        try {
+            $installedPath = self::installNativeOriginal('png');
+            $timestamp = (int)explode('_', basename($installedPath), 2)[0];
+            $response = $this->apiRequest(
+                '/api/webcam.php?id=' . self::$testAirport .
+                '&cam=' . self::$testCam .
+                '&ts=' . $timestamp .
+                '&size=original'
+            );
+
+            $this->assertSame(200, $response['status']);
+            $this->assertStringContainsString('image/png', $response['content_type']);
+            $this->assertSame("\x89PNG\r\n\x1a\n", substr($response['body'], 0, 8));
+            $this->assertConditionalImageHeaders(
+                $response,
+                '/api/webcam.php?id=' . self::$testAirport .
+                '&cam=' . self::$testCam .
+                '&ts=' . $timestamp .
+                '&size=original',
+                true,
+                false
+            );
+        } finally {
+            self::restoreDefaultOriginalFixture($installedPath);
+        }
+    }
+
+    public function testLegacyCurrent_PngOriginalReturnsNativeImageWhenFormatOmitted(): void
+    {
+        $installedPath = null;
+        try {
+            $installedPath = self::installNativeOriginal('png');
+            $response = $this->apiRequest(
+                '/api/webcam.php?id=' . self::$testAirport .
+                '&cam=' . self::$testCam .
+                '&size=original'
+            );
+
+            $this->assertSame(200, $response['status']);
+            $this->assertStringContainsString('image/png', $response['content_type']);
+            $this->assertSame("\x89PNG\r\n\x1a\n", substr($response['body'], 0, 8));
+            $this->assertStringContainsString(
+                '.png"',
+                $response['headers']['Content-Disposition'] ?? ''
+            );
+        } finally {
+            self::restoreDefaultOriginalFixture($installedPath);
+        }
+    }
+
+    public function testLegacyCurrent_ArrayFormatReturnsCleanJsonError(): void
+    {
+        $response = $this->apiRequest(
+            '/api/webcam.php?id=' . self::$testAirport .
+            '&cam=' . self::$testCam .
+            '&fmt%5B%5D=png'
+        );
+
+        $this->assertSame(400, $response['status']);
+        $this->assertSame('fmt must be a single value', $response['json']['error'] ?? null);
+    }
+
+    public function testLegacyHistory_JpegAliasReturnsJpegImage(): void
+    {
+        $path = self::installTimestampedOriginal('jpeg', 'jpg');
+        try {
+            $timestamp = (int)explode('_', basename($path), 2)[0];
+            $response = $this->apiRequest(
+                '/api/webcam-history.php?id=' . self::$testAirport .
+                '&cam=' . self::$testCam .
+                '&ts=' . $timestamp .
+                '&fmt=jpeg&size=original'
+            );
+
+            $this->assertSame(200, $response['status']);
+            $this->assertStringContainsString('image/jpeg', $response['content_type']);
+            $this->assertSame("\xff\xd8\xff", substr($response['body'], 0, 3));
+        } finally {
+            self::removeInstalledNativeOriginal($path);
+        }
+    }
+
+    public function testLegacyHistory_MislabeledPngRejectsExplicitFormat(): void
+    {
+        $path = self::installTimestampedOriginal('png', 'jpg');
+        try {
+            $timestamp = (int)explode('_', basename($path), 2)[0];
+            $response = $this->apiRequest(
+                '/api/webcam-history.php?id=' . self::$testAirport .
+                '&cam=' . self::$testCam .
+                '&ts=' . $timestamp .
+                '&fmt=png&size=original'
+            );
+
+            $this->assertSame(400, $response['status']);
+            $this->assertSame(
+                'jpg',
+                $response['json']['actual_format'] ?? null
+            );
+        } finally {
+            self::removeInstalledNativeOriginal($path);
+        }
+    }
+
+    public function testLegacyHistory_ArrayFormatReturnsCleanJsonError(): void
+    {
+        $response = $this->apiRequest(
+            '/api/webcam-history.php?id=' . self::$testAirport .
+            '&cam=' . self::$testCam .
+            '&fmt%5B%5D=png'
+        );
+
+        $this->assertSame(400, $response['status']);
+        $this->assertSame('fmt must be a single value', $response['json']['error'] ?? null);
+    }
+
+    public function testLegacyHistory_UnsupportedFormatReturnsCleanJsonError(): void
+    {
+        $response = $this->apiRequest(
+            '/api/webcam-history.php?id=' . self::$testAirport .
+            '&cam=' . self::$testCam .
+            '&fmt=gif'
+        );
+
+        $this->assertSame(400, $response['status']);
+        $this->assertSame('Unsupported image format', $response['json']['error'] ?? null);
+    }
+
+    public function testLegacyHistoryManifest_ClassifiesOriginalFromBytes(): void
+    {
+        $path = self::installTimestampedOriginal('png', 'jpg');
+        $timestamp = (int)explode('_', basename($path), 2)[0];
+        $variantPath = dirname($path) . '/' . $timestamp . '_720.png';
+        $img = imagecreatetruecolor(720, 540);
+        imagejpeg($img, $variantPath);
+        try {
+            $response = $this->apiRequest(
+                '/api/webcam-history.php?id=' . self::$testAirport .
+                '&cam=' . self::$testCam
+            );
+            $frames = $response['json']['frames'] ?? [];
+            $matching = array_values(array_filter(
+                $frames,
+                static fn(array $frame): bool => ($frame['timestamp'] ?? null) === $timestamp
+            ));
+
+            $this->assertCount(1, $matching);
+            $this->assertContains('jpg', $matching[0]['formats']);
+            $this->assertNotContains('png', $matching[0]['formats']);
+            $this->assertArrayNotHasKey('720', $matching[0]['variants']);
+        } finally {
+            if (is_file($variantPath)) {
+                unlink($variantPath);
+            }
+            self::removeInstalledNativeOriginal($path);
+        }
+    }
+
+    public function testLegacyHistory_MissingTimestampedSizeDoesNotServeStagingFile(): void
+    {
+        $stagingPath = getWebcamCameraDir(self::$testAirport, self::$testCam) .
+            '/staging_720_jpg.tmp';
+        $img = imagecreatetruecolor(720, 540);
+        imagejpeg($img, $stagingPath);
+
+        try {
+            $response = $this->apiRequest(
+                '/api/webcam-history.php?id=' . self::$testAirport .
+                '&cam=' . self::$testCam .
+                '&ts=' . (time() - 600) .
+                '&fmt=jpg&size=720'
+            );
+
+            $this->assertSame(404, $response['status']);
+        } finally {
+            if (is_file($stagingPath)) {
+                unlink($stagingPath);
+            }
+        }
+    }
+
+    public function testLegacyDownload_LatestUsesLiveCachePolicy(): void
+    {
+        $response = $this->apiRequest(
+            '/api/webcam.php?id=' . self::$testAirport . '&cam=' . self::$testCam . '&download=1'
+        );
+
+        $this->assertSame(200, $response['status']);
+        $cacheControl = $response['headers']['Cache-Control'] ?? '';
+        $this->assertStringContainsString('max-age=60', $cacheControl);
+        $this->assertStringNotContainsString('immutable', $cacheControl);
+    }
+
+    public function testLegacyDownload_TimestampUsesImmutableCachePolicy(): void
+    {
+        $installedPath = null;
+        try {
+            $installedPath = self::installNativeOriginal('png');
+            $timestamp = (int)explode('_', basename($installedPath), 2)[0];
+            $response = $this->apiRequest(
+                '/api/webcam.php?id=' . self::$testAirport .
+                '&cam=' . self::$testCam .
+                '&ts=' . $timestamp .
+                '&download=1'
+            );
+
+            $this->assertSame(200, $response['status']);
+            $this->assertStringContainsString(
+                'immutable',
+                $response['headers']['Cache-Control'] ?? ''
+            );
+        } finally {
+            self::restoreDefaultOriginalFixture($installedPath);
+        }
+    }
+
+    public function testTransform_CorruptNewestOriginal_UsesNewestServableCapture(): void
+    {
+        $timestamp = time() + 120;
+        $framesDir = getWebcamFramesDir(self::$testAirport, self::$testCam, $timestamp);
+        if (!is_dir($framesDir)) {
+            mkdir($framesDir, 0755, true);
+        }
+        $corruptPath = $framesDir . '/' . $timestamp . '_original.jpg';
+        file_put_contents($corruptPath, 'not an image');
+
+        try {
+            $response = $this->apiRequest(
+                '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image?width=320'
+            );
+
+            $this->assertSame(200, $response['status']);
+            $dimensions = getimagesizefromstring($response['body']);
+            $this->assertIsArray($dimensions);
+            $this->assertSame(320, $dimensions[0]);
+        } finally {
+            self::removeInstalledNativeOriginal($corruptPath);
+        }
+    }
+
+    public function testMetadata_CorruptNewestOriginal_UsesNewestServableCapture(): void
+    {
+        $path = '/airports/' . self::$testAirport . '/webcams/' . self::$testCam .
+            '/image?metadata=1';
+        $before = $this->apiRequest($path);
+        $expectedTimestamp = $before['json']['data']['timestamp'] ?? null;
+        $this->assertIsInt($expectedTimestamp);
+        $timestamp = time() + 120;
+        $framesDir = getWebcamFramesDir(self::$testAirport, self::$testCam, $timestamp);
+        if (!is_dir($framesDir)) {
+            mkdir($framesDir, 0755, true);
+        }
+        $corruptPath = $framesDir . '/' . $timestamp . '_original.jpg';
+        file_put_contents($corruptPath, 'not an image');
+
+        try {
+            $response = $this->apiRequest($path);
+
+            $this->assertSame(200, $response['status']);
+            $this->assertSame(
+                $expectedTimestamp,
+                $response['json']['data']['timestamp'] ?? null
+            );
+        } finally {
+            self::removeInstalledNativeOriginal($corruptPath);
+        }
+    }
+
+    public function testLegacyMtime_CorruptNewestOriginal_UsesNewestServableCapture(): void
+    {
+        $before = $this->apiRequest(
+            '/api/webcam.php?id=' . self::$testAirport .
+            '&cam=' . self::$testCam .
+            '&mtime=1'
+        );
+        $expectedTimestamp = $before['json']['timestamp'] ?? null;
+        $this->assertIsInt($expectedTimestamp);
+
+        $timestamp = time() + 120;
+        $framesDir = getWebcamFramesDir(self::$testAirport, self::$testCam, $timestamp);
+        if (!is_dir($framesDir)) {
+            mkdir($framesDir, 0755, true);
+        }
+        $corruptPath = $framesDir . '/' . $timestamp . '_original.jpg';
+        file_put_contents($corruptPath, 'not an image');
+
+        try {
+            $response = $this->apiRequest(
+                '/api/webcam.php?id=' . self::$testAirport .
+                '&cam=' . self::$testCam .
+                '&mtime=1'
+            );
+
+            $this->assertSame(200, $response['status']);
+            $this->assertSame($expectedTimestamp, $response['json']['timestamp'] ?? null);
+        } finally {
+            self::removeInstalledNativeOriginal($corruptPath);
+        }
+    }
+
+    public function testSizeRequest_CorruptNewestOriginal_UsesNewestServableCapture(): void
+    {
+        $installedPath = self::installNativeOriginal('png');
+        $validTimestamp = (int)explode('_', basename($installedPath), 2)[0];
+        $variantPath = dirname($installedPath) . '/' . $validTimestamp . '_720.jpg';
+        $variant = imagecreatetruecolor(1280, 720);
+        imagejpeg($variant, $variantPath);
+
+        $timestamp = time() + 120;
+        $framesDir = getWebcamFramesDir(self::$testAirport, self::$testCam, $timestamp);
+        if (!is_dir($framesDir)) {
+            mkdir($framesDir, 0755, true);
+        }
+        $corruptPath = $framesDir . '/' . $timestamp . '_original.jpg';
+        file_put_contents($corruptPath, 'not an image');
+
+        try {
+            $response = $this->apiRequest(
+                '/airports/' . self::$testAirport . '/webcams/' . self::$testCam .
+                '/image?size=720'
+            );
+
+            $this->assertSame(200, $response['status']);
+            $dimensions = getimagesizefromstring($response['body']);
+            $this->assertIsArray($dimensions);
+            $this->assertSame(720, $dimensions[1]);
+        } finally {
+            self::removeInstalledNativeOriginal($corruptPath);
+            if (is_file($variantPath)) {
+                unlink($variantPath);
+            }
+            self::restoreDefaultOriginalFixture($installedPath);
+        }
+    }
+
+    public function testSizeRequest_InvalidValueFallsBackToOriginal(): void
+    {
+        $response = $this->apiRequest(
+            '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image?size=bogus'
+        );
+
+        $this->assertSame(200, $response['status']);
+        $this->assertStringContainsString('image/jpeg', $response['content_type']);
+    }
+
+    public function testSizeRequest_MissingVariantDoesNotReturnNativeOriginal(): void
+    {
+        $installedPath = null;
+        try {
+            $installedPath = self::installNativeOriginal('png');
+            $response = $this->apiRequest(
+                '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image?size=777'
+            );
+
+            $this->assertSame(503, $response['status']);
+            $this->assertStringContainsString('application/json', $response['content_type']);
+        } finally {
+            self::restoreDefaultOriginalFixture($installedPath);
+        }
+    }
+
+    public function testDownload_NoOriginalReturnsServiceUnavailable(): void
+    {
+        self::removeFixtureTree();
+        try {
+            $response = $this->apiRequest(
+                '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image?download=1'
+            );
+
+            $this->assertSame(503, $response['status']);
+        } finally {
+            self::createTestImages();
+        }
+    }
+
+    private function assertNativeOriginalHttpResponse(string $format, string $contentType, string $magicPrefix): void
+    {
+        $installedPath = null;
+        try {
+            $installedPath = self::installNativeOriginal($format);
+            $response = $this->apiRequest('/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image');
+            if ($response['status'] === 0) {
+                $this->markTestSkipped('Web server not available at ' . self::$apiBaseUrl);
+            }
+
+            $this->assertSame(200, $response['status'], 'Isolated stack should serve the installed native original');
+            $this->assertStringContainsString(
+                $contentType,
+                $response['content_type'],
+                'Content-Type must match the native original'
+            );
+            $this->assertSame(
+                $magicPrefix,
+                substr($response['body'], 0, strlen($magicPrefix)),
+                'Body magic bytes must match the native original'
+            );
+            if ($format === 'webp') {
+                $this->assertSame('WEBP', substr($response['body'], 8, 4));
+            }
+            $this->assertConditionalImageHeaders(
+                $response,
+                '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image',
+                false
+            );
+        } finally {
+            self::restoreDefaultOriginalFixture($installedPath);
+        }
+    }
+
+    private function assertConditionalImageHeaders(
+        array $response,
+        string $path,
+        bool $immutable,
+        bool $expectCors = true
+    ): void
+    {
+        $etag = $response['headers']['ETag'] ?? null;
+        $this->assertNotNull($etag);
+
+        $conditional = $this->apiRequest($path, ['If-None-Match: ' . $etag]);
+        $this->assertSame(304, $conditional['status']);
+        $cacheControl = $conditional['headers']['Cache-Control'] ?? '';
+        $this->assertSame($immutable, str_contains($cacheControl, 'immutable'));
+        $this->assertNotSame('', $cacheControl);
+        if ($expectCors) {
+            $this->assertSame('*', $conditional['headers']['Access-Control-Allow-Origin'] ?? null);
+        }
+    }
+
+    private static function restoreDefaultOriginalFixture(?string $installedPath): void
+    {
+        if ($installedPath !== null) {
+            self::removeInstalledNativeOriginal($installedPath);
+        }
+        self::unlinkOriginalFormatSymlinks();
+        self::createTestImages();
+    }
+
+    private static function unlinkOriginalFormatSymlinks(): void
+    {
+        $cacheDir = getWebcamCameraDir(self::$testAirport, self::$testCam);
+        foreach (['jpg', 'jpeg', 'png', 'webp'] as $ext) {
+            $link = $cacheDir . '/original.' . $ext;
+            if (is_link($link) || file_exists($link)) {
+                unlink($link);
+            }
+        }
+    }
+
+    private static function removeInstalledNativeOriginal(string $path): void
+    {
+        $hourDir = dirname($path);
+        $dateDir = dirname($hourDir);
+        if (is_file($path) || is_link($path)) {
+            unlink($path);
+        }
+        self::rmdirIfEmpty($hourDir);
+        self::rmdirIfEmpty($dateDir);
+    }
+
+    private static function rmdirIfEmpty(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items !== false && count($items) === 2) {
+            rmdir($dir);
+        }
+    }
+
+    private static function installNativeOriginal(string $format): string
+    {
+        $cacheDir = getWebcamCameraDir(self::$testAirport, self::$testCam);
+        if (!is_dir($cacheDir)) {
+            mkdir($cacheDir, 0755, true);
+        }
+
+        // Must outrank the JPEG fixture so getLatestImageTimestamp selects this file.
+        $timestamp = time() + 1;
+        $framesDir = getWebcamFramesDir(self::$testAirport, self::$testCam, $timestamp);
+        if (!is_dir($framesDir)) {
+            mkdir($framesDir, 0755, true);
+        }
+        $subdir = getWebcamFramesSubdir($timestamp);
+        $filename = $timestamp . '_original.' . $format;
+        $path = $framesDir . '/' . $filename;
+
+        $img = imagecreatetruecolor(32, 24);
+        $green = imagecolorallocate($img, 0, 128, 0);
+        imagefill($img, 0, 0, $green);
+        if ($format === 'png') {
+            imagepng($img, $path);
+        } else {
+            imagewebp($img, $path);
+        }
+        self::unlinkOriginalFormatSymlinks();
+        symlink($subdir . '/' . $filename, $cacheDir . '/original.' . $format);
+
+        return $path;
+    }
+
+    private static function installTimestampedOriginal(string $extension, string $actualFormat): string
+    {
+        $timestamp = time() + 30;
+        $framesDir = getWebcamFramesDir(self::$testAirport, self::$testCam, $timestamp);
+        if (!is_dir($framesDir)) {
+            mkdir($framesDir, 0755, true);
+        }
+        $path = $framesDir . '/' . $timestamp . '_original.' . $extension;
+        $img = imagecreatetruecolor(32, 24);
+        if ($actualFormat === 'jpg') {
+            imagejpeg($img, $path);
+        } else {
+            imagepng($img, $path);
+        }
+
+        return $path;
     }
     
     /**
@@ -494,7 +1203,7 @@ class PublicApiWebcamTest extends TestCase
         $data = $response['json'];
         $this->assertTrue($data['success'] ?? false);
         $webcams = $data['webcams'] ?? [];
-        $this->assertNotEmpty($webcams, 'kspb fixture should have webcams');
+        $this->assertNotEmpty($webcams, 'Webcam API fixture should have webcams');
 
         foreach ($webcams as $webcam) {
             $this->assertArrayHasKey('approximate_heading', $webcam);

--- a/tests/Unit/ImageTransformTest.php
+++ b/tests/Unit/ImageTransformTest.php
@@ -17,6 +17,7 @@ namespace AviationWX\Tests;
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../../lib/constants.php';
 require_once __DIR__ . '/../../lib/image-transform.php';
 require_once __DIR__ . '/../../lib/cache-paths.php';
 
@@ -91,6 +92,43 @@ class ImageTransformTest extends TestCase
         
         $this->createdFiles[] = $path;
         return $path;
+    }
+
+    private function createTestPng(int $width, int $height, string $filename = 'test.png'): string
+    {
+        $path = $this->testImageDir . '/' . $filename;
+        if (!function_exists('imagecreatetruecolor') || !function_exists('imagepng')) {
+            $this->markTestSkipped('GD library with PNG support not available');
+        }
+        $img = imagecreatetruecolor($width, $height);
+        $bg = imagecolorallocate($img, 100, 150, 200);
+        imagefill($img, 0, 0, $bg);
+        imagepng($img, $path);
+        $this->createdFiles[] = $path;
+        return $path;
+    }
+
+    private function deleteCacheTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->deleteCacheTree($path);
+            } else {
+                @unlink($path);
+            }
+        }
+        @rmdir($dir);
     }
     
     // =========================================================================
@@ -612,6 +650,65 @@ class ImageTransformTest extends TestCase
         $this->assertNotNull($image);
         $this->assertInstanceOf(\GdImage::class, $image);
         
+    }
+
+    public function testLoadSourceImage_ValidPng_ReturnsGdImage(): void
+    {
+        $source = $this->createTestPng(800, 600, 'load_test.png');
+        $image = loadSourceImage($source);
+        $this->assertNotNull($image);
+        $this->assertInstanceOf(\GdImage::class, $image);
+        $this->assertEquals(800, imagesx($image));
+        $this->assertEquals(600, imagesy($image));
+    }
+
+    public function testGetTransformedImagePath_PngOriginal_CreatesJpegCache(): void
+    {
+        $airportId = 'pngxform_unit';
+        $camIndex = 0;
+        $timestamp = 1704069000;
+        $source = $this->createTestPng(320, 180, 'cam.png');
+        $framesDir = getWebcamFramesDir($airportId, $camIndex, $timestamp);
+        ensureCacheDir($framesDir);
+        $pngPath = getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, 'png');
+        $this->assertTrue(copy($source, $pngPath));
+
+        try {
+            $path = getTransformedImagePath($airportId, $camIndex, $timestamp, 160, 90, 'jpg');
+            $this->assertNotNull($path);
+            $this->assertFileExists($path);
+            $info = getimagesize($path);
+            $this->assertNotFalse($info);
+            $this->assertSame(160, $info[0]);
+            $this->assertSame(90, $info[1]);
+        } finally {
+            $this->deleteCacheTree(CACHE_WEBCAMS_DIR . '/' . $airportId);
+        }
+    }
+
+    public function testGetFaaTransformedImagePath_PngOriginal_CreatesJpegCache(): void
+    {
+        $airportId = 'pngfaaxform_unit';
+        $camIndex = 0;
+        $timestamp = 1704069100;
+        $source = $this->createTestPng(1920, 1080, 'faa_cam.png');
+        $framesDir = getWebcamFramesDir($airportId, $camIndex, $timestamp);
+        ensureCacheDir($framesDir);
+        $pngPath = getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, 'png');
+        $this->assertTrue(copy($source, $pngPath));
+
+        try {
+            $result = getFaaTransformedImagePath($airportId, $camIndex, $timestamp, [
+                'top' => 0,
+                'bottom' => 0,
+                'left' => 0,
+                'right' => 0,
+            ]);
+            $this->assertNotNull($result);
+            $this->assertFileExists($result['path']);
+        } finally {
+            $this->deleteCacheTree(CACHE_WEBCAMS_DIR . '/' . $airportId);
+        }
     }
     
     /**

--- a/tests/Unit/MetricsApplyFlatCountersTest.php
+++ b/tests/Unit/MetricsApplyFlatCountersTest.php
@@ -59,6 +59,45 @@ class MetricsApplyFlatCountersTest extends TestCase
     {
         $this->assertTrue(metrics_flat_counter_key_is_recognized('global_page_views'));
         $this->assertTrue(metrics_flat_counter_key_is_recognized('airport_ksea_views'));
+        $this->assertTrue(metrics_flat_counter_key_is_recognized('webcam_kspb_0_png'));
+        $this->assertTrue(metrics_flat_counter_key_is_recognized('format_png_served'));
         $this->assertFalse(metrics_flat_counter_key_is_recognized('not_a_metric_key'));
+    }
+
+    public function testApply_PngFormatCounters_AreRecorded(): void
+    {
+        $hourId = '2026-08-10-15';
+        $hourData = metrics_new_empty_hour_bucket($hourId);
+        metrics_apply_flat_counters_to_hour_data($hourData, [
+            'webcam_kspb_0_png' => 4,
+            'format_png_served' => 4,
+        ]);
+
+        $this->assertSame(4, $hourData['webcams']['kspb_0']['by_format']['png']);
+        $this->assertSame(4, $hourData['global']['format_served']['png']);
+    }
+
+    public function testSumWebcamFormatTotals_PngBucket_DoesNotWarn(): void
+    {
+        $totals = metricsSumWebcamFormatTotals([
+            'kspb_0' => ['by_format' => ['jpg' => 1, 'png' => 2, 'webp' => 3]],
+        ]);
+
+        $this->assertSame(1, $totals['jpg']);
+        $this->assertSame(2, $totals['png']);
+        $this->assertSame(3, $totals['webp']);
+        $this->assertSame(6, array_sum($totals));
+    }
+
+    public function testSumWebcamFormatTotals_UnknownFormatKey_IsInitialized(): void
+    {
+        $totals = metricsSumWebcamFormatTotals([
+            'kspb_0' => ['by_format' => ['avif' => 5]],
+        ]);
+
+        $this->assertSame(5, $totals['avif']);
+        $this->assertSame(0, $totals['jpg']);
+        $this->assertSame(0, $totals['png']);
+        $this->assertSame(0, $totals['webp']);
     }
 }

--- a/tests/Unit/MetricsHourBucketStructureTest.php
+++ b/tests/Unit/MetricsHourBucketStructureTest.php
@@ -37,7 +37,7 @@ class MetricsHourBucketStructureTest extends TestCase
             ],
         ];
         metrics_normalize_hour_bucket_for_merge($partial, $hourId);
-        $this->assertSame([ 'jpg' => 0, 'webp' => 0 ], $partial['global']['format_served']);
+        $this->assertSame([ 'jpg' => 0, 'png' => 0, 'webp' => 0 ], $partial['global']['format_served']);
         $this->assertSame([ 'webp' => 0, 'jpg_only' => 0 ], $partial['global']['browser_support']);
         $this->assertSame([ 'hits' => 0, 'misses' => 0 ], $partial['global']['cache']);
     }

--- a/tests/Unit/PublicApiWeathercamBulkTest.php
+++ b/tests/Unit/PublicApiWeathercamBulkTest.php
@@ -226,8 +226,11 @@ class PublicApiWeathercamBulkTest extends TestCase
         $this->assertNotEmpty($cam['images']);
         $this->assertSame('original', $cam['images'][0]['variant']);
         $this->assertNull($cam['images'][0]['height']);
-        $this->assertSame('jpg', $cam['images'][0]['format']);
         $this->assertSame($cam['image_url'], $cam['images'][0]['url']);
+        $this->assertStringNotContainsString('fmt=', $cam['images'][0]['url']);
+        if (isset($cam['images'][0]['format'])) {
+            $this->assertContains($cam['images'][0]['format'], ['jpg', 'png', 'webp']);
+        }
 
         $heights = [];
         foreach ($cam['images'] as $image) {
@@ -246,6 +249,72 @@ class PublicApiWeathercamBulkTest extends TestCase
         $this->assertContains(1080, $heights);
         $this->assertContains(720, $heights);
         $this->assertContains(360, $heights);
+    }
+
+    public function testGetWeathercamBulkAirports_MissingOriginal_OmitsCachedFormat(): void
+    {
+        $airportId = 'bulkfmt_missing_unit';
+        $sha = getConfigFileSha256();
+        $this->assertNotNull($sha);
+        rememberWeathercamBulkCatalog([[
+            'id' => $airportId,
+            'webcams' => [[
+                'index' => 0,
+                'images' => [
+                    ['variant' => 'original', 'url' => '/v1/x', 'format' => 'jpg'],
+                ],
+            ]],
+        ]], $sha);
+
+        $airports = getWeathercamBulkAirports(null);
+        $row = $this->findAirport($airports, $airportId);
+        $this->assertNotNull($row);
+        $this->assertArrayNotHasKey('format', $row['webcams'][0]['images'][0]);
+    }
+
+    public function testGetWeathercamBulkAirports_RefreshesCachedOriginalFormat(): void
+    {
+        $airportId = 'bulkfmt_unit';
+        $cam = 0;
+        $ts = time() - 10;
+        $framesDir = getWebcamFramesDir($airportId, $cam, $ts);
+        ensureCacheDir($framesDir);
+        $path = getWebcamOriginalTimestampedPath($airportId, $cam, $ts, 'png');
+        file_put_contents($path, "\x89PNG\r\n\x1a\n" . str_repeat("\x00", 8));
+
+        $sha = getConfigFileSha256();
+        $this->assertNotNull($sha);
+        $cached = [[
+            'id' => $airportId,
+            'webcams' => [[
+                'index' => 0,
+                'images' => [
+                    ['variant' => 'original', 'url' => '/v1/x', 'format' => 'jpg'],
+                ],
+            ]],
+        ]];
+        rememberWeathercamBulkCatalog($cached, $sha);
+
+        try {
+            $airports = getWeathercamBulkAirports(null);
+            $row = $this->findAirport($airports, $airportId);
+            $this->assertNotNull($row);
+            $this->assertSame('png', $row['webcams'][0]['images'][0]['format']);
+            $cachedAgain = recallWeathercamBulkCatalog();
+            $this->assertSame('jpg', $cachedAgain[0]['webcams'][0]['images'][0]['format']);
+        } finally {
+            $base = CACHE_WEBCAMS_DIR . '/' . $airportId;
+            if (is_dir($base)) {
+                $it = new \RecursiveIteratorIterator(
+                    new \RecursiveDirectoryIterator($base, \FilesystemIterator::SKIP_DOTS),
+                    \RecursiveIteratorIterator::CHILD_FIRST
+                );
+                foreach ($it as $file) {
+                    $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+                }
+                rmdir($base);
+            }
+        }
     }
 
     public function testOpenApiWeathercamBulk_IsCatalogPathWithWeathercamOperator(): void
@@ -294,5 +363,44 @@ class PublicApiWeathercamBulkTest extends TestCase
         $this->assertArrayHasKey('image_url', $spec['components']['schemas']['Webcam']['properties'] ?? []);
         $this->assertArrayHasKey('operator', $spec['components']['schemas']['Webcam']['properties'] ?? []);
         $this->assertArrayHasKey('images', $spec['components']['schemas']['Webcam']['properties'] ?? []);
+        $imageFormat = $spec['components']['schemas']['Webcam']['properties']['images']['items']['properties']['format']['enum'] ?? [];
+        $this->assertContains('png', $imageFormat);
+        $this->assertNotContains(
+            'format',
+            $spec['components']['schemas']['Webcam']['properties']['images']['items']['required'] ?? []
+        );
+    }
+
+    public function testOpenApi_HistoryFrame_DocumentsNativeOriginal(): void
+    {
+        $spec = json_decode(
+            (string) file_get_contents(__DIR__ . '/../../api/docs/openapi.json'),
+            true
+        );
+        $this->assertIsArray($spec);
+        $op = $spec['paths']['/airports/{id}/webcams/{cam}/history']['get'] ?? null;
+        $this->assertIsArray($op);
+
+        $fmt = null;
+        $size = null;
+        foreach ($op['parameters'] ?? [] as $param) {
+            if (($param['name'] ?? '') === 'fmt') {
+                $fmt = $param;
+            }
+            if (($param['name'] ?? '') === 'size') {
+                $size = $param;
+            }
+        }
+        $this->assertIsArray($fmt);
+        $this->assertArrayNotHasKey('default', $fmt['schema'] ?? []);
+        $this->assertStringContainsString('Not valid on the original', $fmt['description'] ?? '');
+        $this->assertIsArray($size);
+        $this->assertArrayNotHasKey('default', $size['schema'] ?? []);
+
+        $content = $op['responses']['200']['content'] ?? [];
+        $this->assertArrayHasKey('image/jpeg', $content);
+        $this->assertArrayHasKey('image/png', $content);
+        $this->assertArrayHasKey('image/webp', $content);
+        $this->assertArrayHasKey('400', $op['responses'] ?? []);
     }
 }

--- a/tests/Unit/PublicApiWebcamMetadataTest.php
+++ b/tests/Unit/PublicApiWebcamMetadataTest.php
@@ -214,11 +214,10 @@ class PublicApiWebcamMetadataTest extends TestCase
 
         $this->assertSame(
             [
-                ['variant' => 'original', 'height' => null, 'format' => 'jpg', 'url' => '/v1/airports/test/webcams/0/image'],
                 ['variant' => '600', 'height' => 600, 'format' => 'jpg', 'url' => '/v1/airports/test/webcams/0/image?size=600'],
                 ['variant' => '600', 'height' => 600, 'format' => 'webp', 'url' => '/v1/airports/test/webcams/0/image?fmt=webp&size=600'],
             ],
-            $images
+            array_slice($images, 1)
         );
     }
 }

--- a/tests/Unit/WebcamFormatGenerationTest.php
+++ b/tests/Unit/WebcamFormatGenerationTest.php
@@ -15,9 +15,11 @@ require_once __DIR__ . '/../../lib/config.php';
 require_once __DIR__ . '/../../lib/webcam-format-generation.php';
 require_once __DIR__ . '/../../lib/circuit-breaker.php';
 require_once __DIR__ . '/../../lib/logger.php';
+require_once __DIR__ . '/WebcamUnsupportedPayloads.php';
 
 class WebcamFormatGenerationTest extends TestCase
 {
+    use \WebcamUnsupportedPayloads;
     private $testImageDir;
     
     protected function setUp(): void
@@ -80,6 +82,7 @@ class WebcamFormatGenerationTest extends TestCase
         $file = $this->createTestJpeg('test.jpg');
         $format = detectImageFormat($file);
         $this->assertEquals('jpg', $format);
+        $this->assertSame('jpg', detectImageFormatFromHeader(file_get_contents($file)));
     }
     
     public function testDetectImageFormat_PngFile_ReturnsPng(): void
@@ -94,6 +97,16 @@ class WebcamFormatGenerationTest extends TestCase
         $file = $this->createTestWebp('test.webp');
         $format = detectImageFormat($file);
         $this->assertEquals('webp', $format);
+    }
+
+    public function testDetectImageFormat_TruncatedWebpZeroRiffSize_ReturnsNull(): void
+    {
+        $path = $this->testImageDir . '/truncated.webp';
+        // RIFF + 0xFF00 0000 size + WEBP: a zero-length chunk stub must not be
+        // classified as webp, so a truncated file isn't served with a real type.
+        file_put_contents($path, "RIFF\x00\x00\x00\x00WEBP");
+        $this->assertNull(detectImageFormat($path));
+        $this->assertNull(detectImageFormatFromHeader("RIFF\x00\x00\x00\x00WEBP"));
     }
     
     public function testDetectImageFormat_InvalidFile_ReturnsNull(): void
@@ -125,6 +138,35 @@ class WebcamFormatGenerationTest extends TestCase
         file_put_contents($file, "\xFF"); // Only 1 byte
         $format = detectImageFormat($file);
         $this->assertNull($format);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('unsupportedWebcamPayloadProvider')]
+    public function testDetectImageFormat_UnsupportedPayload_ReturnsNull(string $label, string $bytes): void
+    {
+        $file = $this->testImageDir . '/payload.' . $label;
+        file_put_contents($file, $bytes);
+        $this->assertNull(detectImageFormat($file));
+        $this->assertNull(detectServableWebcamImageFormat($file));
+        $this->assertNull(webcamServableImageContent($file));
+        $this->assertNull(webcamServableImageContentFromBytes($bytes));
+        $this->assertNull(webcamReadServableImage($file));
+        $this->assertNull(webcamImageContentType($label));
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('unsupportedWebcamPayloadProvider')]
+    public function testGenerateVariantsFromOriginal_UnsupportedPayload_DoesNotPromoteAsJpeg(string $label, string $bytes): void
+    {
+        $airportId = 'badpipe_unit';
+        $camIndex = 0;
+        $timestamp = 1704067600;
+        $source = $this->testImageDir . '/payload.' . $label;
+        file_put_contents($source, $bytes);
+
+        $result = generateVariantsFromOriginal($source, $airportId, $camIndex, $timestamp);
+        $this->assertNull($result['original']);
+        $this->assertFileDoesNotExist(
+            getWebcamOriginalTimestampedPath($airportId, $camIndex, $timestamp, 'jpg')
+        );
     }
     
 
@@ -919,6 +961,23 @@ class WebcamFormatGenerationTest extends TestCase
     {
         $path = getTimestampCacheFilePath('kspb', 0, 1703700000, 'jpg', 'original');
         $this->assertStringContainsString('1703700000_original.jpg', $path);
+    }
+
+    public function testGlobWebcamHourDirImageFiles_PngFrame_IsIncluded(): void
+    {
+        $this->createTestJpeg('123_original.jpg');
+        $this->createTestPng('456_original.png');
+        $this->createTestWebp('789_original.webp');
+        file_put_contents($this->testImageDir . '/notes.txt', 'skip');
+
+        $files = globWebcamHourDirImageFiles($this->testImageDir);
+        $basenames = array_map('basename', $files);
+        sort($basenames);
+
+        $this->assertSame(
+            ['123_original.jpg', '456_original.png', '789_original.webp'],
+            $basenames
+        );
     }
 }
 

--- a/tests/Unit/WebcamOriginalResolveTest.php
+++ b/tests/Unit/WebcamOriginalResolveTest.php
@@ -1,0 +1,620 @@
+<?php
+/**
+ * Native original resolve and Public API fmt parsing.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../../lib/webcam-metadata.php';
+require_once __DIR__ . '/../../api/v1/webcam-image.php';
+require_once __DIR__ . '/../../api/v1/webcams.php';
+require_once __DIR__ . '/../../lib/webcam-history.php';
+require_once __DIR__ . '/WebcamUnsupportedPayloads.php';
+
+class WebcamOriginalResolveTest extends TestCase
+{
+    use WebcamUnsupportedPayloads;
+    private string $airportId = 'origfmt_unit';
+    private int $camIndex = 0;
+
+    protected function tearDown(): void
+    {
+        $base = CACHE_WEBCAMS_DIR . '/' . strtolower($this->airportId);
+        if (is_dir($base)) {
+            $this->deleteTreeRecursive($base);
+        }
+        parent::tearDown();
+    }
+
+    private function deleteTreeRecursive(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->deleteTreeRecursive($path);
+            } else {
+                // @: leftover files must not fail tearDown
+                @unlink($path);
+            }
+        }
+        @rmdir($dir);
+    }
+
+    private function jpegBytes(): string
+    {
+        return "\xFF\xD8\xFF\xD9" . str_repeat("\x00", 8);
+    }
+
+    private function pngBytes(): string
+    {
+        return "\x89\x50\x4E\x47\x0D\x0A\x1A\x0A" . str_repeat("\x00", 8);
+    }
+
+    private function webpBytes(): string
+    {
+        return 'RIFF' . pack('V', 12) . 'WEBP';
+    }
+
+    private function writeOriginal(int $timestamp, string $ext, string $bytes): string
+    {
+        $framesDir = getWebcamFramesDir($this->airportId, $this->camIndex, $timestamp);
+        ensureCacheDir($framesDir);
+        $path = getWebcamOriginalTimestampedPath($this->airportId, $this->camIndex, $timestamp, $ext);
+        file_put_contents($path, $bytes);
+        return $path;
+    }
+
+    private function linkOriginal(int $timestamp, string $format, string $targetPath): void
+    {
+        $camDir = getWebcamCameraDir($this->airportId, $this->camIndex);
+        ensureCacheDir($camDir);
+        $symlink = getWebcamOriginalSymlinkPath($this->airportId, $this->camIndex, $format);
+        if (is_link($symlink) || file_exists($symlink)) {
+            unlink($symlink);
+        }
+        $relative = getWebcamFramesSubdir($timestamp) . '/' . basename($targetPath);
+        symlink($relative, $symlink);
+    }
+
+    public function testGetSupportedWebcamSourceFormats_ReturnsJpgPngWebp(): void
+    {
+        $this->assertSame(['jpg', 'png', 'webp'], getSupportedWebcamSourceFormats());
+    }
+
+    public function testNormalizeWebcamFormatName_JpegAlias_ReturnsJpg(): void
+    {
+        $this->assertSame('jpg', normalizeWebcamFormatName('JPEG'));
+    }
+
+    public function testNormalizeWebcamFormatName_Unknown_ReturnsNull(): void
+    {
+        $this->assertNull(normalizeWebcamFormatName('gif'));
+        $this->assertNull(normalizeWebcamFormatName('bmp'));
+    }
+
+    public function testDetectServableWebcamImageFormat_UnknownBytes_ReturnsNull(): void
+    {
+        $path = $this->writeOriginal(1704067000, 'jpg', str_repeat('notanimage!', 2));
+        $this->assertNull(detectServableWebcamImageFormat($path));
+    }
+
+    public function testParsePublicApiWebcamFmtQuery_Omitted_IsNativeOriginal(): void
+    {
+        $parsed = parsePublicApiWebcamFmtQuery(null);
+        $this->assertTrue($parsed['ok']);
+        $this->assertFalse($parsed['explicit']);
+        $this->assertNull($parsed['format']);
+    }
+
+    public function testParsePublicApiWebcamFmtQuery_EmptyString_IsNativeOriginal(): void
+    {
+        $parsed = parsePublicApiWebcamFmtQuery('  ');
+        $this->assertTrue($parsed['ok']);
+        $this->assertFalse($parsed['explicit']);
+        $this->assertNull($parsed['format']);
+    }
+
+    public function testParsePublicApiWebcamFmtQueryFromGet_ArrayValue_ReturnsShapeErrorWithoutWarning(): void
+    {
+        $previousGet = $_GET;
+        $_GET['fmt'] = ['webp'];
+        set_error_handler(
+            static function (int $severity, string $message, string $file, int $line): never {
+                throw new ErrorException($message, 0, $severity, $file, $line);
+            }
+        );
+
+        try {
+            $parsed = parsePublicApiWebcamFmtQueryFromGet();
+        } finally {
+            restore_error_handler();
+            $_GET = $previousGet;
+        }
+
+        $this->assertFalse($parsed['ok']);
+        $this->assertTrue($parsed['explicit']);
+        $this->assertSame('fmt must be a single value', $parsed['error']);
+    }
+
+    public function testParsePublicApiWebcamFmtQuery_Unknown_Errors(): void
+    {
+        $parsed = parsePublicApiWebcamFmtQuery('gif');
+        $this->assertFalse($parsed['ok']);
+        $this->assertSame('Unknown image format', $parsed['error']);
+    }
+
+    public function testParsePublicApiWebcamFmtQuery_JpegAlias_IsJpg(): void
+    {
+        $parsed = parsePublicApiWebcamFmtQuery('jpeg');
+        $this->assertTrue($parsed['ok']);
+        $this->assertSame('jpg', $parsed['format']);
+    }
+
+    public function testParsePublicApiWebcamFmtQuery_Jpg_IsEnabled(): void
+    {
+        $parsed = parsePublicApiWebcamFmtQuery('jpg');
+        $this->assertTrue($parsed['ok']);
+        $this->assertTrue($parsed['explicit']);
+        $this->assertSame('jpg', $parsed['format']);
+    }
+
+    public function testParsePublicApiWebcamFmtQuery_WebpWhenDisabled_Errors(): void
+    {
+        $this->assertFalse(in_array('webp', getEnabledWebcamFormats(), true));
+        $parsed = parsePublicApiWebcamFmtQuery('webp');
+        $this->assertFalse($parsed['ok']);
+        $this->assertSame("Format 'webp' is not enabled", $parsed['error']);
+    }
+
+    public function testParsePublicApiWebcamFmtQuery_PngWhenNotGenerationFormat_Errors(): void
+    {
+        $this->assertFalse(in_array('png', getEnabledWebcamFormats(), true));
+        $parsed = parsePublicApiWebcamFmtQuery('png');
+        $this->assertFalse($parsed['ok']);
+        $this->assertSame("Format 'png' is not enabled", $parsed['error']);
+    }
+
+    public function testPublicApiWebcamContentType_Unsupported_Throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        publicApiWebcamContentType('gif');
+    }
+
+    public function testWebcamReadServableImage_JpegFile_ReturnsJpgAndBytes(): void
+    {
+        $bytes = $this->jpegBytes();
+        $path = $this->writeOriginal(1704067050, 'jpg', $bytes);
+        $read = webcamReadServableImage($path);
+        $this->assertNotNull($read);
+        $this->assertSame('jpg', $read['format']);
+        $this->assertSame('image/jpeg', $read['content_type']);
+        $this->assertSame($bytes, $read['bytes']);
+    }
+
+    public function testWebcamServableImageFileMeta_JpegFile_ReturnsHeaderTypeAndSize(): void
+    {
+        $bytes = $this->jpegBytes();
+        $path = $this->writeOriginal(1704067060, 'jpg', $bytes);
+        $meta = webcamServableImageFileMeta($path);
+        $this->assertNotNull($meta);
+        $this->assertSame('jpg', $meta['format']);
+        $this->assertSame('image/jpeg', $meta['content_type']);
+        $this->assertSame(strlen($bytes), $meta['size']);
+    }
+
+    public function testWebcamSourceFormatFileExtensions_Unknown_ReturnsEmpty(): void
+    {
+        $this->assertSame([], webcamSourceFormatFileExtensions('exe'));
+        $this->assertSame([], webcamSourceFormatFileExtensions('pdf'));
+    }
+
+    public function testPublicApiWebcamContentType_KnownFormats_ReturnsImageMime(): void
+    {
+        $this->assertSame('image/png', publicApiWebcamContentType('png'));
+        $this->assertSame('image/jpeg', publicApiWebcamContentType('jpg'));
+        $this->assertSame('image/webp', publicApiWebcamContentType('webp'));
+    }
+
+    public function testPublicApiWebcamVariantUrl_OriginalPng_OmitsFmt(): void
+    {
+        $this->assertSame(
+            '/v1/airports/kspb/webcams/0/image',
+            publicApiWebcamVariantUrl('kspb', 0, 'original', 'png')
+        );
+        $this->assertSame(
+            '/v1/airports/kspb/webcams/0/image',
+            publicApiWebcamVariantUrl('kspb', 0, 'original', 'jpg')
+        );
+    }
+
+    public function testPublicApiWebcamVariantUrl_SizedWebp_IncludesFmtAndSize(): void
+    {
+        $this->assertSame(
+            '/v1/airports/kspb/webcams/0/image?fmt=webp&size=1080',
+            publicApiWebcamVariantUrl('kspb', 0, '1080', 'webp')
+        );
+        $this->assertSame(
+            '/v1/airports/kspb/webcams/0/image?size=360',
+            publicApiWebcamVariantUrl('kspb', 0, '360', 'jpg')
+        );
+    }
+
+    public function testGetHistoryFrames_PngOriginal_IncludesPngFormat(): void
+    {
+        $ts = time() - 30;
+        $path = $this->writeOriginal($ts, 'png', $this->pngBytes());
+        $frames = getHistoryFrames($this->airportId, $this->camIndex);
+        $match = null;
+        foreach ($frames as $frame) {
+            if ((int) $frame['timestamp'] === $ts) {
+                $match = $frame;
+                break;
+            }
+        }
+        $this->assertNotNull($match);
+        $this->assertContains('png', $match['formats']);
+        $this->assertGreaterThan(0, getHistoryDiskUsage($this->airportId, $this->camIndex));
+        $this->assertFileExists($path);
+    }
+
+    public function testFindHistoricalWebcamSizeFile_ExplicitWebpMissing_DoesNotFallBackToJpeg(): void
+    {
+        $ts = 1704068000;
+        $framesDir = getWebcamFramesDir($this->airportId, $this->camIndex, $ts);
+        ensureCacheDir($framesDir);
+        $jpg = getWebcamVariantPath($this->airportId, $this->camIndex, $ts, 720, 'jpg');
+        file_put_contents($jpg, $this->jpegBytes());
+
+        $found = findHistoricalWebcamSizeFile($this->airportId, $this->camIndex, $ts, 720, 'webp');
+        $this->assertNull($found['path']);
+        $this->assertSame(720, $found['size']);
+    }
+
+    public function testExplicitFmtMatchesFile_JpegBytesInWebpCacheFile_IsRejected(): void
+    {
+        $ts = 1704068020;
+        $framesDir = getWebcamFramesDir($this->airportId, $this->camIndex, $ts);
+        ensureCacheDir($framesDir);
+        $path = getWebcamVariantPath($this->airportId, $this->camIndex, $ts, 720, 'webp');
+        file_put_contents($path, $this->jpegBytes());
+
+        $found = findHistoricalWebcamSizeFile($this->airportId, $this->camIndex, $ts, 720, 'webp');
+        $this->assertSame($path, $found['path']);
+        $meta = webcamServableImageFileMeta($found['path']);
+        $this->assertNotNull($meta);
+        $this->assertSame('jpg', $meta['format']);
+        $this->assertFalse(webcamExplicitFmtMatchesFile(true, 'webp', $meta['format']));
+        $this->assertTrue(webcamExplicitFmtMatchesFile(false, 'webp', $meta['format']));
+    }
+
+    public function testFindHistoricalWebcamSizeFile_MissingHeight_UsesSameFormatOriginal(): void
+    {
+        $ts = 1704068010;
+        $original = $this->writeOriginal($ts, 'webp', $this->webpBytes());
+
+        $found = findHistoricalWebcamSizeFile($this->airportId, $this->camIndex, $ts, 720, 'webp');
+        $this->assertSame($original, $found['path']);
+        $this->assertSame('original', $found['size']);
+    }
+
+    public function testFindHistoricalWebcamSizeFile_MissingHeight_UsesJpegExtensionOriginal(): void
+    {
+        $ts = 1704068110;
+        $original = $this->writeOriginal($ts, 'jpeg', $this->jpegBytes());
+
+        $found = findHistoricalWebcamSizeFile($this->airportId, $this->camIndex, $ts, 720, 'jpg');
+        $this->assertSame($original, $found['path']);
+        $this->assertSame('original', $found['size']);
+    }
+
+    public function testFindHistoricalWebcamSizeFile_MissingTimestamp_DoesNotServeStagingVariant(): void
+    {
+        $ts = 1704068070;
+        ensureCacheDir(getWebcamCameraDir($this->airportId, $this->camIndex));
+        $staging = getStagingPathForVariant($this->airportId, $this->camIndex, 720, 'webp');
+        file_put_contents($staging, $this->webpBytes());
+
+        $found = findHistoricalWebcamSizeFile($this->airportId, $this->camIndex, $ts, 720, 'webp');
+        $this->assertNull($found['path']);
+        $this->assertSame(720, $found['size']);
+    }
+
+    public function testFindHistoricalWebcamSizeFile_MissingTimestamp_DoesNotServeStagingOriginal(): void
+    {
+        $ts = 1704068090;
+        ensureCacheDir(getWebcamCameraDir($this->airportId, $this->camIndex));
+        $staging = getStagingPathForVariant($this->airportId, $this->camIndex, 'original', 'webp');
+        file_put_contents($staging, $this->webpBytes());
+
+        $found = findHistoricalWebcamSizeFile($this->airportId, $this->camIndex, $ts, 720, 'webp');
+        $this->assertNull($found['path']);
+        $this->assertSame(720, $found['size']);
+    }
+
+    public function testGetHistoryFrames_JpegExtension_ReportsJpg(): void
+    {
+        $ts = time() - 20;
+        $this->writeOriginal($ts, 'jpeg', $this->jpegBytes());
+        $frames = getHistoryFrames($this->airportId, $this->camIndex);
+        $match = null;
+        foreach ($frames as $frame) {
+            if ((int) $frame['timestamp'] === $ts) {
+                $match = $frame;
+                break;
+            }
+        }
+        $this->assertNotNull($match);
+        $this->assertContains('jpg', $match['formats']);
+        $this->assertNotContains('jpeg', $match['formats']);
+    }
+
+    public function testGetWebcamOriginalPath_NewerPngSymlink_WinsOverOlderJpeg(): void
+    {
+        $oldTs = 1704067000;
+        $newTs = 1704067600;
+        $jpgPath = $this->writeOriginal($oldTs, 'jpg', $this->jpegBytes());
+        $pngPath = $this->writeOriginal($newTs, 'png', $this->pngBytes());
+        $this->linkOriginal($oldTs, 'jpg', $jpgPath);
+        $this->linkOriginal($newTs, 'png', $pngPath);
+
+        $this->assertSame($pngPath, getWebcamOriginalPath($this->airportId, $this->camIndex));
+    }
+
+    public function testGetWebcamOriginalPath_UnservableJpegSymlink_SkippedForPng(): void
+    {
+        $oldTs = 1704067010;
+        $newTs = 1704067610;
+        $jpgPath = $this->writeOriginal($newTs, 'jpg', str_repeat('notanimage!', 2));
+        $pngPath = $this->writeOriginal($oldTs, 'png', $this->pngBytes());
+        $this->linkOriginal($newTs, 'jpg', $jpgPath);
+        $this->linkOriginal($oldTs, 'png', $pngPath);
+
+        $this->assertSame($pngPath, getWebcamOriginalPath($this->airportId, $this->camIndex));
+    }
+
+    public function testGetWebcamOriginalPath_DirectoryScanNewerPng_WinsWithoutSymlinks(): void
+    {
+        $oldTs = 1704067020;
+        $newTs = 1704067620;
+        $this->writeOriginal($oldTs, 'jpg', $this->jpegBytes());
+        $pngPath = $this->writeOriginal($newTs, 'png', $this->pngBytes());
+
+        $this->assertSame($pngPath, getWebcamOriginalPath($this->airportId, $this->camIndex));
+    }
+
+    public function testGetWebcamOriginalPath_DirectoryScanCorruptNewest_Skipped(): void
+    {
+        $oldTs = 1704067030;
+        $newTs = 1704067630;
+        $pngPath = $this->writeOriginal($oldTs, 'png', $this->pngBytes());
+        $this->writeOriginal($newTs, 'jpg', str_repeat('notanimage!', 2));
+
+        $this->assertSame($pngPath, getWebcamOriginalPath($this->airportId, $this->camIndex));
+    }
+
+    public function testWebcamServableOriginalCaptureRank_UnsupportedBytes_ReturnsNull(): void
+    {
+        $path = $this->writeOriginal(1704067040, 'jpg', str_repeat('notanimage!', 2));
+        $this->assertNull(webcamServableOriginalCaptureRank($path));
+    }
+
+    public function testGetWebcamOriginalPath_SymlinkEscapingAirportCache_IsSkipped(): void
+    {
+        // A valid in-cache original that the resolver should fall back to.
+        $inCache = $this->writeOriginal(1704068000, 'png', $this->pngBytes());
+
+        // Point original.jpg at a file outside the airport cache via an absolute symlink.
+        $outside = CACHE_WEBCAMS_DIR . '/outside_fixture.png';
+        file_put_contents($outside, $this->pngBytes());
+        $camDir = getWebcamCameraDir($this->airportId, $this->camIndex);
+        ensureCacheDir($camDir);
+        $symlink = getWebcamOriginalSymlinkPath($this->airportId, $this->camIndex, 'jpg');
+        symlink($outside, $symlink);
+
+        // The escaping symlink must be refused as a servable original (defense in depth),
+        // so resolution falls back to the in-cache jpeg-free png.
+        $result = getWebcamOriginalPath($this->airportId, $this->camIndex);
+        $this->assertNotSame($outside, $result);
+        $this->assertSame($inCache, $result);
+    }
+
+    public function testGetCurrentServableWebcamOriginal_CorruptNewest_ReturnsOlderValidTimestamp(): void
+    {
+        // Newest file is corrupt and must be skipped; the older valid servable is what
+        // a fail-closed staleness gate must judge, so it must not be masked by the
+        // fresher-but-corrupt filename.
+        $newCorrupt = $this->writeOriginal(1704069000, 'jpg', str_repeat('notanimage!', 3));
+        $oldValid = $this->writeOriginal(1704064000, 'png', $this->pngBytes());
+
+        $servable = getCurrentServableWebcamOriginal($this->airportId, $this->camIndex);
+        $this->assertNotNull($servable);
+        $this->assertSame($oldValid, $servable['path']);
+        $this->assertSame(1704064000, $servable['timestamp']);
+    }
+
+    public function testCleanupOldTimestampFiles_ExpiredPngOriginal_IsRemoved(): void
+    {
+        $oldTs = time() - 120;
+        $newTs = time() - 30;
+        $oldPath = $this->writeOriginal($oldTs, 'png', $this->pngBytes());
+        $newPath = $this->writeOriginal($newTs, 'png', $this->pngBytes());
+
+        $cleaned = cleanupOldTimestampFiles($this->airportId, $this->camIndex, 1);
+
+        $this->assertGreaterThan(0, $cleaned);
+        $this->assertFileDoesNotExist($oldPath);
+        $this->assertFileExists($newPath);
+    }
+
+    public function testCleanupOldTimestampFiles_OriginalSymlinkTarget_IsPreserved(): void
+    {
+        $liveTs = time() - 90000;
+        $livePath = $this->writeOriginal($liveTs, 'png', $this->pngBytes());
+        $otherPath = getWebcamVariantPath($this->airportId, $this->camIndex, $liveTs, 720, 'jpg');
+        file_put_contents($otherPath, $this->jpegBytes());
+        $this->linkOriginal($liveTs, 'png', $livePath);
+
+        $cleaned = cleanupOldTimestampFiles($this->airportId, $this->camIndex, 1);
+
+        $this->assertGreaterThan(0, $cleaned);
+        $this->assertFileExists($livePath);
+        $this->assertFileDoesNotExist($otherPath);
+        $this->assertSame(
+            realpath($livePath),
+            realpath(getWebcamOriginalSymlinkPath($this->airportId, $this->camIndex, 'png'))
+        );
+    }
+
+    public function testResolveWebcamOriginalAtTimestamp_PngFile_ReturnsPng(): void
+    {
+        $ts = 1704067200;
+        $this->writeOriginal($ts, 'png', $this->pngBytes());
+
+        $this->assertSame($ts, getLatestImageTimestamp($this->airportId, $this->camIndex));
+        $resolved = resolveWebcamOriginalAtTimestamp($this->airportId, $this->camIndex, $ts);
+        $this->assertTrue($resolved['ok']);
+        $this->assertSame('png', $resolved['format']);
+    }
+
+    public function testResolveWebcamOriginalAtTimestamp_JpegExtension_ReturnsJpg(): void
+    {
+        $ts = 1704067250;
+        $this->writeOriginal($ts, 'jpeg', $this->jpegBytes());
+
+        $resolved = resolveWebcamOriginalAtTimestamp($this->airportId, $this->camIndex, $ts);
+        $this->assertTrue($resolved['ok']);
+        $this->assertSame('jpg', $resolved['format']);
+    }
+
+    public function testResolveWebcamOriginalAtTimestamp_JpegFile_ReturnsJpg(): void
+    {
+        $ts = 1704067300;
+        $this->writeOriginal($ts, 'jpg', $this->jpegBytes());
+
+        $resolved = resolveWebcamOriginalAtTimestamp($this->airportId, $this->camIndex, $ts);
+        $this->assertTrue($resolved['ok']);
+        $this->assertSame('jpg', $resolved['format']);
+    }
+
+    public function testResolveWebcamOriginalAtTimestamp_StagingJpeg_DoesNotHideTimestampedPng(): void
+    {
+        $ts = 1704068050;
+        $pngPath = $this->writeOriginal($ts, 'png', $this->pngBytes());
+        $staging = getStagingPathForVariant($this->airportId, $this->camIndex, 'original', 'jpg');
+        file_put_contents($staging, $this->jpegBytes());
+
+        $resolved = resolveWebcamOriginalAtTimestamp($this->airportId, $this->camIndex, $ts);
+        $this->assertTrue($resolved['ok']);
+        $this->assertSame('png', $resolved['format']);
+        $this->assertSame($pngPath, $resolved['path']);
+    }
+
+    public function testResolveWebcamOriginalAtTimestamp_MissingTimestamp_DoesNotServeStaging(): void
+    {
+        $this->writeOriginal(1704068051, 'png', $this->pngBytes());
+        $staging = getStagingPathForVariant($this->airportId, $this->camIndex, 'original', 'jpg');
+        file_put_contents($staging, $this->jpegBytes());
+
+        $resolved = resolveWebcamOriginalAtTimestamp($this->airportId, $this->camIndex, 1704068060);
+        $this->assertFalse($resolved['ok']);
+        $this->assertSame('missing', $resolved['error']);
+    }
+
+    public function testResolveWebcamOriginalAtTimestamp_WebpFile_ReturnsWebp(): void
+    {
+        $ts = 1704067350;
+        $this->writeOriginal($ts, 'webp', $this->webpBytes());
+
+        $resolved = resolveWebcamOriginalAtTimestamp($this->airportId, $this->camIndex, $ts);
+        $this->assertTrue($resolved['ok']);
+        $this->assertSame('webp', $resolved['format']);
+    }
+
+    public function testResolveWebcamOriginalAtTimestamp_CorruptJpgWithValidPng_ReturnsPng(): void
+    {
+        $ts = 1704067380;
+        $this->writeOriginal($ts, 'jpg', str_repeat('notanimage!', 2));
+        $this->writeOriginal($ts, 'png', $this->pngBytes());
+
+        $resolved = resolveWebcamOriginalAtTimestamp($this->airportId, $this->camIndex, $ts);
+        $this->assertTrue($resolved['ok']);
+        $this->assertSame('png', $resolved['format']);
+    }
+
+    public function testResolveWebcamOriginalAtTimestamp_UnknownBytes_Errors(): void
+    {
+        $ts = 1704067400;
+        $this->writeOriginal($ts, 'jpg', str_repeat('notanimage!', 2));
+
+        $resolved = resolveWebcamOriginalAtTimestamp($this->airportId, $this->camIndex, $ts);
+        $this->assertFalse($resolved['ok']);
+        $this->assertSame('unknown', $resolved['error']);
+    }
+
+    public function testResolveWebcamOriginalAtTimestamp_Missing_Errors(): void
+    {
+        $resolved = resolveWebcamOriginalAtTimestamp($this->airportId, $this->camIndex, 1704067500);
+        $this->assertFalse($resolved['ok']);
+        $this->assertSame('missing', $resolved['error']);
+    }
+
+    public function testResolveWebcamOriginalAtTimestamp_NonPositiveTimestamp_ReturnsMissing(): void
+    {
+        $resolved = resolveWebcamOriginalAtTimestamp($this->airportId, $this->camIndex, 0);
+        $this->assertFalse($resolved['ok']);
+        $this->assertSame('missing', $resolved['error']);
+    }
+
+    public function testPublicApiWebcamFmtRejectedOnOriginal_ExplicitFmt_ReturnsTrue(): void
+    {
+        $this->assertTrue(publicApiWebcamFmtRejectedOnOriginal(true, 'original', null, null));
+        $this->assertFalse(publicApiWebcamFmtRejectedOnOriginal(false, 'original', null, null));
+        $this->assertFalse(publicApiWebcamFmtRejectedOnOriginal(true, '360', null, null));
+        $this->assertFalse(publicApiWebcamFmtRejectedOnOriginal(true, 'original', 1280, null));
+    }
+
+    public function testFormatWebcamImageVariants_OriginalRow_OmitsFmt(): void
+    {
+        $images = formatWebcamImageVariants('kspb', 0, false);
+        $this->assertSame('original', $images[0]['variant']);
+        $this->assertStringNotContainsString('fmt=', $images[0]['url']);
+        if (isset($images[0]['format'])) {
+            $this->assertContains($images[0]['format'], getSupportedWebcamSourceFormats());
+        }
+        $this->assertSame('jpg', $images[1]['format']);
+        $this->assertStringContainsString('size=', $images[1]['url']);
+    }
+
+    public function testFormatWebcamImageVariants_ServablePngOriginal_IncludesFormatOmitsFmt(): void
+    {
+        $ts = 1704067700;
+        $this->writeOriginal($ts, 'png', $this->pngBytes());
+        $images = formatWebcamImageVariants($this->airportId, $this->camIndex, false);
+        $this->assertSame('original', $images[0]['variant']);
+        $this->assertSame('png', $images[0]['format']);
+        $this->assertStringNotContainsString('fmt=', $images[0]['url']);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('unsupportedWebcamPayloadProvider')]
+    public function testFormatWebcamImageVariants_UnsupportedBytesNamedJpg_OmitsFormat(string $label, string $bytes): void
+    {
+        $ts = 1704067800;
+        $this->writeOriginal($ts, 'jpg', $bytes);
+        $images = formatWebcamImageVariants($this->airportId, $this->camIndex, false);
+        $this->assertSame('original', $images[0]['variant']);
+        $this->assertArrayNotHasKey('format', $images[0]);
+        $this->assertStringNotContainsString('fmt=', $images[0]['url']);
+        $this->assertNotSame('', $label);
+    }
+}

--- a/tests/Unit/WebcamPipelineTest.php
+++ b/tests/Unit/WebcamPipelineTest.php
@@ -11,9 +11,11 @@ require_once __DIR__ . '/../../lib/webcam-pipeline.php';
 require_once __DIR__ . '/../../lib/config.php';
 require_once __DIR__ . '/../../lib/constants.php';
 require_once __DIR__ . '/../../lib/cache-paths.php';
+require_once __DIR__ . '/WebcamUnsupportedPayloads.php';
 
 class WebcamPipelineTest extends TestCase
 {
+    use WebcamUnsupportedPayloads;
     private string $testImagePath;
     private string $testDir;
 
@@ -84,6 +86,18 @@ class WebcamPipelineTest extends TestCase
         $result = $pipeline->process('/nonexistent/path.jpg', time(), 'mjpeg');
         
         $this->assertFalse($result->success, 'Pipeline should fail when staging file is missing');
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('unsupportedWebcamPayloadProvider')]
+    public function testPipeline_UnsupportedStagingFile_FailsInvalidFormat(string $label, string $bytes): void
+    {
+        $path = $this->testDir . '/payload.' . $label;
+        file_put_contents($path, $bytes);
+        $pipeline = ProcessingPipelineFactory::create('kspb', 0, [], ['name' => 'Test Airport']);
+        $result = $pipeline->process($path, time(), 'http');
+
+        $this->assertFalse($result->success);
+        $this->assertSame('invalid_format', $result->errorReason);
     }
 
     /**

--- a/tests/Unit/WebcamUnsupportedPayloads.php
+++ b/tests/Unit/WebcamUnsupportedPayloads.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Shared non-image payloads for webcam allowlist tests.
+ */
+
+trait WebcamUnsupportedPayloads
+{
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function unsupportedWebcamPayloadProvider(): array
+    {
+        $pad = static function (string $header): string {
+            return $header . str_repeat("\x00", 200);
+        };
+
+        return [
+            'pdf' => ['pdf', $pad("%PDF-1.4\n")],
+            'pe_exe' => ['exe', $pad("MZ" . str_repeat("\x90", 64))],
+            'elf' => ['elf', $pad("\x7FELF")],
+            'gif' => ['gif', $pad("GIF89a")],
+            'bmp' => ['bmp', $pad("BM")],
+            'zip' => ['zip', $pad("PK\x03\x04")],
+            'html' => ['html', $pad("<!DOCTYPE html>")],
+            'random' => ['bin', str_repeat("\x01\x02\x03\x04", 50)],
+        ];
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,10 +25,10 @@ if (!defined('AVIATIONWX_LOG_FILE')) {
     define('AVIATIONWX_LOG_FILE', AVIATIONWX_LOG_DIR . '/app.log');
 }
 
-// When hitting a live server (TEST_API_URL), use the same cache path the server uses
-// so integration tests can seed data the server will serve (Docker uses /tmp/aviationwx-cache)
-if (getenv('TEST_API_URL') && !defined('CACHE_BASE_DIR')) {
-    define('CACHE_BASE_DIR', '/tmp/aviationwx-cache');
+// Stateful HTTP fixtures require an explicitly shared, disposable cache path.
+$testCacheDir = getenv('TEST_CACHE_DIR');
+if (is_string($testCacheDir) && $testCacheDir !== '' && !defined('CACHE_BASE_DIR')) {
+    define('CACHE_BASE_DIR', rtrim($testCacheDir, '/'));
 }
 
 // Override metrics cache directories for testing (must be before cache-paths.php is loaded)

--- a/tests/js/webcam-player-cache.test.js
+++ b/tests/js/webcam-player-cache.test.js
@@ -10,6 +10,7 @@
 const {
     makeWebcamPreloadKey,
     pruneWebcamPreloadForCameraPeriod,
+    selectWebcamHistoryFormat,
 } = require('../../public/js/webcam-player-utils.js');
 
 let passed = 0;
@@ -86,6 +87,20 @@ function runTests() {
         }
         if (loading.size !== 0) {
             throw new Error('loading should be empty');
+        }
+    });
+
+    test('history format selection preserves PNG-only frames', () => {
+        const format = selectWebcamHistoryFormat(['png'], 'webp');
+        if (format !== 'png') {
+            throw new Error(`expected png, got ${format}`);
+        }
+    });
+
+    test('history format selection prefers JPEG compatibility fallback', () => {
+        const format = selectWebcamHistoryFormat(['png', 'jpg'], 'webp');
+        if (format !== 'jpg') {
+            throw new Error(`expected jpg, got ${format}`);
         }
     });
 


### PR DESCRIPTION
## Summary
- serve current, historical, and downloadable webcam originals as native JPEG, PNG, or WebP based on magic bytes
- keep catalog format metadata, transforms, retention cleanup, and serve metrics consistent with native originals
- reject malformed `fmt` shapes cleanly and protect live original symlink targets during cleanup
- isolate native-format HTTP fixtures from development cache state

## Contract
- omit `fmt` for the native original; `fmt` remains limited to generated variants
- clients must honor the response `Content-Type` and catalog `images[].format`
- mutable current/download responses use live cache policy; timestamped history remains immutable

## Test plan
- [x] Native lifecycle/config tests (464 tests, 1,023 assertions; 1 skipped)
- [x] Isolated Docker webcam HTTP tests (20 tests, 84 assertions; 1 skipped)
- [x] All tracked unit tests (3,592 tests, 11,770 assertions; 27 skipped, 1 pre-existing warning)
- [x] Full stacked diff whitespace check
- [ ] Full Integration suite is not clean on main-equivalent UI tests (19 unrelated dashboard failures); changed webcam HTTP suite passes independently

Depends on #294.
Closes #293.