### PR TITLE
Isolate CachedDataLoaderTest from shared APCu state

### DIFF
--- a/tests/Unit/CachedDataLoaderTest.php
+++ b/tests/Unit/CachedDataLoaderTest.php
@@ -23,7 +23,8 @@ class CachedDataLoaderTest extends TestCase
             @unlink($this->testCacheFile);
         }
         
-        // Clear the whole APCu namespace so no key from another test leaks in.
+        // Clear the whole APCu user cache for this process so no key from another
+        // test leaks in.
         // Deleting only a few known keys is unsafe because the loader keys here
         // vary per method and any leftover entry makes a test order-dependent.
         if (function_exists('apcu_clear_cache')) {
@@ -38,7 +39,7 @@ class CachedDataLoaderTest extends TestCase
             @unlink($this->testCacheFile);
         }
         
-        // Clear the whole APCu namespace (see setUp).
+        // Clear the whole APCu user cache (see setUp).
         if (function_exists('apcu_clear_cache')) {
             @apcu_clear_cache();
         }

--- a/tests/Unit/CachedDataLoaderTest.php
+++ b/tests/Unit/CachedDataLoaderTest.php
@@ -23,10 +23,10 @@ class CachedDataLoaderTest extends TestCase
             @unlink($this->testCacheFile);
         }
         
-        // Clear the whole APCu user cache for this process so no key from another
-        // test leaks in.
-        // Deleting only a few known keys is unsafe because the loader keys here
-        // vary per method and any leftover entry makes a test order-dependent.
+        // APCu has a single shared user cache with no per-test namespace, so a key
+        // left by another test leaks in here. Clearing only a few known keys is
+        // unsafe: the loader keys vary per method and any leftover makes a test
+        // order-dependent, so clear the whole cache.
         if (function_exists('apcu_clear_cache')) {
             @apcu_clear_cache();
         }
@@ -39,7 +39,8 @@ class CachedDataLoaderTest extends TestCase
             @unlink($this->testCacheFile);
         }
         
-        // Clear the whole APCu user cache (see setUp).
+        // Clear the whole APCu user cache so this test's keys do not leak into
+        // later tests.
         if (function_exists('apcu_clear_cache')) {
             @apcu_clear_cache();
         }

--- a/tests/Unit/CachedDataLoaderTest.php
+++ b/tests/Unit/CachedDataLoaderTest.php
@@ -23,11 +23,11 @@ class CachedDataLoaderTest extends TestCase
             @unlink($this->testCacheFile);
         }
         
-        // Clear APCu cache if available
-        if (function_exists('apcu_delete')) {
-            @apcu_delete('cached_test_key');
-            @apcu_delete('cached_test_bg_stale');
-            @apcu_delete('cached_test_bg_fresh');
+        // Clear the whole APCu namespace so no key from another test leaks in.
+        // Deleting only a few known keys is unsafe because the loader keys here
+        // vary per method and any leftover entry makes a test order-dependent.
+        if (function_exists('apcu_clear_cache')) {
+            @apcu_clear_cache();
         }
     }
     
@@ -38,11 +38,9 @@ class CachedDataLoaderTest extends TestCase
             @unlink($this->testCacheFile);
         }
         
-        // Clear APCu cache
-        if (function_exists('apcu_delete')) {
-            @apcu_delete('cached_test_key');
-            @apcu_delete('cached_test_bg_stale');
-            @apcu_delete('cached_test_bg_fresh');
+        // Clear the whole APCu namespace (see setUp).
+        if (function_exists('apcu_clear_cache')) {
+            @apcu_clear_cache();
         }
         
         parent::tearDown();


### PR DESCRIPTION
Closes #296. In a single process, leftover APCu entries made CachedDataLoaderTest order-dependent: a previous test's cached key (the loader keys here vary per method) leaked into the next, so the second-call/invalidate assertions failed or passed depending on run order.

## Change
- CachedDataLoaderTest now clears the whole APCu namespace in setUp and tearDown (the same pattern PublicApiRateLimitTest already uses) instead of deleting only three guessed keys.

## Test plan
- [x] Repeated full-suite runs: CachedDataLoaderTest and PublicApiRateLimitTest stable (15 tests, 173 assertions OK), no longer in the order-dependent failure set
- [x] php -l clean