### PR TITLE
Normalize isolated test cache permissions after test-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,12 +377,13 @@ test-up: ## Start isolated test container (port 9080, test fixtures)
 		echo "❌ Test container failed to become healthy"; \
 		docker compose -f docker/docker-compose.test.yml logs; \
 		exit 1; \
-	fi; \
-	# The container (root) writes cache frames into /tmp/aviationwx-cache-test while \
-	# unit/integration phpunit runs on the host (non-root). Normalize permissions so \
-	# the host runner can unlink/rewrite frames, avoiding Permission denied in the \
-	# native webcam HTTP suite (#298). SFTP keeps its root-owned chroot dirs. \
-	chmod -R a+rwX /tmp/aviationwx-cache-test'
+	fi'
+	# The container (root) writes webcam frames into the bind-mounted cache while
+	# unit/integration phpunit runs on the host (non-root). Normalize the webcams
+	# frame dir inside the container so the host runner can unlink/rewrite frames,
+	# avoiding Permission denied (#298). Keep the SFTP chroot (/var/sftp) untouched.
+	@docker compose -f docker/docker-compose.test.yml exec -T web \
+		sh -c 'mkdir -p /var/www/html/cache/webcams && chmod -R a+rwX /var/www/html/cache/webcams'
 
 test-down: ## Stop isolated test container
 	@echo "Stopping isolated test environment..."

--- a/Makefile
+++ b/Makefile
@@ -365,17 +365,24 @@ test-up: ## Start isolated test container (port 9080, test fixtures)
 	@docker compose -f docker/docker-compose.test.yml build
 	@docker compose -f docker/docker-compose.test.yml up -d
 	@echo "Waiting for test container to be healthy..."
-	@timeout=60; while [ $$timeout -gt 0 ]; do \
+	@bash -c 'timeout=60; while [ $$timeout -gt 0 ]; do \
 		if docker compose -f docker/docker-compose.test.yml exec -T web curl -sf http://localhost/ >/dev/null 2>&1; then \
 			echo "✓ Test environment ready at http://localhost:9080"; \
-			exit 0; \
+			break; \
 		fi; \
 		sleep 1; \
 		timeout=$$((timeout - 1)); \
 	done; \
-	echo "❌ Test container failed to become healthy"; \
-	docker compose -f docker/docker-compose.test.yml logs; \
-	exit 1
+	if [ $$timeout -le 0 ]; then \
+		echo "❌ Test container failed to become healthy"; \
+		docker compose -f docker/docker-compose.test.yml logs; \
+		exit 1; \
+	fi; \
+	# The container (root) writes cache frames into /tmp/aviationwx-cache-test while \
+	# unit/integration phpunit runs on the host (non-root). Normalize permissions so \
+	# the host runner can unlink/rewrite frames, avoiding Permission denied in the \
+	# native webcam HTTP suite (#298). SFTP keeps its root-owned chroot dirs. \
+	chmod -R a+rwX /tmp/aviationwx-cache-test'
 
 test-down: ## Stop isolated test container
 	@echo "Stopping isolated test environment..."


### PR DESCRIPTION
Closes #298.

The isolated webcam test stack writes cache frames into /tmp/aviationwx-cache-test as root, while unit/integration phpunit runs on the host as a non-root uid. The host runner could not unlink or rewrite those frames, so the native webcam HTTP integration suite failed with Permission denied on every run.

## Change
- Starting isolated test environment...
Cleaning test cache for fresh state...
#1 [internal] load local bake definitions
#1 reading from stdin 489B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 11.22kB done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/php:8.4-apache
#3 DONE 0.5s

#4 [internal] load .dockerignore
#4 transferring context: 864B done
#4 DONE 0.0s

#5 [stage-0  1/38] FROM docker.io/library/php:8.4-apache@sha256:09659527973caf6fb561366fbada1e7a62e81522dce0ba729bac699afad6ad8e
#5 resolve docker.io/library/php:8.4-apache@sha256:09659527973caf6fb561366fbada1e7a62e81522dce0ba729bac699afad6ad8e done
#5 DONE 0.0s

#6 [internal] load build context
#6 transferring context: 26.22kB 0.0s done
#6 DONE 0.0s

#7 [stage-0 12/38] COPY docker/logrotate-sshd /etc/logrotate.d/sshd
#7 CACHED

#8 [stage-0  5/38] COPY composer.json composer.lock* ./
#8 CACHED

#9 [stage-0  6/38] RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer     && composer install --no-dev --optimize-autoloader --no-interaction     && rm -rf /root/.composer/cache
#9 CACHED

#10 [stage-0 20/38] COPY scripts/enable-upload-ftps.sh /usr/local/bin/
#10 CACHED

#11 [stage-0 29/38] RUN mkdir -p /var/www/html/cache/webcams     && chown -R www-data:www-data /var/www/html/cache     && mkdir -p /var/lib/aviationwx     && chown root:www-data /var/lib/aviationwx     && chmod 750 /var/lib/aviationwx     && touch /var/lib/aviationwx/upload-endpoints-refresh.log     && chown root:root /var/lib/aviationwx/upload-endpoints-refresh.log     && chmod 600 /var/lib/aviationwx/upload-endpoints-refresh.log     && touch /var/lib/aviationwx/set-cache-permissions.log     && chown root:root /var/lib/aviationwx/set-cache-permissions.log     && chmod 600 /var/lib/aviationwx/set-cache-permissions.log
#11 CACHED

#12 [stage-0  9/38] COPY docker/proftpd.conf /etc/proftpd/proftpd.conf
#12 CACHED

#13 [stage-0  7/38] COPY config/crontab /etc/cron.d/aviationwx-cron
#13 CACHED

#14 [stage-0 10/38] COPY docker/sshd_config /etc/ssh/sshd_config
#14 CACHED

#15 [stage-0 19/38] COPY scripts/configure-proftpd.sh /usr/local/bin/
#15 CACHED

#16 [stage-0 14/38] COPY docker/fail2ban-jail.conf /etc/fail2ban/jail.d/aviationwx.conf
#16 CACHED

#17 [stage-0 30/38] RUN mkdir -p /var/www/html/cache/uploads     && mkdir -p /etc/proftpd/conf.d     && mkdir -p /var/backups/aviationwx     && chown root:root /var/www/html/cache/uploads     && chmod 755 /var/www/html/cache/uploads
#17 CACHED

#18 [stage-0 24/38] RUN mkdir -p /usr/local/libexec/aviationwx     && chown root:root /usr/local/libexec/aviationwx     && chmod 755 /usr/local/libexec/aviationwx
#18 CACHED

#19 [stage-0 16/38] COPY docker/fail2ban-sshd.conf /etc/fail2ban/filter.d/sshd-sftp.conf
#19 CACHED

#20 [stage-0 33/38] RUN mkdir -p /etc/fail2ban/jail.d     && mkdir -p /var/log/fail2ban     && mkdir -p /var/run/fail2ban
#20 CACHED

#21 [stage-0  4/38] WORKDIR /var/www/html
#21 CACHED

#22 [stage-0 22/38] COPY scripts/resolve-upload-ip.sh /usr/local/bin/
#22 CACHED

#23 [stage-0 28/38] RUN sh scripts/minify-css.sh     && sh scripts/inline-css-tokens.sh public/css/styles.css     && sh scripts/inline-css-tokens.sh public/css/embed-widgets.css     && chown www-data:www-data public/css/styles.css public/css/styles.min.css public/css/embed-widgets.css
#23 CACHED

#24 [stage-0 26/38] RUN chmod 755 /usr/local/libexec/aviationwx/maybe-run-refresh-upload-endpoints.sh     /usr/local/libexec/aviationwx/refresh-upload-endpoints.php     /usr/local/libexec/aviationwx/set-cache-permissions.sh     /usr/local/libexec/aviationwx/repair-sftp-chroot-permissions.sh     /usr/local/libexec/aviationwx/repair-ftp-upload-permissions.sh     /usr/local/libexec/aviationwx/upload-daemon-common.sh     /usr/local/libexec/aviationwx/upload-probe.sh     /usr/local/libexec/aviationwx/upload-probe-runner.sh     /usr/local/libexec/aviationwx/validate-upload-daemon.sh     /usr/local/libexec/aviationwx/pasv-probe.py     /usr/local/libexec/aviationwx/ftp-isolation-probe.py     && chown root:root /usr/local/libexec/aviationwx/maybe-run-refresh-upload-endpoints.sh     /usr/local/libexec/aviationwx/refresh-upload-endpoints.php     /usr/local/libexec/aviationwx/set-cache-permissions.sh     /usr/local/libexec/aviationwx/repair-sftp-chroot-permissions.sh     /usr/local/libexec/aviationwx/repair-ftp-upload-permissions.sh     /usr/local/libexec/aviationwx/upload-daemon-common.sh     /usr/local/libexec/aviationwx/upload-probe.sh     /usr/local/libexec/aviationwx/upload-probe-runner.sh     /usr/local/libexec/aviationwx/validate-upload-daemon.sh     /usr/local/libexec/aviationwx/pasv-probe.py     /usr/local/libexec/aviationwx/ftp-isolation-probe.py
#24 CACHED

#25 [stage-0 36/38] RUN echo "memory_limit = 256M" >> /usr/local/etc/php/conf.d/custom.ini     && echo "upload_max_filesize = 100M" >> /usr/local/etc/php/conf.d/custom.ini     && echo "post_max_size = 100M" >> /usr/local/etc/php/conf.d/custom.ini     && echo "max_execution_time = 60" >> /usr/local/etc/php/conf.d/custom.ini     && echo "apc.enabled = 1" >> /usr/local/etc/php/conf.d/custom.ini     && echo "apc.enable_cli = 1" >> /usr/local/etc/php/conf.d/custom.ini     && echo "apc.shm_size = 64M" >> /usr/local/etc/php/conf.d/custom.ini     && echo "expose_php = Off" >> /usr/local/etc/php/conf.d/security.ini     && echo "display_errors = Off" >> /usr/local/etc/php/conf.d/security.ini     && echo "log_errors = On" >> /usr/local/etc/php/conf.d/security.ini     && echo "error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT" >> /usr/local/etc/php/conf.d/security.ini     && echo "error_log = /var/log/aviationwx/php-error.log" >> /usr/local/etc/php/conf.d/security.ini
#25 CACHED

#26 [stage-0 11/38] COPY docker/logrotate-proftpd /etc/logrotate.d/proftpd
#26 CACHED

#27 [stage-0 34/38] RUN touch /var/log/proftpd.log /var/log/auth.log     && chmod 644 /var/log/proftpd.log /var/log/auth.log
#27 CACHED

#28 [stage-0 27/38] COPY --chown=www-data:www-data . /var/www/html/
#28 CACHED

#29 [stage-0  3/38] RUN a2enmod rewrite
#29 CACHED

#30 [stage-0 35/38] RUN mkdir -p /etc/proftpd && touch /etc/proftpd/ftpd.passwd && chmod 600 /etc/proftpd/ftpd.passwd
#30 CACHED

#31 [stage-0 23/38] RUN chmod 0644 /etc/cron.d/aviationwx-cron     && chown root:root /etc/cron.d/aviationwx-cron     && chmod +x /usr/local/bin/docker-entrypoint.sh     && chmod +x /usr/local/bin/service-watchdog.sh     && chmod +x /usr/local/bin/setup-letsencrypt.sh     && chmod +x /usr/local/bin/configure-proftpd.sh     && chmod +x /usr/local/bin/enable-upload-ftps.sh     && chmod +x /usr/local/bin/create-sftp-user.sh     && chmod +x /usr/local/bin/resolve-upload-ip.sh     && chmod 644 /etc/proftpd/proftpd.conf     && chmod 644 /etc/ssh/sshd_config     && chmod 644 /etc/logrotate.d/proftpd /etc/logrotate.d/sshd /etc/logrotate.d/aviationwx     && chmod 644 /etc/fail2ban/jail.d/aviationwx.conf     && chmod 644 /etc/fail2ban/filter.d/proftpd.conf     && chmod 644 /etc/fail2ban/filter.d/sshd-sftp.conf
#31 CACHED

#32 [stage-0 21/38] COPY scripts/create-sftp-user.sh /usr/local/bin/
#32 CACHED

#33 [stage-0 17/38] COPY scripts/service-watchdog.sh /usr/local/bin/
#33 CACHED

#34 [stage-0 18/38] COPY scripts/setup-letsencrypt.sh /usr/local/bin/
#34 CACHED

#35 [stage-0 25/38] COPY scripts/maybe-run-refresh-upload-endpoints.sh scripts/refresh-upload-endpoints.php scripts/set-cache-permissions.sh scripts/repair-sftp-chroot-permissions.sh scripts/repair-ftp-upload-permissions.sh scripts/upload-daemon-common.sh scripts/upload-probe.sh scripts/upload-probe-runner.sh scripts/validate-upload-daemon.sh scripts/pasv-probe.py scripts/ftp-isolation-probe.py /usr/local/libexec/aviationwx/
#35 CACHED

#36 [stage-0 32/38] RUN usermod -aG www-data ftp
#36 CACHED

#37 [stage-0  8/38] COPY docker/docker-entrypoint.sh /usr/local/bin/
#37 CACHED

#38 [stage-0 37/38] RUN if ! grep -q "^Listen 80" /etc/apache2/ports.conf 2>/dev/null; then         echo "Listen 80" >> /etc/apache2/ports.conf;     fi
#38 CACHED

#39 [stage-0  2/38] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/var/lib/apt,sharing=locked     apt-get update && apt-get install -y     util-linux     libpng-dev     libjpeg-dev     libfreetype6-dev     libzip-dev     curl     git     unzip     ffmpeg     libimage-exiftool-perl     cron     proftpd-core     proftpd-mod-crypto     openssh-server     certbot     openssl     logrotate     rsyslog     net-tools     fail2ban     iptables     jq     python3     libcap2-bin     tini     && docker-php-ext-configure gd --with-freetype --with-jpeg     && docker-php-ext-install -j$(nproc) gd zip pcntl     && pecl channel-update pecl.php.net     && pecl install -a apcu     && docker-php-ext-enable apcu     && setcap cap_sys_nice+ep /usr/bin/nice     && rm -rf /var/lib/apt/lists/*
#39 CACHED

#40 [stage-0 31/38] RUN groupadd -f webcam_users
#40 CACHED

#41 [stage-0 15/38] COPY docker/fail2ban-proftpd.conf /etc/fail2ban/filter.d/proftpd.conf
#41 CACHED

#42 [stage-0 13/38] COPY docker/logrotate-aviationwx /etc/logrotate.d/aviationwx
#42 CACHED

#43 [stage-0 38/38] RUN echo "LogFormat "[apache_access] %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined" >> /etc/apache2/apache2.conf     && echo "# File-based logging with logrotate" >> /etc/apache2/apache2.conf     && echo "ErrorLog /var/log/aviationwx/apache-error.log" >> /etc/apache2/apache2.conf     && echo "CustomLog /var/log/aviationwx/apache-access.log combined" >> /etc/apache2/apache2.conf
#43 CACHED

#44 exporting to image
#44 exporting layers done
#44 exporting manifest sha256:8ea8841c5982f02f612febdbd9a35725d2c0995b1818e36e8a4669c207d9d09c done
#44 exporting config sha256:9eb2ac8737bb73a611ee6c2872113700c62f8e756c88dee0900e4cb4ea865798 done
#44 exporting attestation manifest sha256:f82734f3caa4014ead332fa65aec8a9ae6ac1258c66385965ccb88624f27bba1 done
#44 exporting manifest list sha256:19f2df498492046091a35cbaafda8dbf0c273e623db9921169cb55e6f24a6c2a done
#44 naming to docker.io/library/aviationwx-test:latest done
#44 unpacking to docker.io/library/aviationwx-test:latest done
#44 DONE 0.1s

#45 resolving provenance for metadata file
#45 DONE 0.0s
Waiting for test container to be healthy...
✓ Test environment ready at http://localhost:9080 now warranties the isolated cache: after the container is healthy it runs chmod -R a+rwX /tmp/aviationwx-cache-test, so the host uid can write and clean up. The SFTP chroot keeps its root-owned dirs.

## Test plan
- [x] make test-up runs clean with the new block
- [x] After test-up, a non-root uid (simulated host phpunit) can write into the cache; previously host uid could not
- [x] make -n test-up parses