### PR TITLE
Exclude maintenance sites from the weathercam bulk catalog by default

### DIFF
--- a/api/docs/index.php
+++ b/api/docs/index.php
@@ -580,7 +580,7 @@ $attribution = getPublicApiAttributionText();
                 <span class="endpoint-path">/v1/weathercam/bulk</span>
             </div>
             <div class="endpoint-body">
-                <p class="endpoint-desc">One-query weathercam catalog. Optional <code>operator</code> matches weathercams only (not weather sources). Nested webcam objects include absolute <code>image_url</code> / <code>images</code> URLs. Origin rebuilds when airports.json changes.</p>
+                <p class="endpoint-desc">One-query weathercam catalog. Optional <code>operator</code> matches weathercams only (not weather sources). Maintenance sites are excluded by default; <code>maintenance=true</code> includes them. Nested webcam objects include absolute <code>image_url</code> / <code>images</code> URLs. Origin rebuilds when airports.json changes.</p>
             </div>
         </div>
 

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -535,6 +535,15 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/WeathercamOperator"
+          },
+          {
+            "name": "maintenance",
+            "in": "query",
+            "description": "Maintenance sites are excluded by default. Use 'true' to include airports in maintenance mode; 'false' or omitted excludes them.",
+            "schema": {
+              "type": "string",
+              "enum": ["true", "false"]
+            }
           }
         ],
         "responses": {

--- a/api/v1/weathercam-bulk.php
+++ b/api/v1/weathercam-bulk.php
@@ -10,6 +10,7 @@
  *
  * Query parameters:
  * - operator: Weathercam operator only (not the GET /v1/airports union with weather sources)
+ * - maintenance: true includes maintenance sites (excluded by default; false or omitted excludes)
  */
 
 require_once __DIR__ . '/airports.php';
@@ -33,7 +34,16 @@ function handleGetWeathercamBulk(array $params, array $context): void
         return;
     }
 
+    // Maintenance sites are excluded by default. maintenance=true opts back into
+    // them; maintenance=false is the same as omitting it. Mirrors the airports
+    // list endpoint's maintenance param but keeps the default exclusionary.
+    $maintenanceFilter = parsePublicApiOptionalBooleanQuery('maintenance');
     $catalog = getWeathercamBulkAirports($operatorParse['value']);
+    if ($maintenanceFilter === null || $maintenanceFilter === false) {
+        $catalog = array_values(array_filter($catalog, function ($airport) {
+            return is_array($airport) && !($airport['maintenance'] ?? false);
+        }));
+    }
     $webcamCount = 0;
     foreach ($catalog as $airport) {
         $webcamCount += count($airport['webcams'] ?? []);

--- a/tests/Integration/PublicApiOperatorTest.php
+++ b/tests/Integration/PublicApiOperatorTest.php
@@ -278,4 +278,32 @@ class PublicApiOperatorTest extends TestCase
         $this->assertSame(400, $response['status']);
         $this->assertSame('INVALID_REQUEST', $response['json']['error']['code'] ?? null);
     }
+
+    public function testWeathercamBulk_MaintenanceSitesExcludedByDefault(): void
+    {
+        // pdx is maintenance:true with an aviationwx webcam; it must be absent
+        // from the default catalog (no maintenance param).
+        $response = $this->apiRequest('/weathercam/bulk?operator=aviationwx');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+        $this->assertNull($this->findAirport($response['json']['airports'] ?? [], 'pdx'));
+    }
+
+    public function testWeathercamBulk_MaintenanceEqualsTrueIncludesMaintenanceSites(): void
+    {
+        $response = $this->apiRequest('/weathercam/bulk?operator=aviationwx&maintenance=true');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+        $pdx = $this->findAirport($response['json']['airports'] ?? [], 'pdx');
+        $this->assertNotNull($pdx);
+        $this->assertTrue($pdx['maintenance'] ?? false);
+    }
+
+    public function testWeathercamBulk_MaintenanceEqualsFalseAlsoExcludes(): void
+    {
+        $response = $this->apiRequest('/weathercam/bulk?operator=aviationwx&maintenance=false');
+        $this->skipUnlessPublicApiOk($response);
+        $this->assertSame(200, $response['status']);
+        $this->assertNull($this->findAirport($response['json']['airports'] ?? [], 'pdx'));
+    }
 }


### PR DESCRIPTION
GET /v1/weathercam/bulk now excludes airports under maintenance unless maintenance=true is passed. This mirrors the airports list endpoint's maintenance param but keeps an exclusionary default, so partners consume only live feeds.

## Change
- parse the maintenance query param; drop maintenance rows by default and on maintenance=false, keep them on maintenance=true
- document the param in the OpenAPI spec and the docs index
- integration coverage: a maintenance site (pdx, which is maintenance:true in the fixture) is excluded by default, included on maintenance=true, excluded on maintenance=false

## Test plan
- [x] PublicApiOperatorTest: 19 tests, 74 assertions OK (includes 3 new maintenance-filter cases)
- [x] PublicApiWeathercamBulkTest: 17 tests, 95 assertions OK
- [x] OpenAPI JSON parses; php -l clean