### PR TITLE
Add bulk weathercam healthcheck to the status page

### DIFF
--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -1685,6 +1685,27 @@ function checkAirportHealth(string $airportId, array $airport): array {
 }
 
 /**
+ * Public API endpoints probed by the status page health check.
+ *
+ * Extracted so the endpoint set can be asserted without making real HTTP
+ * calls. kspb is the probe airport because it is commonly available.
+ *
+ * @return array<string,string> Map of endpoint path to display name.
+ */
+function getPublicApiHealthEndpoints(): array {
+    return [
+        '/api/v1/status' => 'API Status',
+        '/api/v1/airports' => 'List Airports',
+        '/api/v1/airports/kspb' => 'Airport Details',
+        '/api/v1/airports/kspb/weather' => 'Weather Data',
+        '/api/v1/airports/kspb/webcams' => 'Webcam List',
+        '/api/v1/airports/kspb/weather/history' => 'Weather History',
+        '/api/v1/weather/bulk?airports=kspb' => 'Bulk Weather',
+        '/api/v1/weathercam/bulk?operator=aviationwx' => 'Bulk Weathercams',
+    ];
+}
+
+/**
  * Check Public API health
  * 
  * Performs lightweight health checks on public API endpoints.
@@ -1703,16 +1724,7 @@ function checkPublicApiHealth(): array {
     
     // Define endpoints to check
     // Use kspb as test airport since it's commonly available
-    $endpoints = [
-        '/api/v1/status' => 'API Status',
-        '/api/v1/airports' => 'List Airports',
-        '/api/v1/airports/kspb' => 'Airport Details',
-        '/api/v1/airports/kspb/weather' => 'Weather Data',
-        '/api/v1/airports/kspb/webcams' => 'Webcam List',
-        '/api/v1/airports/kspb/weather/history' => 'Weather History',
-        '/api/v1/weather/bulk?airports=kspb' => 'Bulk Weather',
-        '/api/v1/weathercam/bulk?operator=aviationwx' => 'Bulk Weathercams',
-    ];
+    $endpoints = getPublicApiHealthEndpoints();
     
     $hasDown = false;
     $hasDegraded = false;

--- a/lib/status-checks.php
+++ b/lib/status-checks.php
@@ -1711,6 +1711,7 @@ function checkPublicApiHealth(): array {
         '/api/v1/airports/kspb/webcams' => 'Webcam List',
         '/api/v1/airports/kspb/weather/history' => 'Weather History',
         '/api/v1/weather/bulk?airports=kspb' => 'Bulk Weather',
+        '/api/v1/weathercam/bulk?operator=aviationwx' => 'Bulk Weathercams',
     ];
     
     $hasDown = false;

--- a/tests/Unit/PublicApiHealthEndpointsTest.php
+++ b/tests/Unit/PublicApiHealthEndpointsTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Regression: the status page Public API probe set must keep its bulk
+ * weathercam entry so a bulk weathercam outage stays visible.
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/status-checks.php';
+
+final class PublicApiHealthEndpointsTest extends TestCase
+{
+    public function testGetPublicApiHealthEndpoints_IncludesBulkWeatherAndBulkWeathercams(): void
+    {
+        $endpoints = getPublicApiHealthEndpoints();
+
+        $this->assertSame(
+            'Bulk Weather',
+            $endpoints['/api/v1/weather/bulk?airports=kspb'] ?? null,
+            'Bulk Weather probe must remain in the endpoint set'
+        );
+        $this->assertSame(
+            'Bulk Weathercams',
+            $endpoints['/api/v1/weathercam/bulk?operator=aviationwx'] ?? null,
+            'Bulk Weathercams probe must remain in the endpoint set'
+        );
+    }
+}


### PR DESCRIPTION
Closes #299.

checkPublicApiHealth() in lib/status-checks.php probes Public API endpoints for the status page. It covered Bulk Weather but not the weathercam catalog added in #294, leaving a Weathercam bulk outage invisible.

## Change
- Add a probe for /api/v1/weathercam/bulk?operator=aviationwx named 'Bulk Weathercams', mirroring the Bulk Weather entry with the same status/message/response_time_ms shape.

## Test plan
- [x] checkPublicApiHealth() enumerates the new Bulk Weathercams endpoint alongside Bulk Weather
- [x] php -l clean