### PR TITLE
Let the web server write on-demand transform caches in the isolated suite

### DIFF
--- a/tests/Integration/PublicApiWebcamTest.php
+++ b/tests/Integration/PublicApiWebcamTest.php
@@ -89,6 +89,9 @@ class PublicApiWebcamTest extends TestCase
         if (!is_dir($framesDir)) {
             mkdir($framesDir, 0755, true);
         }
+        // www-data writes on-demand transform caches here, but the host runner
+        // owns this dir on CI. Make it writable by the container too.
+        @chmod($framesDir, 0777);
         $subdir = getWebcamFramesSubdir($timestamp);
         
         // Create original JPG in date/hour subdir


### PR DESCRIPTION
The native webcam HTTP suite on main has exactly one failure: `Transform CorruptNewestOriginal UsesNewestServableCapture` comes back 503 instead of 200. The three read-only corrupt tests pass, so the source fallback is fine. Only the width/height transform path fails, because it is the only one that writes an on-demand cache file back into the fixture frames dir.

## Change
`createTestImages()` provisions the fixture frames dir as 0755. On Linux CI the host phpunit runner owns that dir, and the container web server writes as www-data, so the transform cache write fails and the endpoint 503s. It passes on my Mac because Docker Desktop does not enforce bind-mount ownership the way Linux CI does.

The fix is one chmod: `createTestImages()` now opens the frames dir to 0777, so the transform path can write its cache. #304 did the inverse inside the container so the host could clean up; this closes the other direction.

## Test plan
- [x] Full `PublicApiWebcamTest` passes in the isolated container (45 tests, 174 assertions, 2 skipped)
- [x] Confirmed on a real Linux filesystem inside the container: www-data cannot write a 0755 root-owned dir, and can after chmod 777
- [x] CI Test and Lint green, including the native webcam HTTP suite (45 tests, 1 skipped)