### PR TITLE
Read global stale error/warning thresholds from the nested config block

### DIFF
--- a/api/webcam.php
+++ b/api/webcam.php
@@ -484,13 +484,13 @@ if (isset($_GET['mtime']) && $_GET['mtime'] === '1') {
     
     $staleErrorThreshold = $cam['stale_error_seconds']
         ?? $airport['stale_error_seconds']
-        ?? $config['stale_error_seconds']
+        ?? $config['config']['stale_error_seconds']
         ?? DEFAULT_STALE_ERROR_SECONDS;
     $staleErrorThreshold = max(MIN_STALE_ERROR_SECONDS, (int)$staleErrorThreshold);
     
     $staleWarningThreshold = $cam['stale_warning_seconds']
         ?? $airport['stale_warning_seconds']
-        ?? $config['stale_warning_seconds']
+        ?? $config['config']['stale_warning_seconds']
         ?? DEFAULT_STALE_WARNING_SECONDS;
     $staleWarningThreshold = max(MIN_STALE_WARNING_SECONDS, (int)$staleWarningThreshold);
     


### PR DESCRIPTION
Closes #311.

`api/webcam.php` resolved the global tier of `stale_error_seconds` and `stale_warning_seconds` from a top-level `$config` key, but the global config lives under `config.config`. Custom global error/warning thresholds were silently ignored on the private webcam API while `getStaleErrorSeconds()`/`getStaleWarningSeconds()` honored them elsewhere.

Both tiers now read the nested path from the already-loaded `$config`, keeping the camera > airport > global > default precedence.

## Test plan
- [x] `php -l api/webcam.php` clean
- [x] `FailClosedStalenessTest` + `WebcamStaleThresholdTest` pass (20 tests)
- [ ] CI Test and Lint