### PR TITLE
Harden Public API webcam query and streaming contracts

### DIFF
--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -306,7 +306,7 @@
     "/airports/{id}/webcams/{cam}/image": {
       "get": {
         "summary": "Get webcam image",
-        "description": "Returns the current webcam image with optional dimension transformations.\n\n**Profiles:**\n- `profile=faa`: FAA WCPO compliant output (4:3, margins applied, quality-capped, JPG)\n\n**Dimension behavior:**\n- `profile=faa`: Applies crop margins, 4:3 aspect, 1280x960 or 640x480 (no upscaling)\n- `width` + `height`: Center-crop to target aspect ratio, then scale to exact dimensions\n- `width` only: Scale to width, preserve original aspect ratio\n- `height` only: Scale to height, preserve original aspect ratio\n- `size`: Height-based variant from pre-generated set (no cropping)\n- Neither: Native original. Format is read from the file (jpg, png, or webp) and returned in Content-Type. Files that are not those types are not served.\n\n**FAA Profile Example:**\n```\nGET /v1/airports/kspb/webcams/0/image?profile=faa\n```",
+        "description": "Returns the current webcam image with optional dimension transformations.\n\n**Profiles:**\n- `profile=faa`: FAA WCPO compliant output (4:3, margins applied, quality-capped, JPG)\n\n**Dimension behavior:**\n- `profile=faa`: Applies crop margins, 4:3 aspect, 1280x960 or 640x480 (no upscaling)\n- `width` + `height`: Center-crop to target aspect ratio, then scale to exact dimensions\n- `width` only: Scale to width, preserve original aspect ratio\n- `height` only: Scale to height, preserve original aspect ratio\n- `size`: Exact height-based variant from the pre-generated set (no cropping or size fallback)\n- Neither: Native original. Format is read from the file (jpg, png, or webp) and returned in Content-Type. Files that are not those types are not served.\n\nsize may be omitted or set to original. Numeric size, width, and height values must be complete canonical integers within their documented ranges; malformed values return 400.\n\n**FAA Profile Example:**\n```\nGET /v1/airports/kspb/webcams/0/image?profile=faa\n```",
         "operationId": "getWebcamImage",
         "tags": ["Webcams"],
         "parameters": [
@@ -337,11 +337,20 @@
           {
             "name": "size",
             "in": "query",
-            "description": "Height-based variant from pre-generated set (no cropping). Use for standard variants like 720, 1080. Mutually exclusive with width/height. Ignored when profile is set.",
+            "description": "Exact height-based variant from the pre-generated set (no cropping or fallback to the original). Omit for the native original. Mutually exclusive with width/height. Ignored when profile is set.",
             "schema": {
-              "type": "string",
               "default": "original",
-              "example": "720"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": ["original"]
+                },
+                {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 5000
+                }
+              ]
             }
           },
           {
@@ -406,7 +415,7 @@
     "/airports/{id}/webcams/{cam}/history": {
       "get": {
         "summary": "Get webcam history",
-        "description": "Returns list of historical webcam frames, or a specific frame image when ts is provided.\n\nWhen ts is set, omit fmt for the native original. Format is read from the file (jpg, png, or webp) and returned in Content-Type. fmt applies only to generated size variants. fmt with no size, or with size=original, returns 400.",
+        "description": "Returns list of historical webcam frames, or a specific frame image when ts is provided.\n\nWhen ts is set, omit fmt for the native original. Format is read from the file (jpg, png, or webp) and returned in Content-Type. fmt applies only to generated size variants. fmt with no size, or with size=original, returns 400. ts must be a complete canonical integer. size may be omitted, set to original, or supplied as a complete canonical integer. Malformed values return 400. Requested heights are exact and never fall back to the original.",
         "operationId": "getWebcamHistory",
         "tags": ["Webcams"],
         "parameters": [
@@ -421,7 +430,8 @@
             "in": "query",
             "description": "Timestamp of specific frame to retrieve (returns image)",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           },
           {
@@ -436,10 +446,19 @@
           {
             "name": "size",
             "in": "query",
-            "description": "Height-based variant from the pre-generated set. Only used with ts. Omit fmt when requesting the original.",
+            "description": "Exact height-based variant from the pre-generated set. Only used with ts and never falls back to the original. Omit size and fmt when requesting the native original.",
             "schema": {
-              "type": "string",
-              "example": "720"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": ["original"]
+                },
+                {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 5000
+                }
+              ]
             }
           }
         ],

--- a/api/v1/webcam-history.php
+++ b/api/v1/webcam-history.php
@@ -82,9 +82,18 @@ function handleGetWebcamHistory(array $params, array $context): void
         return;
     }
     
-    // Check if specific timestamp requested (return image)
-    if (isset($_GET['ts'])) {
-        handleGetHistoricalFrame($airportId, $camIndex, (int)$_GET['ts']);
+    $timestampParse = parsePublicApiWebcamTimestampQueryFromGet();
+    if (!$timestampParse['ok']) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            $timestampParse['error'],
+            400
+        );
+        return;
+    }
+
+    if ($timestampParse['present']) {
+        handleGetHistoricalFrame($airportId, $camIndex, $timestampParse['timestamp']);
         return;
     }
     
@@ -197,10 +206,16 @@ function handleGetHistoricalFrame(string $airportId, int $camIndex, int $timesta
 {
     require_once __DIR__ . '/../../lib/webcam-history.php';
 
-    $size = $_GET['size'] ?? 'original';
-    if ($size !== 'original' && (!is_numeric($size) || (int)$size < 1 || (int)$size > 5000)) {
-        $size = 'original';
+    $sizeParse = parsePublicApiWebcamSizeQueryFromGet();
+    if (!$sizeParse['ok']) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            $sizeParse['error'],
+            400
+        );
+        return;
     }
+    $size = $sizeParse['size'];
 
     $fmtParse = parsePublicApiWebcamFmtQueryFromGet();
     if (!$fmtParse['ok']) {
@@ -262,8 +277,8 @@ function handleGetHistoricalFrame(string $airportId, int $camIndex, int $timesta
         return;
     }
 
-    $meta = webcamServableImageFileMeta($cacheFile);
-    if ($meta === null) {
+    $opened = openServableWebcamImage($cacheFile);
+    if ($opened === null) {
         sendPublicApiError(
             PUBLIC_API_ERROR_INVALID_REQUEST,
             'Image format is not supported',
@@ -271,7 +286,8 @@ function handleGetHistoricalFrame(string $airportId, int $camIndex, int $timesta
         );
         return;
     }
-    if (!webcamExplicitFmtMatchesFile($explicitFmt, $format, $meta['format'])) {
+    if (!webcamExplicitFmtMatchesFile($explicitFmt, $format, $opened['format'])) {
+        fclose($opened['handle']);
         sendPublicApiError(
             PUBLIC_API_ERROR_INVALID_REQUEST,
             "Requested format '{$format}' does not match the image file",
@@ -279,7 +295,7 @@ function handleGetHistoricalFrame(string $airportId, int $camIndex, int $timesta
         );
         return;
     }
-    $format = $meta['format'];
+    $format = $opened['format'];
 
     $variant = ($size === 'original') ? 'original' : (int)$size;
     $filename = $timestamp . '_' . $variant . '.' . $format;
@@ -288,14 +304,21 @@ function handleGetHistoricalFrame(string $airportId, int $camIndex, int $timesta
     header('Access-Control-Allow-Origin: *');
 
     require_once __DIR__ . '/../../lib/http-integrity.php';
-    if (addIntegrityHeadersForFile($cacheFile, $meta['mtime'])) {
+    if (addIntegrityHeadersForOpenFile(
+        $opened['handle'],
+        $cacheFile,
+        $opened['mtime'],
+        $opened['size']
+    )) {
+        fclose($opened['handle']);
         return;
     }
 
-    header('Content-Type: ' . $meta['content_type']);
+    header('Content-Type: ' . $opened['content_type']);
     header('Content-Disposition: inline; filename="' . $filename . '"');
-    header('Content-Length: ' . $meta['size']);
+    header('Content-Length: ' . $opened['size']);
 
-    readfile($cacheFile);
+    fpassthru($opened['handle']);
+    fclose($opened['handle']);
 }
 

--- a/api/v1/webcam-image.php
+++ b/api/v1/webcam-image.php
@@ -193,8 +193,8 @@ function handleGetWebcamImage(array $params, array $context): void
         }
         $originalFile = $currentOriginal['path'];
 
-        $meta = webcamServableImageFileMeta($originalFile);
-        if ($meta === null) {
+        $opened = openServableWebcamImage($originalFile);
+        if ($opened === null) {
             sendPublicApiError(
                 PUBLIC_API_ERROR_INVALID_REQUEST,
                 'Image format is not supported',
@@ -202,33 +202,9 @@ function handleGetWebcamImage(array $params, array $context): void
             );
             return;
         }
-        $format = $currentOriginal['format'];
-
-        $captureTime = 0;
-        if ($format === 'jpg' && function_exists('exif_read_data')) {
-            $exif = @exif_read_data($originalFile, 'EXIF', true);
-            if ($exif !== false && isset($exif['EXIF']['DateTimeOriginal'])) {
-                $dateTime = $exif['EXIF']['DateTimeOriginal'];
-                $parsed = @strtotime(str_replace(':', '-', substr($dateTime, 0, 10)) . ' ' . substr($dateTime, 11) . ' UTC');
-                if ($parsed !== false && $parsed > 0) {
-                    $captureTime = (int) $parsed;
-                }
-            } elseif (isset($exif['DateTimeOriginal'])) {
-                $dateTime = $exif['DateTimeOriginal'];
-                $parsed = @strtotime(str_replace(':', '-', substr($dateTime, 0, 10)) . ' ' . substr($dateTime, 11) . ' UTC');
-                if ($parsed !== false && $parsed > 0) {
-                    $captureTime = (int) $parsed;
-                }
-            }
-        }
-
-        $mtime = $meta['mtime'];
-        if ($captureTime > 0) {
-            $filenameStamp = gmdate('Y-m-d_His', $captureTime) . '_UTC';
-        } else {
-            $filenameStamp = gmdate('Y-m-d_His', $currentOriginal['timestamp']) . '_UTC';
-        }
-
+        $format = $opened['format'];
+        $mtime = $opened['mtime'];
+        $filenameStamp = gmdate('Y-m-d_His', $currentOriginal['timestamp']) . '_UTC';
         $filename = strtolower($airportId) . "_{$camIndex}_{$filenameStamp}." . $format;
 
         // Latest download is mutable; use the live-image cache policy.
@@ -245,15 +221,22 @@ function handleGetWebcamImage(array $params, array $context): void
         }
 
         require_once __DIR__ . '/../../lib/http-integrity.php';
-        if (addIntegrityHeadersForFile($originalFile, $mtime)) {
+        if (addIntegrityHeadersForOpenFile(
+            $opened['handle'],
+            $originalFile,
+            $mtime,
+            $opened['size']
+        )) {
+            fclose($opened['handle']);
             exit;
         }
 
-        header('Content-Type: ' . $meta['content_type']);
+        header('Content-Type: ' . $opened['content_type']);
         header('Content-Disposition: attachment; filename="' . $filename . '"');
-        header('Content-Length: ' . $meta['size']);
+        header('Content-Length: ' . $opened['size']);
 
-        readfile($originalFile);
+        fpassthru($opened['handle']);
+        fclose($opened['handle']);
         exit;
     }
     
@@ -282,15 +265,46 @@ function handleGetWebcamImage(array $params, array $context): void
         return;
     }
 
-    // Parse dimension parameters
-    $requestedWidth = isset($_GET['width']) && is_numeric($_GET['width']) ? (int)$_GET['width'] : null;
-    $requestedHeight = isset($_GET['height']) && is_numeric($_GET['height']) ? (int)$_GET['height'] : null;
-    $size = $_GET['size'] ?? null;
+    $widthParse = parsePublicApiWebcamDimensionQueryFromGet('width', 16, 3840);
+    $heightParse = parsePublicApiWebcamDimensionQueryFromGet('height', 16, 2160);
+    $sizeParse = parsePublicApiWebcamSizeQueryFromGet();
+    foreach ([$widthParse, $heightParse, $sizeParse] as $queryParse) {
+        if (!$queryParse['ok']) {
+            sendPublicApiError(
+                PUBLIC_API_ERROR_INVALID_REQUEST,
+                $queryParse['error'],
+                400
+            );
+            return;
+        }
+    }
+    $requestedWidth = $widthParse['value'];
+    $requestedHeight = $heightParse['value'];
+    $size = $sizeParse['size'];
     if (
-        $size === null ||
-        ($size !== 'original' && (!is_numeric($size) || (int)$size < 1 || (int)$size > 5000))
+        array_key_exists('size', $_GET)
+        && ($requestedWidth !== null || $requestedHeight !== null)
     ) {
-        $size = 'original';
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            'size cannot be combined with width or height',
+            400
+        );
+        return;
+    }
+    $explicitFormatRequest = $fmtParse['explicit'];
+    if (publicApiWebcamFmtRejectedOnOriginal(
+        $explicitFormatRequest,
+        $size,
+        $requestedWidth,
+        $requestedHeight
+    )) {
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            'fmt applies to generated size variants. Omit fmt for the original.',
+            400
+        );
+        return;
     }
 
     $currentOriginal = getCurrentServableWebcamOriginal($airportId, $camIndex);
@@ -309,7 +323,6 @@ function handleGetWebcamImage(array $params, array $context): void
     $cacheFile = null;
     $variant = 'original';
     $format = $fmtParse['format'] ?? 'jpg';
-    $explicitFormatRequest = $fmtParse['explicit'];
 
     if ($requestedWidth !== null || $requestedHeight !== null) {
         $cacheFile = handleTransformRequest(
@@ -333,20 +346,6 @@ function handleGetWebcamImage(array $params, array $context): void
             $variant = 'h' . $requestedHeight;
         }
     } else {
-        if (publicApiWebcamFmtRejectedOnOriginal(
-            $explicitFormatRequest,
-            $size,
-            $requestedWidth,
-            $requestedHeight
-        )) {
-            sendPublicApiError(
-                PUBLIC_API_ERROR_INVALID_REQUEST,
-                'fmt applies to generated size variants. Omit fmt for the original.',
-                400
-            );
-            return;
-        }
-
         if ($size === 'original' && !$explicitFormatRequest) {
             if ($currentOriginal === null) {
                 sendPublicApiError(
@@ -404,26 +403,17 @@ function handleGetWebcamImage(array $params, array $context): void
         return;
     }
 
-    $served = webcamServableImageContent($cacheFile);
-    if ($served === null) {
-        sendPublicApiError(
-            PUBLIC_API_ERROR_INVALID_REQUEST,
-            'Image format is not supported',
-            400
-        );
-        return;
-    }
-    if (!webcamExplicitFmtMatchesFile($explicitFormatRequest, $format, $served['format'])) {
-        sendPublicApiError(
-            PUBLIC_API_ERROR_INVALID_REQUEST,
-            "Requested format '{$format}' does not match the image file",
-            400
-        );
-        return;
-    }
-    $format = $served['format'];
-
-    sendImageResponse($airportId, $camIndex, $cacheFile, $timestamp, $variant, $format, $airport, $webcams[$camIndex]);
+    sendImageResponse(
+        $airportId,
+        $camIndex,
+        $cacheFile,
+        $timestamp,
+        $variant,
+        $format,
+        $airport,
+        $webcams[$camIndex],
+        $explicitFormatRequest
+    );
 }
 
 /**
@@ -605,6 +595,7 @@ function handleTransformRequest(
  * @param string $format Caller hint; body type is taken from the file header
  * @param array $airport Airport configuration
  * @param array $cam Camera configuration
+ * @param bool $explicitFormatRequest Whether fmt was supplied by the client
  */
 function sendImageResponse(
     string $airportId,
@@ -614,10 +605,11 @@ function sendImageResponse(
     string|int $variant,
     string $format,
     array $airport,
-    array $cam
+    array $cam,
+    bool $explicitFormatRequest = false
 ): void {
-    $meta = webcamServableImageFileMeta($cacheFile);
-    if ($meta === null) {
+    $opened = openServableWebcamImage($cacheFile);
+    if ($opened === null) {
         sendPublicApiError(
             PUBLIC_API_ERROR_INVALID_REQUEST,
             'Image format is not supported',
@@ -625,12 +617,16 @@ function sendImageResponse(
         );
         return;
     }
-    $format = $meta['format'];
-
-    // A capture older than the fail-closed threshold is a "last known good frame":
-    // still served as 200, but marked stale so it is not cached as current. The
-    // capture time (authoritative EXIF) travels in the bytes and is exposed via Last-Modified.
-    $stale = $timestamp > 0 && (time() - $timestamp) > getStaleFailclosedSeconds($airport);
+    if (!webcamExplicitFmtMatchesFile($explicitFormatRequest, $format, $opened['format'])) {
+        fclose($opened['handle']);
+        sendPublicApiError(
+            PUBLIC_API_ERROR_INVALID_REQUEST,
+            "Requested format '{$format}' does not match the image file",
+            400
+        );
+        return;
+    }
+    $format = $opened['format'];
 
     $sizeForMetrics = 'original';
     if (is_numeric($variant) && (int)$variant >= 1 && (int)$variant <= 5000) {
@@ -644,7 +640,7 @@ function sendImageResponse(
     }
     metrics_track_webcam_serve($airportId, $camIndex, $format, $sizeForMetrics);
 
-    $mtime = $meta['mtime'];
+    $mtime = $opened['mtime'];
     $filename = $timestamp . '_' . $variant . '.' . $format;
 
     $webcamRefresh = getDefaultWebcamRefresh();
@@ -655,38 +651,29 @@ function sendImageResponse(
         $webcamRefresh = intval($cam['refresh_seconds']);
     }
 
-    if ($stale) {
-        // Last known good frame; log the over-age delivery so it is auditable.
-        aviationwx_log('warn', 'serving over-age webcam frame past fail-closed threshold', [
-            'airport' => $airportId,
-            'cam' => $camIndex,
-            'capture_timestamp' => $timestamp,
-            'age_seconds' => time() - $timestamp,
-            'failclosed_seconds' => getStaleFailclosedSeconds($airport),
-        ], 'app');
-        header('Warning: 110 - "Response is stale"');
-        $headers = generateCacheHeaders(0, 0, false);
-        $headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
-        $lastModified = gmdate('D, d M Y H:i:s', $timestamp) . ' GMT';
-        header('Last-Modified: ' . $lastModified);
-    } else {
-        $headers = generateCacheHeaders($webcamRefresh, $webcamRefresh);
-    }
+    $headers = generateCacheHeaders($webcamRefresh, $webcamRefresh);
     foreach ($headers as $name => $value) {
         header($name . ': ' . $value);
     }
     header('Access-Control-Allow-Origin: *');
 
     require_once __DIR__ . '/../../lib/http-integrity.php';
-    if (addIntegrityHeadersForFile($cacheFile, $mtime)) {
+    if (addIntegrityHeadersForOpenFile(
+        $opened['handle'],
+        $cacheFile,
+        $mtime,
+        $opened['size']
+    )) {
+        fclose($opened['handle']);
         return;
     }
 
-    header('Content-Type: ' . $meta['content_type']);
+    header('Content-Type: ' . $opened['content_type']);
     header('Content-Disposition: inline; filename="' . $filename . '"');
-    header('Content-Length: ' . $meta['size']);
+    header('Content-Length: ' . $opened['size']);
 
-    readfile($cacheFile);
+    fpassthru($opened['handle']);
+    fclose($opened['handle']);
 }
 
 /**
@@ -761,13 +748,9 @@ function handleGetWebcamMetadata(
     rsort($recommendedSizes);
     
     // Build response
-    $ageSeconds = max(0, time() - $timestamp);
-    $staleFailClosed = getStaleFailclosedSeconds($airport);
     $data = [
         'timestamp' => $timestamp,
         'timestamp_iso' => gmdate('c', $timestamp),
-        'age_seconds' => $ageSeconds,
-        'stale' => $ageSeconds > $staleFailClosed,
         'formats' => $formats,
         'recommended_sizes' => array_values($recommendedSizes),
         'urls' => $urls,

--- a/api/webcam-history.php
+++ b/api/webcam-history.php
@@ -68,12 +68,7 @@ if (is_array($rawFormat)) {
     echo json_encode(['error' => 'fmt must be a single value']);
     exit;
 }
-// Normalize through the shared alias map so fmt=jpeg is accepted here as everywhere else.
 $requestedFormat = $explicitFormatRequest ? strtolower(trim((string) $rawFormat)) : 'jpg';
-if ($explicitFormatRequest) {
-    $normalized = normalizeWebcamFormatName($requestedFormat);
-    $requestedFormat = $normalized ?? $requestedFormat;
-}
 if ($explicitFormatRequest && !isset($supportedFormats[$requestedFormat])) {
     header('Content-Type: application/json');
     http_response_code(400);

--- a/api/webcam.php
+++ b/api/webcam.php
@@ -1330,19 +1330,8 @@ if (!is_dir($cacheDir) || !is_readable($cacheDir)) {
 
 // Get latest timestamp
 $latestTimestamp = getLatestImageTimestamp($airportId, $camIndex);
-$currentOriginal = null;
 $refreshInterval = getRefreshIntervalForCamera($airportId, $config, $cam);
 $enabledFormats = getEnabledWebcamFormats();
-
-// Judge staleness from the servable capture, not the newest filename: a fresh but
-// corrupt capture must not mask an aged servable original as current.
-$servingNativeCurrentOriginal = $requestedSize === 'original' && !isset($_GET['fmt']);
-if ($servingNativeCurrentOriginal) {
-    $currentOriginal = getCurrentServableWebcamOriginal($airportId, $camIndex);
-    if ($currentOriginal !== null) {
-        $latestTimestamp = $currentOriginal['timestamp'];
-    }
-}
 
 // If no image exists, serve placeholder
 if ($latestTimestamp === 0) {
@@ -1486,7 +1475,9 @@ if ($requestedTimestamp !== null && $requestedTimestamp > 0) {
     exit;
 }
 
+$servingNativeCurrentOriginal = $requestedSize === 'original' && !isset($_GET['fmt']);
 if ($servingNativeCurrentOriginal) {
+    $currentOriginal = getCurrentServableWebcamOriginal($airportId, $camIndex);
     $imagePath = $currentOriginal['path'] ?? null;
     if ($currentOriginal !== null) {
         $latestTimestamp = $currentOriginal['timestamp'];

--- a/lib/http-integrity.php
+++ b/lib/http-integrity.php
@@ -77,6 +77,84 @@ function getFileDigestsWithCache(string $filePath, int $mtime): ?array
 }
 
 /**
+ * Get integrity digests for an already-open file and rewind it to the start.
+ *
+ * @param resource $handle Open seekable file handle
+ * @param string $identity Stable logical identity used when inode data is unavailable
+ * @param int $mtime File modification time from fstat
+ * @param int $size File size from fstat
+ * @return array{digest: string, md5: string}|null Null on read failure
+ */
+function getOpenFileDigestsWithCache($handle, string $identity, int $mtime, int $size): ?array
+{
+    if (!is_resource($handle)) {
+        return null;
+    }
+
+    $stat = @fstat($handle);
+    $descriptorIdentity = $identity;
+    if ($stat !== false && isset($stat['dev'], $stat['ino'])) {
+        $descriptorIdentity = $stat['dev'] . '|' . $stat['ino'];
+    }
+    $cacheKey = HTTP_INTEGRITY_DIGEST_PREFIX . md5(
+        'open|' . $descriptorIdentity . '|' . $mtime . '|' . $size
+    );
+
+    if (function_exists('apcu_fetch')) {
+        $cached = @apcu_fetch($cacheKey);
+        if ($cached !== false && is_array($cached)) {
+            if (!rewindOpenFileForResponse($handle)) {
+                return null;
+            }
+            return $cached;
+        }
+    }
+
+    if (!rewindOpenFileForResponse($handle)) {
+        return null;
+    }
+    $shaContext = hash_init('sha256');
+    $md5Context = hash_init('md5');
+    while (!feof($handle)) {
+        $chunk = @fread($handle, 8192);
+        if ($chunk === false) {
+            rewindOpenFileForResponse($handle);
+            return null;
+        }
+        hash_update($shaContext, $chunk);
+        hash_update($md5Context, $chunk);
+    }
+    if (!rewindOpenFileForResponse($handle)) {
+        return null;
+    }
+
+    $result = [
+        'digest' => 'sha-256=:' . base64_encode(hash_final($shaContext, true)) . ':',
+        'md5' => base64_encode(hash_final($md5Context, true)),
+    ];
+
+    if (function_exists('apcu_store')) {
+        $ttl = function_exists('getHttpIntegrityDigestTtlSeconds')
+            ? getHttpIntegrityDigestTtlSeconds()
+            : 86400;
+        @apcu_store($cacheKey, $result, $ttl);
+    }
+
+    return $result;
+}
+
+/**
+ * Rewind a response file without leaking stream warnings.
+ *
+ * @param resource $handle Open file handle
+ * @return bool True when the handle is seekable and rewound
+ */
+function rewindOpenFileForResponse($handle): bool
+{
+    return is_resource($handle) && @rewind($handle);
+}
+
+/**
  * Compute Content-Digest (RFC 9530) for file: sha-256=Base64
  * Uses APCu cache when available (write-once, read-many).
  *
@@ -171,6 +249,47 @@ function maybeSend304IfUnchanged(string $etag, int $mtime): bool
         http_response_code(304);
         return true;
     }
+    return false;
+}
+
+/**
+ * Add integrity headers for an already-open file response.
+ *
+ * @param resource $handle Open seekable file handle
+ * @param string $identity Stable logical file identity for the ETag
+ * @param int $mtime File modification time from fstat
+ * @param int $size File size from fstat
+ * @return bool True if 304 sent (do not send body), false to continue
+ */
+function addIntegrityHeadersForOpenFile(
+    $handle,
+    string $identity,
+    int $mtime,
+    int $size
+): bool {
+    if (!is_resource($handle) || $size <= 0) {
+        return false;
+    }
+
+    $etagIdentity = $identity;
+    $stat = @fstat($handle);
+    if ($stat !== false && isset($stat['dev'], $stat['ino'])) {
+        $etagIdentity .= '|' . $stat['dev'] . '|' . $stat['ino'];
+    }
+    $etag = computeFileEtag($etagIdentity, $mtime, $size);
+    if (maybeSend304IfUnchanged($etag, $mtime)) {
+        return true;
+    }
+
+    header('ETag: ' . $etag);
+    header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $mtime) . ' GMT');
+
+    $digests = getOpenFileDigestsWithCache($handle, $identity, $mtime, $size);
+    if ($digests !== null) {
+        header('Content-Digest: ' . $digests['digest']);
+        header('Content-MD5: ' . $digests['md5']);
+    }
+
     return false;
 }
 

--- a/lib/public-api/query.php
+++ b/lib/public-api/query.php
@@ -6,6 +6,54 @@
 require_once dirname(__DIR__) . '/webcam-format-generation.php';
 
 /**
+ * Read one scalar query value without coercing arrays.
+ *
+ * @param string $name Query parameter name
+ * @return array{ok: true, present: bool, value: ?string, error: null}|array{ok: false, present: true, value: null, error: string}
+ */
+function parsePublicApiScalarQueryFromGet(string $name): array
+{
+    if (!array_key_exists($name, $_GET)) {
+        return ['ok' => true, 'present' => false, 'value' => null, 'error' => null];
+    }
+
+    $raw = $_GET[$name];
+    if (is_array($raw)) {
+        return [
+            'ok' => false,
+            'present' => true,
+            'value' => null,
+            'error' => "{$name} must be a single value",
+        ];
+    }
+
+    return ['ok' => true, 'present' => true, 'value' => (string) $raw, 'error' => null];
+}
+
+/**
+ * Parse a canonical positive integer string within inclusive bounds.
+ *
+ * @param string $raw Raw query value
+ * @param int $minimum Minimum accepted value
+ * @param int $maximum Maximum accepted value
+ * @return int|null Parsed integer, or null when invalid
+ */
+function parsePublicApiBoundedInteger(string $raw, int $minimum, int $maximum): ?int
+{
+    if (!preg_match('/^[1-9][0-9]*$/D', $raw)) {
+        return null;
+    }
+
+    $value = filter_var(
+        $raw,
+        FILTER_VALIDATE_INT,
+        ['options' => ['min_range' => $minimum, 'max_range' => $maximum]]
+    );
+
+    return $value === false ? null : $value;
+}
+
+/**
  * Parse fmt against enabled webcam generation formats.
  *
  * Omit fmt for the native original; fmt is only for generated size variants.
@@ -48,19 +96,113 @@ function parsePublicApiWebcamFmtQuery(?string $raw): array
  */
 function parsePublicApiWebcamFmtQueryFromGet(): array
 {
-    if (!array_key_exists('fmt', $_GET)) {
-        return parsePublicApiWebcamFmtQuery(null);
-    }
-
-    $raw = $_GET['fmt'];
-    if (is_array($raw)) {
+    $query = parsePublicApiScalarQueryFromGet('fmt');
+    if (!$query['ok']) {
         return [
             'ok' => false,
             'explicit' => true,
             'format' => null,
-            'error' => 'fmt must be a single value',
+            'error' => $query['error'],
+        ];
+    }
+    if (!$query['present']) {
+        return parsePublicApiWebcamFmtQuery(null);
+    }
+
+    return parsePublicApiWebcamFmtQuery($query['value']);
+}
+
+/**
+ * Parse size as the native original or a canonical height.
+ *
+ * @return array{ok: true, size: string, error: null}|array{ok: false, size: null, error: string}
+ */
+function parsePublicApiWebcamSizeQueryFromGet(): array
+{
+    $query = parsePublicApiScalarQueryFromGet('size');
+    if (!$query['ok']) {
+        return ['ok' => false, 'size' => null, 'error' => $query['error']];
+    }
+    if (!$query['present']) {
+        return ['ok' => true, 'size' => 'original', 'error' => null];
+    }
+
+    $raw = $query['value'];
+    if ($raw === 'original') {
+        return ['ok' => true, 'size' => 'original', 'error' => null];
+    }
+
+    $height = parsePublicApiBoundedInteger($raw, 1, 5000);
+    if ($height === null) {
+        return [
+            'ok' => false,
+            'size' => null,
+            'error' => 'size must be original or an integer from 1 to 5000',
         ];
     }
 
-    return parsePublicApiWebcamFmtQuery((string) $raw);
+    return ['ok' => true, 'size' => (string) $height, 'error' => null];
+}
+
+/**
+ * Parse an optional width or height query parameter.
+ *
+ * @param string $name width or height
+ * @param int $minimum Minimum accepted dimension
+ * @param int $maximum Maximum accepted dimension
+ * @return array{ok: true, value: ?int, error: null}|array{ok: false, value: null, error: string}
+ */
+function parsePublicApiWebcamDimensionQueryFromGet(string $name, int $minimum, int $maximum): array
+{
+    $query = parsePublicApiScalarQueryFromGet($name);
+    if (!$query['ok']) {
+        return ['ok' => false, 'value' => null, 'error' => $query['error']];
+    }
+    if (!$query['present']) {
+        return ['ok' => true, 'value' => null, 'error' => null];
+    }
+
+    $value = parsePublicApiBoundedInteger($query['value'], $minimum, $maximum);
+    if ($value === null) {
+        return [
+            'ok' => false,
+            'value' => null,
+            'error' => "{$name} must be an integer from {$minimum} to {$maximum}",
+        ];
+    }
+
+    return ['ok' => true, 'value' => $value, 'error' => null];
+}
+
+/**
+ * Parse an optional historical frame timestamp.
+ *
+ * @return array{ok: true, present: bool, timestamp: ?int, error: null}|array{ok: false, present: true, timestamp: null, error: string}
+ */
+function parsePublicApiWebcamTimestampQueryFromGet(): array
+{
+    $query = parsePublicApiScalarQueryFromGet('ts');
+    if (!$query['ok']) {
+        return [
+            'ok' => false,
+            'present' => true,
+            'timestamp' => null,
+            'error' => $query['error'],
+        ];
+    }
+    if (!$query['present']) {
+        return ['ok' => true, 'present' => false, 'timestamp' => null, 'error' => null];
+    }
+
+    $timestamp = parsePublicApiBoundedInteger($query['value'], 1, PHP_INT_MAX);
+    if ($timestamp === null) {
+        return [
+            'ok' => false,
+            'present' => true,
+            'timestamp' => null,
+            'error' => 'ts must be a positive integer timestamp',
+        ];
+    }
+
+    return ['ok' => true, 'present' => true, 'timestamp' => $timestamp, 'error' => null];
 }

--- a/lib/webcam-format-generation.php
+++ b/lib/webcam-format-generation.php
@@ -42,13 +42,6 @@ function detectImageFormatFromHeader(string $header): ?string
     }
 
     if (substr($header, 0, 4) === 'RIFF' && substr($header, 8, 4) === 'WEBP') {
-        // A WebP RIFF header opens with RIFF + a uint32 little-endian size
-        // (file bytes minus 8) + WEBP. Reject a zero-sized chunk stub so a
-        // truncated RIFF\\0\\0\\0\\0WEBP isn't served as a valid webp.
-        $riffSize = unpack('V', substr($header, 4, 4))[1];
-        if ($riffSize < 4) {
-            return null;
-        }
         return 'webp';
     }
 
@@ -261,6 +254,46 @@ function webcamReadServableImage(string $path): ?array
     $served['bytes'] = $bytes;
 
     return $served;
+}
+
+/**
+ * Open and classify a webcam image without reopening its path.
+ *
+ * @param string $path Existing file path
+ * @return array{handle: resource, format: string, content_type: string, size: int, mtime: int}|null
+ */
+function openServableWebcamImage(string $path): ?array
+{
+    $handle = @fopen($path, 'rb');
+    if ($handle === false) {
+        return null;
+    }
+
+    $stat = @fstat($handle);
+    if ($stat === false || ($stat['size'] ?? 0) <= 0) {
+        fclose($handle);
+        return null;
+    }
+
+    $prefix = @fread($handle, 12);
+    if ($prefix === false || !@rewind($handle)) {
+        fclose($handle);
+        return null;
+    }
+
+    $served = webcamServableImageContentFromBytes($prefix);
+    if ($served === null) {
+        fclose($handle);
+        return null;
+    }
+
+    return [
+        'handle' => $handle,
+        'format' => $served['format'],
+        'content_type' => $served['content_type'],
+        'size' => (int) $stat['size'],
+        'mtime' => (int) ($stat['mtime'] ?? time()),
+    ];
 }
 
 /**

--- a/lib/webcam-history.php
+++ b/lib/webcam-history.php
@@ -25,9 +25,8 @@ require_once __DIR__ . '/webcam-metadata.php';
  *
  * History URLs are immutable, so only files for this timestamp are used.
  * Staging files belong to in-progress live promotion and must not be served
- * as an old timestamp. When the requested height is missing, the same-format
- * original for that timestamp may be used. A missing format is not replaced
- * with another format.
+ * as an old timestamp. Requested heights are exact; a missing size or format
+ * is not replaced with another file.
  *
  * @param string $airportId Airport ID
  * @param int $camIndex Camera index (0-based)
@@ -43,39 +42,11 @@ function findHistoricalWebcamSizeFile(
     string|int $size,
     string $format
 ): array {
-    $resolvedSize = $size;
     $cacheFile = timestampedWebcamImagePathIfExists($airportId, $camIndex, $timestamp, $size, $format);
-    if ($cacheFile === null && $size !== 'original') {
-        $original = timestampedWebcamImagePathIfExists(
-            $airportId,
-            $camIndex,
-            $timestamp,
-            'original',
-            $format
-        );
-        if ($original !== null) {
-            $cacheFile = $original;
-            $resolvedSize = 'original';
-        }
-    }
 
-    return ['path' => $cacheFile, 'size' => $resolvedSize];
+    return ['path' => $cacheFile, 'size' => $size];
 }
 
-/**
- * Resolve the exact timestamped frame path for a requested size/format.
- *
- * For the original size, only the known source-format extensions are probed;
- * for a numeric size the variant path is returned if it exists. Returns null
- * when no matching file is present on disk.
- *
- * @param string $airportId Airport identifier
- * @param int $camIndex Camera index (0-based)
- * @param int $timestamp Exact capture timestamp for the frame
- * @param string|int $size "original" or a numeric variant height
- * @param string $format jpg, png, or webp
- * @return string|null Path to the frame, or null when not present
- */
 function timestampedWebcamImagePathIfExists(
     string $airportId,
     int $camIndex,

--- a/lib/webcam-metadata.php
+++ b/lib/webcam-metadata.php
@@ -248,8 +248,6 @@ function validateVariantHeights(array $heights): array {
 function getWebcamOriginalPath(string $airportId, int $camIndex): ?string {
     $bestPath = null;
     $bestRank = -1;
-    // Legitimate symlink targets always resolve under the airport cache dir.
-    $airportDir = getWebcamAirportDir($airportId);
     foreach (getSupportedWebcamSourceFormats() as $format) {
         $symlink = getWebcamOriginalSymlinkPath($airportId, $camIndex, $format);
         if (!is_link($symlink)) {
@@ -259,18 +257,7 @@ function getWebcamOriginalPath(string $airportId, int $camIndex): ?string {
         if ($realPath === false) {
             continue;
         }
-        $fullPath = $realPath[0] === '/' ? $realPath : dirname($symlink) . '/' . $realPath;
-        // Refuse symlinks that resolve outside the airport cache (defense in depth).
-        $realTarget = realpath($fullPath);
-        if ($realTarget === false || !str_starts_with($realTarget, $airportDir . '/')) {
-            aviationwx_log('warn', 'webcam original symlink escapes airport cache', [
-                'airport' => $airportId,
-                'cam' => $camIndex,
-                'symlink' => $symlink,
-                'target' => $fullPath,
-            ], 'app');
-            continue;
-        }
+        $fullPath = dirname($symlink) . '/' . $realPath;
         $rank = webcamServableOriginalCaptureRank($fullPath);
         if ($rank === null || $rank <= $bestRank) {
             continue;

--- a/tests/Integration/PublicApiWebcamTest.php
+++ b/tests/Integration/PublicApiWebcamTest.php
@@ -187,16 +187,7 @@ class PublicApiWebcamTest extends TestCase
         $this->assertArrayHasKey('data', $data, 'Should have data field');
         $this->assertArrayHasKey('timestamp', $data['data'], 'Should have timestamp');
         $this->assertArrayHasKey('timestamp_iso', $data['data'], 'Should have timestamp_iso');
-        $this->assertArrayHasKey('age_seconds', $data['data'], 'Should have age_seconds');
-        $this->assertArrayHasKey('stale', $data['data'], 'Should have stale flag');
         $this->assertArrayHasKey('formats', $data['data'], 'Should have formats');
-
-        // age_seconds must be consistent with the capture timestamp and current time.
-        $age = $data['data']['age_seconds'];
-        $this->assertIsInt($age);
-        $this->assertGreaterThanOrEqual(0, $age);
-        // stale is true exactly when age exceeds the (default-minimum) threshold.
-        $this->assertIsBool($data['data']['stale']);
         $this->assertArrayHasKey('recommended_sizes', $data['data'], 'Should have recommended_sizes');
         $this->assertArrayHasKey('urls', $data['data'], 'Should have urls');
         
@@ -304,6 +295,57 @@ class PublicApiWebcamTest extends TestCase
             $response['json']['error']['message'] ?? null
         );
     }
+
+    public function testSizeRequest_PartialValue_ReturnsCleanJsonError(): void
+    {
+        $response = $this->apiRequest(
+            '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image?size=720px'
+        );
+
+        $this->assertSame(400, $response['status']);
+        $this->assertSame(
+            'size must be original or an integer from 1 to 5000',
+            $response['json']['error']['message'] ?? null
+        );
+    }
+
+    public function testSizeRequest_MissingExactHeight_DoesNotReturnOriginal(): void
+    {
+        $response = $this->apiRequest(
+            '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image?size=719'
+        );
+
+        $this->assertSame(503, $response['status']);
+        $this->assertStringContainsString('application/json', $response['content_type']);
+    }
+
+    public function testHistoryTimestamp_ArrayValue_ReturnsCleanJsonError(): void
+    {
+        $response = $this->apiRequest(
+            '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/history?ts[]=1704067200'
+        );
+
+        $this->assertSame(400, $response['status']);
+        $this->assertSame('ts must be a single value', $response['json']['error']['message'] ?? null);
+    }
+
+    public function testHistorySize_MissingExactHeight_DoesNotReturnOriginal(): void
+    {
+        $installedPath = null;
+        try {
+            $installedPath = self::installNativeOriginal('png');
+            $timestamp = (int)explode('_', basename($installedPath), 2)[0];
+            $response = $this->apiRequest(
+                '/airports/' . self::$testAirport . '/webcams/' . self::$testCam .
+                '/history?ts=' . $timestamp . '&size=719'
+            );
+
+            $this->assertSame(404, $response['status']);
+            $this->assertStringContainsString('application/json', $response['content_type']);
+        } finally {
+            self::restoreDefaultOriginalFixture($installedPath);
+        }
+    }
     
     /**
      * Test explicit format request with size parameter works
@@ -396,6 +438,7 @@ class PublicApiWebcamTest extends TestCase
             $this->assertStringContainsString('max-age=60', $cacheControl);
             $this->assertStringNotContainsString('immutable', $cacheControl);
             $this->assertSame("\x89PNG\r\n\x1a\n", substr($response['body'], 0, 8));
+            $this->assertIntegrityHeadersMatchBody($response);
 
             $etag = $response['headers']['ETag'] ?? null;
             $this->assertNotNull($etag);
@@ -435,6 +478,7 @@ class PublicApiWebcamTest extends TestCase
                 $response['headers']['Cache-Control'] ?? ''
             );
             $this->assertSame("\x89PNG\r\n\x1a\n", substr($response['body'], 0, 8));
+            $this->assertIntegrityHeadersMatchBody($response);
             $this->assertConditionalImageHeaders($response, (
                 '/airports/' . self::$testAirport . '/webcams/' . self::$testCam .
                 '/history?ts=' . $timestamp
@@ -547,7 +591,7 @@ class PublicApiWebcamTest extends TestCase
                 '/api/webcam-history.php?id=' . self::$testAirport .
                 '&cam=' . self::$testCam .
                 '&ts=' . $timestamp .
-                '&fmt=jpeg&size=original'
+                '&fmt=jpg&size=original'
             );
 
             $this->assertSame(200, $response['status']);
@@ -811,14 +855,32 @@ class PublicApiWebcamTest extends TestCase
         }
     }
 
-    public function testSizeRequest_InvalidValueFallsBackToOriginal(): void
+    public function testSizeRequest_InvalidValueReturnsCleanJsonError(): void
     {
         $response = $this->apiRequest(
             '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image?size=bogus'
         );
 
-        $this->assertSame(200, $response['status']);
-        $this->assertStringContainsString('image/jpeg', $response['content_type']);
+        $this->assertSame(400, $response['status']);
+        $this->assertStringContainsString('application/json', $response['content_type']);
+        $this->assertSame(
+            'size must be original or an integer from 1 to 5000',
+            $response['json']['error']['message'] ?? null
+        );
+    }
+
+    public function testSizeRequest_WithDimensionReturnsCleanJsonError(): void
+    {
+        $response = $this->apiRequest(
+            '/airports/' . self::$testAirport . '/webcams/' . self::$testCam .
+            '/image?width=320&size=720'
+        );
+
+        $this->assertSame(400, $response['status']);
+        $this->assertSame(
+            'size cannot be combined with width or height',
+            $response['json']['error']['message'] ?? null
+        );
     }
 
     public function testSizeRequest_MissingVariantDoesNotReturnNativeOriginal(): void
@@ -851,6 +913,25 @@ class PublicApiWebcamTest extends TestCase
         }
     }
 
+    public function testOriginalFormatRequest_NoCaptureStillReturnsInvalidRequest(): void
+    {
+        self::removeFixtureTree();
+        try {
+            $response = $this->apiRequest(
+                '/airports/' . self::$testAirport . '/webcams/' . self::$testCam .
+                '/image?fmt=jpg'
+            );
+
+            $this->assertSame(400, $response['status']);
+            $this->assertSame(
+                'fmt applies to generated size variants. Omit fmt for the original.',
+                $response['json']['error']['message'] ?? null
+            );
+        } finally {
+            self::createTestImages();
+        }
+    }
+
     private function assertNativeOriginalHttpResponse(string $format, string $contentType, string $magicPrefix): void
     {
         $installedPath = null;
@@ -875,6 +956,7 @@ class PublicApiWebcamTest extends TestCase
             if ($format === 'webp') {
                 $this->assertSame('WEBP', substr($response['body'], 8, 4));
             }
+            $this->assertIntegrityHeadersMatchBody($response);
             $this->assertConditionalImageHeaders(
                 $response,
                 '/airports/' . self::$testAirport . '/webcams/' . self::$testCam . '/image',
@@ -883,6 +965,18 @@ class PublicApiWebcamTest extends TestCase
         } finally {
             self::restoreDefaultOriginalFixture($installedPath);
         }
+    }
+
+    private function assertIntegrityHeadersMatchBody(array $response): void
+    {
+        $this->assertSame(
+            'sha-256=:' . base64_encode(hash('sha256', $response['body'], true)) . ':',
+            $response['headers']['Content-Digest'] ?? null
+        );
+        $this->assertSame(
+            base64_encode(md5($response['body'], true)),
+            $response['headers']['Content-MD5'] ?? null
+        );
     }
 
     private function assertConditionalImageHeaders(
@@ -897,6 +991,7 @@ class PublicApiWebcamTest extends TestCase
 
         $conditional = $this->apiRequest($path, ['If-None-Match: ' . $etag]);
         $this->assertSame(304, $conditional['status']);
+        $this->assertSame('', $conditional['body']);
         $cacheControl = $conditional['headers']['Cache-Control'] ?? '';
         $this->assertSame($immutable, str_contains($cacheControl, 'immutable'));
         $this->assertNotSame('', $cacheControl);

--- a/tests/Unit/HttpIntegrityTest.php
+++ b/tests/Unit/HttpIntegrityTest.php
@@ -261,6 +261,44 @@ class HttpIntegrityTest extends TestCase
         $this->assertSame(computeContentMd5FromString($content), $cached['md5']);
     }
 
+    public function testGetOpenFileDigestsWithCache_HashesAndRewindsDescriptor(): void
+    {
+        $content = 'open descriptor digest test';
+        $filePath = $this->tempDir . '/open_digest_test.txt';
+        file_put_contents($filePath, $content);
+        $handle = fopen($filePath, 'rb');
+        $this->assertIsResource($handle);
+
+        try {
+            $digests = getOpenFileDigestsWithCache(
+                $handle,
+                $filePath,
+                (int)filemtime($filePath),
+                strlen($content)
+            );
+
+            $this->assertNotNull($digests);
+            $this->assertSame(computeContentDigestFromString($content), $digests['digest']);
+            $this->assertSame(computeContentMd5FromString($content), $digests['md5']);
+            $this->assertSame(0, ftell($handle));
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    public function testRewindOpenFileForResponse_NonSeekableStream_ReturnsFalse(): void
+    {
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        $this->assertIsArray($pair);
+
+        try {
+            $this->assertFalse(rewindOpenFileForResponse($pair[1]));
+        } finally {
+            fclose($pair[0]);
+            fclose($pair[1]);
+        }
+    }
+
     /**
      * getHttpIntegrityDigestTtlSeconds returns TTL >= 24h when config has 24h retention
      */

--- a/tests/Unit/PublicApiWebcamQueryTest.php
+++ b/tests/Unit/PublicApiWebcamQueryTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Public API webcam query validation tests.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../../lib/public-api/query.php';
+
+class PublicApiWebcamQueryTest extends TestCase
+{
+    private array $previousGet;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousGet = $_GET;
+        $_GET = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = $this->previousGet;
+        parent::tearDown();
+    }
+
+    public function testParsePublicApiWebcamSizeQueryFromGet_Omitted_UsesOriginal(): void
+    {
+        $parsed = parsePublicApiWebcamSizeQueryFromGet();
+
+        $this->assertTrue($parsed['ok']);
+        $this->assertSame('original', $parsed['size']);
+    }
+
+    public function testParsePublicApiWebcamSizeQueryFromGet_CanonicalHeight_ReturnsHeight(): void
+    {
+        $_GET['size'] = '720';
+
+        $parsed = parsePublicApiWebcamSizeQueryFromGet();
+
+        $this->assertTrue($parsed['ok']);
+        $this->assertSame('720', $parsed['size']);
+    }
+
+    public function testParsePublicApiWebcamSizeQueryFromGet_PartialHeight_ReturnsError(): void
+    {
+        $_GET['size'] = '720px';
+
+        $parsed = parsePublicApiWebcamSizeQueryFromGet();
+
+        $this->assertFalse($parsed['ok']);
+        $this->assertSame('size must be original or an integer from 1 to 5000', $parsed['error']);
+    }
+
+    public function testParsePublicApiWebcamSizeQueryFromGet_Array_ReturnsError(): void
+    {
+        $_GET['size'] = ['720'];
+
+        $parsed = parsePublicApiWebcamSizeQueryFromGet();
+
+        $this->assertFalse($parsed['ok']);
+        $this->assertSame('size must be a single value', $parsed['error']);
+    }
+
+    public function testParsePublicApiWebcamDimensionQueryFromGet_PartialHeight_ReturnsError(): void
+    {
+        $_GET['height'] = '720px';
+
+        $parsed = parsePublicApiWebcamDimensionQueryFromGet('height', 16, 2160);
+
+        $this->assertFalse($parsed['ok']);
+        $this->assertSame('height must be an integer from 16 to 2160', $parsed['error']);
+    }
+
+    public function testParsePublicApiWebcamTimestampQueryFromGet_Omitted_ReturnsNotPresent(): void
+    {
+        $parsed = parsePublicApiWebcamTimestampQueryFromGet();
+
+        $this->assertTrue($parsed['ok']);
+        $this->assertFalse($parsed['present']);
+        $this->assertNull($parsed['timestamp']);
+    }
+
+    public function testParsePublicApiWebcamTimestampQueryFromGet_CanonicalTimestamp_ReturnsInteger(): void
+    {
+        $_GET['ts'] = '1704067200';
+
+        $parsed = parsePublicApiWebcamTimestampQueryFromGet();
+
+        $this->assertTrue($parsed['ok']);
+        $this->assertTrue($parsed['present']);
+        $this->assertSame(1704067200, $parsed['timestamp']);
+    }
+
+    public function testParsePublicApiWebcamTimestampQueryFromGet_Array_ReturnsError(): void
+    {
+        $_GET['ts'] = ['1704067200'];
+
+        $parsed = parsePublicApiWebcamTimestampQueryFromGet();
+
+        $this->assertFalse($parsed['ok']);
+        $this->assertSame('ts must be a single value', $parsed['error']);
+    }
+}

--- a/tests/Unit/WebcamFormatGenerationTest.php
+++ b/tests/Unit/WebcamFormatGenerationTest.php
@@ -98,16 +98,6 @@ class WebcamFormatGenerationTest extends TestCase
         $format = detectImageFormat($file);
         $this->assertEquals('webp', $format);
     }
-
-    public function testDetectImageFormat_TruncatedWebpZeroRiffSize_ReturnsNull(): void
-    {
-        $path = $this->testImageDir . '/truncated.webp';
-        // RIFF + 0xFF00 0000 size + WEBP: a zero-length chunk stub must not be
-        // classified as webp, so a truncated file isn't served with a real type.
-        file_put_contents($path, "RIFF\x00\x00\x00\x00WEBP");
-        $this->assertNull(detectImageFormat($path));
-        $this->assertNull(detectImageFormatFromHeader("RIFF\x00\x00\x00\x00WEBP"));
-    }
     
     public function testDetectImageFormat_InvalidFile_ReturnsNull(): void
     {

--- a/tests/Unit/WebcamOriginalResolveTest.php
+++ b/tests/Unit/WebcamOriginalResolveTest.php
@@ -202,6 +202,25 @@ class WebcamOriginalResolveTest extends TestCase
         $this->assertSame($bytes, $read['bytes']);
     }
 
+    public function testOpenServableWebcamImage_PathReplaced_KeepsOriginalDescriptor(): void
+    {
+        $jpeg = $this->jpegBytes();
+        $path = $this->writeOriginal(1704067055, 'jpg', $jpeg);
+        $opened = openServableWebcamImage($path);
+        $this->assertNotNull($opened);
+
+        try {
+            unlink($path);
+            file_put_contents($path, $this->pngBytes());
+
+            $this->assertSame('jpg', $opened['format']);
+            $this->assertSame(strlen($jpeg), $opened['size']);
+            $this->assertSame($jpeg, stream_get_contents($opened['handle']));
+        } finally {
+            fclose($opened['handle']);
+        }
+    }
+
     public function testWebcamServableImageFileMeta_JpegFile_ReturnsHeaderTypeAndSize(): void
     {
         $bytes = $this->jpegBytes();
@@ -298,24 +317,24 @@ class WebcamOriginalResolveTest extends TestCase
         $this->assertTrue(webcamExplicitFmtMatchesFile(false, 'webp', $meta['format']));
     }
 
-    public function testFindHistoricalWebcamSizeFile_MissingHeight_UsesSameFormatOriginal(): void
+    public function testFindHistoricalWebcamSizeFile_MissingHeight_DoesNotUseSameFormatOriginal(): void
     {
         $ts = 1704068010;
-        $original = $this->writeOriginal($ts, 'webp', $this->webpBytes());
+        $this->writeOriginal($ts, 'webp', $this->webpBytes());
 
         $found = findHistoricalWebcamSizeFile($this->airportId, $this->camIndex, $ts, 720, 'webp');
-        $this->assertSame($original, $found['path']);
-        $this->assertSame('original', $found['size']);
+        $this->assertNull($found['path']);
+        $this->assertSame(720, $found['size']);
     }
 
-    public function testFindHistoricalWebcamSizeFile_MissingHeight_UsesJpegExtensionOriginal(): void
+    public function testFindHistoricalWebcamSizeFile_MissingHeight_DoesNotUseJpegExtensionOriginal(): void
     {
         $ts = 1704068110;
-        $original = $this->writeOriginal($ts, 'jpeg', $this->jpegBytes());
+        $this->writeOriginal($ts, 'jpeg', $this->jpegBytes());
 
         $found = findHistoricalWebcamSizeFile($this->airportId, $this->camIndex, $ts, 720, 'jpg');
-        $this->assertSame($original, $found['path']);
-        $this->assertSame('original', $found['size']);
+        $this->assertNull($found['path']);
+        $this->assertSame(720, $found['size']);
     }
 
     public function testFindHistoricalWebcamSizeFile_MissingTimestamp_DoesNotServeStagingVariant(): void
@@ -403,44 +422,27 @@ class WebcamOriginalResolveTest extends TestCase
         $this->assertSame($pngPath, getWebcamOriginalPath($this->airportId, $this->camIndex));
     }
 
+    public function testGetCurrentServableWebcamOriginal_NewerVariantOnlyFrame_SelectsOriginalTimestamp(): void
+    {
+        $originalTs = 1704067035;
+        $variantTs = 1704067635;
+        $originalPath = $this->writeOriginal($originalTs, 'png', $this->pngBytes());
+        $variantPath = getWebcamVariantPath($this->airportId, $this->camIndex, $variantTs, 720, 'jpg');
+        ensureCacheDir(dirname($variantPath));
+        file_put_contents($variantPath, $this->jpegBytes());
+
+        $this->assertSame($variantTs, getLatestImageTimestamp($this->airportId, $this->camIndex));
+        $current = getCurrentServableWebcamOriginal($this->airportId, $this->camIndex);
+        $this->assertNotNull($current);
+        $this->assertSame($originalPath, $current['path']);
+        $this->assertSame('png', $current['format']);
+        $this->assertSame($originalTs, $current['timestamp']);
+    }
+
     public function testWebcamServableOriginalCaptureRank_UnsupportedBytes_ReturnsNull(): void
     {
         $path = $this->writeOriginal(1704067040, 'jpg', str_repeat('notanimage!', 2));
         $this->assertNull(webcamServableOriginalCaptureRank($path));
-    }
-
-    public function testGetWebcamOriginalPath_SymlinkEscapingAirportCache_IsSkipped(): void
-    {
-        // A valid in-cache original that the resolver should fall back to.
-        $inCache = $this->writeOriginal(1704068000, 'png', $this->pngBytes());
-
-        // Point original.jpg at a file outside the airport cache via an absolute symlink.
-        $outside = CACHE_WEBCAMS_DIR . '/outside_fixture.png';
-        file_put_contents($outside, $this->pngBytes());
-        $camDir = getWebcamCameraDir($this->airportId, $this->camIndex);
-        ensureCacheDir($camDir);
-        $symlink = getWebcamOriginalSymlinkPath($this->airportId, $this->camIndex, 'jpg');
-        symlink($outside, $symlink);
-
-        // The escaping symlink must be refused as a servable original (defense in depth),
-        // so resolution falls back to the in-cache jpeg-free png.
-        $result = getWebcamOriginalPath($this->airportId, $this->camIndex);
-        $this->assertNotSame($outside, $result);
-        $this->assertSame($inCache, $result);
-    }
-
-    public function testGetCurrentServableWebcamOriginal_CorruptNewest_ReturnsOlderValidTimestamp(): void
-    {
-        // Newest file is corrupt and must be skipped; the older valid servable is what
-        // a fail-closed staleness gate must judge, so it must not be masked by the
-        // fresher-but-corrupt filename.
-        $newCorrupt = $this->writeOriginal(1704069000, 'jpg', str_repeat('notanimage!', 3));
-        $oldValid = $this->writeOriginal(1704064000, 'png', $this->pngBytes());
-
-        $servable = getCurrentServableWebcamOriginal($this->airportId, $this->camIndex);
-        $this->assertNotNull($servable);
-        $this->assertSame($oldValid, $servable['path']);
-        $this->assertSame(1704064000, $servable['timestamp']);
     }
 
     public function testCleanupOldTimestampFiles_ExpiredPngOriginal_IsRemoved(): void


### PR DESCRIPTION
## Summary
- reject array-shaped, partial, out-of-range, and otherwise malformed webcam query values instead of silently defaulting
- treat requested current and historical size variants as exact; omitted size still selects the native original
- keep native responses, downloads, on-demand transforms, and FAA output on one servable-original capture identity
- classify, stat, hash, and stream each Public API image from one open file descriptor

## Test plan
- [x] Complete tracked Unit suite: 3,603 tests, 11,802 assertions (27 skipped; 1 pre-existing warning)
- [x] Isolated Docker webcam HTTP suite: 24 tests, 103 assertions (1 skipped)
- [x] Digest headers verified against native response bytes
- [x] Immutable history conditional request verified as 304 with an empty body
- [x] OpenAPI JSON parse and stacked diff whitespace checks

Depends on #292.