### PR TITLE
Add opt-in NASR schema drift probes

### DIFF
--- a/.github/workflows/weekly-upstream-api-probes.yml
+++ b/.github/workflows/weekly-upstream-api-probes.yml
@@ -28,7 +28,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
-          extensions: curl, json, mbstring
+          extensions: curl, json, mbstring, zip
           coverage: none
 
       - name: Cache Composer dependencies

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -80,6 +80,16 @@ That uses [`phpunit.external-apis.xml`](../phpunit.external-apis.xml): `APP_ENV=
 
 **Scheduled CI:** [`.github/workflows/weekly-upstream-api-probes.yml`](../.github/workflows/weekly-upstream-api-probes.yml) builds `/tmp/upstream-probe-airports.json` from `config/airports.json.example` plus optional repository secret `OPENWEATHERMAP_API_KEY`, then runs `scripts/run-upstream-api-probes-with-retries.sh` with **5 attempts** and exponential backoff (30s, 60s, 120s, 240s, capped at 300s between attempts). Tune with `UPSTREAM_PROBE_MAX_ATTEMPTS`, `UPSTREAM_PROBE_INITIAL_BACKOFF_SEC`, and `UPSTREAM_PROBE_MAX_BACKOFF_SEC` in the workflow file. The probe gate uses `RUN_EXTERNAL_UPSTREAM_TESTS=1` and refuses `CONFIG_PATH` paths containing `airports.json.test` (not `isTestMode()`), so the job still runs when the workspace `config/airports.json` contains test markers.
 
+### NASR schema drift probes
+
+[`tests/Integration/NasrSchemaDriftIntegrationTest.php`](../tests/Integration/NasrSchemaDriftIntegrationTest.php) downloads the current NASR cycle's APT and FRQ zips and asserts their layout and CSV header prefixes still match what the parsers expect (`NASR_CSV_HEADER_PREFIX` in [`lib/nasr/csv-validation.php`](../lib/nasr/csv-validation.php)). It runs in the same `UpstreamApiProbes` suite, so `make test-external-apis` and the weekly job cover it.
+
+A failure here means FAA changed a subscription URL or CSV column before the scheduled refresh could fail. Fix by:
+
+1. Comparing the failing header against the upstream file (download the current cycle zip from the FAA NASR subscription page).
+2. Updating the matching prefix in `NASR_CSV_HEADER_PREFIX`, then the parser in [`lib/nasr/parse.php`](../lib/nasr/parse.php) (APT) or [`lib/nasr/frequencies-parse.php`](../lib/nasr/frequencies-parse.php) (FRQ).
+3. Regenerating the fixtures under `tests/Fixtures/nasr/` so unit tests track the new shape.
+
 ## Isolated Test Environment
 
 The test environment runs in a separate Docker container that is completely isolated from development:

--- a/lib/nasr/extract.php
+++ b/lib/nasr/extract.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * NASR subscription zip extraction (allowlisted CSV entries only).
+ */
+
+/**
+ * Extract only NASR APT CSV files from a zip, rejecting path traversal entries.
+ *
+ * @param ZipArchive $zip Open archive
+ * @param string $extractDir Destination directory (flat; no subpaths)
+ * @return bool True when APT_BASE, APT_RWY, and APT_RWY_END were all written
+ */
+function nasrExtractAllowlistedAptCsvFromZip(ZipArchive $zip, string $extractDir): bool
+{
+    $allowed = ['APT_BASE.csv', 'APT_RWY.csv', 'APT_RWY_END.csv', 'APT_RMK.csv'];
+    $written = [];
+
+    for ($i = 0; $i < $zip->numFiles; $i++) {
+        $entry = $zip->getNameIndex($i);
+        if (!is_string($entry) || $entry === '') {
+            continue;
+        }
+        $normalized = str_replace('\\', '/', $entry);
+        if (str_starts_with($normalized, '/') || preg_match('#(^|/)\.\.(/|$)#', $normalized) === 1) {
+            continue;
+        }
+        $base = basename($normalized);
+        if (!in_array($base, $allowed, true)) {
+            continue;
+        }
+
+        $stream = $zip->getStream($entry);
+        if ($stream === false) {
+            return false;
+        }
+        $dest = $extractDir . '/' . $base;
+        $destHandle = @fopen($dest, 'wb');
+        if ($destHandle === false) {
+            fclose($stream);
+            return false;
+        }
+        $copied = stream_copy_to_stream($stream, $destHandle);
+        fclose($stream);
+        fclose($destHandle);
+        if ($copied === false) {
+            return false;
+        }
+        $written[$base] = true;
+    }
+
+    foreach (['APT_BASE.csv', 'APT_RWY.csv', 'APT_RWY_END.csv'] as $name) {
+        if (empty($written[$name])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Extract only the NASR FRQ.csv file from a zip.
+ *
+ * @param ZipArchive $zip Open archive
+ * @param string $extractDir Destination directory (flat; no subpaths)
+ * @return bool True when FRQ.csv was written
+ */
+function nasrExtractAllowlistedFrqCsvFromZip(ZipArchive $zip, string $extractDir): bool
+{
+    for ($i = 0; $i < $zip->numFiles; $i++) {
+        $name = $zip->getNameIndex($i);
+        if (!is_string($name) || basename($name) !== 'FRQ.csv') {
+            continue;
+        }
+
+        $stream = $zip->getStream($name);
+        if ($stream === false) {
+            return false;
+        }
+        $dest = $extractDir . '/FRQ.csv';
+        $destHandle = @fopen($dest, 'wb');
+        if ($destHandle === false) {
+            fclose($stream);
+            return false;
+        }
+        $copied = stream_copy_to_stream($stream, $destHandle);
+        fclose($stream);
+        fclose($destHandle);
+        if ($copied === false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    return false;
+}

--- a/phpunit.external-apis.xml
+++ b/phpunit.external-apis.xml
@@ -16,6 +16,7 @@
         <testsuite name="UpstreamApiProbes">
             <file>tests/Integration/UpstreamApiProbeTest.php</file>
             <file>tests/Integration/NasrDiscoveryIntegrationTest.php</file>
+            <file>tests/Integration/NasrSchemaDriftIntegrationTest.php</file>
         </testsuite>
     </testsuites>
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,7 @@
             <exclude>tests/Integration/WeatherEndpointTest.php</exclude>
             <exclude>tests/Integration/UpstreamApiProbeTest.php</exclude>
             <exclude>tests/Integration/NasrDiscoveryIntegrationTest.php</exclude>
+            <exclude>tests/Integration/NasrSchemaDriftIntegrationTest.php</exclude>
         </testsuite>
         <testsuite name="Performance">
             <directory>tests/Performance</directory>

--- a/scripts/fetch-nasr-apt.php
+++ b/scripts/fetch-nasr-apt.php
@@ -19,6 +19,7 @@ require_once __DIR__ . '/../lib/nasr/cache.php';
 require_once __DIR__ . '/../lib/nasr/discovery.php';
 require_once __DIR__ . '/../lib/nasr/util.php';
 require_once __DIR__ . '/../lib/nasr/csv-validation.php';
+require_once __DIR__ . '/../lib/nasr/extract.php';
 
 @ini_set('memory_limit', '1024M');
 
@@ -100,62 +101,6 @@ function downloadNasrAptCsvDirectory(): ?array
 
     nasrCleanupDirectory($tmpRoot);
     return null;
-}
-
-/**
- * Extract only NASR APT CSV files from a zip, rejecting path traversal entries.
- *
- * @param ZipArchive $zip Open archive
- * @param string $extractDir Destination directory (flat; no subpaths)
- */
-function nasrExtractAllowlistedAptCsvFromZip(ZipArchive $zip, string $extractDir): bool
-{
-    $allowed = ['APT_BASE.csv', 'APT_RWY.csv', 'APT_RWY_END.csv', 'APT_RMK.csv'];
-    $written = [];
-
-    for ($i = 0; $i < $zip->numFiles; $i++) {
-        $entry = $zip->getNameIndex($i);
-        if (!is_string($entry) || $entry === '') {
-            continue;
-        }
-        $normalized = str_replace('\\', '/', $entry);
-        if (str_starts_with($normalized, '/') || preg_match('#(^|/)\.\.(/|$)#', $normalized) === 1) {
-            continue;
-        }
-        $base = basename($normalized);
-        if (!in_array($base, $allowed, true)) {
-            continue;
-        }
-
-        $stream = $zip->getStream($entry);
-        if ($stream === false) {
-            return false;
-        }
-        $dest = $extractDir . '/' . $base;
-        $destHandle = @fopen($dest, 'wb');
-        if ($destHandle === false) {
-            fclose($stream);
-            return false;
-        }
-        $copied = stream_copy_to_stream($stream, $destHandle);
-        fclose($stream);
-        fclose($destHandle);
-        if ($copied === false) {
-            return false;
-        }
-        $written[$base] = true;
-    }
-
-    foreach ($allowed as $name) {
-        if ($name === 'APT_RMK.csv') {
-            continue;
-        }
-        if (empty($written[$name])) {
-            return false;
-        }
-    }
-
-    return true;
 }
 
 /**

--- a/scripts/fetch-nasr-frq.php
+++ b/scripts/fetch-nasr-frq.php
@@ -19,6 +19,7 @@ require_once __DIR__ . '/../lib/nasr/frequencies-cache.php';
 require_once __DIR__ . '/../lib/nasr/discovery.php';
 require_once __DIR__ . '/../lib/nasr/util.php';
 require_once __DIR__ . '/../lib/nasr/csv-validation.php';
+require_once __DIR__ . '/../lib/nasr/extract.php';
 
 /**
  * Download and extract FRQ.csv to a temp directory.
@@ -77,22 +78,7 @@ function downloadNasrFrqCsvDirectory(): ?array
         return null;
     }
 
-    $extracted = false;
-    for ($i = 0; $i < $zip->numFiles; $i++) {
-        $name = $zip->getNameIndex($i);
-        if (!is_string($name) || basename($name) !== 'FRQ.csv') {
-            continue;
-        }
-        $contents = $zip->getFromIndex($i);
-        if ($contents === false) {
-            break;
-        }
-        if (file_put_contents($extractDir . '/FRQ.csv', $contents, LOCK_EX) === false) {
-            break;
-        }
-        $extracted = true;
-        break;
-    }
+    $extracted = nasrExtractAllowlistedFrqCsvFromZip($zip, $extractDir);
     $zip->close();
 
     if (!$extracted || !is_readable($extractDir . '/FRQ.csv')) {

--- a/tests/Integration/NasrSchemaDriftIntegrationTest.php
+++ b/tests/Integration/NasrSchemaDriftIntegrationTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Live NASR schema-drift probes (network-dependent).
+ *
+ * Downloads the current-cycle APT and FRQ zips and asserts the zip layout and
+ * CSV header prefixes still match what the parsers expect. A mismatch means FAA
+ * changed a URL or column before the scheduled refresh could fail silently.
+ *
+ * Not part of the default Integration suite (see phpunit.xml exclude).
+ * Opt-in via RUN_EXTERNAL_UPSTREAM_TESTS=1 (make test-external-apis).
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/nasr/discovery.php';
+require_once __DIR__ . '/../../lib/nasr/csv-validation.php';
+require_once __DIR__ . '/../../lib/nasr/extract.php';
+require_once __DIR__ . '/../../lib/nasr/util.php';
+
+class NasrSchemaDriftIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (getenv('RUN_EXTERNAL_UPSTREAM_TESTS') !== '1') {
+            $this->markTestSkipped(
+                'Live NASR schema checks are opt-in. Run: make test-external-apis (see docs/TESTING.md).'
+            );
+        }
+    }
+
+    public function testBuildNasrAptDownloadPlans_CurrentCycleZips_MatchParserSchema(): void
+    {
+        $plans = buildNasrAptDownloadPlans();
+        $this->assertNotSame(
+            [],
+            $plans,
+            'NASR cycle discovery returned no plans; FAA index or zip URL may have drifted'
+        );
+
+        $effectiveDate = $plans[0]['effective_date'] ?? null;
+        $this->assertNotNull($effectiveDate, 'NASR plan missing effective date');
+
+        $this->assertAptZipMatchesSchema($plans[0]['source_url']);
+        $this->assertFrqZipMatchesSchema($effectiveDate);
+    }
+
+    private function assertAptZipMatchesSchema(string $sourceUrl): void
+    {
+        $tmpRoot = $this->makeTempDir('apt');
+        try {
+            $zipPath = $tmpRoot . '/apt.zip';
+            $this->assertTrue(
+                nasrHttpDownloadToFile($sourceUrl, $zipPath),
+                'NASR APT zip download failed: ' . $sourceUrl
+            );
+            $this->assertTrue(nasrDownloadedZipFileIsValid($zipPath), 'NASR APT zip download was empty or not a valid zip');
+
+            $extractDir = $tmpRoot . '/csv';
+            $this->assertTrue(@mkdir($extractDir, 0700, true) || is_dir($extractDir), 'Failed to create NASR CSV extract dir');
+            $zip = new ZipArchive();
+            $this->assertTrue($zip->open($zipPath) === true, 'NASR APT zip could not be opened');
+            $this->assertTrue(
+                nasrExtractAllowlistedAptCsvFromZip($zip, $extractDir),
+                'NASR APT zip entry names changed'
+            );
+            $zip->close();
+
+            $this->assertTrue(nasrAptCsvDirectoryIsValid($extractDir), 'NASR APT CSV headers changed');
+
+            // The parser validates APT_RMK.csv when present; probe it too so a
+            // header drift there is caught rather than silently skipping remarks.
+            if (is_readable($extractDir . '/APT_RMK.csv')) {
+                $this->assertTrue(
+                    nasrCsvFileIsValid($extractDir . '/APT_RMK.csv', NASR_CSV_HEADER_PREFIX['APT_RMK']),
+                    'NASR APT_RMK CSV header changed'
+                );
+            }
+        } finally {
+            nasrCleanupDirectory($tmpRoot);
+        }
+    }
+
+    private function assertFrqZipMatchesSchema(string $effectiveDate): void
+    {
+        $frqUrl = buildNasrFrqZipUrl($effectiveDate);
+        $this->assertNotSame('', $frqUrl, 'NASR FRQ URL could not be built for cycle');
+
+        $tmpRoot = $this->makeTempDir('frq');
+        try {
+            $zipPath = $tmpRoot . '/frq.zip';
+            $this->assertTrue(
+                nasrHttpDownloadToFile($frqUrl, $zipPath),
+                'NASR FRQ zip download failed: ' . $frqUrl
+            );
+            $this->assertTrue(nasrDownloadedZipFileIsValid($zipPath), 'NASR FRQ zip download was empty or not a valid zip');
+
+            $extractDir = $tmpRoot . '/csv';
+            $this->assertTrue(@mkdir($extractDir, 0700, true) || is_dir($extractDir), 'Failed to create NASR CSV extract dir');
+            $zip = new ZipArchive();
+            $this->assertTrue($zip->open($zipPath) === true, 'NASR FRQ zip could not be opened');
+            $this->assertTrue(
+                nasrExtractAllowlistedFrqCsvFromZip($zip, $extractDir),
+                'NASR FRQ zip entry names changed'
+            );
+            $zip->close();
+
+            $this->assertTrue(nasrFrqCsvFileIsValid($extractDir . '/FRQ.csv'), 'NASR FRQ CSV header changed');
+        } finally {
+            nasrCleanupDirectory($tmpRoot);
+        }
+    }
+
+    private function makeTempDir(string $label): string
+    {
+        $dir = sys_get_temp_dir() . '/aviationwx-nasr-drift-' . $label . '-' . getmypid() . '-' . bin2hex(random_bytes(4));
+        $this->assertTrue(@mkdir($dir, 0700, true) || is_dir($dir), 'Failed to create NASR probe temp dir');
+
+        return $dir;
+    }
+}

--- a/tests/Unit/NasrExtractTest.php
+++ b/tests/Unit/NasrExtractTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Unit tests for NASR zip extraction helpers.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/nasr/extract.php';
+
+class NasrExtractTest extends TestCase
+{
+    private string $fixtureDir;
+
+    protected function setUp(): void
+    {
+        $this->fixtureDir = __DIR__ . '/../Fixtures/nasr';
+    }
+
+    public function testNasrExtractAllowlistedAptCsvFromZip_CompleteArchive_ExtractsExpectedCsvs(): void
+    {
+        $zipPath = sys_get_temp_dir() . '/nasr_apt_extract_' . bin2hex(random_bytes(4)) . '.zip';
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($zipPath, ZipArchive::CREATE) === true);
+        $this->assertTrue($zip->addFile($this->fixtureDir . '/APT_BASE.csv', 'APT_BASE.csv'));
+        $this->assertTrue($zip->addFile($this->fixtureDir . '/APT_RWY.csv', 'APT_RWY.csv'));
+        $this->assertTrue($zip->addFile($this->fixtureDir . '/APT_RWY_END.csv', 'APT_RWY_END.csv'));
+        $this->assertTrue($zip->addFile($this->fixtureDir . '/APT_RMK.csv', 'APT_RMK.csv'));
+        $zip->close();
+
+        $extractDir = $this->makeExtractDir('apt_extract');
+
+        try {
+            $zip = new ZipArchive();
+            $this->assertTrue($zip->open($zipPath) === true);
+            $this->assertTrue(nasrExtractAllowlistedAptCsvFromZip($zip, $extractDir));
+            $zip->close();
+
+            $this->assertFileExists($extractDir . '/APT_BASE.csv');
+            $this->assertFileExists($extractDir . '/APT_RWY.csv');
+            $this->assertFileExists($extractDir . '/APT_RWY_END.csv');
+            $this->assertFileExists($extractDir . '/APT_RMK.csv');
+        } finally {
+            @unlink($zipPath);
+            $this->removeTree($extractDir);
+        }
+    }
+
+    public function testNasrExtractAllowlistedAptCsvFromZip_MissingRequiredCsv_ReturnsFalse(): void
+    {
+        $zipPath = sys_get_temp_dir() . '/nasr_apt_partial_' . bin2hex(random_bytes(4)) . '.zip';
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($zipPath, ZipArchive::CREATE) === true);
+        $this->assertTrue($zip->addFile($this->fixtureDir . '/APT_BASE.csv', 'APT_BASE.csv'));
+        $zip->close();
+
+        $extractDir = $this->makeExtractDir('apt_partial');
+
+        try {
+            $zip = new ZipArchive();
+            $this->assertTrue($zip->open($zipPath) === true);
+            $this->assertFalse(nasrExtractAllowlistedAptCsvFromZip($zip, $extractDir));
+            $zip->close();
+        } finally {
+            @unlink($zipPath);
+            $this->removeTree($extractDir);
+        }
+    }
+
+    public function testNasrExtractAllowlistedAptCsvFromZip_TraversalEntry_IsSkipped(): void
+    {
+        $zipPath = sys_get_temp_dir() . '/nasr_apt_traversal_' . bin2hex(random_bytes(4)) . '.zip';
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($zipPath, ZipArchive::CREATE) === true);
+        $this->assertTrue($zip->addFile($this->fixtureDir . '/APT_RWY.csv', 'APT_RWY.csv'));
+        $this->assertTrue($zip->addFile($this->fixtureDir . '/APT_RWY_END.csv', 'APT_RWY_END.csv'));
+
+        // APT_BASE.csv only appears as a traversal entry. Its basename matches the
+        // allowlist, so without the guard the file would be written; the guard
+        // must reject the entry, leaving the required APT_BASE.csv missing.
+        $this->assertTrue($zip->addFile($this->fixtureDir . '/APT_BASE.csv', '../APT_BASE.csv'));
+        $zip->close();
+
+        $extractDir = $this->makeExtractDir('apt_traversal');
+
+        try {
+            $zip = new ZipArchive();
+            $this->assertTrue($zip->open($zipPath) === true);
+            $this->assertFalse(nasrExtractAllowlistedAptCsvFromZip($zip, $extractDir));
+            $zip->close();
+
+            $this->assertFileDoesNotExist($extractDir . '/APT_BASE.csv');
+        } finally {
+            @unlink($zipPath);
+            $this->removeTree($extractDir);
+        }
+    }
+
+    public function testNasrExtractAllowlistedFrqCsvFromZip_CompleteArchive_WritesFrqCsv(): void
+    {
+        $zipPath = sys_get_temp_dir() . '/nasr_frq_extract_' . bin2hex(random_bytes(4)) . '.zip';
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($zipPath, ZipArchive::CREATE) === true);
+        $this->assertTrue($zip->addFile($this->fixtureDir . '/FRQ.csv', 'FRQ.csv'));
+        $zip->close();
+
+        $extractDir = $this->makeExtractDir('frq_extract');
+
+        try {
+            $zip = new ZipArchive();
+            $this->assertTrue($zip->open($zipPath) === true);
+            $this->assertTrue(nasrExtractAllowlistedFrqCsvFromZip($zip, $extractDir));
+            $zip->close();
+
+            $this->assertFileExists($extractDir . '/FRQ.csv');
+        } finally {
+            @unlink($zipPath);
+            $this->removeTree($extractDir);
+        }
+    }
+
+    public function testNasrExtractAllowlistedFrqCsvFromZip_MissingFrqEntry_ReturnsFalse(): void
+    {
+        $zipPath = sys_get_temp_dir() . '/nasr_frq_missing_' . bin2hex(random_bytes(4)) . '.zip';
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($zipPath, ZipArchive::CREATE) === true);
+        $this->assertTrue($zip->addFile($this->fixtureDir . '/APT_BASE.csv', 'APT_BASE.csv'));
+        $zip->close();
+
+        $extractDir = $this->makeExtractDir('frq_missing');
+
+        try {
+            $zip = new ZipArchive();
+            $this->assertTrue($zip->open($zipPath) === true);
+            $this->assertFalse(nasrExtractAllowlistedFrqCsvFromZip($zip, $extractDir));
+            $zip->close();
+        } finally {
+            @unlink($zipPath);
+            $this->removeTree($extractDir);
+        }
+    }
+
+    private function makeExtractDir(string $label): string
+    {
+        $dir = sys_get_temp_dir() . '/nasr_' . $label . '_' . bin2hex(random_bytes(4));
+        $this->assertNotFalse(@mkdir($dir, 0700, true), 'Failed to create NASR extract temp dir');
+
+        return $dir;
+    }
+
+    private function removeTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->removeTree($path);
+            } else {
+                @unlink($path);
+            }
+        }
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
Closes #201.

FAA can change a NASR subscription URL or CSV column and the scheduled refresh would only find out after it fails. This adds an opt-in probe that downloads the current-cycle APT and FRQ zips and asserts their layout and header prefixes still match `NASR_CSV_HEADER_PREFIX`, so schema drift fails loudly before production.

- Move the zip extraction helpers out of the fetch scripts into `lib/nasr/extract.php` so the probe shares them without loading a CLI script. The APT helper keeps its traversal guard; FRQ behavior unchanged.
- Add `NasrSchemaDriftIntegrationTest` to the `UpstreamApiProbes` suite and exclude it from the default Integration suite, so `make test-external-apis` and the weekly job pick it up.
- Add `zip` to the weekly workflow PHP extensions.
- Document interpreting a drift failure in `docs/TESTING.md`.

## Test plan
- [x] `php -l` clean on all changed files
- [x] Nasr unit tests pass (130 tests), including new `NasrExtractTest` (5 tests)
- [ ] CI Test and Lint