### PR TITLE
Drop dead camera-level stale error/warning reads

### DIFF
--- a/api/webcam.php
+++ b/api/webcam.php
@@ -482,14 +482,12 @@ if (isset($_GET['mtime']) && $_GET['mtime'] === '1') {
     // Calculate staleness status for frontend display
     $failClosedThreshold = getWebcamStaleFailclosedSeconds($cam, $airport, $config);
     
-    $staleErrorThreshold = $cam['stale_error_seconds']
-        ?? $airport['stale_error_seconds']
+    $staleErrorThreshold = $airport['stale_error_seconds']
         ?? $config['config']['stale_error_seconds']
         ?? DEFAULT_STALE_ERROR_SECONDS;
     $staleErrorThreshold = max(MIN_STALE_ERROR_SECONDS, (int)$staleErrorThreshold);
     
-    $staleWarningThreshold = $cam['stale_warning_seconds']
-        ?? $airport['stale_warning_seconds']
+    $staleWarningThreshold = $airport['stale_warning_seconds']
         ?? $config['config']['stale_warning_seconds']
         ?? DEFAULT_STALE_WARNING_SECONDS;
     $staleWarningThreshold = max(MIN_STALE_WARNING_SECONDS, (int)$staleWarningThreshold);


### PR DESCRIPTION
Follow-up to #314.

Camera-level `stale_error_seconds` / `stale_warning_seconds` are not valid webcam config fields (only `stale_failclosed_seconds` is), so the two `$cam[...]` reads in the frontend staleness display always resolved to null. Drop them and resolve those tiers as airport -> global -> default, matching `getStaleErrorSeconds()` / `getStaleWarningSeconds()` elsewhere.

Base is #314's branch; merges after #314 lands.

## Test plan
- [x] `php -l api/webcam.php` clean
- [x] `FailClosedStalenessTest` + `WebcamStaleThresholdTest` pass (20 tests)
- [ ] CI Test and Lint