### PR TITLE
Summarize weathercams in one walk for the airports list

### DIFF
--- a/api/v1/airports.php
+++ b/api/v1/airports.php
@@ -102,8 +102,9 @@ function formatAirportSummary(string $airportId, array $airport, ?string $operat
     // has_weather and has_webcams are airport capabilities. webcam_count still
     // counts matching weathercams when operator is set.
     $hasWeather = hasWeatherSources($airport);
-    $webcamCount = countWeathercamsForOperator($airport, $operatorFilter);
-    $hasWebcams = countWeathercamsForOperator($airport, null) > 0;
+    $webcamSummary = summarizeWeathercams($airport, $operatorFilter);
+    $webcamCount = $webcamSummary['matching'];
+    $hasWebcams = $webcamSummary['total'] > 0;
 
     $baseDomain = getBaseDomain();
     $url = 'https://' . $airportId . '.' . $baseDomain . '/';

--- a/lib/operator.php
+++ b/lib/operator.php
@@ -143,6 +143,36 @@ function weatherSourceMatchesOperator(array $source, ?string $operatorFilter): b
 }
 
 /**
+ * Weathercam presence and operator-sliced count in a single walk.
+ *
+ * @param array $airport Airport configuration
+ * @param string|null $operatorFilter Lowercase slug, or null for no filter
+ * @return array{total: int, matching: int} Total configured weathercams and
+ *         the count matching the operator filter
+ */
+function summarizeWeathercams(array $airport, ?string $operatorFilter): array
+{
+    $webcams = $airport['webcams'] ?? [];
+    if (!is_array($webcams)) {
+        return ['total' => 0, 'matching' => 0];
+    }
+
+    $total = 0;
+    $matching = 0;
+    foreach ($webcams as $webcam) {
+        if (!is_array($webcam)) {
+            continue;
+        }
+        $total++;
+        if (weathercamMatchesOperator($webcam, $operatorFilter)) {
+            $matching++;
+        }
+    }
+
+    return ['total' => $total, 'matching' => $matching];
+}
+
+/**
  * Count weathercams on an airport that match an optional operator filter.
  *
  * @param array $airport Airport configuration
@@ -151,19 +181,7 @@ function weatherSourceMatchesOperator(array $source, ?string $operatorFilter): b
  */
 function countWeathercamsForOperator(array $airport, ?string $operatorFilter): int
 {
-    $webcams = $airport['webcams'] ?? [];
-    if (!is_array($webcams)) {
-        return 0;
-    }
-
-    $count = 0;
-    foreach ($webcams as $webcam) {
-        if (is_array($webcam) && weathercamMatchesOperator($webcam, $operatorFilter)) {
-            $count++;
-        }
-    }
-
-    return $count;
+    return summarizeWeathercams($airport, $operatorFilter)['matching'];
 }
 
 /**

--- a/tests/Unit/OperatorConfigTest.php
+++ b/tests/Unit/OperatorConfigTest.php
@@ -110,6 +110,23 @@ class OperatorConfigTest extends TestCase
         $this->assertSame(1, $wsdot['webcam_count']);
     }
 
+    public function testSummarizeWeathercams_CountsTotalAndMatchingInOneWalk(): void
+    {
+        $airport = [
+            'webcams' => [
+                ['name' => 'Ours'],
+                ['name' => 'WSDOT', 'operator' => 'wsdot'],
+                'not-an-array',
+            ],
+        ];
+
+        $all = summarizeWeathercams($airport, null);
+        $this->assertSame(['total' => 2, 'matching' => 2], $all);
+
+        $aviationwx = summarizeWeathercams($airport, 'aviationwx');
+        $this->assertSame(['total' => 2, 'matching' => 1], $aviationwx);
+    }
+
     public function testParsePublicApiOptionalBooleanQuery_ReadsTrueFalse(): void
     {
         $originalGet = $_GET;


### PR DESCRIPTION
Closes #291.

`formatAirportSummary()` walked webcams twice: once for the operator-sliced `webcam_count`, once for the unfiltered `has_webcams` presence. Added `summarizeWeathercams()` so a single walk yields both, and kept `countWeathercamsForOperator()` as a thin wrapper for its other callers.

The boolean-query fold for `maintenance` / `limited_availability` was already in place from #294; this closes the remaining single-walk piece. Left `handleListAirports` handler coverage out per the issue's optional note.

## Test plan
- [x] `php -l` clean on both files
- [x] `OperatorConfigTest` passes (14 tests), including a new `summarizeWeathercams` unit test
- [ ] CI Test and Lint