### PR TITLE
Make FTP isolation probe test robust to runtime tooling

### DIFF
--- a/tests/Unit/FtpUploadIsolationTest.php
+++ b/tests/Unit/FtpUploadIsolationTest.php
@@ -113,8 +113,26 @@ class FtpUploadIsolationTest extends TestCase
     {
         $script = __DIR__ . '/../../scripts/ftp-isolation-probe.py';
         $this->assertFileExists($script);
-        exec('python3 -m py_compile ' . escapeshellarg($script) . ' 2>&1', $output, $code);
+
+        // The script is Python; if python3 is not on PATH, skip rather than fail
+        // on exit 127 so tool-light/container runtimes don't mark it a regression.
+        if (!self::pythonAvailable()) {
+            $this->markTestSkipped('python3 not available');
+        }
+
+        // Compile to a temp pycache prefix so the (possibly read-only) scripts
+        // dir is never written; skip when python3 is absent rather than fail on
+        // exit 127 in tool-light/container runtimes.
+        $cmd = 'PYTHONPYCACHEPREFIX=' . escapeshellarg(sys_get_temp_dir()) .
+            ' python3 -m py_compile ' . escapeshellarg($script) . ' 2>&1';
+        exec($cmd, $output, $code);
         $this->assertSame(0, $code, implode("\n", $output));
+    }
+
+    private static function pythonAvailable(): bool
+    {
+        exec('command -v python3 >/dev/null 2>&1', $out, $code);
+        return $code === 0;
     }
 
     /**

--- a/tests/Unit/FtpUploadIsolationTest.php
+++ b/tests/Unit/FtpUploadIsolationTest.php
@@ -123,7 +123,13 @@ class FtpUploadIsolationTest extends TestCase
         // Compile to a temp pycache prefix so the (possibly read-only) scripts
         // dir is never written; skip when python3 is absent rather than fail on
         // exit 127 in tool-light/container runtimes.
-        $cmd = 'PYTHONPYCACHEPREFIX=' . escapeshellarg(sys_get_temp_dir()) .
+        $pycacheDir = sys_get_temp_dir() . '/aviationwx-pycompile-' . getmypid();
+        @mkdir($pycacheDir, 0700, true);
+        register_shutdown_function(static function () use ($pycacheDir): void {
+            self::removePycompileDir($pycacheDir);
+        });
+
+        $cmd = 'PYTHONPYCACHEPREFIX=' . escapeshellarg($pycacheDir) .
             ' python3 -m py_compile ' . escapeshellarg($script) . ' 2>&1';
         exec($cmd, $output, $code);
         $this->assertSame(0, $code, implode("\n", $output));
@@ -133,6 +139,28 @@ class FtpUploadIsolationTest extends TestCase
     {
         exec('command -v python3 >/dev/null 2>&1', $out, $code);
         return $code === 0;
+    }
+
+    private static function removePycompileDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items !== false) {
+            foreach ($items as $item) {
+                if ($item === '.' || $item === '..') {
+                    continue;
+                }
+                $path = $dir . '/' . $item;
+                if (is_dir($path)) {
+                    self::removePycompileDir($path);
+                } else {
+                    @unlink($path);
+                }
+            }
+        }
+        @rmdir($dir);
     }
 
     /**


### PR DESCRIPTION
Closes #297.

testFtpIsolationProbeScript_IsPresentAndValidPython failed in container and tool-light runtimes for two reasons:
- python3 -m py_compile writes scripts/__pycache__, which is read-only under the test mounts (Errno 30), returning a non-zero code.
- With no python3 on PATH it exits 127 and is reported as a regression.

## Change
- Compile with PYTHONPYCACHEPREFIX to a temp dir so the scripts mount is never written.
- Skip cleanly when python3 is unavailable instead of failing on exit 127.

## Test plan
- [x] FtpUploadIsolationTest + ValidateUploadDaemonRuntimeTest: 14 tests, 73 assertions, OK (1 expected skip), no more read-only/127 failure
- [x] php -l clean