### PR TITLE
Add Public API capability filters and weathercam catalog

### DIFF
--- a/api/docs/index.php
+++ b/api/docs/index.php
@@ -461,8 +461,8 @@ $attribution = getPublicApiAttributionText();
             <h3>🚀 Quick Start</h3>
             <p>Get current weather for an airport:</p>
             <pre><code>curl https://api.aviationwx.org/v1/airports/kspb/weather</code></pre>
-            <p>List all available airports:</p>
-            <pre><code>curl https://api.aviationwx.org/v1/airports</code></pre>
+            <p>List AviationWX-operated weathercams (absolute image URLs):</p>
+            <pre><code>curl https://api.aviationwx.org/v1/weathercam/bulk?operator=aviationwx</code></pre>
         </div>
         
         <h2>Authentication</h2>
@@ -500,7 +500,7 @@ $attribution = getPublicApiAttributionText();
                 <span class="endpoint-path">/v1/airports</span>
             </div>
             <div class="endpoint-body">
-                <p class="endpoint-desc">List all available airports with basic metadata. Optional <code>operator</code> includes an airport when it has one or more weathercams or weather sources with that operator, including weather-source type defaults when operator is omitted (for example metar is faa).</p>
+                <p class="endpoint-desc">List all available airports with basic metadata. Optional <code>operator</code> includes an airport when it has one or more weathercams or weather sources with that operator, including weather-source type defaults when operator is omitted (for example metar is faa). Optional <code>has_webcams=true</code> keeps airports that have weathercams configured (not sliced by operator). Optional <code>has_weather=true</code> keeps airports with weather sources configured (not sliced by operator). When <code>operator</code> is set, <code>webcam_count</code> still counts matching weathercams only.</p>
             </div>
         </div>
         
@@ -571,6 +571,16 @@ $attribution = getPublicApiAttributionText();
             </div>
             <div class="endpoint-body">
                 <p class="endpoint-desc">Get weather for multiple airports in a single request (max <?= getPublicApiBulkMaxAirports() ?> airports).</p>
+            </div>
+        </div>
+        
+        <div class="endpoint">
+            <div class="endpoint-header">
+                <span class="method">GET</span>
+                <span class="endpoint-path">/v1/weathercam/bulk</span>
+            </div>
+            <div class="endpoint-body">
+                <p class="endpoint-desc">One-query weathercam catalog. Optional <code>operator</code> matches weathercams only (not weather sources). Nested webcam objects include absolute <code>image_url</code> / <code>images</code> URLs. Origin rebuilds when airports.json changes.</p>
             </div>
         </div>
         

--- a/api/docs/index.php
+++ b/api/docs/index.php
@@ -583,7 +583,7 @@ $attribution = getPublicApiAttributionText();
                 <p class="endpoint-desc">One-query weathercam catalog. Optional <code>operator</code> matches weathercams only (not weather sources). Nested webcam objects include absolute <code>image_url</code> / <code>images</code> URLs. Origin rebuilds when airports.json changes.</p>
             </div>
         </div>
-        
+
         <div class="endpoint">
             <div class="endpoint-header">
                 <span class="method">GET</span>

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -29,7 +29,7 @@
     "/airports": {
       "get": {
         "summary": "List all airports",
-        "description": "Returns a list of all enabled airports with basic metadata. Optional operator includes an airport when airports.json has one or more weathercams or weather sources with that operator, including weather-source type defaults when operator is omitted.",
+        "description": "Returns a list of all enabled airports with basic metadata. Optional operator includes an airport when airports.json has one or more weathercams or weather sources with that operator, including weather-source type defaults when operator is omitted. Optional has_webcams keeps airports that have weathercams configured; it is not sliced by operator. Optional has_weather keeps airports that have weather sources configured; it is not sliced by operator. When operator is set, webcam_count still counts matching weathercams only.",
         "operationId": "listAirports",
         "tags": ["Airports"],
         "parameters": [
@@ -53,6 +53,24 @@
           },
           {
             "$ref": "#/components/parameters/Operator"
+          },
+          {
+            "name": "has_webcams",
+            "in": "query",
+            "description": "Filter by whether the airport has weathercams. Use 'true' for airports with one or more weathercams, 'false' for none. Not sliced by operator.",
+            "schema": {
+              "type": "string",
+              "enum": ["true", "false"]
+            }
+          },
+          {
+            "name": "has_weather",
+            "in": "query",
+            "description": "Filter by whether the airport has weather sources configured. Use 'true' for airports with weather, 'false' for none. Not sliced by operator; weather remains the fused observation.",
+            "schema": {
+              "type": "string",
+              "enum": ["true", "false"]
+            }
           }
         ],
         "responses": {
@@ -486,6 +504,37 @@
         }
       }
     },
+    "/weathercam/bulk": {
+      "get": {
+        "summary": "Weathercam catalog",
+        "description": "One-query catalog of listed airports that have matching weathercams. Nested webcam objects match GET /airports/{id}/webcams, with absolute image and history URLs. Optional operator matches weathercams only; weather sources do not affect membership. Airports with no matching weathercam are omitted. Unlike GET /weather/bulk, this is a full catalog (no airports query and no max-airport cap). The origin response is rebuilt when airports.json changes.",
+        "operationId": "getWeathercamBulk",
+        "tags": ["Webcams"],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/WeathercamOperator"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebcamBulkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
     "/operations": {
       "get": {
         "summary": "Get operations snapshot",
@@ -673,6 +722,17 @@
         "name": "operator",
         "in": "query",
         "description": "Operating-network slug. Query values are lowercased before matching. Invalid slugs return 400. Matching uses airports.json. Omitted weathercam operator is aviationwx. Omitted weather-source operator uses the type default: metar is faa, nws is nws, swob_auto and swob_man are navcanada, awosnet is awosnet, synopticdata is synopticdata, and other types are aviationwx.",
+        "schema": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$",
+          "maxLength": 64,
+          "example": "aviationwx"
+        }
+      },
+      "WeathercamOperator": {
+        "name": "operator",
+        "in": "query",
+        "description": "Weathercam operating-network slug. Query values are lowercased before matching. Invalid slugs return 400. Matching uses airports.json weathercams only; omitted weathercam operator is aviationwx. Airports with no matching weathercam are omitted. Weather sources do not affect membership.",
         "schema": {
           "type": "string",
           "pattern": "^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$",
@@ -1248,7 +1308,7 @@
           },
           "has_webcams": {
             "type": "boolean",
-            "description": "True when the airport has one or more weathercams. When operator is set, only matching weathercams are counted."
+            "description": "True when the airport has one or more weathercams. Not sliced by operator."
           },
           "webcam_count": {
             "type": "integer",
@@ -1932,7 +1992,8 @@
                 "image_url",
                 "refresh_seconds",
                 "approximate_heading",
-                "operator"
+                "operator",
+                "images"
               ],
               "properties": {
                 "index": {
@@ -1942,11 +2003,12 @@
                   "type": "string"
                 },
                 "image_url": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Current image. Origin-relative /v1 path on GET /airports/{id}/webcams. Absolute canonical Public API v1 URL on GET /weathercam/bulk."
                 },
                 "history_url": {
                   "type": "string",
-                  "description": "URL to webcam history endpoint. Present only when webcam history retention is greater than zero for this airport (airport-specific, global, or default setting)."
+                  "description": "History endpoint. Present only when webcam history retention is greater than zero. Origin-relative on GET /airports/{id}/webcams; absolute on GET /weathercam/bulk."
                 },
                 "history_enabled": {
                   "type": "boolean",
@@ -1966,8 +2028,82 @@
                 "operator": {
                   "type": "string",
                   "description": "Operating network slug. Omitted config is aviationwx. Other networks (for example wsdot) are explicit."
+                },
+                "images": {
+                  "type": "array",
+                  "description": "Configured original plus height variants. Original is jpg only. Sized rows follow enabled formats. Not a disk probe of the current frame.",
+                  "items": {
+                    "type": "object",
+                    "required": ["variant", "height", "format", "url"],
+                    "properties": {
+                      "variant": {
+                        "type": "string",
+                        "description": "'original' or a height in pixels as a string"
+                      },
+                      "height": {
+                        "type": "integer",
+                        "nullable": true,
+                        "description": "Variant height in pixels; null for original"
+                      },
+                      "format": {
+                        "type": "string",
+                        "enum": ["jpg", "webp"]
+                      },
+                      "url": {
+                        "type": "string"
+                      }
+                    }
+                  }
                 }
               }
+            }
+          }
+        }
+      },
+      "WebcamBulkResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "meta": {
+            "allOf": [
+              { "$ref": "#/components/schemas/Meta" },
+              {
+                "type": "object",
+                "properties": {
+                  "total": {
+                    "type": "integer",
+                    "description": "Airports in this response"
+                  },
+                  "webcam_count": {
+                    "type": "integer",
+                    "description": "Weathercams in this response"
+                  },
+                  "coordinate_system": {
+                    "type": "string",
+                    "example": "WGS84"
+                  }
+                }
+              }
+            ]
+          },
+          "airports": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                { "$ref": "#/components/schemas/AirportSummary" },
+                {
+                  "type": "object",
+                  "required": ["webcams"],
+                  "properties": {
+                    "webcams": {
+                      "type": "array",
+                      "description": "Same webcam objects as GET /airports/{id}/webcams. Image, history, and images[].url are absolute canonical Public API v1 URLs."
+                    }
+                  }
+                }
+              ]
             }
           }
         }

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -57,19 +57,19 @@
           {
             "name": "has_webcams",
             "in": "query",
-            "description": "Filter by whether the airport has weathercams. Use 'true' for airports with one or more weathercams, 'false' for none. Not sliced by operator.",
+            "description": "Filter by whether the airport has weathercams. Use 'true' or '1' for airports with one or more weathercams; use 'false' or '0' for none. Not sliced by operator.",
             "schema": {
               "type": "string",
-              "enum": ["true", "false"]
+              "enum": ["true", "false", "1", "0"]
             }
           },
           {
             "name": "has_weather",
             "in": "query",
-            "description": "Filter by whether the airport has weather sources configured. Use 'true' for airports with weather, 'false' for none. Not sliced by operator; weather remains the fused observation.",
+            "description": "Filter by whether the airport has weather sources configured. Use 'true' or '1' for airports with weather; use 'false' or '0' for none. Not sliced by operator; weather remains the fused observation.",
             "schema": {
               "type": "string",
-              "enum": ["true", "false"]
+              "enum": ["true", "false", "1", "0"]
             }
           }
         ],

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -1973,6 +1973,79 @@
           }
         }
       },
+      "Webcam": {
+        "type": "object",
+        "required": [
+          "index",
+          "name",
+          "image_url",
+          "refresh_seconds",
+          "approximate_heading",
+          "operator",
+          "images"
+        ],
+        "properties": {
+          "index": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "image_url": {
+            "type": "string",
+            "description": "Current image. Origin-relative /v1 path on GET /airports/{id}/webcams. Absolute canonical Public API v1 URL on GET /weathercam/bulk."
+          },
+          "history_url": {
+            "type": "string",
+            "description": "History endpoint. Present only when webcam history retention is greater than zero. Origin-relative on GET /airports/{id}/webcams; absolute on GET /weathercam/bulk."
+          },
+          "history_enabled": {
+            "type": "boolean",
+            "enum": [true],
+            "description": "Present and true when webcam history retention is greater than zero for this airport."
+          },
+          "refresh_seconds": {
+            "type": "integer"
+          },
+          "approximate_heading": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0,
+            "maximum": 360,
+            "description": "Direction the camera lens points, in true-north degrees clockwise from north (0-360). Non-null on active non-maintenance airports. Null when the airport is in maintenance or heading is not yet commissioned."
+          },
+          "operator": {
+            "type": "string",
+            "description": "Operating network slug. Omitted config is aviationwx. Other networks (for example wsdot) are explicit."
+          },
+          "images": {
+            "type": "array",
+            "description": "Configured original plus height variants. Original is jpg only. Sized rows follow enabled formats. Not a disk probe of the current frame.",
+            "items": {
+              "type": "object",
+              "required": ["variant", "height", "format", "url"],
+              "properties": {
+                "variant": {
+                  "type": "string",
+                  "description": "'original' or a height in pixels as a string"
+                },
+                "height": {
+                  "type": "integer",
+                  "nullable": true,
+                  "description": "Variant height in pixels; null for original"
+                },
+                "format": {
+                  "type": "string",
+                  "enum": ["jpg", "webp"]
+                },
+                "url": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
       "WebcamListResponse": {
         "type": "object",
         "properties": {
@@ -1985,77 +2058,7 @@
           "webcams": {
             "type": "array",
             "items": {
-              "type": "object",
-              "required": [
-                "index",
-                "name",
-                "image_url",
-                "refresh_seconds",
-                "approximate_heading",
-                "operator",
-                "images"
-              ],
-              "properties": {
-                "index": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "image_url": {
-                  "type": "string",
-                  "description": "Current image. Origin-relative /v1 path on GET /airports/{id}/webcams. Absolute canonical Public API v1 URL on GET /weathercam/bulk."
-                },
-                "history_url": {
-                  "type": "string",
-                  "description": "History endpoint. Present only when webcam history retention is greater than zero. Origin-relative on GET /airports/{id}/webcams; absolute on GET /weathercam/bulk."
-                },
-                "history_enabled": {
-                  "type": "boolean",
-                  "enum": [true],
-                  "description": "Present and true when webcam history retention is greater than zero for this airport."
-                },
-                "refresh_seconds": {
-                  "type": "integer"
-                },
-                "approximate_heading": {
-                  "type": "integer",
-                  "nullable": true,
-                  "minimum": 0,
-                  "maximum": 360,
-                  "description": "Direction the camera lens points, in true-north degrees clockwise from north (0-360). Non-null on active non-maintenance airports. Null when the airport is in maintenance or heading is not yet commissioned."
-                },
-                "operator": {
-                  "type": "string",
-                  "description": "Operating network slug. Omitted config is aviationwx. Other networks (for example wsdot) are explicit."
-                },
-                "images": {
-                  "type": "array",
-                  "description": "Configured original plus height variants. Original is jpg only. Sized rows follow enabled formats. Not a disk probe of the current frame.",
-                  "items": {
-                    "type": "object",
-                    "required": ["variant", "height", "format", "url"],
-                    "properties": {
-                      "variant": {
-                        "type": "string",
-                        "description": "'original' or a height in pixels as a string"
-                      },
-                      "height": {
-                        "type": "integer",
-                        "nullable": true,
-                        "description": "Variant height in pixels; null for original"
-                      },
-                      "format": {
-                        "type": "string",
-                        "enum": ["jpg", "webp"]
-                      },
-                      "url": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              }
+              "$ref": "#/components/schemas/Webcam"
             }
           }
         }
@@ -2099,7 +2102,10 @@
                   "properties": {
                     "webcams": {
                       "type": "array",
-                      "description": "Same webcam objects as GET /airports/{id}/webcams. Image, history, and images[].url are absolute canonical Public API v1 URLs."
+                      "description": "Same webcam objects as GET /airports/{id}/webcams. Image, history, and images[].url are absolute canonical Public API v1 URLs.",
+                      "items": {
+                        "$ref": "#/components/schemas/Webcam"
+                      }
                     }
                   }
                 }

--- a/api/v1/airports.php
+++ b/api/v1/airports.php
@@ -29,33 +29,12 @@ require_once __DIR__ . '/../../lib/weather/utils.php';
  */
 function handleListAirports(array $params, array $context): void
 {
-    $includeUnlisted = false;
-    if (isset($_GET['include_unlisted'])) {
-        $unlistedParam = strtolower(trim($_GET['include_unlisted']));
-        $includeUnlisted = ($unlistedParam === 'true' || $unlistedParam === '1');
-    }
+    $includeUnlisted = parsePublicApiOptionalBooleanQuery('include_unlisted') ?? false;
 
     $airports = getPublicApiAirports(true, $includeUnlisted);
 
-    $maintenanceFilter = null;
-    if (isset($_GET['maintenance'])) {
-        $maintenanceParam = strtolower(trim($_GET['maintenance']));
-        if ($maintenanceParam === 'true' || $maintenanceParam === '1') {
-            $maintenanceFilter = true;
-        } elseif ($maintenanceParam === 'false' || $maintenanceParam === '0') {
-            $maintenanceFilter = false;
-        }
-    }
-
-    $limitedAvailabilityFilter = null;
-    if (isset($_GET['limited_availability'])) {
-        $limitedParam = strtolower(trim($_GET['limited_availability']));
-        if ($limitedParam === 'true' || $limitedParam === '1') {
-            $limitedAvailabilityFilter = true;
-        } elseif ($limitedParam === 'false' || $limitedParam === '0') {
-            $limitedAvailabilityFilter = false;
-        }
-    }
+    $maintenanceFilter = parsePublicApiOptionalBooleanQuery('maintenance');
+    $limitedAvailabilityFilter = parsePublicApiOptionalBooleanQuery('limited_availability');
 
     $operatorParse = parseOperatorQueryFromGet();
     if (!$operatorParse['ok']) {

--- a/api/v1/airports.php
+++ b/api/v1/airports.php
@@ -12,8 +12,8 @@
  * - limited_availability: Filter by limited availability ('true' or 'false')
  * - include_unlisted: Include unlisted airports ('true' or 'false', default: false)
  * - operator: Include airports that have one or more matching weathercams or weather sources
- * - has_webcams: Filter by weathercam presence ('true' or 'false'); not operator-sliced
- * - has_weather: Filter by weather-source presence ('true' or 'false'); not operator-sliced
+ * - has_webcams: Filter by weathercam presence ('true'/'1' or 'false'/'0'); not operator-sliced
+ * - has_weather: Filter by weather-source presence ('true'/'1' or 'false'/'0'); not operator-sliced
  */
 
 require_once __DIR__ . '/../../lib/public-api/middleware.php';

--- a/api/v1/airports.php
+++ b/api/v1/airports.php
@@ -12,6 +12,8 @@
  * - limited_availability: Filter by limited availability ('true' or 'false')
  * - include_unlisted: Include unlisted airports ('true' or 'false', default: false)
  * - operator: Include airports that have one or more matching weathercams or weather sources
+ * - has_webcams: Filter by weathercam presence ('true' or 'false'); not operator-sliced
+ * - has_weather: Filter by weather-source presence ('true' or 'false'); not operator-sliced
  */
 
 require_once __DIR__ . '/../../lib/public-api/middleware.php';
@@ -27,17 +29,14 @@ require_once __DIR__ . '/../../lib/weather/utils.php';
  */
 function handleListAirports(array $params, array $context): void
 {
-    // Parse include_unlisted filter parameter (default: false)
     $includeUnlisted = false;
     if (isset($_GET['include_unlisted'])) {
         $unlistedParam = strtolower(trim($_GET['include_unlisted']));
         $includeUnlisted = ($unlistedParam === 'true' || $unlistedParam === '1');
     }
-    
-    // Get airports (listed by default, optionally including unlisted)
+
     $airports = getPublicApiAirports(true, $includeUnlisted);
-    
-    // Parse maintenance filter parameter
+
     $maintenanceFilter = null;
     if (isset($_GET['maintenance'])) {
         $maintenanceParam = strtolower(trim($_GET['maintenance']));
@@ -47,8 +46,7 @@ function handleListAirports(array $params, array $context): void
             $maintenanceFilter = false;
         }
     }
-    
-    // Parse limited_availability filter parameter
+
     $limitedAvailabilityFilter = null;
     if (isset($_GET['limited_availability'])) {
         $limitedParam = strtolower(trim($_GET['limited_availability']));
@@ -69,18 +67,18 @@ function handleListAirports(array $params, array $context): void
         return;
     }
     $operatorFilter = $operatorParse['value'];
-    
-    // Format airports for response
+
+    $hasWebcamsFilter = parsePublicApiOptionalBooleanQuery('has_webcams');
+    $hasWeatherFilter = parsePublicApiOptionalBooleanQuery('has_weather');
+
     $formattedAirports = [];
     foreach ($airports as $airportId => $airport) {
         $formatted = formatAirportSummary($airportId, $airport, $operatorFilter);
-        
-        // Apply maintenance filter if specified
+
         if ($maintenanceFilter !== null && $formatted['maintenance'] !== $maintenanceFilter) {
             continue;
         }
-        
-        // Apply limited_availability filter if specified
+
         if ($limitedAvailabilityFilter !== null && $formatted['limited_availability'] !== $limitedAvailabilityFilter) {
             continue;
         }
@@ -88,19 +86,24 @@ function handleListAirports(array $params, array $context): void
         if ($operatorFilter !== null && !airportMatchesOperator($airport, $operatorFilter)) {
             continue;
         }
-        
+
+        if ($hasWebcamsFilter !== null && $formatted['has_webcams'] !== $hasWebcamsFilter) {
+            continue;
+        }
+
+        if ($hasWeatherFilter !== null && $formatted['has_weather'] !== $hasWeatherFilter) {
+            continue;
+        }
+
         $formattedAirports[] = $formatted;
     }
-    
-    // Sort by airport ID for consistent ordering
+
     usort($formattedAirports, function ($a, $b) {
         return strcmp($a['id'], $b['id']);
     });
-    
-    // Send cache headers for metadata
+
     sendPublicApiCacheHeaders('metadata');
-    
-    // Send response
+
     sendPublicApiSuccess(
         ['airports' => $formattedAirports],
         ['total' => count($formattedAirports), 'coordinate_system' => 'WGS84']
@@ -117,10 +120,11 @@ function handleListAirports(array $params, array $context): void
  */
 function formatAirportSummary(string $airportId, array $airport, ?string $operatorFilter = null): array
 {
-    // Weather is always the fused observation, so has_weather is not operator-sliced.
+    // has_weather and has_webcams are airport capabilities. webcam_count still
+    // counts matching weathercams when operator is set.
     $hasWeather = hasWeatherSources($airport);
     $webcamCount = countWeathercamsForOperator($airport, $operatorFilter);
-    $hasWebcams = $webcamCount > 0;
+    $hasWebcams = countWeathercamsForOperator($airport, null) > 0;
 
     $baseDomain = getBaseDomain();
     $url = 'https://' . $airportId . '.' . $baseDomain . '/';
@@ -144,5 +148,35 @@ function formatAirportSummary(string $airportId, array $airport, ?string $operat
         'webcam_count' => $webcamCount,
         'url' => $url,
     ];
+}
+
+/**
+ * Parse an optional true/false Public API query flag.
+ *
+ * Recognizes true/false and 1/0. Omitted or unrecognized values mean no filter.
+ *
+ * @param string $name Query parameter name
+ * @return bool|null True/false when recognized, null when omitted or unrecognized
+ */
+function parsePublicApiOptionalBooleanQuery(string $name): ?bool
+{
+    if (!array_key_exists($name, $_GET)) {
+        return null;
+    }
+
+    $raw = $_GET[$name];
+    if (is_array($raw)) {
+        return null;
+    }
+
+    $param = strtolower(trim((string) $raw));
+    if ($param === 'true' || $param === '1') {
+        return true;
+    }
+    if ($param === 'false' || $param === '0') {
+        return false;
+    }
+
+    return null;
 }
 

--- a/api/v1/router.php
+++ b/api/v1/router.php
@@ -106,6 +106,9 @@ function routePublicApiRequest(string $path, array $context): void
         
         // GET /v1/weather/bulk
         '#^/weather/bulk$#' => ['file' => 'weather-bulk.php', 'handler' => 'handleGetWeatherBulk'],
+
+        // GET /v1/weathercam/bulk
+        '#^/weathercam/bulk$#' => ['file' => 'weathercam-bulk.php', 'handler' => 'handleGetWeathercamBulk'],
         
         // GET /v1/status
         '#^/status$#' => ['file' => 'status.php', 'handler' => 'handleGetStatus'],

--- a/api/v1/weathercam-bulk.php
+++ b/api/v1/weathercam-bulk.php
@@ -149,7 +149,8 @@ function rememberWeathercamBulkCatalogIfConfigShaStable(
     array $airports,
     ?string $shaBefore,
     ?string $shaAfter
-): void {
+): void
+{
     if ($shaBefore === null || $shaBefore === '' || $shaBefore !== $shaAfter) {
         return;
     }

--- a/api/v1/weathercam-bulk.php
+++ b/api/v1/weathercam-bulk.php
@@ -60,8 +60,9 @@ function getWeathercamBulkAirports(?string $operatorFilter): array
 {
     $full = recallWeathercamBulkCatalog();
     if ($full === null) {
+        $shaBefore = getConfigFileSha256();
         $full = buildWeathercamBulkAirports(getPublicApiAirports(true, false), null);
-        rememberWeathercamBulkCatalog($full);
+        rememberWeathercamBulkCatalogIfConfigShaStable($full, $shaBefore, getConfigFileSha256());
     }
 
     return filterWeathercamBulkAirportsByOperator($full, $operatorFilter);
@@ -134,6 +135,26 @@ function filterWeathercamBulkAirportsByOperator(array $airports, ?string $operat
     }
 
     return $filtered;
+}
+
+/**
+ * Cache a rebuilt catalog only when airports.json SHA matches before and after the walk.
+ *
+ * Otherwise a config save mid-rebuild can store the previous rows under the new SHA
+ * until TTL or the next change.
+ *
+ * @param list<array<string, mixed>> $airports
+ */
+function rememberWeathercamBulkCatalogIfConfigShaStable(
+    array $airports,
+    ?string $shaBefore,
+    ?string $shaAfter
+): void {
+    if ($shaBefore === null || $shaBefore === '' || $shaBefore !== $shaAfter) {
+        return;
+    }
+
+    rememberWeathercamBulkCatalog($airports, $shaBefore);
 }
 
 /**

--- a/api/v1/weathercam-bulk.php
+++ b/api/v1/weathercam-bulk.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Public API - Weathercam Catalog
+ *
+ * GET /v1/weathercam/bulk
+ *
+ * One-query catalog: listed airports that have matching weathercams, each
+ * nested with the same webcam objects as GET /v1/airports/{id}/webcams.
+ * Image and history URLs are absolute (canonical Public API v1 base).
+ *
+ * Query parameters:
+ * - operator: Weathercam operator only (not the GET /v1/airports union with weather sources)
+ */
+
+require_once __DIR__ . '/airports.php';
+require_once __DIR__ . '/webcams.php';
+
+/**
+ * Handle GET /v1/weathercam/bulk request
+ *
+ * @param array $params Path parameters (empty for this endpoint)
+ * @param array $context Request context from middleware
+ */
+function handleGetWeathercamBulk(array $params, array $context): void
+{
+    $operatorParse = parseOperatorQueryFromGet();
+    if (!$operatorParse['ok']) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            $operatorParse['error'],
+            400
+        );
+        return;
+    }
+
+    $catalog = getWeathercamBulkAirports($operatorParse['value']);
+    $webcamCount = 0;
+    foreach ($catalog as $airport) {
+        $webcamCount += count($airport['webcams'] ?? []);
+    }
+
+    sendPublicApiCacheHeaders('metadata');
+    sendPublicApiSuccess(
+        ['airports' => $catalog],
+        [
+            'total' => count($catalog),
+            'webcam_count' => $webcamCount,
+            'coordinate_system' => 'WGS84',
+        ]
+    );
+}
+
+/**
+ * Cached catalog, then optional weathercam-operator slice.
+ *
+ * @param string|null $operatorFilter Lowercase slug, or null for every weathercam
+ * @return list<array<string, mixed>>
+ */
+function getWeathercamBulkAirports(?string $operatorFilter): array
+{
+    $full = recallWeathercamBulkCatalog();
+    if ($full === null) {
+        $full = buildWeathercamBulkAirports(getPublicApiAirports(true, false), null);
+        rememberWeathercamBulkCatalog($full);
+    }
+
+    return filterWeathercamBulkAirportsByOperator($full, $operatorFilter);
+}
+
+/**
+ * Compose airport summaries with nested matching weathercams.
+ *
+ * Airports with no matching weathercam are omitted. Unlike GET /v1/airports,
+ * weather-source operator does not keep an airport in this catalog.
+ *
+ * @param array<string, mixed> $airports Airport ID to configuration
+ * @param string|null $operatorFilter Lowercase slug, or null for every weathercam
+ * @return list<array<string, mixed>>
+ */
+function buildWeathercamBulkAirports(array $airports, ?string $operatorFilter): array
+{
+    $formattedAirports = [];
+    foreach ($airports as $airportId => $airport) {
+        if (!is_string($airportId) || $airportId === '' || !is_array($airport)) {
+            continue;
+        }
+        $webcams = listFormattedWebcamsForAirport($airportId, $airport, $operatorFilter, true);
+        if ($webcams === []) {
+            continue;
+        }
+        $summary = formatAirportSummary($airportId, $airport, $operatorFilter);
+        $summary['webcams'] = $webcams;
+        $formattedAirports[] = $summary;
+    }
+
+    usort($formattedAirports, function ($a, $b) {
+        return strcmp((string) $a['id'], (string) $b['id']);
+    });
+
+    return $formattedAirports;
+}
+
+/**
+ * Slice a full catalog by resolved weathercam operator without mutating cache rows.
+ *
+ * @param list<array<string, mixed>> $airports
+ * @param string|null $operatorFilter Lowercase slug, or null for no slice
+ * @return list<array<string, mixed>>
+ */
+function filterWeathercamBulkAirportsByOperator(array $airports, ?string $operatorFilter): array
+{
+    if ($operatorFilter === null) {
+        return $airports;
+    }
+
+    $filtered = [];
+    foreach ($airports as $airport) {
+        if (!is_array($airport)) {
+            continue;
+        }
+        $webcams = [];
+        foreach ($airport['webcams'] ?? [] as $webcam) {
+            if (is_array($webcam) && ($webcam['operator'] ?? '') === $operatorFilter) {
+                $webcams[] = $webcam;
+            }
+        }
+        if ($webcams === []) {
+            continue;
+        }
+        $row = $airport;
+        $row['webcams'] = $webcams;
+        $row['webcam_count'] = count($webcams);
+        $filtered[] = $row;
+    }
+
+    return $filtered;
+}
+
+/**
+ * Store the unfiltered catalog for the given airports.json SHA.
+ *
+ * @param list<array<string, mixed>> $airports
+ * @param string|null $sha Config SHA; omitted uses getConfigFileSha256()
+ */
+function rememberWeathercamBulkCatalog(array $airports, ?string $sha = null): void
+{
+    $sha = $sha ?? getConfigFileSha256();
+    if ($sha === null || $sha === '') {
+        return;
+    }
+
+    $GLOBALS['_aviationwx_weathercam_bulk_sha'] = $sha;
+    $GLOBALS['_aviationwx_weathercam_bulk_airports'] = $airports;
+
+    if (function_exists('apcu_store')) {
+        apcu_store(
+            'aviationwx_weathercam_bulk',
+            ['sha' => $sha, 'airports' => $airports],
+            CONFIG_CACHE_TTL
+        );
+    }
+}
+
+/**
+ * @return list<array<string, mixed>>|null
+ */
+function recallWeathercamBulkCatalog(): ?array
+{
+    $sha = getConfigFileSha256();
+    if ($sha === null || $sha === '') {
+        return null;
+    }
+
+    $localSha = $GLOBALS['_aviationwx_weathercam_bulk_sha'] ?? null;
+    $localAirports = $GLOBALS['_aviationwx_weathercam_bulk_airports'] ?? null;
+    if ($localSha === $sha && is_array($localAirports)) {
+        return $localAirports;
+    }
+
+    if (function_exists('apcu_fetch')) {
+        $cached = apcu_fetch('aviationwx_weathercam_bulk');
+        if (
+            is_array($cached)
+            && ($cached['sha'] ?? '') === $sha
+            && isset($cached['airports'])
+            && is_array($cached['airports'])
+        ) {
+            $GLOBALS['_aviationwx_weathercam_bulk_sha'] = $sha;
+            $GLOBALS['_aviationwx_weathercam_bulk_airports'] = $cached['airports'];
+            return $cached['airports'];
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Drop in-request and APCu weathercam catalog cache.
+ */
+function resetWeathercamBulkCatalogCache(): void
+{
+    $GLOBALS['_aviationwx_weathercam_bulk_sha'] = null;
+    $GLOBALS['_aviationwx_weathercam_bulk_airports'] = null;
+    if (function_exists('apcu_delete')) {
+        apcu_delete('aviationwx_weathercam_bulk');
+    }
+}

--- a/api/v1/weathercam-bulk.php
+++ b/api/v1/weathercam-bulk.php
@@ -61,7 +61,9 @@ function getWeathercamBulkAirports(?string $operatorFilter): array
     $full = recallWeathercamBulkCatalog();
     if ($full === null) {
         $shaBefore = getConfigFileSha256();
-        $full = buildWeathercamBulkAirports(getPublicApiAirports(true, false), null);
+        $config = loadConfig();
+        $airports = is_array($config) ? getListedAirports($config) : [];
+        $full = buildWeathercamBulkAirports($airports, null, $config);
         rememberWeathercamBulkCatalogIfConfigShaStable($full, $shaBefore, getConfigFileSha256());
     }
 
@@ -76,16 +78,28 @@ function getWeathercamBulkAirports(?string $operatorFilter): array
  *
  * @param array<string, mixed> $airports Airport ID to configuration
  * @param string|null $operatorFilter Lowercase slug, or null for every weathercam
+ * @param array|null $config Already-loaded configuration, or null to load it once
  * @return list<array<string, mixed>>
  */
-function buildWeathercamBulkAirports(array $airports, ?string $operatorFilter): array
+function buildWeathercamBulkAirports(
+    array $airports,
+    ?string $operatorFilter,
+    ?array $config = null
+): array
 {
+    $config ??= loadConfig();
     $formattedAirports = [];
     foreach ($airports as $airportId => $airport) {
         if (!is_string($airportId) || $airportId === '' || !is_array($airport)) {
             continue;
         }
-        $webcams = listFormattedWebcamsForAirport($airportId, $airport, $operatorFilter, true);
+        $webcams = listFormattedWebcamsForAirport(
+            $airportId,
+            $airport,
+            $operatorFilter,
+            true,
+            $config
+        );
         if ($webcams === []) {
             continue;
         }

--- a/api/v1/webcams.php
+++ b/api/v1/webcams.php
@@ -14,6 +14,7 @@
 require_once __DIR__ . '/../../lib/public-api/middleware.php';
 require_once __DIR__ . '/../../lib/public-api/response.php';
 require_once __DIR__ . '/../../lib/config.php';
+require_once __DIR__ . '/../../lib/webcam-metadata.php';
 
 /**
  * Handle GET /v1/airports/{id}/webcams request
@@ -55,33 +56,52 @@ function handleListWebcams(array $params, array $context): void
         return;
     }
     $weathercamOperatorFilter = $operatorParse['value'];
+    $formattedWebcams = listFormattedWebcamsForAirport($airportId, $airport, $weathercamOperatorFilter);
 
-    $webcams = $airport['webcams'] ?? [];
-
-    // Keep original indexes so image URLs do not move when a filter omits a camera
-    $formattedWebcams = [];
-    foreach ($webcams as $index => $webcam) {
-        if (!is_array($webcam) || !weathercamMatchesOperator($webcam, $weathercamOperatorFilter)) {
-            continue;
-        }
-        $formattedWebcams[] = formatWebcamMetadata($airportId, $index, $webcam, $airport);
-    }
-    
-    // Build metadata
     $meta = [
         'airport_id' => $airportId,
         'airport_name' => $airport['name'] ?? '',
         'webcam_count' => count($formattedWebcams),
     ];
-    
-    // Send cache headers for metadata
+
     sendPublicApiCacheHeaders('metadata');
-    
-    // Send response
     sendPublicApiSuccess(
         ['webcams' => $formattedWebcams],
         $meta
     );
+}
+
+/**
+ * Format weathercams for one airport, keeping original config indexes.
+ *
+ * @param string $airportId Airport ID
+ * @param array $airport Airport configuration
+ * @param string|null $operatorFilter Lowercase slug, or null for every weathercam
+ * @param bool $absoluteUrls When true, image and history URLs use the canonical v1 base
+ * @return list<array<string, mixed>>
+ */
+function listFormattedWebcamsForAirport(
+    string $airportId,
+    array $airport,
+    ?string $operatorFilter,
+    bool $absoluteUrls = false
+): array {
+    $webcams = $airport['webcams'] ?? [];
+    $formattedWebcams = [];
+    foreach ($webcams as $index => $webcam) {
+        if (!is_array($webcam) || !weathercamMatchesOperator($webcam, $operatorFilter)) {
+            continue;
+        }
+        $formattedWebcams[] = formatWebcamMetadata(
+            $airportId,
+            (int) $index,
+            $webcam,
+            $airport,
+            $absoluteUrls
+        );
+    }
+
+    return $formattedWebcams;
 }
 
 /**
@@ -91,33 +111,81 @@ function handleListWebcams(array $params, array $context): void
  * @param int $index Weathercam index
  * @param array $webcam Weathercam configuration
  * @param array $airport Airport configuration
+ * @param bool $absoluteUrls When true, image and history URLs use the canonical v1 base
  * @return array Formatted weathercam metadata
  */
-function formatWebcamMetadata(string $airportId, int $index, array $webcam, array $airport): array
-{
-    // Check if history is enabled for this weathercam (max_frames >= 2 enables history)
+function formatWebcamMetadata(
+    string $airportId,
+    int $index,
+    array $webcam,
+    array $airport,
+    bool $absoluteUrls = false
+): array {
     $historyEnabled = isWebcamHistoryEnabledForAirport($airportId);
-    
-    // Get refresh interval
-    $refreshSeconds = $webcam['refresh_seconds'] 
-        ?? $airport['webcam_refresh_seconds'] 
+
+    $refreshSeconds = $webcam['refresh_seconds']
+        ?? $airport['webcam_refresh_seconds']
         ?? 60;
-    
+
+    $imagePath = '/airports/' . $airportId . '/webcams/' . $index . '/image';
     $metadata = [
         'index' => $index,
         'name' => $webcam['name'] ?? 'Camera ' . ($index + 1),
-        'image_url' => '/v1/airports/' . $airportId . '/webcams/' . $index . '/image',
+        'image_url' => publicApiV1Url($imagePath, $absoluteUrls),
         'refresh_seconds' => $refreshSeconds,
         'approximate_heading' => formatWebcamApproximateHeadingForApi($webcam),
         'operator' => getWeathercamOperator($webcam),
+        'images' => formatWebcamImageVariants($airportId, $index, $absoluteUrls),
     ];
 
     if ($historyEnabled) {
         $metadata['history_enabled'] = true;
-        $metadata['history_url'] = '/v1/airports/' . $airportId . '/webcams/' . $index . '/history';
+        $metadata['history_url'] = publicApiV1Url(
+            '/airports/' . $airportId . '/webcams/' . $index . '/history',
+            $absoluteUrls
+        );
     }
 
     return $metadata;
+}
+
+/**
+ * Configured original plus height variants. Original is jpg only.
+ *
+ * @param string $airportId Airport ID
+ * @param int $index Weathercam index
+ * @param bool $absoluteUrls When true, URLs use the canonical v1 base
+ * @return list<array{variant: string, height: int|null, format: string, url: string}>
+ */
+function formatWebcamImageVariants(string $airportId, int $index, bool $absoluteUrls): array
+{
+    $imagePath = '/airports/' . $airportId . '/webcams/' . $index . '/image';
+    $images = [
+        [
+            'variant' => 'original',
+            'height' => null,
+            'format' => 'jpg',
+            'url' => publicApiV1Url($imagePath, $absoluteUrls),
+        ],
+    ];
+
+    foreach (getVariantHeights($airportId, $index) as $height) {
+        foreach (getEnabledWebcamFormats() as $format) {
+            $query = [];
+            if ($format !== 'jpg') {
+                $query['fmt'] = $format;
+            }
+            $query['size'] = (string) $height;
+            $images[] = [
+                'variant' => (string) $height,
+                'height' => (int) $height,
+                'format' => $format,
+                'url' => publicApiV1Url($imagePath, $absoluteUrls, $query),
+            ];
+        }
+    }
+
+    return $images;
 }
 
 /**

--- a/api/v1/webcams.php
+++ b/api/v1/webcams.php
@@ -85,7 +85,8 @@ function listFormattedWebcamsForAirport(
     array $airport,
     ?string $operatorFilter,
     bool $absoluteUrls = false
-): array {
+): array
+{
     $webcams = $airport['webcams'] ?? [];
     $formattedWebcams = [];
     foreach ($webcams as $index => $webcam) {
@@ -120,7 +121,8 @@ function formatWebcamMetadata(
     array $webcam,
     array $airport,
     bool $absoluteUrls = false
-): array {
+): array
+{
     $historyEnabled = isWebcamHistoryEnabledForAirport($airportId);
 
     $refreshSeconds = $webcam['refresh_seconds']

--- a/api/v1/webcams.php
+++ b/api/v1/webcams.php
@@ -169,8 +169,9 @@ function formatWebcamImageVariants(string $airportId, int $index, bool $absolute
         ],
     ];
 
+    $formats = getEnabledWebcamFormats();
     foreach (getVariantHeights($airportId, $index) as $height) {
-        foreach (getEnabledWebcamFormats() as $format) {
+        foreach ($formats as $format) {
             $query = [];
             if ($format !== 'jpg') {
                 $query['fmt'] = $format;

--- a/api/v1/webcams.php
+++ b/api/v1/webcams.php
@@ -56,7 +56,13 @@ function handleListWebcams(array $params, array $context): void
         return;
     }
     $weathercamOperatorFilter = $operatorParse['value'];
-    $formattedWebcams = listFormattedWebcamsForAirport($airportId, $airport, $weathercamOperatorFilter);
+    $formattedWebcams = listFormattedWebcamsForAirport(
+        $airportId,
+        $airport,
+        $weathercamOperatorFilter,
+        false,
+        loadConfig()
+    );
 
     $meta = [
         'airport_id' => $airportId,
@@ -78,15 +84,18 @@ function handleListWebcams(array $params, array $context): void
  * @param array $airport Airport configuration
  * @param string|null $operatorFilter Lowercase slug, or null for every weathercam
  * @param bool $absoluteUrls When true, image and history URLs use the canonical v1 base
+ * @param array|null $config Already-loaded configuration, or null to load it once
  * @return list<array<string, mixed>>
  */
 function listFormattedWebcamsForAirport(
     string $airportId,
     array $airport,
     ?string $operatorFilter,
-    bool $absoluteUrls = false
+    bool $absoluteUrls = false,
+    ?array $config = null
 ): array
 {
+    $config ??= loadConfig();
     $webcams = $airport['webcams'] ?? [];
     $formattedWebcams = [];
     foreach ($webcams as $index => $webcam) {
@@ -98,7 +107,8 @@ function listFormattedWebcamsForAirport(
             (int) $index,
             $webcam,
             $airport,
-            $absoluteUrls
+            $absoluteUrls,
+            $config
         );
     }
 
@@ -113,6 +123,7 @@ function listFormattedWebcamsForAirport(
  * @param array $webcam Weathercam configuration
  * @param array $airport Airport configuration
  * @param bool $absoluteUrls When true, image and history URLs use the canonical v1 base
+ * @param array|null $config Already-loaded configuration
  * @return array Formatted weathercam metadata
  */
 function formatWebcamMetadata(
@@ -120,10 +131,11 @@ function formatWebcamMetadata(
     int $index,
     array $webcam,
     array $airport,
-    bool $absoluteUrls = false
+    bool $absoluteUrls = false,
+    ?array $config = null
 ): array
 {
-    $historyEnabled = isWebcamHistoryEnabledForAirport($airportId);
+    $historyEnabled = isWebcamHistoryEnabledForAirport($airportId, $config);
 
     $refreshSeconds = $webcam['refresh_seconds']
         ?? $airport['webcam_refresh_seconds']
@@ -137,7 +149,7 @@ function formatWebcamMetadata(
         'refresh_seconds' => $refreshSeconds,
         'approximate_heading' => formatWebcamApproximateHeadingForApi($webcam),
         'operator' => getWeathercamOperator($webcam),
-        'images' => formatWebcamImageVariants($airportId, $index, $absoluteUrls),
+        'images' => formatWebcamImageVariants($airportId, $index, $absoluteUrls, $config),
     ];
 
     if ($historyEnabled) {
@@ -157,9 +169,15 @@ function formatWebcamMetadata(
  * @param string $airportId Airport ID
  * @param int $index Weathercam index
  * @param bool $absoluteUrls When true, URLs use the canonical v1 base
+ * @param array|null $config Already-loaded configuration
  * @return list<array{variant: string, height: int|null, format: string, url: string}>
  */
-function formatWebcamImageVariants(string $airportId, int $index, bool $absoluteUrls): array
+function formatWebcamImageVariants(
+    string $airportId,
+    int $index,
+    bool $absoluteUrls,
+    ?array $config = null
+): array
 {
     $imagePath = '/airports/' . $airportId . '/webcams/' . $index . '/image';
     $images = [
@@ -171,8 +189,8 @@ function formatWebcamImageVariants(string $airportId, int $index, bool $absolute
         ],
     ];
 
-    $formats = getEnabledWebcamFormats();
-    foreach (getVariantHeights($airportId, $index) as $height) {
+    $formats = getEnabledWebcamFormats($config);
+    foreach (getVariantHeights($airportId, $index, $config) as $height) {
         foreach ($formats as $format) {
             $query = [];
             if ($format !== 'jpg') {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -613,7 +613,7 @@ All weather sources are configured in a unified `weather_sources` array. Sources
 | `dyaconlive` | Dyacon MS-100 advisory aviation station (DyaconLive+ API) | ~10 minutes |
 | `davis_weatherlink_live` | Davis WeatherLink Live via bridge push cache (`awxb_` key + enable row) | Adapter rate (typically ≤10s; ≤1 Hz ceiling) |
 
-**Operator:** Optional `operator` on each `weather_sources[]` row is a lowercase slug. Public API `GET /v1/airports?operator=` matches airports.json (configured weathercams and weather sources), not the live fused observation. Omit `operator` to use the type default:
+**Operator:** Optional `operator` on each `weather_sources[]` row is a lowercase slug. Public API `GET /v1/airports?operator=` matches airports.json (configured weathercams and weather sources), not the live fused observation. Optional `has_webcams=true` keeps airports that have weathercams configured; it is not sliced by operator. Optional `has_weather=true` keeps airports that have weather sources configured; it is not sliced by operator. When `operator` is set, `webcam_count` still counts matching weathercams only. `GET /v1/weathercam/bulk` is the partner catalog: listed airports with matching weathercams, nested webcam objects, and absolute image URLs. Matching on that path is weathercams only. The origin catalog is rebuilt when airports.json changes. Omit `operator` to use the type default:
 
 | `type` | Default `operator` |
 |--------|--------------------|

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -185,7 +185,7 @@ vendor/bin/phpunit --testsuite Unit
 
 **What they test:**
 - Configuration validation
-- **Operator identity:** `tests/Unit/OperatorConfigTest.php` covers weathercam and weather-source defaults, airports.json matching (not live fused weather), and `GET` `operator` query parsing. Config slug validation is in `tests/Unit/ConfigValidationTest.php`. Camera metadata includes `operator` in `tests/Unit/PublicApiWebcamMetadataTest.php`.
+- **Operator identity:** `tests/Unit/OperatorConfigTest.php` covers weathercam and weather-source defaults, airports.json matching (not live fused weather), and `GET` `operator` query parsing. Config slug validation is in `tests/Unit/ConfigValidationTest.php`. Camera metadata includes `operator` in `tests/Unit/PublicApiWebcamMetadataTest.php`. `GET /v1/weathercam/bulk` catalog composition, config-SHA cache, and absolute image URLs are in `tests/Unit/PublicApiWeathercamBulkTest.php`.
 - Weather calculations
 - Data parsing and formatting
 - Utility functions
@@ -201,7 +201,7 @@ vendor/bin/phpunit --testsuite Integration
 
 **What they test:**
 - API endpoint responses
-- **Public API `operator` query:** `tests/Integration/PublicApiOperatorTest.php` (running stack, typically `TEST_API_URL=http://localhost:9080`). Airport list membership and `webcam_count` use airports.json. Webcam list keeps original indexes. Weather ignores `operator`. Cases skip when no server is listening.
+- **Public API `operator` query:** `tests/Integration/PublicApiOperatorTest.php` (running stack, typically `TEST_API_URL=http://localhost:9080`). Airport list membership and `webcam_count` use airports.json. Optional `has_webcams` / `has_weather` filter the list and are not operator-sliced; `webcam_count` still counts matching weathercams when `operator` is set. `GET /v1/weathercam/bulk` is weathercam-only, omits airports with no matching cam, and returns absolute image URLs. Webcam list keeps original indexes. Weather ignores `operator`. Cases skip when no server is listening.
 - Cache behavior
 - HTML output validation
 - Webcam refresh initialization

--- a/lib/config.php
+++ b/lib/config.php
@@ -2029,6 +2029,9 @@ function validateCropMargins(mixed $margins, string $context): array {
 /**
  * True when a Public API canonical base is safe to concatenate with /airports/... paths.
  *
+ * The path after the origin must be `/v1` (trailing slashes allowed) because
+ * `publicApiV1Url()` appends `/airports/...` onto this value.
+ *
  * @param string $url Trimmed candidate URL
  * @return bool
  */
@@ -2053,8 +2056,12 @@ function isValidCanonicalPublicApiBaseUrl(string $url): bool
         return false;
     }
 
-    return !isset($parts['query']) && !isset($parts['fragment'])
-        && !isset($parts['user']) && !isset($parts['pass']);
+    if (isset($parts['query']) || isset($parts['fragment'])
+        || isset($parts['user']) || isset($parts['pass'])) {
+        return false;
+    }
+
+    return rtrim((string) ($parts['path'] ?? ''), '/') === '/v1';
 }
 
 /**
@@ -2067,7 +2074,7 @@ function isValidCanonicalPublicApiBaseUrl(string $url): bool
  * - bulk_max_airports
  * - weather_history settings
  * - partner_keys
- * - canonical_base_url (optional; absolute http(s) URL with host, no query/fragment/userinfo)
+ * - canonical_base_url (optional; absolute http(s) URL ending in /v1, with host, no query/fragment/userinfo)
  * 
  * @param mixed $publicApi The public_api config value to validate
  * @return array Array of error messages (empty if valid)
@@ -2146,7 +2153,7 @@ function validatePublicApiConfig(mixed $publicApi): array {
             if ($trimmed === '') {
                 $errors[] = "config.public_api.canonical_base_url must be a non-empty string when set";
             } elseif (!isValidCanonicalPublicApiBaseUrl($trimmed)) {
-                $errors[] = "config.public_api.canonical_base_url must be an absolute http:// or https:// URL with a host and no query, fragment, or userinfo";
+                $errors[] = "config.public_api.canonical_base_url must be an absolute http:// or https:// URL ending in /v1, with a host and no query, fragment, or userinfo";
             }
         }
     }

--- a/lib/config.php
+++ b/lib/config.php
@@ -2575,12 +2575,12 @@ function getConfigFileSha256(): ?string
  * @return void
  */
 function clearConfigCache(): void {
+    $GLOBALS['_aviationwx_weathercam_bulk_sha'] = null;
+    $GLOBALS['_aviationwx_weathercam_bulk_airports'] = null;
     if (function_exists('apcu_delete')) {
         apcu_delete('aviationwx_config');
         apcu_delete('aviationwx_config_sha');
-    }
-    if (function_exists('resetWeathercamBulkCatalogCache')) {
-        resetWeathercamBulkCatalogCache();
+        apcu_delete('aviationwx_weathercam_bulk');
     }
     require_once __DIR__ . '/airport-country-resolution-merge.php';
     countryResolutionResetMergeFingerprint();

--- a/lib/config.php
+++ b/lib/config.php
@@ -2027,6 +2027,33 @@ function validateCropMargins(mixed $margins, string $context): array {
 }
 
 /**
+ * True when a Public API canonical base is safe to concatenate with /airports/... paths.
+ *
+ * @param string $url Trimmed candidate URL
+ * @return bool
+ */
+function isValidCanonicalPublicApiBaseUrl(string $url): bool
+{
+    $parts = parse_url($url);
+    if (!is_array($parts)) {
+        return false;
+    }
+
+    $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+    if ($scheme !== 'http' && $scheme !== 'https') {
+        return false;
+    }
+
+    $host = $parts['host'] ?? '';
+    if (!is_string($host) || $host === '') {
+        return false;
+    }
+
+    return !isset($parts['query']) && !isset($parts['fragment'])
+        && !isset($parts['user']) && !isset($parts['pass']);
+}
+
+/**
  * Validate public_api configuration section
  * 
  * Validates the nested public_api configuration including:
@@ -2036,7 +2063,7 @@ function validateCropMargins(mixed $margins, string $context): array {
  * - bulk_max_airports
  * - weather_history settings
  * - partner_keys
- * - canonical_base_url (optional; must be string if key present)
+ * - canonical_base_url (optional; absolute http(s) URL with host, no query/fragment/userinfo)
  * 
  * @param mixed $publicApi The public_api config value to validate
  * @return array Array of error messages (empty if valid)
@@ -2114,8 +2141,8 @@ function validatePublicApiConfig(mixed $publicApi): array {
             $trimmed = trim($publicApi['canonical_base_url']);
             if ($trimmed === '') {
                 $errors[] = "config.public_api.canonical_base_url must be a non-empty string when set";
-            } elseif (!preg_match('#^https?://#i', $trimmed)) {
-                $errors[] = "config.public_api.canonical_base_url must start with http:// or https://";
+            } elseif (!isValidCanonicalPublicApiBaseUrl($trimmed)) {
+                $errors[] = "config.public_api.canonical_base_url must be an absolute http:// or https:// URL with a host and no query, fragment, or userinfo";
             }
         }
     }

--- a/lib/config.php
+++ b/lib/config.php
@@ -2034,6 +2034,10 @@ function validateCropMargins(mixed $margins, string $context): array {
  */
 function isValidCanonicalPublicApiBaseUrl(string $url): bool
 {
+    if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+        return false;
+    }
+
     $parts = parse_url($url);
     if (!is_array($parts)) {
         return false;

--- a/lib/config.php
+++ b/lib/config.php
@@ -2541,6 +2541,9 @@ function clearConfigCache(): void {
         apcu_delete('aviationwx_config');
         apcu_delete('aviationwx_config_sha');
     }
+    if (function_exists('resetWeathercamBulkCatalogCache')) {
+        resetWeathercamBulkCatalogCache();
+    }
     require_once __DIR__ . '/airport-country-resolution-merge.php';
     countryResolutionResetMergeFingerprint();
 }

--- a/lib/config.php
+++ b/lib/config.php
@@ -1440,12 +1440,16 @@ function isWebpGenerationEnabled(): bool {
 /**
  * Get list of enabled formats for webcam generation
  * 
+ * @param array|null $config Already-loaded configuration, or null to load it
  * @return array Array of enabled format strings: ['jpg', 'webp']
  */
-function getEnabledWebcamFormats(): array {
+function getEnabledWebcamFormats(?array $config = null): array {
     $formats = ['jpg']; // Always enabled
-    
-    if (isWebpGenerationEnabled()) {
+
+    $webpEnabled = $config === null
+        ? isWebpGenerationEnabled()
+        : (bool)($config['config']['webcam_generate_webp'] ?? false);
+    if ($webpEnabled) {
         $formats[] = 'webp';
     }
     
@@ -1593,10 +1597,11 @@ const WEBCAM_HISTORY_FRAME_SAFETY_MULTIPLIER = 2.0;
  * History is considered enabled when retention > 0 and would result in >= 2 frames.
  * 
  * @param string $airportId Airport ID (e.g., 'kspb')
+ * @param array|null $config Already-loaded configuration, or null to load it
  * @return bool True if webcam history enabled for this airport
  */
-function isWebcamHistoryEnabledForAirport(string $airportId): bool {
-    $retentionHours = getWebcamHistoryRetentionHours($airportId);
+function isWebcamHistoryEnabledForAirport(string $airportId, ?array $config = null): bool {
+    $retentionHours = getWebcamHistoryRetentionHours($airportId, $config);
     return $retentionHours > 0;
 }
 
@@ -1607,10 +1612,11 @@ function isWebcamHistoryEnabledForAirport(string $airportId): bool {
  * Supports both new time-based config and legacy frame-based config.
  * 
  * @param string $airportId Airport ID (e.g., 'kspb')
+ * @param array|null $config Already-loaded configuration, or null to load it
  * @return float Retention period in hours
  */
-function getWebcamHistoryRetentionHours(string $airportId): float {
-    $config = loadConfig();
+function getWebcamHistoryRetentionHours(string $airportId, ?array $config = null): float {
+    $config ??= loadConfig();
     if ($config === null) {
         return WEBCAM_HISTORY_RETENTION_HOURS_DEFAULT;
     }

--- a/lib/public-api/config.php
+++ b/lib/public-api/config.php
@@ -76,6 +76,27 @@ function getCanonicalPublicApiV1BaseUrl(): string
 }
 
 /**
+ * Build a Public API v1 URL from a path under that base.
+ *
+ * @param string $v1Path Path after /v1 (for example /airports/kspb/webcams/0/image)
+ * @param bool $absolute When true, prefix getCanonicalPublicApiV1BaseUrl(); when false, prefix /v1
+ * @param array<string, scalar> $query Optional query parameters
+ * @return string Relative /v1/... path or absolute canonical URL
+ */
+function publicApiV1Url(string $v1Path, bool $absolute = false, array $query = []): string
+{
+    $path = '/' . ltrim($v1Path, '/');
+    $url = $absolute
+        ? getCanonicalPublicApiV1BaseUrl() . $path
+        : '/v1' . $path;
+    if ($query === []) {
+        return $url;
+    }
+
+    return $url . '?' . http_build_query($query, '', '&', PHP_QUERY_RFC3986);
+}
+
+/**
  * Get rate limits for a specific tier
  * 
  * Tiers:

--- a/lib/webcam-metadata.php
+++ b/lib/webcam-metadata.php
@@ -180,10 +180,11 @@ function buildWebcamMetadataFromFile(string $filePath, string $airportId, int $c
  * 
  * @param string $airportId Airport identifier
  * @param int $camIndex Camera index (0-based)
+ * @param array|null $config Already-loaded configuration, or null to load it
  * @return array Array of heights (integers)
  */
-function getVariantHeights(string $airportId, int $camIndex): array {
-    $config = loadConfig();
+function getVariantHeights(string $airportId, int $camIndex, ?array $config = null): array {
+    $config ??= loadConfig();
     if ($config === null) {
         return [1080, 720, 360];
     }

--- a/tests/Integration/PublicApiOperatorTest.php
+++ b/tests/Integration/PublicApiOperatorTest.php
@@ -125,6 +125,55 @@ class PublicApiOperatorTest extends TestCase
         $this->assertNull($this->findAirport($airports, 'kspb'));
     }
 
+    public function testListAirports_HasWebcamsTrueIsIndependentOfOperator(): void
+    {
+        $response = $this->apiRequest('/airports?operator=faa&has_webcams=true');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+
+        $airports = $response['json']['airports'] ?? [];
+        $kspb = $this->findAirport($airports, 'kspb');
+        $this->assertNotNull($kspb, 'kspb matches faa via METAR and has weathercams');
+        $this->assertTrue($kspb['has_webcams']);
+        $this->assertSame(0, $kspb['webcam_count'], 'webcam_count stays operator-sliced');
+        $this->assertNull($this->findAirport($airports, '03s'));
+    }
+
+    public function testListAirports_HasWebcamsTrueKeepsAviationwxCameras(): void
+    {
+        $response = $this->apiRequest('/airports?operator=aviationwx&has_webcams=true');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+
+        $airports = $response['json']['airports'] ?? [];
+        $kspb = $this->findAirport($airports, 'kspb');
+        $this->assertNotNull($kspb);
+        $this->assertTrue($kspb['has_webcams']);
+        $this->assertSame(1, $kspb['webcam_count']);
+    }
+
+    public function testListAirports_HasWeatherTrueKeepsKspb(): void
+    {
+        $response = $this->apiRequest('/airports?has_weather=true');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+
+        $airports = $response['json']['airports'] ?? [];
+        $kspb = $this->findAirport($airports, 'kspb');
+        $this->assertNotNull($kspb);
+        $this->assertTrue($kspb['has_weather']);
+    }
+
+    public function testListAirports_HasWeatherFalseOmitsKspb(): void
+    {
+        $response = $this->apiRequest('/airports?has_weather=false');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+
+        $airports = $response['json']['airports'] ?? [];
+        $this->assertNull($this->findAirport($airports, 'kspb'));
+    }
+
     public function testListAirports_InvalidOperatorReturns400(): void
     {
         $response = $this->apiRequest('/airports?operator=not%20valid');
@@ -191,5 +240,42 @@ class PublicApiOperatorTest extends TestCase
             $filtered['json']['weather'] ?? false,
             'Weather must stay fused and ignore operator'
         );
+    }
+
+    public function testWeathercamBulk_OperatorAviationwxIsCamOnlyWithAbsoluteUrls(): void
+    {
+        $response = $this->apiRequest('/weathercam/bulk?operator=aviationwx');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+
+        $airports = $response['json']['airports'] ?? [];
+        $kspb = $this->findAirport($airports, 'kspb');
+        $this->assertNotNull($kspb);
+        $this->assertCount(1, $kspb['webcams']);
+        $this->assertSame(0, $kspb['webcams'][0]['index']);
+        $this->assertSame('aviationwx', $kspb['webcams'][0]['operator']);
+        $this->assertSame(1, $kspb['webcam_count']);
+        $this->assertStringContainsString('/airports/kspb/webcams/0/image', $kspb['webcams'][0]['image_url']);
+        $this->assertMatchesRegularExpression('#^https?://#', $kspb['webcams'][0]['image_url']);
+        $this->assertSame($kspb['webcams'][0]['image_url'], $kspb['webcams'][0]['images'][0]['url'] ?? null);
+        $this->assertNull($this->findAirport($airports, '03s'));
+    }
+
+    public function testWeathercamBulk_OperatorFaaOmitsWeatherSourceOnlyMatches(): void
+    {
+        $response = $this->apiRequest('/weathercam/bulk?operator=faa');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+        $airports = $response['json']['airports'] ?? [];
+        $this->assertNull($this->findAirport($airports, 'kspb'));
+        $this->assertNull($this->findAirport($airports, '03s'));
+    }
+
+    public function testWeathercamBulk_InvalidOperatorReturns400(): void
+    {
+        $response = $this->apiRequest('/weathercam/bulk?operator=not%20valid');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(400, $response['status']);
+        $this->assertSame('INVALID_REQUEST', $response['json']['error']['code'] ?? null);
     }
 }

--- a/tests/Unit/ConfigCacheTest.php
+++ b/tests/Unit/ConfigCacheTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Configuration cache invalidation tests.
+ */
+
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class ConfigCacheTest extends TestCase
+{
+    #[RunInSeparateProcess]
+    public function testClearConfigCache_WithoutEndpointLoaded_ClearsWeathercamCatalog(): void
+    {
+        $this->assertFalse(function_exists('resetWeathercamBulkCatalogCache'));
+
+        $GLOBALS['_aviationwx_weathercam_bulk_sha'] = 'test-sha';
+        $GLOBALS['_aviationwx_weathercam_bulk_airports'] = [['id' => 'stale']];
+        if (function_exists('apcu_store')) {
+            apcu_store('aviationwx_weathercam_bulk', ['sha' => 'test-sha', 'airports' => []]);
+        }
+
+        clearConfigCache();
+
+        $this->assertNull($GLOBALS['_aviationwx_weathercam_bulk_sha'] ?? null);
+        $this->assertNull($GLOBALS['_aviationwx_weathercam_bulk_airports'] ?? null);
+        if (function_exists('apcu_fetch')) {
+            $this->assertFalse(apcu_fetch('aviationwx_weathercam_bulk'));
+        }
+    }
+}

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -5445,7 +5445,7 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
     }
 
-    public function testPublicApiCanonicalBaseUrl_ValidLocalhostWithPort()
+    public function testPublicApiCanonicalBaseUrl_ValidLocalhostWithPort(): void
     {
         $config = $this->createMinimalConfig();
         $config['config']['public_api'] = [
@@ -5455,7 +5455,7 @@ class ConfigValidationTest extends TestCase
         $this->assertTrue($result['valid'], implode(', ', $result['errors']));
     }
 
-    public function testPublicApiCanonicalBaseUrl_InvalidHostWithSpace()
+    public function testPublicApiCanonicalBaseUrl_InvalidHostWithSpace(): void
     {
         $config = $this->createMinimalConfig();
         $config['config']['public_api'] = [
@@ -5466,7 +5466,7 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
     }
 
-    public function testPublicApiCanonicalBaseUrl_InvalidMissingHost()
+    public function testPublicApiCanonicalBaseUrl_InvalidMissingHost(): void
     {
         $config = $this->createMinimalConfig();
         $config['config']['public_api'] = [
@@ -5477,7 +5477,7 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
     }
 
-    public function testPublicApiCanonicalBaseUrl_InvalidQuery()
+    public function testPublicApiCanonicalBaseUrl_InvalidQuery(): void
     {
         $config = $this->createMinimalConfig();
         $config['config']['public_api'] = [
@@ -5488,7 +5488,7 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
     }
 
-    public function testPublicApiCanonicalBaseUrl_InvalidFragment()
+    public function testPublicApiCanonicalBaseUrl_InvalidFragment(): void
     {
         $config = $this->createMinimalConfig();
         $config['config']['public_api'] = [
@@ -5499,7 +5499,7 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
     }
 
-    public function testPublicApiCanonicalBaseUrl_InvalidUserinfo()
+    public function testPublicApiCanonicalBaseUrl_InvalidUserinfo(): void
     {
         $config = $this->createMinimalConfig();
         $config['config']['public_api'] = [
@@ -5510,7 +5510,7 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
     }
 
-    public function testPublicApiCanonicalBaseUrl_ValidTrailingSlash()
+    public function testPublicApiCanonicalBaseUrl_ValidTrailingSlash(): void
     {
         $config = $this->createMinimalConfig();
         $config['config']['public_api'] = [
@@ -5520,7 +5520,7 @@ class ConfigValidationTest extends TestCase
         $this->assertTrue($result['valid'], implode(', ', $result['errors']));
     }
 
-    public function testPublicApiCanonicalBaseUrl_InvalidMissingV1Path()
+    public function testPublicApiCanonicalBaseUrl_InvalidMissingV1Path(): void
     {
         $config = $this->createMinimalConfig();
         $config['config']['public_api'] = [
@@ -5531,7 +5531,7 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
     }
 
-    public function testPublicApiCanonicalBaseUrl_InvalidNonV1Path()
+    public function testPublicApiCanonicalBaseUrl_InvalidNonV1Path(): void
     {
         $config = $this->createMinimalConfig();
         $config['config']['public_api'] = [

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -5455,6 +5455,17 @@ class ConfigValidationTest extends TestCase
         $this->assertTrue($result['valid'], implode(', ', $result['errors']));
     }
 
+    public function testPublicApiCanonicalBaseUrl_InvalidHostWithSpace()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => 'https://exa mple.com/v1',
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
+    }
+
     public function testPublicApiCanonicalBaseUrl_InvalidMissingHost()
     {
         $config = $this->createMinimalConfig();

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -5510,6 +5510,38 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
     }
 
+    public function testPublicApiCanonicalBaseUrl_ValidTrailingSlash()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => 'https://api.example.com/v1/',
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], implode(', ', $result['errors']));
+    }
+
+    public function testPublicApiCanonicalBaseUrl_InvalidMissingV1Path()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => 'https://example.com',
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
+    }
+
+    public function testPublicApiCanonicalBaseUrl_InvalidNonV1Path()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => 'https://example.com/api',
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
+    }
+
     // =========================================================================
     // Existing Config Fields - Ensure Still Validated
     // =========================================================================

--- a/tests/Unit/ConfigValidationTest.php
+++ b/tests/Unit/ConfigValidationTest.php
@@ -5445,6 +5445,60 @@ class ConfigValidationTest extends TestCase
         $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
     }
 
+    public function testPublicApiCanonicalBaseUrl_ValidLocalhostWithPort()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => 'http://localhost:9080/v1',
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertTrue($result['valid'], implode(', ', $result['errors']));
+    }
+
+    public function testPublicApiCanonicalBaseUrl_InvalidMissingHost()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => 'https://',
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
+    }
+
+    public function testPublicApiCanonicalBaseUrl_InvalidQuery()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => 'https://example.com/v1?tenant=a',
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
+    }
+
+    public function testPublicApiCanonicalBaseUrl_InvalidFragment()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => 'https://example.com/v1#docs',
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
+    }
+
+    public function testPublicApiCanonicalBaseUrl_InvalidUserinfo()
+    {
+        $config = $this->createMinimalConfig();
+        $config['config']['public_api'] = [
+            'canonical_base_url' => 'https://user:pass@example.com/v1',
+        ];
+        $result = validateAirportsJsonStructure($config);
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('canonical_base_url', implode(' ', $result['errors']));
+    }
+
     // =========================================================================
     // Existing Config Fields - Ensure Still Validated
     // =========================================================================

--- a/tests/Unit/OperatorConfigTest.php
+++ b/tests/Unit/OperatorConfigTest.php
@@ -101,13 +101,65 @@ class OperatorConfigTest extends TestCase
 
         $faa = formatAirportSummary('kspb', $airport, 'faa');
         $this->assertTrue($faa['has_weather']);
-        $this->assertFalse($faa['has_webcams']);
+        $this->assertTrue($faa['has_webcams'], 'has_webcams is not operator-sliced');
         $this->assertSame(0, $faa['webcam_count']);
 
         $wsdot = formatAirportSummary('kspb', $airport, 'wsdot');
         $this->assertTrue($wsdot['has_weather']);
         $this->assertTrue($wsdot['has_webcams']);
         $this->assertSame(1, $wsdot['webcam_count']);
+    }
+
+    public function testParsePublicApiOptionalBooleanQuery_ReadsTrueFalse(): void
+    {
+        $originalGet = $_GET;
+        try {
+            $_GET = [];
+            $this->assertNull(parsePublicApiOptionalBooleanQuery('has_webcams'));
+            $this->assertNull(parsePublicApiOptionalBooleanQuery('has_weather'));
+
+            $_GET = ['has_webcams' => 'true', 'has_weather' => 'FALSE'];
+            $this->assertTrue(parsePublicApiOptionalBooleanQuery('has_webcams'));
+            $this->assertFalse(parsePublicApiOptionalBooleanQuery('has_weather'));
+
+            $_GET = ['has_webcams' => '1'];
+            $this->assertTrue(parsePublicApiOptionalBooleanQuery('has_webcams'));
+
+            $_GET = ['has_webcams' => 'maybe'];
+            $this->assertNull(parsePublicApiOptionalBooleanQuery('has_webcams'));
+
+            $_GET = ['has_webcams' => ['true']];
+            $this->assertNull(parsePublicApiOptionalBooleanQuery('has_webcams'));
+        } finally {
+            $_GET = $originalGet;
+        }
+    }
+
+    public function testOpenApiHasWebcamsAndHasWeatherQuery_AreAirportListFilters(): void
+    {
+        $spec = json_decode(
+            (string) file_get_contents(__DIR__ . '/../../api/docs/openapi.json'),
+            true
+        );
+        $this->assertIsArray($spec);
+        $params = $spec['paths']['/airports']['get']['parameters'] ?? [];
+        $names = [];
+        foreach ($params as $param) {
+            if (isset($param['name'])) {
+                $names[] = $param['name'];
+            }
+        }
+        $this->assertContains('has_webcams', $names);
+        $this->assertContains('has_weather', $names);
+
+        $webcamParamNames = [];
+        foreach ($spec['paths']['/airports/{id}/webcams']['get']['parameters'] ?? [] as $param) {
+            if (isset($param['name'])) {
+                $webcamParamNames[] = $param['name'];
+            }
+        }
+        $this->assertNotContains('has_webcams', $webcamParamNames);
+        $this->assertNotContains('has_weather', $webcamParamNames);
     }
 
     public function testParseOperatorQueryParam_NormalizesAndRejectsInvalidSlug(): void

--- a/tests/Unit/OperatorConfigTest.php
+++ b/tests/Unit/OperatorConfigTest.php
@@ -128,8 +128,15 @@ class OperatorConfigTest extends TestCase
             $_GET = ['has_webcams' => 'maybe'];
             $this->assertNull(parsePublicApiOptionalBooleanQuery('has_webcams'));
 
-            $_GET = ['has_webcams' => ['true']];
-            $this->assertNull(parsePublicApiOptionalBooleanQuery('has_webcams'));
+            foreach ([
+                'has_webcams',
+                'include_unlisted',
+                'maintenance',
+                'limited_availability',
+            ] as $name) {
+                $_GET = [$name => ['true']];
+                $this->assertNull(parsePublicApiOptionalBooleanQuery($name));
+            }
         } finally {
             $_GET = $originalGet;
         }

--- a/tests/Unit/OperatorConfigTest.php
+++ b/tests/Unit/OperatorConfigTest.php
@@ -248,4 +248,23 @@ class OperatorConfigTest extends TestCase
         $this->assertStringContainsString('awosnet', $description);
         $this->assertStringContainsString('synopticdata', $description);
     }
+
+    public function testOpenApiCapabilityFilters_DocumentAcceptedBooleanAliases(): void
+    {
+        $spec = json_decode(
+            (string) file_get_contents(__DIR__ . '/../../api/docs/openapi.json'),
+            true
+        );
+        $parameters = $spec['paths']['/airports']['get']['parameters'] ?? [];
+        $enums = [];
+        foreach ($parameters as $parameter) {
+            $name = $parameter['name'] ?? '';
+            if ($name === 'has_webcams' || $name === 'has_weather') {
+                $enums[$name] = $parameter['schema']['enum'] ?? [];
+            }
+        }
+
+        $this->assertSame(['true', 'false', '1', '0'], $enums['has_webcams'] ?? null);
+        $this->assertSame(['true', 'false', '1', '0'], $enums['has_weather'] ?? null);
+    }
 }

--- a/tests/Unit/PublicApiConfigTest.php
+++ b/tests/Unit/PublicApiConfigTest.php
@@ -487,5 +487,31 @@ class PublicApiConfigTest extends TestCase
 
         $this->assertSame('https://weather.example.com/v1', getCanonicalPublicApiV1BaseUrl());
     }
+
+    public function testPublicApiV1Url_RelativeAndAbsolute_DoNotDoubleV1Prefix(): void
+    {
+        $this->createTestConfig([
+            'config' => [
+                'public_api' => [
+                    'enabled' => true,
+                    'canonical_base_url' => 'https://weather.example.com/v1',
+                ],
+            ],
+            'airports' => [],
+        ]);
+
+        $this->assertSame(
+            '/v1/airports/kspb/webcams/0/image',
+            publicApiV1Url('/airports/kspb/webcams/0/image')
+        );
+        $this->assertSame(
+            'https://weather.example.com/v1/airports/kspb/webcams/0/image',
+            publicApiV1Url('/airports/kspb/webcams/0/image', true)
+        );
+        $this->assertSame(
+            'https://weather.example.com/v1/airports/kspb/webcams/0/image?fmt=webp&size=1080',
+            publicApiV1Url('/airports/kspb/webcams/0/image', true, ['fmt' => 'webp', 'size' => '1080'])
+        );
+    }
 }
 

--- a/tests/Unit/PublicApiWeathercamBulkTest.php
+++ b/tests/Unit/PublicApiWeathercamBulkTest.php
@@ -138,6 +138,29 @@ class PublicApiWeathercamBulkTest extends TestCase
         $this->assertCount(2, $again[0]['webcams']);
     }
 
+    public function testRememberWeathercamBulkCatalogIfConfigShaStable_MatchingSha_StoresCatalog(): void
+    {
+        $sha = getConfigFileSha256();
+        $this->assertNotNull($sha);
+        $payload = [['id' => 'kspb']];
+        rememberWeathercamBulkCatalogIfConfigShaStable($payload, $sha, $sha);
+        $this->assertSame($payload, recallWeathercamBulkCatalog());
+    }
+
+    public function testRememberWeathercamBulkCatalogIfConfigShaStable_MismatchedSha_DoesNotStore(): void
+    {
+        $sha = getConfigFileSha256();
+        $this->assertNotNull($sha);
+        rememberWeathercamBulkCatalogIfConfigShaStable([['id' => 'stale']], $sha, $sha . 'changed');
+        $this->assertNull(recallWeathercamBulkCatalog());
+    }
+
+    public function testRememberWeathercamBulkCatalogIfConfigShaStable_EmptyBeforeSha_DoesNotStore(): void
+    {
+        rememberWeathercamBulkCatalogIfConfigShaStable([['id' => 'stale']], '', 'not-empty');
+        $this->assertNull(recallWeathercamBulkCatalog());
+    }
+
     public function testRecallWeathercamBulkCatalog_MatchingSha_ReturnsAirports(): void
     {
         $sha = getConfigFileSha256();

--- a/tests/Unit/PublicApiWeathercamBulkTest.php
+++ b/tests/Unit/PublicApiWeathercamBulkTest.php
@@ -254,5 +254,22 @@ class PublicApiWeathercamBulkTest extends TestCase
         $description = $spec['components']['parameters']['WeathercamOperator']['description'] ?? '';
         $this->assertStringContainsString('weathercam', strtolower($description));
         $this->assertStringContainsString('weather sources do not', strtolower($description));
+
+        $webcamRef = '#/components/schemas/Webcam';
+        $this->assertSame(
+            $webcamRef,
+            $spec['components']['schemas']['WebcamListResponse']['properties']['webcams']['items']['$ref'] ?? null
+        );
+        $bulkWebcams = null;
+        foreach ($spec['components']['schemas']['WebcamBulkResponse']['properties']['airports']['items']['allOf'] ?? [] as $part) {
+            if (isset($part['properties']['webcams'])) {
+                $bulkWebcams = $part['properties']['webcams'];
+                break;
+            }
+        }
+        $this->assertSame($webcamRef, $bulkWebcams['items']['$ref'] ?? null);
+        $this->assertArrayHasKey('image_url', $spec['components']['schemas']['Webcam']['properties'] ?? []);
+        $this->assertArrayHasKey('operator', $spec['components']['schemas']['Webcam']['properties'] ?? []);
+        $this->assertArrayHasKey('images', $spec['components']['schemas']['Webcam']['properties'] ?? []);
     }
 }

--- a/tests/Unit/PublicApiWeathercamBulkTest.php
+++ b/tests/Unit/PublicApiWeathercamBulkTest.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Unit tests for GET /v1/weathercam/bulk catalog composition and config-SHA cache.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class PublicApiWeathercamBulkTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/../../lib/weather/utils.php';
+        require_once __DIR__ . '/../../api/v1/weathercam-bulk.php';
+        resetWeathercamBulkCatalogCache();
+    }
+
+    protected function tearDown(): void
+    {
+        resetWeathercamBulkCatalogCache();
+        parent::tearDown();
+    }
+
+    /**
+     * @param list<array<string, mixed>> $airports
+     * @return array<string, mixed>|null
+     */
+    private function findAirport(array $airports, string $id): ?array
+    {
+        foreach ($airports as $airport) {
+            if (($airport['id'] ?? '') === $id) {
+                return $airport;
+            }
+        }
+        return null;
+    }
+
+    public function testBuildWeathercamBulkAirports_OmitsWeatherSourceOnlyMatch(): void
+    {
+        $airports = [
+            'kspb' => [
+                'name' => 'Scappoose',
+                'lat' => 45.77,
+                'lon' => -122.86,
+                'timezone' => 'UTC',
+                'webcams' => [
+                    ['name' => 'North'],
+                    ['name' => 'DOT', 'operator' => 'wsdot'],
+                ],
+                'weather_sources' => [
+                    ['type' => 'metar', 'station_id' => 'KSPB'],
+                ],
+            ],
+            '03s' => [
+                'name' => 'Weather only',
+                'lat' => 45.0,
+                'lon' => -122.0,
+                'timezone' => 'UTC',
+                'webcams' => [],
+                'weather_sources' => [
+                    ['type' => 'metar', 'station_id' => 'KSPB'],
+                ],
+            ],
+        ];
+
+        $faa = buildWeathercamBulkAirports($airports, 'faa');
+        $this->assertNull($this->findAirport($faa, 'kspb'));
+        $this->assertNull($this->findAirport($faa, '03s'));
+
+        $aviationwx = buildWeathercamBulkAirports($airports, 'aviationwx');
+        $kspb = $this->findAirport($aviationwx, 'kspb');
+        $this->assertNotNull($kspb);
+        $this->assertCount(1, $kspb['webcams']);
+        $this->assertSame(0, $kspb['webcams'][0]['index']);
+        $this->assertSame(1, $kspb['webcam_count']);
+        $this->assertNull($this->findAirport($aviationwx, '03s'));
+    }
+
+    public function testBuildWeathercamBulkAirports_SkipsNonArrayAirportRows(): void
+    {
+        $catalog = buildWeathercamBulkAirports(
+            [
+                'kspb' => 'not-an-airport',
+                'kcma' => [
+                    'name' => 'Camarillo',
+                    'timezone' => 'UTC',
+                    'webcams' => [
+                        ['name' => 'West'],
+                    ],
+                ],
+            ],
+            null
+        );
+
+        $this->assertNull($this->findAirport($catalog, 'kspb'));
+        $this->assertNotNull($this->findAirport($catalog, 'kcma'));
+    }
+
+    public function testBuildWeathercamBulkAirports_SortsByAirportId(): void
+    {
+        $airports = [
+            's40' => [
+                'name' => 'Later',
+                'timezone' => 'UTC',
+                'webcams' => [['name' => 'A']],
+            ],
+            'kspb' => [
+                'name' => 'Earlier',
+                'timezone' => 'UTC',
+                'webcams' => [['name' => 'B']],
+            ],
+        ];
+
+        $catalog = buildWeathercamBulkAirports($airports, null);
+        $this->assertSame(['kspb', 's40'], array_column($catalog, 'id'));
+    }
+
+    public function testFilterWeathercamBulkAirportsByOperator_DoesNotMutateCachedRows(): void
+    {
+        $cached = [
+            [
+                'id' => 'kspb',
+                'webcam_count' => 2,
+                'webcams' => [
+                    ['index' => 0, 'operator' => 'aviationwx'],
+                    ['index' => 1, 'operator' => 'wsdot'],
+                ],
+            ],
+        ];
+
+        $aviationwx = filterWeathercamBulkAirportsByOperator($cached, 'aviationwx');
+        $this->assertCount(1, $aviationwx[0]['webcams']);
+        $this->assertSame(1, $aviationwx[0]['webcam_count']);
+        $this->assertCount(2, $cached[0]['webcams']);
+        $this->assertSame(2, $cached[0]['webcam_count']);
+
+        $again = filterWeathercamBulkAirportsByOperator($cached, null);
+        $this->assertCount(2, $again[0]['webcams']);
+    }
+
+    public function testRecallWeathercamBulkCatalog_MatchingSha_ReturnsAirports(): void
+    {
+        $sha = getConfigFileSha256();
+        $this->assertNotNull($sha);
+        $payload = [['id' => 'kspb']];
+        rememberWeathercamBulkCatalog($payload, $sha);
+        $this->assertSame($payload, recallWeathercamBulkCatalog());
+    }
+
+    public function testRecallWeathercamBulkCatalog_MismatchedSha_ReturnsNull(): void
+    {
+        rememberWeathercamBulkCatalog([['id' => 'stale']], 'not-the-current-config-sha');
+        $this->assertNull(recallWeathercamBulkCatalog());
+    }
+
+    public function testGetWeathercamBulkAirports_UsesCatalogCachedForConfigSha(): void
+    {
+        $sha = getConfigFileSha256();
+        $this->assertNotNull($sha);
+        rememberWeathercamBulkCatalog([], $sha);
+        $this->assertSame([], getWeathercamBulkAirports(null));
+
+        resetWeathercamBulkCatalogCache();
+        $rebuilt = getWeathercamBulkAirports(null);
+        $this->assertNotSame([], $rebuilt);
+        $this->assertNotNull($this->findAirport($rebuilt, 'kspb'));
+    }
+
+    public function testGetWeathercamBulkAirports_OperatorSliceDoesNotCorruptFullCache(): void
+    {
+        $aviationwx = getWeathercamBulkAirports('aviationwx');
+        $kspbFiltered = $this->findAirport($aviationwx, 'kspb');
+        $this->assertNotNull($kspbFiltered);
+        $this->assertCount(1, $kspbFiltered['webcams']);
+        $this->assertSame('aviationwx', $kspbFiltered['webcams'][0]['operator']);
+
+        $all = getWeathercamBulkAirports(null);
+        $kspbAll = $this->findAirport($all, 'kspb');
+        $this->assertNotNull($kspbAll);
+        $this->assertCount(2, $kspbAll['webcams']);
+    }
+
+    public function testGetWeathercamBulkAirports_FixtureOmitsFaaBecauseNoFaaWeathercam(): void
+    {
+        $this->assertTrue(airportMatchesOperator(
+            getPublicApiAirport('kspb') ?? [],
+            'faa'
+        ));
+        $this->assertNull($this->findAirport(getWeathercamBulkAirports('faa'), 'kspb'));
+        $this->assertNull($this->findAirport(getWeathercamBulkAirports('faa'), '03s'));
+    }
+
+    public function testGetWeathercamBulkAirports_AbsoluteImageUrlsAndConfiguredVariants(): void
+    {
+        $base = getCanonicalPublicApiV1BaseUrl();
+        $kspb = $this->findAirport(getWeathercamBulkAirports('aviationwx'), 'kspb');
+        $this->assertNotNull($kspb);
+        $cam = $kspb['webcams'][0];
+        $this->assertSame($base . '/airports/kspb/webcams/0/image', $cam['image_url']);
+        $this->assertStringStartsNotWith('/v1', $cam['image_url']);
+        $this->assertSame(0, substr_count($cam['image_url'], '/v1/v1/'));
+
+        $this->assertNotEmpty($cam['images']);
+        $this->assertSame('original', $cam['images'][0]['variant']);
+        $this->assertNull($cam['images'][0]['height']);
+        $this->assertSame('jpg', $cam['images'][0]['format']);
+        $this->assertSame($cam['image_url'], $cam['images'][0]['url']);
+
+        $heights = [];
+        foreach ($cam['images'] as $image) {
+            $this->assertStringStartsWith($base . '/airports/kspb/webcams/0/image', $image['url']);
+            if ($image['variant'] !== 'original') {
+                $heights[] = $image['height'];
+                $this->assertSame((string) $image['height'], $image['variant']);
+                $this->assertStringContainsString('size=' . $image['height'], $image['url']);
+                if ($image['format'] === 'jpg') {
+                    $this->assertStringNotContainsString('fmt=', $image['url']);
+                } else {
+                    $this->assertStringContainsString('fmt=' . $image['format'], $image['url']);
+                }
+            }
+        }
+        $this->assertContains(1080, $heights);
+        $this->assertContains(720, $heights);
+        $this->assertContains(360, $heights);
+    }
+
+    public function testOpenApiWeathercamBulk_IsCatalogPathWithWeathercamOperator(): void
+    {
+        $spec = json_decode(
+            (string) file_get_contents(__DIR__ . '/../../api/docs/openapi.json'),
+            true
+        );
+        $this->assertIsArray($spec);
+        $path = $spec['paths']['/weathercam/bulk']['get'] ?? null;
+        $this->assertIsArray($path);
+
+        $names = [];
+        foreach ($path['parameters'] ?? [] as $param) {
+            if (isset($param['$ref'])) {
+                $this->assertSame('#/components/parameters/WeathercamOperator', $param['$ref']);
+                $names[] = 'operator';
+                continue;
+            }
+            if (isset($param['name'])) {
+                $names[] = $param['name'];
+            }
+        }
+        $this->assertContains('operator', $names);
+        $this->assertNotContains('has_webcams', $names);
+        $this->assertNotContains('has_weather', $names);
+        $this->assertNotContains('airports', $names);
+
+        $description = $spec['components']['parameters']['WeathercamOperator']['description'] ?? '';
+        $this->assertStringContainsString('weathercam', strtolower($description));
+        $this->assertStringContainsString('weather sources do not', strtolower($description));
+    }
+}

--- a/tests/Unit/PublicApiWebcamMetadataTest.php
+++ b/tests/Unit/PublicApiWebcamMetadataTest.php
@@ -191,4 +191,34 @@ class PublicApiWebcamMetadataTest extends TestCase
         $this->assertArrayHasKey('approximate_heading', $formatted);
         $this->assertNull($formatted['approximate_heading']);
     }
+
+    public function testFormatWebcamImageVariants_UsesProvidedConfiguration(): void
+    {
+        self::loadFormatWebcamMetadata();
+
+        $config = [
+            'config' => [
+                'webcam_generate_webp' => true,
+                'webcam_variant_heights' => [480],
+            ],
+            'airports' => [
+                'test' => [
+                    'webcams' => [
+                        ['variant_heights' => [600]],
+                    ],
+                ],
+            ],
+        ];
+
+        $images = formatWebcamImageVariants('test', 0, false, $config);
+
+        $this->assertSame(
+            [
+                ['variant' => 'original', 'height' => null, 'format' => 'jpg', 'url' => '/v1/airports/test/webcams/0/image'],
+                ['variant' => '600', 'height' => 600, 'format' => 'jpg', 'url' => '/v1/airports/test/webcams/0/image?size=600'],
+                ['variant' => '600', 'height' => 600, 'format' => 'webp', 'url' => '/v1/airports/test/webcams/0/image?fmt=webp&size=600'],
+            ],
+            $images
+        );
+    }
 }

--- a/tests/Unit/PublicApiWebcamMetadataTest.php
+++ b/tests/Unit/PublicApiWebcamMetadataTest.php
@@ -69,18 +69,26 @@ class PublicApiWebcamMetadataTest extends TestCase
             ],
         ];
 
-        $formatted = [];
-        foreach ($airport['webcams'] as $index => $webcam) {
-            if (!weathercamMatchesOperator($webcam, 'wsdot')) {
-                continue;
-            }
-            $formatted[] = formatWebcamMetadata('kspb', $index, $webcam, $airport);
-        }
+        $formatted = listFormattedWebcamsForAirport('kspb', $airport, 'wsdot');
 
         $this->assertCount(1, $formatted);
         $this->assertSame(1, $formatted[0]['index']);
         $this->assertSame('wsdot', $formatted[0]['operator']);
         $this->assertSame('/v1/airports/kspb/webcams/1/image', $formatted[0]['image_url']);
+        $this->assertSame('/v1/airports/kspb/webcams/1/image', $formatted[0]['images'][0]['url']);
+    }
+
+    public function testFormatWebcamMetadata_AbsoluteUrls_UseCanonicalV1Base(): void
+    {
+        self::loadFormatWebcamMetadata();
+
+        $airport = ['enabled' => true, 'maintenance' => false];
+        $webcam = ['name' => 'North', 'approximate_heading' => 0];
+        $formatted = formatWebcamMetadata('kspb', 0, $webcam, $airport, true);
+        $base = getCanonicalPublicApiV1BaseUrl();
+
+        $this->assertSame($base . '/airports/kspb/webcams/0/image', $formatted['image_url']);
+        $this->assertSame($formatted['image_url'], $formatted['images'][0]['url']);
     }
 
     public function testFormatWebcamMetadata_NullHeadingWhenOmitted(): void


### PR DESCRIPTION
## Summary
- add `has_webcams` and `has_weather` capability filters to the airports list
- add the one-query partner weathercam catalog with operator filtering and canonical image URLs
- validate canonical Public API configuration and keep catalog caches coherent across config changes

## Test plan
- [x] Focused catalog/config tests (356 tests, 767 assertions)
- [x] All tracked unit tests (3,503 tests, 11,498 assertions; 27 skipped, 1 pre-existing warning)
- [x] PHP syntax checks for changed endpoint/config files
- [x] `git diff --check origin/main...HEAD`

## Follow-up
- Production WSDOT cameras require explicit `operator: wsdot` configuration per issue #289.
- Native PNG/WebP originals will be handled in a stacked follow-up PR for issue #293.