### PR TITLE
Resolve the global fail-closed threshold through the shared helper

### DIFF
--- a/api/webcam.php
+++ b/api/webcam.php
@@ -480,11 +480,7 @@ if (isset($_GET['mtime']) && $_GET['mtime'] === '1') {
     }
     
     // Calculate staleness status for frontend display
-    $failClosedThreshold = $cam['stale_failclosed_seconds']
-        ?? $airport['stale_failclosed_seconds']
-        ?? $config['stale_failclosed_seconds']
-        ?? DEFAULT_STALE_FAILCLOSED_SECONDS;
-    $failClosedThreshold = max(MIN_STALE_FAILCLOSED_SECONDS, (int)$failClosedThreshold);
+    $failClosedThreshold = getWebcamStaleFailclosedSeconds($cam, $airport, $config);
     
     $staleErrorThreshold = $cam['stale_error_seconds']
         ?? $airport['stale_error_seconds']
@@ -1345,13 +1341,7 @@ if ($latestTimestamp === 0) {
 // If the image is too old (exceeds fail-closed threshold), return 503 Service Unavailable
 // This prevents display of dangerously outdated data to aviation users.
 // The fail-closed threshold is configurable: camera > airport > global > default (3 hours)
-$failClosedThreshold = $cam['stale_failclosed_seconds']
-    ?? $airport['stale_failclosed_seconds']
-    ?? $config['stale_failclosed_seconds']
-    ?? DEFAULT_STALE_FAILCLOSED_SECONDS;
-
-// Enforce minimum fail-closed threshold
-$failClosedThreshold = max(MIN_STALE_FAILCLOSED_SECONDS, (int)$failClosedThreshold);
+$failClosedThreshold = getWebcamStaleFailclosedSeconds($cam, $airport, $config);
 
 $imageAge = time() - $latestTimestamp;
 if ($imageAge > $failClosedThreshold) {

--- a/lib/config.php
+++ b/lib/config.php
@@ -999,14 +999,19 @@ function getStaleFailclosedSeconds(?array $airport = null): int {
  *
  * @param array|null $webcam Webcam config (camera-level override)
  * @param array|null $airport Airport config (airport-level override)
+ * @param array|null $config Already-loaded root config, or null to load it.
+ *        api/webcam.php already has $config in scope; pass it to avoid a
+ *        redundant loadConfig() (and its file read + SHA) per request.
  * @return int Fail-closed threshold in seconds
  */
-function getWebcamStaleFailclosedSeconds(?array $webcam, ?array $airport): int {
+function getWebcamStaleFailclosedSeconds(?array $webcam, ?array $airport, ?array $config = null): int {
     $value = null;
     if ($webcam !== null && isset($webcam['stale_failclosed_seconds'])) {
         $value = $webcam['stale_failclosed_seconds'];
     } elseif ($airport !== null && isset($airport['stale_failclosed_seconds'])) {
         $value = $airport['stale_failclosed_seconds'];
+    } elseif ($config !== null) {
+        $value = $config['config']['stale_failclosed_seconds'] ?? DEFAULT_STALE_FAILCLOSED_SECONDS;
     } else {
         $value = getGlobalConfig('stale_failclosed_seconds') ?? DEFAULT_STALE_FAILCLOSED_SECONDS;
     }

--- a/tests/Unit/WebcamStaleThresholdTest.php
+++ b/tests/Unit/WebcamStaleThresholdTest.php
@@ -3,9 +3,10 @@
  * Unit Tests for getWebcamStaleFailclosedSeconds() precedence.
  *
  * The effective webcam fail-closed threshold follows camera -> airport -> global
- * -> default precedence, matching api/webcam.php. The camera and airport overrides
- * are deterministic and covered here; the global -> built-in default fallback is a
- * one-liner also exercised by FailClosedStalenessTest via getStaleFailclosedSeconds().
+ * -> default precedence, matching api/webcam.php. The camera, airport, and
+ * preloaded-config tiers are deterministic and covered here; the global ->
+ * built-in default fallback is a one-liner also exercised by
+ * FailClosedStalenessTest via getStaleFailclosedSeconds().
  */
 
 use PHPUnit\Framework\TestCase;
@@ -49,5 +50,15 @@ class WebcamStaleThresholdTest extends TestCase
             []
         );
         $this->assertSame(MIN_STALE_FAILCLOSED_SECONDS, $threshold);
+    }
+
+    public function testGetWebcamStaleFailclosedSeconds_PreloadedConfig_UsesGlobalTier(): void
+    {
+        $threshold = getWebcamStaleFailclosedSeconds(
+            [],
+            [],
+            ['config' => ['stale_failclosed_seconds' => 9000]]
+        );
+        $this->assertSame(9000, $threshold);
     }
 }


### PR DESCRIPTION
Closes #307.

The private webcam API read the global fail-closed threshold from `$config['stale_failclosed_seconds']` at the top level, but the global tier lives under `config.config`. A deployment with a non-default global override would silently fall back to the 3h default on `api/webcam.php` while the public API, fixed in #301, honors the override.

Both fail-closed sites now call `getWebcamStaleFailclosedSeconds($cam, $airport)`, which resolves the global tier through `getGlobalConfig()` and keeps the camera > airport > global > default precedence.

## Test plan
- [x] `php -l api/webcam.php` clean
- [x] `WebcamStaleThresholdTest` passes (4 tests)
- [ ] CI Test and Lint