### PR TITLE
Use webcamRefreshInterval() in sendImageResponse()

### DIFF
--- a/api/v1/webcam-image.php
+++ b/api/v1/webcam-image.php
@@ -694,13 +694,7 @@ function sendImageResponse(
     $mtime = $opened['mtime'];
     $filename = $timestamp . '_' . $variant . '.' . $format;
 
-    $webcamRefresh = getDefaultWebcamRefresh();
-    if (isset($airport['webcam_refresh_seconds'])) {
-        $webcamRefresh = intval($airport['webcam_refresh_seconds']);
-    }
-    if (isset($cam['refresh_seconds'])) {
-        $webcamRefresh = intval($cam['refresh_seconds']);
-    }
+    $webcamRefresh = webcamRefreshInterval($airport, $cam);
 
     // Over-age: last known good frame, served as 200 but no-store and flagged
     // stale; fresh frames below the threshold use the normal refresh TTL.


### PR DESCRIPTION
Closes #308.

`sendImageResponse()` still inlined the three-tier refresh lookup (`getDefaultWebcamRefresh()` → airport `webcam_refresh_seconds` → cam `refresh_seconds`) while the download branch already used `webcamRefreshInterval()`. Point it at the helper so the two cache-policy paths can't drift.

## Test plan
- [x] `php -l api/v1/webcam-image.php` clean
- [x] `PublicApiWebcamTest` passes in the isolated stack (47 tests)
- [ ] CI Test and Lint